### PR TITLE
Bramble TUI: adaptive color theme for light/dark terminals

### DIFF
--- a/bramble/app/filetree.go
+++ b/bramble/app/filetree.go
@@ -15,16 +15,16 @@ import (
 var (
 	fileTreeHeaderStyle = lipgloss.NewStyle().
 				Bold(true).
-				Foreground(lipgloss.Color("12")).
+				Foreground(accentColor).
 				BorderBottom(true).
 				BorderStyle(lipgloss.NormalBorder()).
-				BorderForeground(lipgloss.Color("12"))
+				BorderForeground(accentColor)
 
 	fileTreeHeaderDimStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("242")).
+				Foreground(dimColor).
 				BorderBottom(true).
 				BorderStyle(lipgloss.NormalBorder()).
-				BorderForeground(lipgloss.Color("242"))
+				BorderForeground(dimColor)
 )
 
 // FileTree displays a navigable tree of changed files from a WorktreeContext.

--- a/bramble/app/helpoverlay.go
+++ b/bramble/app/helpoverlay.go
@@ -144,12 +144,12 @@ func (h *HelpOverlay) View() string {
 
 // Styles for help overlay (package-level to avoid allocations in View)
 var (
-	helpSectionTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("14"))
-	helpKeyStyle          = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
+	helpSectionTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(idleColor)
+	helpKeyStyle          = lipgloss.NewStyle().Bold(true).Foreground(accentColor)
 	helpKeyAlignStyle     = lipgloss.NewStyle().Width(12).Align(lipgloss.Right)
 	helpBoxStyle          = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("240")).
+				BorderForeground(borderColor).
 				Padding(1, 2)
 )
 

--- a/bramble/app/splitpane.go
+++ b/bramble/app/splitpane.go
@@ -73,7 +73,7 @@ func (sp *SplitPane) RightWidth(totalWidth int) int {
 }
 
 var dividerStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("240"))
+	Foreground(borderColor)
 
 // Render composites left and right content into a split or single layout.
 // When PaneLayoutSingle, only rightContent is shown.

--- a/bramble/app/toast.go
+++ b/bramble/app/toast.go
@@ -149,17 +149,17 @@ func (tm *ToastManager) View() string {
 
 var (
 	toastSuccessStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color("22")). // dark green background
-				Foreground(lipgloss.Color("10")). // bright green text
+				Background(lipgloss.AdaptiveColor{Light: "194", Dark: "22"}).
+				Foreground(lipgloss.AdaptiveColor{Light: "22", Dark: "10"}).
 				Padding(0, 1)
 
 	toastInfoStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("17")). // dark blue background
-			Foreground(lipgloss.Color("14")). // cyan text
+			Background(lipgloss.AdaptiveColor{Light: "153", Dark: "17"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "17", Dark: "14"}).
 			Padding(0, 1)
 
 	toastErrorStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("52")). // dark red background
-			Foreground(lipgloss.Color("9")).  // bright red text
+			Background(lipgloss.AdaptiveColor{Light: "217", Dark: "52"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "52", Dark: "9"}).
 			Padding(0, 1)
 )

--- a/bramble/app/view.go
+++ b/bramble/app/view.go
@@ -13,65 +13,81 @@ import (
 	"github.com/bazelment/yoloswe/bramble/session"
 )
 
+// Adaptive colors: {Light terminal, Dark terminal}
+//
+// Light values target a white (#ffffff) background.
+// Dark values target a near-black (#1c1c1c) background.
+var (
+	accentColor  = lipgloss.AdaptiveColor{Light: "4", Dark: "12"}    // navy / bright blue
+	dimColor     = lipgloss.AdaptiveColor{Light: "238", Dark: "242"} // muted text
+	borderColor  = lipgloss.AdaptiveColor{Light: "248", Dark: "240"} // subtle lines
+	barBgColor   = lipgloss.AdaptiveColor{Light: "254", Dark: "236"} // bar fill
+	barFgColor   = lipgloss.AdaptiveColor{Light: "236", Dark: "252"} // bar primary text
+	selectBg     = lipgloss.AdaptiveColor{Light: "195", Dark: "240"} // highlight row (light cyan / dark gray)
+	selectFg     = lipgloss.AdaptiveColor{Light: "0", Dark: "15"}    // black / white
+	errorColor   = lipgloss.AdaptiveColor{Light: "1", Dark: "9"}     // dark red / bright red
+	runningColor = lipgloss.AdaptiveColor{Light: "2", Dark: "10"}    // dark green / bright green
+	idleColor    = lipgloss.AdaptiveColor{Light: "6", Dark: "14"}    // dark cyan / bright cyan
+	pendingColor = lipgloss.AdaptiveColor{Light: "3", Dark: "11"}    // dark yellow / bright yellow
+	doneColor    = lipgloss.AdaptiveColor{Light: "244", Dark: "8"}   // gray / dark gray
+)
+
 // Styles
 var (
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("12"))
+			Foreground(accentColor)
 
 	selectedStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("240")).
