### PR TITLE
bramble: fix notify error suppression in stop hooks

### DIFF
--- a/bramble/main.go
+++ b/bramble/main.go
@@ -498,10 +498,10 @@ var notifyCmd = &cobra.Command{
 	Use:   "notify",
 	Short: "Notify bramble that a session needs attention",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// When triggered by Claude's stop hook (CLAUDECODE=1), errors are
+		// When triggered by Claude's stop hook (--silent), errors are
 		// non-actionable (socket gone, session cleaned up, etc.), so
 		// suppress them to avoid noisy stderr in the Claude session.
-		silent := os.Getenv("CLAUDECODE") == "1"
+		silent, _ := cmd.Flags().GetBool("silent")
 
 		client, err := ipc.NewClientFromEnv()
 		if err != nil {
@@ -599,6 +599,7 @@ func init() {
 	newSessionCmd.Flags().Bool("create-worktree", false, "Create a new worktree for the branch")
 
 	notifyCmd.Flags().String("session-id", "", "Session ID to notify")
+	notifyCmd.Flags().Bool("silent", false, "Suppress errors silently (used by stop hooks)")
 	_ = notifyCmd.MarkFlagRequired("session-id")
 
 	capturePaneCmd.Flags().String("session-id", "", "Session ID to capture pane from")

--- a/bramble/session/tmux_runner.go
+++ b/bramble/session/tmux_runner.go
@@ -203,7 +203,7 @@ func (r *tmuxRunner) buildCommand() (binary string, args []string) {
 					Stop: []hookGroup{{
 						Hooks: []hookEntry{{
 							Type:    "command",
-							Command: quotedBin + " notify --session-id " + quotedID,
+							Command: quotedBin + " notify --silent --session-id " + quotedID,
 						}},
 					}},
 				},


### PR DESCRIPTION
## Summary
- The `CLAUDECODE=1` env var check from #70 never worked because `agent-cli-wrapper` strips `CLAUDECODE` from the subprocess environment before launching the Claude CLI
- Replace with an explicit `--silent` flag on the `notify` command, passed in the hook command string in `tmux_runner.go`
- This ensures error suppression works regardless of environment variable inheritance

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel test //bramble/...` passes
- [ ] Manual: launch a bramble session, verify no "Stop hook error" noise when the session ends or socket is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI flag and hook-command change that only affects error suppression behavior when IPC is unavailable; no data or auth logic is modified.
> 
> **Overview**
> Ensures tmux/Claude *Stop* hooks can suppress non-actionable `notify` errors without relying on environment inheritance.
> 
> `bramble notify` now accepts `--silent` to swallow IPC/client/server errors, and `tmux_runner` updates the injected Stop hook command to pass `--silent` when invoking `notify`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bcfe8bbc286209594e4319b7259307ecbd55121. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->