### PR TITLE
Bramble: show worktree op messages after lobby content

### DIFF
--- a/bramble/app/welcome.go
+++ b/bramble/app/welcome.go
@@ -37,17 +37,6 @@ func (m Model) renderWelcome(width, height int) string {
 	wt := m.selectedWorktree()
 	inTmux := m.sessionManager.IsInTmuxMode()
 
-	// Show worktree operation messages if any (e.g. "Creating worktree...")
-	if len(m.worktreeOpMessages) > 0 {
-		b.WriteString("\n")
-		for _, msg := range m.worktreeOpMessages {
-			b.WriteString("  ")
-			b.WriteString(msg)
-			b.WriteString("\n")
-		}
-		return b.String()
-	}
-
 	b.WriteString("\n")
 
 	if !hasWorktrees {
@@ -96,6 +85,16 @@ func (m Model) renderWelcome(width, height int) string {
 			}
 			b.WriteString("\n")
 			b.WriteString(renderTimeline(timeline, maxTimelineLines))
+		}
+	}
+
+	// Show worktree operation messages if any (e.g. "Creating worktree...")
+	if len(m.worktreeOpMessages) > 0 {
+		b.WriteString("\n")
+		for _, msg := range m.worktreeOpMessages {
+			b.WriteString("  ")
+			b.WriteString(msg)
+			b.WriteString("\n")
 		}
 	}
 

--- a/bramble/app/welcome_test.go
+++ b/bramble/app/welcome_test.go
@@ -112,9 +112,9 @@ func TestWelcomeWorktreeOpMessages(t *testing.T) {
 
 	view := m.renderWelcome(80, 20)
 
-	// Should show operation messages instead of welcome
+	// Should show both welcome content and operation messages
 	assert.Contains(t, view, "Creating worktree")
-	assert.NotContains(t, view, "Welcome")
+	assert.Contains(t, view, "Welcome")
 }
 
 func TestRenderOutputAreaDelegatesToWelcome(t *testing.T) {


### PR DESCRIPTION
## Summary
- Worktree operation messages (e.g. "Creating worktree...", "Fetching latest from origin...") now appear **after** the normal lobby/welcome view instead of replacing it
- Users can see both the welcome screen content and the progress messages simultaneously

## Test plan
- [x] `bazel test //bramble/app/... --test_timeout=60` passes
- [ ] Manual: create a worktree and confirm the lobby view shows both the normal content and the operation messages below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts rendering order for operation status messages; main risk is minor layout/spacing regressions in the welcome view.
> 
> **Overview**
> Worktree operation progress messages in the welcome/lobby view no longer replace the entire screen; they are now appended below the normal welcome content.
> 
> Updates the `TestWelcomeWorktreeOpMessages` expectation to assert both the welcome text and the operation message are present in the rendered output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccc685e483a845f1a4be9f7e9c54b661a9ba8816. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->