### PR TITLE
docs: add README.md for symphony and voice modules

### DIFF
--- a/symphony/README.md
+++ b/symphony/README.md
@@ -1,0 +1,134 @@
+# Symphony
+
+Orchestrator daemon that polls a Linear project for issues and dispatches them to Codex agents running in isolated workspaces. Each issue gets its own workspace directory, a rendered prompt from a configurable template, and an agent session that runs until the task completes, fails, or times out. Failed tasks retry with exponential backoff.
+
+## Architecture
+
+```
+WORKFLOW.md (config + prompt template)
+        |
+        v
+  ┌─────────────┐       ┌──────────────┐
+  │ Orchestrator │──────►│ Linear API   │  poll for candidate issues
+  │  event loop  │◄──────│ (GraphQL)    │  reconcile running issues
+  └──────┬───────┘       └──────────────┘
+         │
+    dispatch per issue
+         │
+  ┌──────┴───────┐
+  │  Worker      │  1. create/reuse workspace
+  │  goroutine   │  2. run lifecycle hooks
+  │              │  3. render prompt template
+  │              │  4. start Codex session
+  │              │  5. stream events until done
+  └──────────────┘
+         │
+  ┌──────┴───────┐
+  │ HTTP server  │  GET /           dashboard (auto-refresh)
+  │ (optional)   │  GET /api/v1/state   JSON snapshot
+  │              │  GET /api/v1/refresh  trigger poll
+  └──────────────┘
+```
+
+## Packages
+
+| Package | Purpose |
+|---------|---------|
+| `cmd/symphony` | CLI entry point. Loads WORKFLOW.md, creates tracker + orchestrator, starts HTTP server |
+| `orchestrator` | Single-authority event loop: poll, dispatch, reconcile, retry |
+| `agent` | Manages Codex app-server subprocess (JSON-RPC over stdio) |
+| `config` | Parses WORKFLOW.md config section with env var expansion and hot reload |
+| `model` | Domain types: Issue, Workspace, RunAttempt, RunStatus, LiveSession |
+| `tracker` | Issue tracker interface |
+| `tracker/linear` | Linear GraphQL client with cursor-based pagination |
+| `workspace` | Per-issue directory creation, path safety, lifecycle hooks |
+| `prompt` | Jinja2-like template rendering for agent prompts |
+| `http` | HTTP server with JSON API and HTML dashboard |
+| `logging` | Structured logging helpers |
+| `integration` | Integration tests with fake Codex binary |
+
+## Configuration
+
+Symphony reads a `WORKFLOW.md` file with YAML front matter for config and markdown body for the prompt template.
+
+```yaml
+---
+config:
+  tracker:
+    kind: linear
+    endpoint: https://api.linear.app/graphql
+    api_key: $LINEAR_API_KEY
+    project_slug: myteam/myproject
+    active_states: [Todo, "In Progress"]
+    terminal_states: [Done, Cancelled, Closed]
+
+  polling:
+    interval_ms: 30000
+
+  workspace:
+    root: ~/symphony_workspaces
+
+  hooks:
+    after_create: "bash .symphony/setup.sh"
+    before_run: "source .venv/bin/activate"
+    after_run: "git push origin"
+    timeout_ms: 120000
+
+  agent:
+    max_concurrent_agents: 10
+    max_turns: 20
+    max_retry_backoff_ms: 300000
+
+  codex:
+    command: "codex app-server"
+    approval_policy: auto
+    turn_timeout_ms: 3600000
+    stall_timeout_ms: 300000
+
+  server:
+    port: 8080
+---
+
+You are a software engineer working on issue {{ issue.identifier }}.
+Title: {{ issue.title }}
+
+{% if issue.description %}
+Description:
+{{ issue.description }}
+{% endif %}
+```
+
+Environment variables (`$VAR_NAME`) are resolved at load time. Config hot-reloads without restarting the daemon.
+
+## Usage
+
+```bash
+# Build
+bazel build //symphony/cmd/symphony
+
+# Run with default ./WORKFLOW.md
+symphony
+
+# Custom workflow file and HTTP port
+symphony -port 8080 /path/to/workflow.md
+```
+
+The HTTP dashboard at `http://127.0.0.1:{port}/` shows running sessions, retry queue, and aggregate token usage. Auto-refreshes every 5 seconds.
+
+## Prompt Template Variables
+
+| Variable | Description |
+|----------|-------------|
+| `{{ issue.id }}` | Tracker-internal ID |
+| `{{ issue.identifier }}` | Human-readable identifier (e.g., `PROJ-123`) |
+| `{{ issue.title }}` | Issue title |
+| `{{ issue.description }}` | Issue body text |
+| `{{ issue.priority }}` | Priority level |
+| `{{ issue.state }}` | Current state name |
+| `{{ issue.branch_name }}` | Suggested branch name |
+| `{{ issue.url }}` | Web URL to the issue |
+| `{{ issue.labels }}` | Comma-separated labels |
+| `{{ issue.blocked_by }}` | Blocking issue identifiers |
+| `{{ attempt }}` | Current retry attempt number |
+
+Conditionals: `{% if issue.description %}...{% endif %}`

