### PR TITLE
Bramble: auto-switch to newly created worktree

### DIFF
--- a/bramble/app/BUILD.bazel
+++ b/bramble/app/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     name = "app_test",
     srcs = [
         "aggregate_cost_test.go",
+        "auto_switch_test.go",
         "confirmprompt_test.go",
         "dropdown_test.go",
         "filetree_open_test.go",

--- a/bramble/app/auto_switch_test.go
+++ b/bramble/app/auto_switch_test.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/bramble/session"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+func TestWorktreeOpResult_SetsAutoSwitch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate a successful worktree create result
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		branch:   "feature/new",
+		messages: []string{"Created worktree feature/new"},
+	})
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "feature/new", m2.pendingWorktreeSelect)
+	assert.Empty(t, m2.pendingPlannerPrompt)
+}
+
+func TestWorktreeOpResult_ErrorDoesNotSetAutoSwitch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate a failed worktree create result
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		branch:   "feature/bad",
+		messages: []string{"Failed"},
+		err:      assert.AnError,
+	})
+	m2 := newModel.(Model)
+
+	assert.Empty(t, m2.pendingWorktreeSelect)
+}
+
+func TestWorktreeOpResult_NoBranchDoesNotSetAutoSwitch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate a delete/sync result (no branch)
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		messages: []string{"Deleted worktree"},
+	})
+	m2 := newModel.(Model)
+
+	assert.Empty(t, m2.pendingWorktreeSelect)
+}
+
+func TestWorktreesMsg_SelectsNewWorktreeWithoutPlanner(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Set pending selection (as createWorktree would)
+	m.pendingWorktreeSelect = "feature/new"
+	// No planner prompt (manual 'n' key)
+
+	// Simulate worktrees refresh arriving with the new worktree
+	newModel, _ := m.Update(worktreesMsg{worktrees: []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+		{Branch: "feature/new", Path: "/tmp/wt/feature-new"},
+	}})
+	m2 := newModel.(Model)
+
+	// Should have selected the new worktree
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature/new", selected.ID)
+	// Pending state should be cleared
+	assert.Empty(t, m2.pendingWorktreeSelect)
+	assert.Empty(t, m2.pendingPlannerPrompt)
+}
+
+func TestWorktreeOpResult_ClearsStalePlannerPrompt(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate stale state from a task flow
+	m.pendingPlannerPrompt = "stale task prompt"
+
+	// Manual worktree create succeeds
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		branch:   "feature/manual",
+		messages: []string{"Created worktree feature/manual"},
+	})
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "feature/manual", m2.pendingWorktreeSelect)
+	// Stale prompt should be cleared
+	assert.Empty(t, m2.pendingPlannerPrompt)
+}

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -222,17 +222,17 @@ func (m *Model) currentWorktreeSessions() []session.SessionInfo {
 }
 
 // visibleSessions returns the sessions that should be displayed in the session list.
