### PR TITLE
Add daily release workflow with CalVer tagging

### DIFF
--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: write
 
+# Ensure only one daily-release run executes at a time to prevent tag races.
+# cancel-in-progress: false so a queued run still executes after the current
+# one finishes (unlike CI where stale runs are cancelled).
+concurrency:
+  group: daily-release
+  cancel-in-progress: false
+
 jobs:
   daily-release:
     name: Tag Daily Release


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Actions workflow that runs daily at 10:00 UTC
- Checks for new commits since the last tag; skips if none
- Creates a CalVer tag (`vYYYY.MM.DD`) which triggers the existing `release.yaml` for the full build/release/Homebrew flow
- Handles same-day collisions by appending `.1`, `.2`, etc.
- Also supports manual trigger via `workflow_dispatch`

## Test plan
- [ ] Verify workflow syntax with `act` or by triggering manually via GitHub Actions UI
- [ ] Confirm tag creation triggers the existing release pipeline
- [ ] Test same-day collision handling by running twice manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated tag creation that can trigger the production release pipeline; misconfiguration could cause unintended releases or tag churn, though it’s gated to `main` and skips when no new commits exist.
> 
> **Overview**
> Adds a new `daily-release.yaml` GitHub Actions workflow that runs daily (and on manual dispatch) to **create and push a CalVer tag** `vYYYY.MM.DD` for `main` when there are commits since the last `v*` tag.
> 
> The workflow enforces single-run concurrency to avoid tag races, uses a GitHub App token (instead of `GITHUB_TOKEN`) so the tag push triggers the existing `release.yaml`, and appends `.1`, `.2`, etc. to handle same-day tag collisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd87b7bb62a499afc45c08fbaa296940478a936c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->