### PR TITLE
Bramble: add model selection with provider-aware routing

### DIFF
--- a/bramble/app/filetree_open_test.go
+++ b/bramble/app/filetree_open_test.go
@@ -279,8 +279,8 @@ func TestHandleKeyPress_UpDownNavigatesSessionListInTmuxSplitRightFocus(t *testi
 	m := NewModel(context.Background(), "/tmp/wt", "test-repo", "", mgr, nil, worktrees, 80, 24)
 
 	// Start sessions so navigation has items
-	_, _ = mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A")
-	_, _ = mgr.StartSession(session.SessionTypeBuilder, "/tmp/wt/main", "session B")
+	_, _ = mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A", "")
+	_, _ = mgr.StartSession(session.SessionTypeBuilder, "/tmp/wt/main", "session B", "")
 
 	// Set up split pane with right focus (session list)
 	m.splitPane.Toggle()

--- a/bramble/app/helpoverlay_test.go
+++ b/bramble/app/helpoverlay_test.go
@@ -212,7 +212,7 @@ func TestBuildHelpSectionsWithSession(t *testing.T) {
 	m := NewModel(ctx, "/tmp/wt", "test-repo", "", mgr, nil, worktrees, 80, 24)
 
 	// Add a session
-	sessionID, err := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/feature-auth", "test plan")
+	sessionID, err := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/feature-auth", "test plan", "")
 	if err != nil {
 		t.Fatalf("Failed to start session: %v", err)
 	}

--- a/bramble/app/merge_test.go
+++ b/bramble/app/merge_test.go
@@ -107,7 +107,7 @@ func TestMergeKey_ActiveSession(t *testing.T) {
 	}
 
 	// Start a running session for this worktree
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/feature", "test")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/feature", "test", "")
 	require.NoError(t, err)
 
 	m2 := pressKey(m, 'm')

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -36,7 +36,7 @@ type Model struct { //nolint:govet // fieldalignment: readability over padding f
 	sessions              []session.SessionInfo
 	cachedHistory         []*session.SessionMeta
 	worktreeOpMessages    []string
-	inputHandler          func(string) tea.Cmd
+	inputHandler          func(value, model string, sessionType session.SessionType) tea.Cmd
 	confirmHandler        func(string) tea.Cmd
 	confirmCancelHandler  func() tea.Cmd
 	confirmPrompt         *ConfirmPrompt
@@ -61,6 +61,10 @@ type Model struct { //nolint:govet // fieldalignment: readability over padding f
 	editor                string
 	inputPrompt           string
 	wtRoot                string
+	defaultPlanModel      string              // Remembered default model for plan sessions
+	defaultBuildModel     string              // Remembered default model for build sessions
+	pendingModel          string              // Model for the current input flow (transient)
+	pendingSessionType    session.SessionType // Session type for current input flow (transient)
 	viewingSessionID      session.SessionID
 	historyBranch         string
 	scrollOffset          int
@@ -94,6 +98,8 @@ func NewModel(ctx context.Context, wtRoot, repoName, editor string, sessionManag
 		focus:              FocusOutput,
 		width:              width,
 		height:             height,
+		defaultPlanModel:   "opus",
+		defaultBuildModel:  "sonnet",
 		worktreeDropdown:   wtDropdown,
 		sessionDropdown:    NewDropdown(nil),
 		taskModal:          NewTaskModal(),
@@ -591,6 +597,7 @@ type (
 	startSessionMsg struct {
 		sessionType session.SessionType
 		prompt      string
+		model       string
 	}
 	createWorktreeMsg struct{ branch string }
 	editorResultMsg   struct{ err error }

--- a/bramble/app/quick_switch_test.go
+++ b/bramble/app/quick_switch_test.go
@@ -18,9 +18,9 @@ func TestQuickSwitch_SwitchesToSession(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Start two sessions
-	sess1, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "first prompt")
+	sess1, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "first prompt", "")
 	require.NoError(t, err)
-	sess2, err := m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/main", "second prompt")
+	sess2, err := m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/main", "second prompt", "")
 	require.NoError(t, err)
 
 	m.sessions = m.sessionManager.GetAllSessions()
@@ -47,7 +47,7 @@ func TestQuickSwitch_OutOfRange_ShowsToast(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Start only one session
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "first prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "first prompt", "")
 	require.NoError(t, err)
 
 	m.sessions = m.sessionManager.GetAllSessions()
@@ -85,11 +85,11 @@ func TestQuickSwitch_TmuxMode_SelectsIndex(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Start three sessions
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "first prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "first prompt", "")
 	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/main", "second prompt")
+	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/main", "second prompt", "")
 	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "third prompt")
+	_, err = m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "third prompt", "")
 	require.NoError(t, err)
 
 	m.sessions = m.sessionManager.GetAllSessions()
@@ -111,7 +111,7 @@ func TestQuickSwitch_SessionDropdownShowsNumbers(t *testing.T) {
 
 	// Start several sessions to test numbering
 	for i := 0; i < 5; i++ {
-		_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "prompt")
+		_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "prompt", "")
 		require.NoError(t, err)
 	}
 

--- a/bramble/app/quit_confirm_test.go
+++ b/bramble/app/quit_confirm_test.go
@@ -35,7 +35,7 @@ func TestQuitConfirm_ActiveSessions_ShowsConfirmation(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session to make it active
-	sessID, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	sessID, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 	require.NotEmpty(t, sessID)
 
@@ -64,7 +64,7 @@ func TestQuitConfirm_SecondQ_Quits(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -89,7 +89,7 @@ func TestQuitConfirm_Y_Quits(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -114,7 +114,7 @@ func TestQuitConfirm_OtherKey_Cancels(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -144,7 +144,7 @@ func TestQuitConfirm_CtrlC_AlwaysQuits(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -164,7 +164,7 @@ func TestQuitConfirm_IdleSessions_CountAsActive(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session and make it idle
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 
 	// Simulate session becoming idle (normally done by session manager)
@@ -184,7 +184,7 @@ func TestQuitConfirm_CompletedSessions_DontCount(t *testing.T) {
 	}, "test-repo")
 
 	// Start a session and mark it as completed
-	sessID, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt")
+	sessID, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "test prompt", "")
 	require.NoError(t, err)
 
 	// Get the internal session and mark it completed

--- a/bramble/app/show_all_sessions_test.go
+++ b/bramble/app/show_all_sessions_test.go
@@ -19,9 +19,9 @@ func TestAllSessionsOverlay_Show(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Start sessions on different worktrees
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main task")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main task", "")
 	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature task")
+	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature task", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -78,9 +78,9 @@ func TestAllSessionsOverlay_Select_TUIMode(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main task")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main task", "")
 	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature task")
+	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature task", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -134,9 +134,9 @@ func TestAllSessionsOverlay_QuickSwitch(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main task")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "main task", "")
 	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature task")
+	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "feature task", "")
 	require.NoError(t, err)
 	m.sessions = m.sessionManager.GetAllSessions()
 
@@ -164,9 +164,9 @@ func TestAllSessionsOverlay_FilterTerminal(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Start 2 sessions via the manager (will be running = non-terminal)
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "task 1")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "task 1", "")
 	require.NoError(t, err)
-	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "task 2")
+	_, err = m.sessionManager.StartSession(session.SessionTypeBuilder, "/tmp/wt/feature", "task 2", "")
 	require.NoError(t, err)
 
 	// Open overlay - all sessions are running (non-terminal), so all should appear
@@ -226,7 +226,7 @@ func TestAllSessionsOverlay_FreshFromManager(t *testing.T) {
 
 	// Start a session via the manager but do NOT update m.sessions —
 	// simulates the case where no sessionEventMsg has arrived yet.
-	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "fresh task")
+	_, err := m.sessionManager.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "fresh task", "")
 	require.NoError(t, err)
 	// m.sessions is intentionally left empty / stale
 

