### PR TITLE
Repo housekeeping: dependabot, security policy, CodeQL, pin golangci-lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/agent-cli-wrapper"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/bramble"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/medivac"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/multiagent"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/wt"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/yoloswe"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- **dependabot.yml**: weekly updates for GitHub Actions and all 6 Go modules (grouped)
- **SECURITY.md**: vulnerability reporting via GitHub private security advisories
- **CodeQL scanning**: new workflow for Go static analysis (PRs + weekly schedule)
- **Pin golangci-lint**: replace `curl | sh` from master with `golangci-lint-action@v7` to eliminate supply chain risk
- **.gitattributes**: hide `go.sum` from diffs/language stats, enforce LF line endings

## Test plan
- [ ] CI lint job passes with golangci-lint-action
- [ ] CodeQL workflow appears in Actions tab after merge
- [ ] Dependabot picks up config in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)