### PR TITLE
daily-release: fix tag push not triggering release workflow

### DIFF
--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for changes since last release
         id: check


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to the checkout step in `daily-release.yaml`
- Without this, `actions/checkout` installs a credential helper that injects `GITHUB_TOKEN` for all github.com requests, overriding the App token set via `url.insteadOf` — so the tag push was effectively made with `GITHUB_TOKEN`, which by design doesn't trigger downstream workflows

## Test plan
- [x] Verified tags were being created but release workflow never triggered
- [x] Confirmed `persist-credentials: true` (default) was the root cause by checking job logs showing the credential helper active
- [ ] After merge, trigger daily-release manually and verify the release workflow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release-tagging workflow’s authentication behavior; misconfiguration could prevent tags from pushing or alter which token is used to push, impacting release automation.
> 
> **Overview**
> Ensures the `daily-release` GitHub Actions workflow does **not** persist `actions/checkout` credentials by setting `persist-credentials: false`.
> 
> This prevents the default `GITHUB_TOKEN` credential helper from overriding the GitHub App token used for `git push`, so tag pushes can correctly trigger downstream release workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b257770880c4b86ed2fd898e4e210e38d9d80142. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->