-// When showAllSessions is true, returns all non-terminal sessions across all worktrees.
+// When showAllSessions is true, returns all non-terminal sessions across all worktrees
+// using the cached m.sessions field for consistent state within a render cycle.
 // Otherwise, returns sessions for the current worktree only.
 func (m *Model) visibleSessions() []session.SessionInfo {
 	if !m.showAllSessions {
 		return m.currentWorktreeSessions()
 	}
-	allSessions := m.sessionManager.GetAllSessions()
 	var active []session.SessionInfo
-	for i := range allSessions {
-		if !allSessions[i].Status.IsTerminal() {
-			active = append(active, allSessions[i])
+	for i := range m.sessions {
+		if !m.sessions[i].Status.IsTerminal() {
+			active = append(active, m.sessions[i])
 		}
 	}
 	return active
@@ -621,6 +621,7 @@ type (
 	// worktreeOpResultMsg contains the result of a worktree operation
 	worktreeOpResultMsg struct {
 		err      error
+		branch   string // non-empty for create operations, used for auto-switch
 		messages []string
 	}
 	// taskWorktreeCreatedMsg is sent when a worktree is created for a task (then planner should start)

--- a/bramble/app/show_all_sessions_test.go
+++ b/bramble/app/show_all_sessions_test.go
@@ -94,19 +94,19 @@ func TestVisibleSessions_AllNonTerminal(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main session")
-	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature session")
-	require.NoError(t, err)
-	m.sessions = m.sessionManager.GetAllSessions()
+	// Use cached sessions directly to avoid race with background goroutines
+	m.sessions = []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main"},
+		{ID: "s2", Status: session.StatusRunning, WorktreePath: "/tmp/wt/feature"},
+		{ID: "s3", Status: session.StatusCompleted, WorktreePath: "/tmp/wt/main"},
+	}
 
-	// Toggle to show all — both running sessions should be visible
+	// Toggle to show all — only non-terminal sessions should be visible
 	m.showAllSessions = true
 	sessions := m.visibleSessions()
 	assert.Len(t, sessions, 2)
 
 	// Verify filtering logic: visibleSessions only returns non-terminal.
-	// All started sessions are in Running state, so all should appear.
 	for _, s := range sessions {
 		assert.False(t, s.Status.IsTerminal(), "visibleSessions should exclude terminal sessions")
 	}
@@ -142,11 +142,11 @@ func TestShowAllSessions_QuickSwitch_TmuxMode(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main session")
-	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature session")
-	require.NoError(t, err)
-	m.sessions = m.sessionManager.GetAllSessions()
+	// Use cached sessions directly to avoid race with background goroutines
+	m.sessions = []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main"},
+		{ID: "s2", Status: session.StatusRunning, WorktreePath: "/tmp/wt/feature"},
+	}
 
 	// Toggle to show all sessions
 	m.showAllSessions = true
@@ -187,11 +187,11 @@ func TestShowAllSessions_NavigateDown(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "s1")
-	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "s2")
-	require.NoError(t, err)
-	m.sessions = m.sessionManager.GetAllSessions()
+	// Use cached sessions directly to avoid race with background goroutines
+	m.sessions = []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main"},
+		{ID: "s2", Status: session.StatusRunning, WorktreePath: "/tmp/wt/feature"},
+	}
 
 	m.showAllSessions = true
 	m.selectedSessionIndex = 0


### PR DESCRIPTION
## Summary
- After pressing `n` to create a new worktree, Bramble now automatically switches the view to it instead of staying on the previously selected worktree
- Reuses the existing `pendingWorktreeSelect` mechanism from the task-based creation flow
- When no planner prompt is pending (manual `n` key vs task `t` key), skips starting a planner session

## Test plan
- [x] `bazel build //bramble/...` passes
- [x] `bazel test //bramble/app:app_test` passes
- [ ] Manual: press `n`, enter a branch name → view should switch to the new worktree
- [ ] Manual: press `t`, create a task with new worktree → planner should still auto-start as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TUI update/state transitions around worktree refresh and session visibility, so regressions could affect navigation or unintended session starts, but changes are localized and covered by new tests.
> 
> **Overview**
> After creating a worktree via the manual `n` flow, Bramble now **auto-selects the newly created worktree** on the next `worktreesMsg` refresh (reusing `pendingWorktreeSelect`).
> 
> `worktreeOpResultMsg` now carries the created `branch`, and `worktreesMsg` handling only starts a planner session when a `pendingPlannerPrompt` is present (task flow), avoiding accidental planner starts for manual creation; stale prompts are cleared.
> 
> Separately, `visibleSessions()` now filters “show all sessions” from the cached `m.sessions` slice for render-consistent state, and tests were updated/added (including new `auto_switch_test.go`) to cover the new behavior and reduce racey session-manager usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c45e2ddfd276d100cf80f59aace360c8686d9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->