### PR TITLE
Add procattr package, enhance multiagent sessions, fix integration test tagging

### DIFF
--- a/agent-cli-wrapper/claude/BUILD.bazel
+++ b/agent-cli-wrapper/claude/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//agent-cli-wrapper/internal/ndjson",
+        "//agent-cli-wrapper/internal/procattr",
         "//agent-cli-wrapper/protocol",
         "@com_github_invopop_jsonschema//:jsonschema",
     ],

--- a/agent-cli-wrapper/codex/BUILD.bazel
+++ b/agent-cli-wrapper/codex/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     ],
     importpath = "github.com/bazelment/yoloswe/agent-cli-wrapper/codex",
     visibility = ["//visibility:public"],
+    deps = ["//agent-cli-wrapper/internal/procattr"],
 )
 
 go_test(

--- a/agent-cli-wrapper/internal/procattr/BUILD.bazel
+++ b/agent-cli-wrapper/internal/procattr/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "procattr",
+    srcs = [
+        "procattr_linux.go",
+        "procattr_other.go",
+        "signal.go",
+    ],
+    importpath = "github.com/bazelment/yoloswe/agent-cli-wrapper/internal/procattr",
+    visibility = ["//agent-cli-wrapper:__subpackages__"],
+)
+
+go_test(
+    name = "procattr_test",
+    srcs = ["procattr_test.go"],
+    embed = [":procattr"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/agent-cli-wrapper/internal/procattr/procattr_linux.go
+++ b/agent-cli-wrapper/internal/procattr/procattr_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+// Package procattr provides platform-specific subprocess configuration
+// for orphan prevention.
+package procattr
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// Set configures process group and parent-death signal for subprocess
+// orphan prevention. On Linux, Pdeathsig causes the child to receive SIGTERM
+// when the parent process dies (e.g. OOM kill, SIGKILL).
+func Set(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:   true,
+		Pdeathsig: syscall.SIGTERM,
+	}
+}

--- a/agent-cli-wrapper/internal/procattr/procattr_other.go
+++ b/agent-cli-wrapper/internal/procattr/procattr_other.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+// Package procattr provides platform-specific subprocess configuration
+// for orphan prevention.
+package procattr
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// Set configures process group for subprocess orphan prevention.
+// On non-Linux platforms, Pdeathsig is not available. Setpgid creates a
+// process group, enabling kill -<signal> -<pgid> cleanup by the parent.
+func Set(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/agent-cli-wrapper/internal/procattr/procattr_test.go
+++ b/agent-cli-wrapper/internal/procattr/procattr_test.go
@@ -1,0 +1,79 @@
+package procattr
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSet_ConfiguresSysProcAttr(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("echo", "test")
+	require.Nil(t, cmd.SysProcAttr)
+
+	Set(cmd)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setpgid, "Setpgid should be true for process group creation")
+}
+
+func TestSet_Idempotent(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("echo", "test")
+
+	Set(cmd)
+	first := cmd.SysProcAttr
+
+	Set(cmd)
+	second := cmd.SysProcAttr
+
+	// Both calls should configure the same fields.
+	assert.Equal(t, first.Setpgid, second.Setpgid)
+}
+
+func TestSignalGroup_NilProcess(t *testing.T) {
+	t.Parallel()
+	err := SignalGroup(nil, syscall.SIGTERM)
+	assert.NoError(t, err, "SignalGroup with nil process should be a no-op")
+}
+
+func TestKillGroup_NilProcess(t *testing.T) {
+	t.Parallel()
+	err := KillGroup(nil)
+	assert.NoError(t, err, "KillGroup with nil process should be a no-op")
+}
+
+func TestSignalGroup_RunningProcess(t *testing.T) {
+	t.Parallel()
+
+	// Start a sleep process with a process group.
+	cmd := exec.Command("sleep", "60")
+	Set(cmd)
+	require.NoError(t, cmd.Start())
+
+	// Signal the process group with SIGTERM.
+	err := SignalGroup(cmd.Process, syscall.SIGTERM)
+	assert.NoError(t, err)
+
+	// Wait for process to exit (should be killed by SIGTERM).
+	_ = cmd.Wait()
+}
+
+func TestKillGroup_RunningProcess(t *testing.T) {
+	t.Parallel()
+
+	// Start a sleep process with a process group.
+	cmd := exec.Command("sleep", "60")
+	Set(cmd)
+	require.NoError(t, cmd.Start())
+
+	// Kill the process group.
+	err := KillGroup(cmd.Process)
+	assert.NoError(t, err)
+
+	// Wait for process to exit (should be killed by SIGKILL).
+	_ = cmd.Wait()
+}

--- a/agent-cli-wrapper/internal/procattr/signal.go
+++ b/agent-cli-wrapper/internal/procattr/signal.go
@@ -1,0 +1,21 @@
+package procattr
+
+import (
+	"os"
+	"syscall"
+)
+
+// SignalGroup sends a signal to the entire process group of the given process.
+// Using the negative PID causes the kernel to deliver the signal to all
+// processes in the group, not just the direct child.
+func SignalGroup(p *os.Process, sig syscall.Signal) error {
+	if p == nil {
+		return nil
+	}
+	return syscall.Kill(-p.Pid, sig)
+}
+
+// KillGroup sends SIGKILL to the entire process group of the given process.
+func KillGroup(p *os.Process) error {
+	return SignalGroup(p, syscall.SIGKILL)
+}

--- a/bramble/app/BUILD.bazel
+++ b/bramble/app/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     name = "app_test",
     srcs = [
         "aggregate_cost_test.go",
+        "auto_switch_test.go",
         "confirmprompt_test.go",
         "dropdown_test.go",
         "filetree_open_test.go",

--- a/bramble/app/auto_switch_test.go
+++ b/bramble/app/auto_switch_test.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/bramble/session"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+func TestWorktreeOpResult_SetsAutoSwitch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate a successful worktree create result
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		branch:   "feature/new",
+		messages: []string{"Created worktree feature/new"},
+	})
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "feature/new", m2.pendingWorktreeSelect)
+	assert.Empty(t, m2.pendingPlannerPrompt)
+}
+
+func TestWorktreeOpResult_ErrorDoesNotSetAutoSwitch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate a failed worktree create result
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		branch:   "feature/bad",
+		messages: []string{"Failed"},
+		err:      assert.AnError,
+	})
+	m2 := newModel.(Model)
+
+	assert.Empty(t, m2.pendingWorktreeSelect)
+}
+
+func TestWorktreeOpResult_NoBranchDoesNotSetAutoSwitch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate a delete/sync result (no branch)
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		messages: []string{"Deleted worktree"},
+	})
+	m2 := newModel.(Model)
+
+	assert.Empty(t, m2.pendingWorktreeSelect)
+}
+
+func TestWorktreesMsg_SelectsNewWorktreeWithoutPlanner(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Set pending selection (as createWorktree would)
+	m.pendingWorktreeSelect = "feature/new"
+	// No planner prompt (manual 'n' key)
+
+	// Simulate worktrees refresh arriving with the new worktree
+	newModel, _ := m.Update(worktreesMsg{worktrees: []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+		{Branch: "feature/new", Path: "/tmp/wt/feature-new"},
+	}})
+	m2 := newModel.(Model)
+
+	// Should have selected the new worktree
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature/new", selected.ID)
+	// Pending state should be cleared
+	assert.Empty(t, m2.pendingWorktreeSelect)
+	assert.Empty(t, m2.pendingPlannerPrompt)
+}
+
+func TestWorktreeOpResult_ClearsStalePlannerPrompt(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Simulate stale state from a task flow
+	m.pendingPlannerPrompt = "stale task prompt"
+
+	// Manual worktree create succeeds
+	newModel, _ := m.Update(worktreeOpResultMsg{
+		branch:   "feature/manual",
+		messages: []string{"Created worktree feature/manual"},
+	})
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "feature/manual", m2.pendingWorktreeSelect)
+	// Stale prompt should be cleared
+	assert.Empty(t, m2.pendingPlannerPrompt)
+}

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -222,17 +222,17 @@ func (m *Model) currentWorktreeSessions() []session.SessionInfo {
 }
 
 // visibleSessions returns the sessions that should be displayed in the session list.