--- a/bramble/app/update_scroll_test.go
+++ b/bramble/app/update_scroll_test.go
@@ -23,8 +23,8 @@ func TestScrollPositionPreservedOnSessionSwitch(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Create two sessions
-	sessionA, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A")
-	sessionB, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session B")
+	sessionA, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A", "")
+	sessionB, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session B", "")
 
 	// View session A and scroll
 	m.viewingSessionID = sessionA
@@ -85,7 +85,7 @@ func TestScrollPositionClearedOnWorktreeSwitch(t *testing.T) {
 	m.updateSessionDropdown()
 
 	// Create session on worktree 1
-	sessionA, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A")
+	sessionA, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A", "")
 	m.viewingSessionID = sessionA
 	m.scrollOffset = 15
 
@@ -116,12 +116,12 @@ func TestNewSessionStartsAtBottom(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	// Create and view session A
-	sessionA, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A")
+	sessionA, _ := mgr.StartSession(session.SessionTypePlanner, "/tmp/wt/main", "session A", "")
 	m.viewingSessionID = sessionA
 	m.scrollOffset = 20
 
 	// Start a new session
-	newModel, _ := m.startSession(session.SessionTypePlanner, "new session")
+	newModel, _ := m.startSession(session.SessionTypePlanner, "new session", "")
 	m2 := newModel.(Model)
 
 	// Check that old session's scroll was saved

--- a/bramble/app/view.go
+++ b/bramble/app/view.go
@@ -645,7 +645,11 @@ func (m Model) renderStatusBar() string {
 	} else if m.focus == FocusConfirm && m.confirmPrompt != nil {
 		hints = []string{"See prompt for keys", "[Esc] Cancel"}
 	} else if m.inputMode {
-		hints = []string{"[Tab] Switch", "[Enter] Send", "[Shift+Enter] Newline", "[Esc] Cancel", "[?]help"}
+		hints = []string{"[Tab] Switch", "[Enter] Send", "[Shift+Enter] Newline", "[Esc] Cancel"}
+		if m.pendingModel != "" {
+			hints = append(hints, "[Alt+M] "+m.pendingModel)
+		}
+		hints = append(hints, "[?]help")
 	} else if m.focus == FocusWorktreeDropdown || m.focus == FocusSessionDropdown {
 		hints = []string{"[↑/↓]select", "[Enter]choose", "[Esc]close", "[?]help", "[q]uit"}
 	} else if inTmuxMode {

--- a/bramble/session/tmux_test.go
+++ b/bramble/session/tmux_test.go
@@ -53,6 +53,144 @@ func TestBuildShellCommand(t *testing.T) {
 	}
 }
 
+func TestBuildShellCommandCodex(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+		args []string
+	}{
+		{
+			name: "codex with model",
+			cmd:  "codex",
+			args: []string{"--model", "gpt-5.3-codex", "fix the bug"},
+			want: "codex '--model' 'gpt-5.3-codex' 'fix the bug'",
+		},
+		{
+			name: "codex with yolo",
+			cmd:  "codex",
+			args: []string{"--model", "gpt-5.2", "--dangerously-bypass-approvals-and-sandbox", "build feature"},
+			want: "codex '--model' 'gpt-5.2' '--dangerously-bypass-approvals-and-sandbox' 'build feature'",
+		},
+		{
+			name: "claude with model flag",
+			cmd:  "claude",
+			args: []string{"--model", "opus", "--permission-mode", "plan", "plan this"},
+			want: "claude '--model' 'opus' '--permission-mode' 'plan' 'plan this'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildShellCommand(tt.cmd, tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTmuxRunnerBuildCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   tmuxRunner
+		wantBin  string
+		wantArgs []string
+	}{
+		{
+			name: "claude planner with model",
+			runner: tmuxRunner{
+				model:          "opus",
+				provider:       ProviderClaude,
+				permissionMode: "plan",
+				prompt:         "plan this",
+			},
+			wantBin:  "claude",
+			wantArgs: []string{"--model", "opus", "--permission-mode", "plan", "plan this"},
+		},
+		{
+			name: "codex builder",
+			runner: tmuxRunner{
+				model:    "gpt-5.3-codex",
+				provider: ProviderCodex,
+				prompt:   "build it",
+			},
+			wantBin:  "codex",
+			wantArgs: []string{"--model", "gpt-5.3-codex", "build it"},
+		},
+		{
+			name: "codex with yolo",
+			runner: tmuxRunner{
+				model:    "gpt-5.2",
+				provider: ProviderCodex,
+				prompt:   "build it",
+				yoloMode: true,
+			},
+			wantBin:  "codex",
+			wantArgs: []string{"--model", "gpt-5.2", "--dangerously-bypass-approvals-and-sandbox", "build it"},
+		},
+		{
+			name: "claude with yolo",
+			runner: tmuxRunner{
+				model:    "sonnet",
+				provider: ProviderClaude,
+				prompt:   "build it",
+				yoloMode: true,
+			},
+			wantBin:  "claude",
+			wantArgs: []string{"--model", "sonnet", "--allow-dangerously-skip-permissions", "--dangerously-skip-permissions", "build it"},
+		},
+		{
+			name: "empty provider defaults to claude",
+			runner: tmuxRunner{
+				model:  "haiku",
+				prompt: "quick task",
+			},
+			wantBin:  "claude",
+			wantArgs: []string{"--model", "haiku", "quick task"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBin, gotArgs := tt.runner.buildCommand()
+			assert.Equal(t, tt.wantBin, gotBin)
+			assert.Equal(t, tt.wantArgs, gotArgs)
+		})
+	}
+}
+
+func TestModelByID(t *testing.T) {
+	m, ok := ModelByID("opus")
+	assert.True(t, ok)
+	assert.Equal(t, "opus", m.ID)
+	assert.Equal(t, ProviderClaude, m.Provider)
+
+	m, ok = ModelByID("gpt-5.3-codex")
+	assert.True(t, ok)
+	assert.Equal(t, "gpt-5.3-codex", m.ID)
+	assert.Equal(t, ProviderCodex, m.Provider)
+
+	_, ok = ModelByID("nonexistent")
+	assert.False(t, ok)
+}
+
+func TestNextModel(t *testing.T) {
+	// Starting from opus, cycle through all models
+	current := "opus"
+	seen := make(map[string]bool)
+	for i := 0; i < len(AvailableModels); i++ {
+		next := NextModel(current)
+		assert.False(t, seen[next.ID], "cycle should not repeat before visiting all models")
+		seen[next.ID] = true
+		current = next.ID
+	}
+	// After a full cycle, should be back to opus
+	assert.Equal(t, "opus", current)
+
+	// Unknown model returns first model
+	m := NextModel("nonexistent")
+	assert.Equal(t, AvailableModels[0].ID, m.ID)
+}
+
 func TestParsePaneDeadOutput(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/bramble/session/types.go
+++ b/bramble/session/types.go
@@ -15,6 +15,50 @@ const (
 	SessionTypeBuilder SessionType = "builder"
 )
 
+// Provider names for agent backends.
+const (
+	ProviderClaude = "claude"
+	ProviderCodex  = "codex"
+)
+
+// AgentModel describes a model available for session execution.
+type AgentModel struct {
+	ID       string // Model identifier passed to --model flag (e.g. "opus", "gpt-5.3-codex")
+	Provider string // Binary/provider name: "claude" or "codex"
+	Label    string // Display label for the UI (e.g. "opus (claude)")
+}
+
+// AvailableModels is the ordered list of models. Ctrl+M cycles through this list.
+var AvailableModels = []AgentModel{
+	{ID: "opus", Provider: ProviderClaude, Label: "opus"},
+	{ID: "sonnet", Provider: ProviderClaude, Label: "sonnet"},
+	{ID: "haiku", Provider: ProviderClaude, Label: "haiku"},
+	{ID: "gpt-5.3-codex", Provider: ProviderCodex, Label: "gpt-5.3-codex"},
+	{ID: "gpt-5.2", Provider: ProviderCodex, Label: "gpt-5.2"},
+	{ID: "gpt-5.1-codex-max", Provider: ProviderCodex, Label: "gpt-5.1-codex-max"},
+}
+
+// ModelByID returns the AgentModel for the given ID, or false if not found.
+func ModelByID(id string) (AgentModel, bool) {
+	for _, m := range AvailableModels {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return AgentModel{}, false
+}
+
+// NextModel returns the next model in the cycle after currentID.
+// If currentID is not found, returns the first model.
+func NextModel(currentID string) AgentModel {
+	for i, m := range AvailableModels {
+		if m.ID == currentID {
+			return AvailableModels[(i+1)%len(AvailableModels)]
+		}
+	}
+	return AvailableModels[0]
+}
+
 // SessionStatus represents the lifecycle state of a session.
 type SessionStatus string
 

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -44,6 +44,9 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 
 	// Build thread options
 	var threadOpts []codex.ThreadOption
+	if cfg.Model != "" {
+		threadOpts = append(threadOpts, codex.WithModel(cfg.Model))
+	}
 	if cfg.WorkDir != "" {
 		threadOpts = append(threadOpts, codex.WithWorkDir(cfg.WorkDir))
 	}


### PR DESCRIPTION
## Summary
- Add per-session model selection (Alt+M) when starting plan/build sessions, cycling through 6 models across 2 providers (claude: opus/sonnet/haiku, codex: gpt-5.3-codex/gpt-5.2/gpt-5.1-codex-max)
- Separate remembered defaults for plan vs build session types
- Provider-aware routing: codex models launch the `codex` binary in tmux mode, and route to `CodexProvider` with model/workdir in TUI mode
- Model registry in `session/types.go` with `NextModel()` / `ModelByID()` helpers

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel build //bramble/...` and `bazel build //multiagent/...` pass
- [x] `bazel test //bramble/... --test_timeout=60` passes (all existing + new tests)
- [x] `bazel test //multiagent/agent:agent_test` passes
- [ ] Manual: press `p` → see `Plan prompt [opus]:` → `Alt+M` → cycles through models → submit starts session with selected model
- [ ] Manual: press `b` → see `Build prompt [sonnet]:` → `Alt+M` → cycles models → remembered on next use
- [ ] Manual: select codex model in tmux mode → verify `codex --model <model>` binary launches
- [ ] Manual: `--yolo` + codex model → verify `--dangerously-bypass-approvals-and-sandbox` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-start and execution routing paths (tmux CLI invocation and in-process provider selection), so incorrect defaults/flags could break launching sessions across providers; changes are localized and test-covered.
> 
> **Overview**
> Adds per-session model selection when starting plan/build sessions: prompts now display the current model, `Alt+M` cycles through a registry of Claude and Codex models, and the app remembers separate default models for planner vs builder.
> 
> Extends session startup APIs to accept a `model` parameter and routes execution based on the selected model/provider: tmux mode launches the appropriate CLI (`claude` vs `codex`) with provider-specific flags, while TUI mode can route Codex models through `CodexProvider` (passing model/workdir) or through configured providers. Updates tests to match the new `StartSession` signature and adds coverage for model registry and tmux command construction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d1d6a720fb5494a119e93eb94f19396820b07f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->