### PR TITLE
bramble: fix tmux sessions stuck in idle state after user resumes

### DIFF
--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -599,9 +599,9 @@ func (m *Manager) ReconcileTmuxSessions() error {
 			m.outputs[session.ID] = make([]OutputLine, 0, 16)
 			m.outputsMu.Unlock()
 
-			// Emit the state-change event without calling updateSessionStatus, which
-			// would overwrite session.StartedAt with time.Now() and lose the
-			// historical start time preserved from the stored session.
+			// Emit the state-change event directly rather than calling updateSessionStatus,
+			// so we avoid any side-effects on StartedAt or other fields for this
+			// re-adoption path that restores a stored session.
 			select {
 			case m.events <- SessionStateChangeEvent{
 				SessionID: session.ID,
@@ -1731,6 +1731,8 @@ func (m *Manager) updateSessionStatus(session *Session, newStatus SessionStatus)
 	now := time.Now()
 	switch newStatus {
 	case StatusRunning:
+		// Set StartedAt only when first starting (Pending→Running) or when missing;
+		// preserve the original start time when resuming from Idle.
 		if oldStatus == StatusPending || session.StartedAt == nil {
 			session.StartedAt = &now
 		}

--- a/bramble/session/manager_test.go
+++ b/bramble/session/manager_test.go
@@ -1326,6 +1326,7 @@ func TestReposWithLiveTmuxSessions_SkipsNonTmuxSessions(t *testing.T) {
 
 func TestUpdateSessionStatus_IdleToRunningPreservesStartedAt(t *testing.T) {
 	m := NewManager()
+	defer m.Close()
 
 	originalStart := time.Now().Add(-5 * time.Minute)
 
@@ -1334,7 +1335,9 @@ func TestUpdateSessionStatus_IdleToRunningPreservesStartedAt(t *testing.T) {
 		Status:    StatusIdle,
 		StartedAt: &originalStart,
 	}
+	m.mu.Lock()
 	m.sessions["test-session"] = session
+	m.mu.Unlock()
 
 	m.updateSessionStatus(session, StatusRunning)
 
@@ -1344,12 +1347,15 @@ func TestUpdateSessionStatus_IdleToRunningPreservesStartedAt(t *testing.T) {
 
 func TestUpdateSessionStatus_PendingToRunningSetsStartedAt(t *testing.T) {
 	m := NewManager()
+	defer m.Close()
 
 	session := &Session{
 		ID:     "test-session",
 		Status: StatusPending,
 	}
+	m.mu.Lock()
 	m.sessions["test-session"] = session
+	m.mu.Unlock()
 
 	m.updateSessionStatus(session, StatusRunning)
 


### PR DESCRIPTION
## Summary
- Fix tmux-monitored sessions that get stuck showing "AWAITING FOLLOW-UP" after the user starts a new interaction in the tmux pane
- Add idle → running transition in `captureRecentOutput()` when pane status bar parsing detects `IsWorking`
- Preserve original `StartedAt` timestamp when resuming from idle (only set on initial pending → running transition)

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel test //bramble/session/... --test_timeout=60` passes
- [x] Unit tests for `updateSessionStatus` idle→running (preserves StartedAt) and pending→running (sets StartedAt)
- [ ] Manual: launch tmux session via bramble, wait for idle, send new prompt, verify command center shows Running within ~15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session state transitions for tmux-tracked sessions, which could cause incorrect status/timestamp reporting if the pane-status parsing or transition conditions misfire. Scope is contained and covered by targeted unit tests for `StartedAt` behavior.
> 
> **Overview**
> Fixes tmux-monitored sessions that remain in `StatusIdle` after the user resumes activity by transitioning `Idle → Running` when `captureRecentOutput()` detects the pane is working.
> 
> Updates `updateSessionStatus` to **preserve `StartedAt`** when resuming from idle (only setting it on `Pending → Running` or when missing), and adds unit tests covering both the idle-resume and initial-start timestamp cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73c5ae14aa5a6e4bcd3eba83bedc9b183eb75a8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->