-// When showAllSessions is true, returns all non-terminal sessions across all worktrees.
+// When showAllSessions is true, returns all non-terminal sessions across all worktrees
+// using the cached m.sessions field for consistent state within a render cycle.
 // Otherwise, returns sessions for the current worktree only.
 func (m *Model) visibleSessions() []session.SessionInfo {
 	if !m.showAllSessions {
 		return m.currentWorktreeSessions()
 	}
-	allSessions := m.sessionManager.GetAllSessions()
 	var active []session.SessionInfo
-	for i := range allSessions {
-		if !allSessions[i].Status.IsTerminal() {
-			active = append(active, allSessions[i])
+	for i := range m.sessions {
+		if !m.sessions[i].Status.IsTerminal() {
+			active = append(active, m.sessions[i])
 		}
 	}
 	return active
@@ -621,6 +621,7 @@ type (
 	// worktreeOpResultMsg contains the result of a worktree operation
 	worktreeOpResultMsg struct {
 		err      error
+		branch   string // non-empty for create operations, used for auto-switch
 		messages []string
 	}
 	// taskWorktreeCreatedMsg is sent when a worktree is created for a task (then planner should start)

--- a/bramble/app/show_all_sessions_test.go
+++ b/bramble/app/show_all_sessions_test.go
@@ -94,19 +94,19 @@ func TestVisibleSessions_AllNonTerminal(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main session")
-	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature session")
-	require.NoError(t, err)
-	m.sessions = m.sessionManager.GetAllSessions()
+	// Use cached sessions directly to avoid race with background goroutines
+	m.sessions = []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main"},
+		{ID: "s2", Status: session.StatusRunning, WorktreePath: "/tmp/wt/feature"},
+		{ID: "s3", Status: session.StatusCompleted, WorktreePath: "/tmp/wt/main"},
+	}
 
-	// Toggle to show all — both running sessions should be visible
+	// Toggle to show all — only non-terminal sessions should be visible
 	m.showAllSessions = true
 	sessions := m.visibleSessions()
 	assert.Len(t, sessions, 2)
 
 	// Verify filtering logic: visibleSessions only returns non-terminal.
-	// All started sessions are in Running state, so all should appear.
 	for _, s := range sessions {
 		assert.False(t, s.Status.IsTerminal(), "visibleSessions should exclude terminal sessions")
 	}
@@ -142,11 +142,11 @@ func TestShowAllSessions_QuickSwitch_TmuxMode(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main session")
-	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature session")
-	require.NoError(t, err)
-	m.sessions = m.sessionManager.GetAllSessions()
+	// Use cached sessions directly to avoid race with background goroutines
+	m.sessions = []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main"},
+		{ID: "s2", Status: session.StatusRunning, WorktreePath: "/tmp/wt/feature"},
+	}
 
 	// Toggle to show all sessions
 	m.showAllSessions = true
@@ -187,11 +187,11 @@ func TestShowAllSessions_NavigateDown(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "s1")
-	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "s2")
-	require.NoError(t, err)
-	m.sessions = m.sessionManager.GetAllSessions()
+	// Use cached sessions directly to avoid race with background goroutines
+	m.sessions = []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main"},
+		{ID: "s2", Status: session.StatusRunning, WorktreePath: "/tmp/wt/feature"},
+	}
 
 	m.showAllSessions = true
 	m.selectedSessionIndex = 0

--- a/multiagent/agent/config.go
+++ b/multiagent/agent/config.go
@@ -1,7 +1,10 @@
 // Package agent provides core types and interfaces for the multi-agent system.
 package agent
 
-import "time"
+import (
+	"log/slog"
+	"time"
+)
 
 // AgentRole identifies the type of agent.
 type AgentRole string
@@ -26,35 +29,17 @@ func (r AgentRole) IsLongRunning() bool {
 
 // AgentConfig configures an agent instance.
 type AgentConfig struct {
-	// Role identifies the agent type.
-	Role AgentRole
-
-	// Model specifies the Claude model to use (e.g., "haiku", "sonnet", "opus").
-	Model string
-
-	// SystemPrompt is the system prompt for this agent.
-	SystemPrompt string
-
-	// WorkDir is the working directory for file operations.
-	WorkDir string
-
-	// SessionDir is the directory for storing session recordings.
-	// For long-running agents: SessionDir/role/
-	// For ephemeral agents: SessionDir/role/task-xxx/
-	SessionDir string
-
-	// MaxTurnsPerTask limits turns for ephemeral agents (prevents runaway).
+	Logger          *slog.Logger
+	Role            AgentRole
+	Model           string
+	SystemPrompt    string
+	WorkDir         string
+	SessionDir      string
+	AllowedTools    []string
 	MaxTurnsPerTask int
-
-	// TurnTimeout is the maximum time to wait for a turn to complete.
-	TurnTimeout time.Duration
-
-	// BudgetUSD is the cost budget for this agent (0 = unlimited).
-	BudgetUSD float64
-
-	// TaskTimeout is the maximum time for a single task execution (0 = unlimited).
-	// Only applies to ephemeral agents (Designer, Builder, Reviewer).
-	TaskTimeout time.Duration
+	TurnTimeout     time.Duration
+	BudgetUSD       float64
+	TaskTimeout     time.Duration
 }
 
 // DefaultConfig returns a config with sensible defaults.

--- a/multiagent/agent/session_test.go
+++ b/multiagent/agent/session_test.go
@@ -181,7 +181,7 @@ func TestRunSessionWithFileTracking_StopBeforeWait(t *testing.T) {
 	var err error
 
 	go func() {
-		result, execResult, err = runSessionWithFileTracking(ctx, mock, "test prompt")
+		result, execResult, err = runSessionWithFileTracking(ctx, mock, "test prompt", nopLogger)
 		close(done)
 	}()
 
@@ -228,7 +228,7 @@ func TestRunSessionWithFileTracking_TracksFiles(t *testing.T) {
 		mockSessionRunner: newMockSessionRunner(),
 	}
 
-	result, execResult, err := runSessionWithFileTracking(ctx, customMock, "test")
+	result, execResult, err := runSessionWithFileTracking(ctx, customMock, "test", nopLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestRunSessionWithFileTracking_StopError(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	_, _, err := runSessionWithFileTracking(ctx, mock, "test")
+	_, _, err := runSessionWithFileTracking(ctx, mock, "test", nopLogger)
 	if err == nil {
 		t.Fatal("expected error from Stop failure")
 	}
@@ -319,7 +319,7 @@ func TestRunSessionWithFileTracking_StopFailsToCloseEvents(t *testing.T) {
 	ctx := context.Background()
 
 	start := time.Now()
-	result, execResult, err := runSessionWithFileTracking(ctx, mock, "test")
+	result, execResult, err := runSessionWithFileTracking(ctx, mock, "test", nopLogger)
 	elapsed := time.Since(start)
 
 	// Should complete (with timeout) rather than deadlock forever

--- a/wt/integration/BUILD.bazel
+++ b/wt/integration/BUILD.bazel
@@ -8,6 +8,10 @@ go_test(
         "branch_change_test.go",
         "integration_test.go",
     ],
+    tags = [
+        "local",
+        "manual",
+    ],
     deps = [
         "//wt",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
## Summary
- Add `agent-cli-wrapper/internal/procattr` package for platform-specific subprocess orphan prevention (process groups, `Pdeathsig` on Linux), used by both claude and codex process managers
- Extend `multiagent/agent` with `EphemeralSession` (fresh session per task with file tracking), structured `slog` logging, `LoggingEvents()`, and `RecordUsage()` for streaming cost accounting
- Remove duplicate `go_default_test` targets from 5 integration BUILD files that lacked the `manual` tag, causing spurious failures in `bazel test //...`
- Add missing `manual`/`local` tags to `wt/integration/BUILD.bazel`

## Test plan
- [x] `bazel build //...` passes
- [x] `bazel test //...` — all 21 tests pass, 0 failures
- [x] New `procattr` package has unit tests covering process group setup and signal delivery
- [x] Integration tests properly excluded from `bazel test //...` via `manual` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess lifecycle/termination behavior and agent session accounting/logging, where mistakes can cause lingering processes or double-counted usage; changes are localized and covered by new unit tests.
> 
> **Overview**
> Prevents orphaned Claude/Codex subprocesses by introducing `internal/procattr` (process groups + Linux `Pdeathsig`) and updating both process managers to signal/kill the *entire process group* during shutdown.
> 
> Enhances `multiagent/agent` sessions with structured `slog` logging, optional `AllowedTools` wiring into Claude session options, and a new `LoggingEvents()` stream that logs tool/turn completion while enabling accurate streaming cost accounting.
> 
> Improves Bramble TUI worktree UX by auto-switching to newly created worktrees (without always starting a planner session) and makes “show all sessions” use the cached `m.sessions` to avoid racey tests; adds new coverage for the auto-switch flow. Marks `wt/integration` tests with `manual`/`local` tags to avoid running in `bazel test //...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6106e5e7b49289f6acfe5f60f29833c70b1cb516. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->