### PR TITLE
bramble: support editor commands with flags

### DIFF
--- a/bramble/app/editor_test.go
+++ b/bramble/app/editor_test.go
@@ -33,11 +33,11 @@ func TestShellSplit(t *testing.T) {
 
 func TestEditorCommand(t *testing.T) {
 	tests := []struct {
-		name       string
-		editor     string
-		path       string
-		wantBin    string
-		wantArgs   []string
+		name     string
+		editor   string
+		path     string
+		wantBin  string
+		wantArgs []string
 	}{
 		{
 			name:     "simple editor",

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -1932,7 +1932,9 @@ func editorCommand(editor, path string) *exec.Cmd {
 	if len(parts) == 0 {
 		return exec.Command("code", path)
 	}
-	args := append(parts[1:], path)
+	args := make([]string, len(parts)-1, len(parts))
+	copy(args, parts[1:])
+	args = append(args, path)
 	return exec.Command(parts[0], args...)
 }
 


### PR DESCRIPTION
## Summary
- Fix editor invocation to support commands with flags like `emacsclient -n` or `code --wait`
- Previously, the entire editor string was passed as the executable name to `exec.Command`, causing commands with flags to fail
- Added `editorCommand()` helper that splits the editor string with `strings.Fields()` so flags are passed as separate arguments

## Test plan
- [x] `bazel build //bramble/...` passes
- [x] `bazel test //bramble/...` passes (5/5 tests)
- [ ] Manual: set `EDITOR="emacsclient -n"` and verify file/worktree opening works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to how the external editor process is launched, with added unit tests; main risk is edge cases in the lightweight shell-style parsing (no backslash escaping).
> 
> **Overview**
> Fixes editor launching so configured editor strings can include flags and quoted paths (e.g. `emacsclient -n`, `code --wait`, or editor paths with spaces), instead of treating the entire string as the executable.
> 
> Introduces `editorCommand`/`shellSplit` helpers and switches the file-open and worktree-open actions to use them, plus adds unit tests covering whitespace/quoting and fallback behavior when `EDITOR` is empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26ddb2113c4a9ede6b2bd66a88562f62bc83b8e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->