-			Foreground(lipgloss.Color("15"))
+			Background(selectBg).
+			Foreground(selectFg)
 
 	dimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("242"))
+			Foreground(dimColor)
 
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("9"))
+			Foreground(errorColor)
 
 	topBarStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("236")).
-			Foreground(lipgloss.Color("252")).
+			Background(barBgColor).
+			Foreground(barFgColor).
 			Padding(0, 1)
 
 	statusBarStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("236")).
-			Foreground(lipgloss.Color("242"))
+			Background(barBgColor).
+			Foreground(dimColor)
 
 	runningStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("10"))
+			Foreground(runningColor)
 
 	idleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("14"))
+			Foreground(idleColor)
 
 	pendingStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("11"))
+			Foreground(pendingColor)
 
 	completedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("8"))
+			Foreground(doneColor)
 
 	failedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("9"))
+			Foreground(errorColor)
 
 	borderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("240")).
+			BorderForeground(borderColor).
 			BorderLeft(false).
 			BorderRight(false)
-
-	// Shared input box styles — keep interactive components visually consistent.
-	inputBoxBorderColor = lipgloss.Color("12")
 
 	// inputBoxStyle is for inline input components (TextArea, Dropdown overlays).
 	inputBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(inputBoxBorderColor).
+			BorderForeground(accentColor).
 			Padding(0, 1)
 
 	// modalBoxStyle is for centered modal dialogs (TaskModal, RepoPicker).
 	modalBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(inputBoxBorderColor).
+			BorderForeground(accentColor).
 			Padding(1, 2)
 )
 
@@ -624,7 +640,7 @@ func (m Model) renderStatusBar() string {
 		// Tmux mode: show session list navigation hints
 		hints = []string{"[↑/↓] Navigate", "[Enter] Switch to session"}
 		if hasWorktree {
-			hints = append(hints, "[p] Plan", "[b] Build")
+			hints = append(hints, "[p] Plan", "[b] Build", "[w] Window")
 		}
 		hints = append(hints, "[Alt-W] Worktree", "[?]help", "[q] Quit")
 	} else if m.viewingSessionID != "" {

--- a/bramble/app/welcome.go
+++ b/bramble/app/welcome.go
@@ -14,15 +14,15 @@ import (
 var (
 	welcomeTitleStyle = lipgloss.NewStyle().
 				Bold(true).
-				Foreground(lipgloss.Color("12")).
+				Foreground(accentColor).
 				MarginBottom(1)
 
 	welcomeKeyStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("14"))
+			Foreground(idleColor)
 
 	welcomeDescStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("252"))
+				Foreground(barFgColor)
 )
 
 // renderWelcome renders the welcome/empty state for the center area.


### PR DESCRIPTION
## Summary
- Replace all hardcoded `lipgloss.Color()` values with `lipgloss.AdaptiveColor{Light, Dark}` across the entire bramble TUI so it renders correctly on both light and dark terminal backgrounds
- Define 12 shared adaptive color variables (accent, dim, border, bar bg/fg, selection, error, running, idle, pending, completed) in `view.go`, used by all UI components
- Update new files from recent PRs (`welcome.go`, `helpoverlay.go`, `toast.go`) to use the same adaptive palette

## Test plan
- [x] `bazel build //bramble/...` passes
- [x] `bazel test //bramble/...` passes (including new tests for `w` keybinding and status bar hint)
- [x] `scripts/lint.sh` passes (Go lint + Bazel lint)
- [ ] Manual: verify TUI appearance on a dark terminal
- [ ] Manual: verify TUI appearance on a light/white terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentation-layer styling changes plus small hint/test additions; low risk aside from potential visual regressions across terminals/themes.
> 
> **Overview**
> Introduces a shared `lipgloss.AdaptiveColor` palette in `view.go` and updates TUI component styles (headers, borders, selection, welcome/help screens, split divider, and toasts) to use these adaptive colors instead of hardcoded `lipgloss.Color(...)`, improving rendering on both light and dark terminal themes.
> 
> Also updates the tmux-mode status bar hints to include `[w] Window` and adds tests covering the `w` key behavior outside tmux (toast shown) and the conditional rendering of the window hint in tmux vs TUI mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81cc3330f5353e7f39ca499bec030ab831c25588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->