### PR TITLE
bramble: improve add-repo dialog input and window sizing

### DIFF
--- a/bramble/app/BUILD.bazel
+++ b/bramble/app/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//wt/taskrouter",
         "@com_github_charmbracelet_bubbles//key",
         "@com_github_charmbracelet_bubbles//textarea",
+        "@com_github_charmbracelet_bubbles//textinput",
         "@com_github_charmbracelet_bubbletea//:bubbletea",
         "@com_github_charmbracelet_glamour//:glamour",
         "@com_github_charmbracelet_lipgloss//:lipgloss",


### PR DESCRIPTION
## Summary
- enlarge the initial add-repo/cloning dialog so URL entry has more room
- switch add-repo URL input to bubbles `textinput` for paste support and readline-style keybindings
- keep URL input focused/synced across mode transitions and add targeted tests for paste/readline behavior

## Testing
- scripts/lint.sh
- bazel test //bramble/app:app_test
- bazel test //...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/input handling changes scoped to the TUI repo picker; main risk is regressions in key handling or focus/resize behavior during mode transitions.
> 
> **Overview**
> Upgrades the add-repo URL entry UI to use `bubbles/textinput` (enabling paste and readline-style editing) and adds logic to keep the input focused, synced, and correctly resized across list/URL/cloning mode transitions.
> 
> Widens the modal when in URL-input or cloning modes to give more room for long URLs and updates the on-screen hints accordingly. Tests are updated/expanded to cover paste/multi-rune insertion and Ctrl+A/Ctrl+E cursor behavior, and Bazel deps add `@...//textinput`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28ba47f2c0af68e16261a251353ed633df9352d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->