### PR TITLE
Fix bramble test compilation after taskRouter addition

### DIFF
--- a/bramble/app/filetree_open_test.go
+++ b/bramble/app/filetree_open_test.go
@@ -276,7 +276,7 @@ func TestHandleKeyPress_UpDownNavigatesSessionListInTmuxSplitRightFocus(t *testi
 	worktrees := []wt.Worktree{
 		{Branch: "main", Path: "/tmp/wt/main"},
 	}
-	m := NewModel(context.Background(), "/tmp/wt", "test-repo", "", mgr, worktrees, 80, 24)
+	m := NewModel(context.Background(), "/tmp/wt", "test-repo", "", mgr, nil, worktrees, 80, 24)
 
 	// Start sessions so navigation has items
 	_, _ = mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A")

--- a/bramble/app/output_test.go
+++ b/bramble/app/output_test.go
@@ -1040,7 +1040,7 @@ func TestWindowKeyOutsideTmux(t *testing.T) {
 	})
 	defer mgr.Close()
 
-	m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, []wt.Worktree{
+	m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, nil, []wt.Worktree{
 		{Branch: "main", Path: "/tmp/wt/main"},
 	}, 80, 24)
 	m.worktreeDropdown.SelectIndex(0)
@@ -1065,7 +1065,7 @@ func TestStatusBarWindowHint(t *testing.T) {
 		})
 		defer mgr.Close()
 
-		m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, []wt.Worktree{
+		m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, nil, []wt.Worktree{
 			{Branch: "main", Path: "/tmp/wt/main"},
 		}, 80, 24)
 		m.worktreeDropdown.SelectIndex(0)
@@ -1080,7 +1080,7 @@ func TestStatusBarWindowHint(t *testing.T) {
 		})
 		defer mgr.Close()
 
-		m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, []wt.Worktree{
+		m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, nil, []wt.Worktree{
 			{Branch: "main", Path: "/tmp/wt/main"},
 		}, 80, 24)
 		m.worktreeDropdown.SelectIndex(0)


### PR DESCRIPTION
## Summary
- PR #14 added a `*taskrouter.Router` parameter to `NewModel` but missed 4 test call sites
- Added the missing `nil` argument to `NewModel` calls in `filetree_open_test.go` and `output_test.go`
- `bazel test bramble/...` now passes cleanly

## Test plan
- [x] `bazel test bramble/...` passes (2/2 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only signature alignment; no production logic changes and the new argument is passed as `nil`.
> 
> **Overview**
> Fixes test compilation after `NewModel` gained a `*taskrouter.Router` parameter by updating remaining test call sites to pass an explicit `nil` router.
> 
> Changes are limited to `filetree_open_test.go` and `output_test.go` and should restore `bazel test bramble/...` green without affecting runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e35cce4504e8d54f36037f49f2d1efe76b14304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->