### PR TITLE
bramble: suppress notify errors when triggered by Claude stop hook

### DIFF
--- a/bramble/main.go
+++ b/bramble/main.go
@@ -498,8 +498,16 @@ var notifyCmd = &cobra.Command{
 	Use:   "notify",
 	Short: "Notify bramble that a session needs attention",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// When triggered by Claude's stop hook (CLAUDECODE=1), errors are
+		// non-actionable (socket gone, session cleaned up, etc.), so
+		// suppress them to avoid noisy stderr in the Claude session.
+		silent := os.Getenv("CLAUDECODE") == "1"
+
 		client, err := ipc.NewClientFromEnv()
 		if err != nil {
+			if silent {
+				return nil
+			}
 			return err
 		}
 		sessionID, _ := cmd.Flags().GetString("session-id")
@@ -509,9 +517,15 @@ var notifyCmd = &cobra.Command{
 			Params: &ipc.NotifyParams{SessionID: sessionID},
 		})
 		if err != nil {
+			if silent {
+				return nil
+			}
 			return err
 		}
 		if !resp.OK {
+			if silent {
+				return nil
+			}
 			return fmt.Errorf("server error: %s", resp.Error)
 		}
 		return nil


### PR DESCRIPTION
## Summary
- When `bramble notify` is invoked as a Claude stop hook (`CLAUDECODE=1`), silently suppress errors (socket gone, session cleaned up, etc.) since they are non-actionable for the user
- Errors are preserved when running outside Claude (e.g. integration tests) to maintain debuggability

## Test plan
- [x] `bazel build //bramble/...` passes
- [x] `bazel test //bramble/...` passes
- [x] `scripts/lint.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, env-gated change that only alters CLI error reporting for `notify`, with normal behavior preserved outside `CLAUDECODE=1`.
> 
> **Overview**
> Makes `bramble notify` *silently ignore* failures when run with `CLAUDECODE=1`, covering IPC client creation errors, send failures, and non-OK server responses.
> 
> Outside that environment flag, `notify` continues to return errors as before for debuggability (e.g., tests and manual CLI usage).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f45693393173dbb2a990870a718ee0e924b6a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->