--- a/voice/README.md
+++ b/voice/README.md
@@ -1,0 +1,86 @@
+# Voice
+
+Speech-to-text package with a provider-agnostic streaming interface. Currently implements Deepgram's WebSocket API for real-time transcription with voice activity detection.
+
+## Packages
+
+| Package | Purpose |
+|---------|---------|
+| `stt` | Core interfaces (`StreamingTranscriber`, `Session`) and types (`Event`, `AudioConfig`) |
+| `stt/deepgram` | Deepgram WebSocket streaming implementation |
+| `stt/logging` | JSONL event logger for session analysis and latency measurement |
+| `cmd/voicetest` | CLI tool for testing transcription end-to-end |
+
+## How It Works
+
+```
+Audio source (WAV file or mic)
+        |
+  ChunkPCM() splits into 20ms frames
+        |
+        v
+  ┌─────────────────┐
+  │ Session          │
+  │  SendAudio()  ───┼──► WebSocket ──► Deepgram API
+  │  Events()     ◄──┼──  speech-start, partial, final, speech-end
+  │  Close()         │
+  └─────────────────┘
+        |
+        v
+  Event channel: EventSpeechStart → EventPartialText → EventFinalText → EventSpeechEnd
+```
+
+1. Create a `StreamingTranscriber` (e.g., `deepgram.NewStreamingProvider`)
+2. Call `StartSession` with audio config and options (VAD, interim results, language)
+3. Send audio chunks via `SendAudio`
+4. Consume typed events from `Events()` channel
+5. Call `Close` when done
+
+## Event Types
+
+| Type | Meaning |
+|------|---------|
+| `EventSpeechStart` | Voice activity detected |
+| `EventPartialText` | Interim transcription (still being refined) |
+| `EventFinalText` | Confirmed final transcription |
+| `EventSpeechEnd` | Voice activity ended |
+| `EventError` | Transcription error |
+
+## Audio Utilities
+
+The `stt` package includes WAV encoding/decoding and PCM helpers:
+
+- `EncodeWAV` / `DecodeWAV` — read and write 16-bit mono PCM WAV files
+- `GenerateSineWAV` / `GenerateSilenceWAV` — generate test audio
+- `ChunkPCM` — split raw PCM into fixed-size chunks for streaming
+- `PCMFromWAV` — extract raw PCM bytes from WAV data
+
+Default audio config: 16kHz sample rate, 16-bit depth, mono, 20ms chunks.
+
+## voicetest CLI
+
+```bash
+# Build
+bazel build //voice/cmd/voicetest
+
+# Stream a WAV file through Deepgram
+DEEPGRAM_API_KEY=... voicetest --file input.wav --log output.jsonl
+
+# Flags
+#   --provider deepgram   STT provider (default: deepgram)
+#   --file input.wav      WAV file to stream (real-time paced)
+#   --log output.jsonl    Optional JSONL log for session analysis
+```
+
+Output:
+```
+[speech-start]
+[partial] "hello"
+[partial] "hello world"
+[final] "hello world" (confidence: 0.95)
+[speech-end]
+```
+
+## Thread Safety
+
+`SendAudio` is safe to call concurrently with `Events()`. `SendAudio` and `Close` must not be called concurrently with each other. Cancelling the context passed to `StartSession` closes the connection.


### PR DESCRIPTION
## Summary
- Add `symphony/README.md`: architecture diagram, package table, WORKFLOW.md config reference, CLI usage, prompt template variables
- Add `voice/README.md`: streaming interface overview, event types, audio utilities, voicetest CLI usage, thread safety notes

## Test plan
- [x] No code changes, docs only
- [x] Verified content matches current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change adding module READMEs; no runtime behavior, APIs, or configs are modified. Risk is limited to potential documentation inaccuracies or drift from implementation.
> 
> **Overview**
> Adds new module documentation for **`symphony`** and **`voice`**.
> 
> `Symphony` README documents the orchestrator architecture, package layout, `WORKFLOW.md` configuration/prompt template format (with example YAML), and basic CLI/dashboard usage. `Voice` README documents the streaming STT API concepts, event types, audio utilities, `voicetest` CLI usage, and thread-safety expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4237be5f1b005cf0d0922281c9b5b16093c50443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->