### PR TITLE
voice/stt: add speech-to-text package with Deepgram streaming provider

### DIFF
--- a/bramble/cmd/readline-voice-spike/BUILD.bazel
+++ b/bramble/cmd/readline-voice-spike/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "readline-voice-spike_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/bazelment/yoloswe/bramble/cmd/readline-voice-spike",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_ergochat_readline//:readline",
+    ],
+)
+
+go_binary(
+    name = "readline-voice-spike",
+    embed = [":readline-voice-spike_lib"],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)

--- a/bramble/cmd/readline-voice-spike/README.md
+++ b/bramble/cmd/readline-voice-spike/README.md
@@ -1,0 +1,88 @@
+# readline-voice-spike
+
+Manual spike binary to verify that ANSI escape sequences for partial voice text
+coexist with `ergochat/readline` terminal control without garbling output.
+
+This is the prerequisite for voice/stt Phase 2: integrating the STT session
+into the delegator's `VoiceInputSource`.
+
+## How to run
+
+Must be run on a real terminal (not in a pipe or CI):
+
+```
+bazel run //bramble/cmd/readline-voice-spike
+```
+
+The program:
+1. Opens a readline prompt (`>>> `), mirroring the delegator's config.
+2. Starts a fake STT event stream: two utterances with realistic partial-text
+   timing (~120ms between partials).
+3. Renders partial text on the line below the prompt using DECSC/DECRC.
+4. After each utterance, clears the partial line and calls `rl.Refresh()`.
+5. Exits ~3 seconds after the second utterance ends.
+
+While it runs, type freely — test arrow keys, Backspace, and multi-character
+edits to exercise readline's cursor management alongside the voice writes.
+
+## ANSI approach being tested
+
+**DECSC/DECRC save/restore cursor** (VT100, xterm-compatible):
+
+```
+\0337  — DECSC: save cursor position
+\n     — move down one line (below the prompt)
+\033[K — erase to end of line
+\033[2m<text>\033[0m  — dim partial text
+\0338  — DECRC: restore cursor to where readline left it
+```
+
+A `sync.Mutex` serializes all stderr writes between readline and the voice
+rendering goroutine to prevent interleaving.
+
+## Success criteria
+
+The spike **passes** if all of the following hold throughout the full session:
+
+1. The readline prompt (`>>> `) remains visible and at its expected screen
+   position during and between all partial text updates.
+2. The user can type characters, use Backspace, and press arrow keys normally —
+   no garbled characters appear in the input line.
+3. Partial text appears on the line below the prompt and is replaced cleanly
+   on each update (no residue from previous partials).
+4. After each `EventFinalText`, the partial line disappears and the prompt
+   redraws cleanly.
+5. The second utterance cycle behaves identically to the first.
+
+## Failure criteria
+
+The spike **fails** if any of the following occur:
+
+- Partial text overwrites or collides with the readline prompt line.
+- The prompt drifts downward over time as partials accumulate.
+- After a partial update, readline's redraw leaves duplicate or partial prompt
+  artifacts above or below the expected position.
+- Arrow keys or Backspace produce unexpected output in the input area.
+
+## Fallback plan
+
+If the spike fails, the fallback is to suppress the readline prompt during
+active speech and restore it after the utterance ends:
+
+1. On `EventSpeechStart`: call `SetPrompt("")` and `rl.Clean()` to quiet
+   readline visually.
+2. Render partials using the spinner's existing `\r\033[K` pattern (safe
+   because readline is not painting the cursor).
+3. On `EventFinalText` / `EventSpeechEnd`: call `SetPrompt(">>> ")` and
+   `RefreshPrompt()` to restore.
+
+This is slightly worse UX (prompt disappears during speech) but is safe and
+proven by the spinner's existing approach in `spinner.go`.
+
+## Alternative ANSI approaches
+
+| Approach | Notes |
+|----------|-------|
+| `\033[s` / `\033[u` (ANSI SC/RC) | Same concept as DECSC/DECRC; some terminals support only one variant — try if DECSC causes issues |
+| Terminal title bar (`\033]0;...\007`) | Sidesteps cursor positioning entirely; visually subtle |
+| Absolute cursor positioning (`\033[row;colH`) | More robust on some terminals; requires tracking terminal size and resize events |

--- a/bramble/cmd/readline-voice-spike/main.go
+++ b/bramble/cmd/readline-voice-spike/main.go
@@ -1,0 +1,209 @@
+// Command readline-voice-spike is a manual spike binary that verifies
+// ANSI escape sequences for partial voice text coexist with readline's
+// terminal control without garbling output.
+//
+// This spike is the prerequisite for voice/stt Phase 2 integration into the
+// delegator's VoiceInputSource. Run it on a real terminal; it will not work
+// correctly in a non-TTY environment.
+//
+// Usage:
+//
+//	bazel run //bramble/cmd/readline-voice-spike
+//
+// See README.md for success/failure criteria.
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/ergochat/readline"
+)
+
+func main() {
+	if !isTerminal(os.Stdin) {
+		fmt.Fprintln(os.Stderr, "readline-voice-spike: must be run on a real terminal (stdin is not a TTY)")
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stderr, "readline-voice-spike: starting — type freely while voice partials appear below the prompt")
+	fmt.Fprintln(os.Stderr, "Press Ctrl-C or Ctrl-D to exit early.")
+
+	rl, err := readline.NewEx(&readline.Config{
+		Prompt: ">>> ",
+		// Match the delegator's config: both streams go to stderr.
+		Stdout: os.Stderr,
+		Stderr: os.Stderr,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "readline init error: %v\n", err)
+		os.Exit(1)
+	}
+	defer rl.Close()
+
+	vr := &voiceRenderer{rl: rl}
+
+	// Drive a fake STT event stream.
+	events := fakeEvents()
+	doneCh := make(chan struct{})
+
+	go func() {
+		defer close(doneCh)
+		vr.run(events)
+	}()
+
+	// Accept readline input concurrently while voice events render.
+	lineCh := make(chan string)
+	go func() {
+		defer close(lineCh)
+		for {
+			line, err := rl.Readline()
+			if err != nil {
+				return
+			}
+			lineCh <- line
+		}
+	}()
+
+	for {
+		select {
+		case line, ok := <-lineCh:
+			if !ok {
+				return
+			}
+			// Print typed lines to stdout (delegator pattern).
+			fmt.Printf("you typed: %q\n", line)
+		case <-doneCh:
+			fmt.Fprintln(os.Stderr, "\nreadline-voice-spike: voice session complete")
+			fmt.Fprintln(os.Stderr, "Check above: did the prompt stay stable? Were partials readable?")
+			// Drain remaining input lines until Ctrl-D/C.
+			for range lineCh {
+			}
+			return
+		}
+	}
+}
+
+// voiceRenderer renders partial voice text below the readline prompt using
+// DECSC/DECRC (save/restore cursor) ANSI sequences. A mutex serializes all
+// writes to stderr so readline and the voice goroutine never interleave.
+type voiceRenderer struct {
+	rl  *readline.Instance
+	mu  sync.Mutex
+	has bool // true when a partial line is currently displayed
+}
+
+// renderPartial writes text below the readline prompt using DECSC/DECRC.
+//
+// Sequence:
+//
+//	\0337  — DECSC: save cursor position (terminal stores row, col)
+//	\n     — move down one line below the prompt
+//	\033[K — erase to end of line (clear previous partial)
+//	\033[2m — dim style for partial text
+//	text
+//	\033[0m — reset style
+//	\0338  — DECRC: restore cursor (back where readline left it)
+func (vr *voiceRenderer) renderPartial(text string) {
+	vr.mu.Lock()
+	defer vr.mu.Unlock()
+	fmt.Fprintf(os.Stderr, "\0337\n\033[K\033[2m[voice] %s\033[0m\0338", text)
+	vr.has = true
+}
+
+// clearPartial erases the partial line below the prompt and refreshes readline.
+func (vr *voiceRenderer) clearPartial() {
+	vr.mu.Lock()
+	defer vr.mu.Unlock()
+	if vr.has {
+		fmt.Fprintf(os.Stderr, "\0337\n\033[K\0338")
+		vr.has = false
+	}
+	vr.rl.Refresh()
+}
+
+// run processes a slice of pre-timed events.
+func (vr *voiceRenderer) run(events []timedEvent) {
+	for _, te := range events {
+		time.Sleep(te.delay)
+		switch te.typ {
+		case evSpeechStart:
+			vr.mu.Lock()
+			fmt.Fprintf(os.Stderr, "\0337\n\033[K\033[2m[voice] ...\033[0m\0338")
+			vr.has = true
+			vr.mu.Unlock()
+		case evPartial:
+			vr.renderPartial(te.text)
+		case evFinal:
+			vr.clearPartial()
+			// Print the final transcription above the prompt (like committed text).
+			vr.mu.Lock()
+			fmt.Fprintf(os.Stderr, "\r\033[K[voice final] %q\n", te.text)
+			vr.mu.Unlock()
+			vr.rl.Refresh()
+		case evSpeechEnd:
+			vr.clearPartial()
+		}
+	}
+}
+
+type eventKind int
+
+const (
+	evSpeechStart eventKind = iota
+	evPartial
+	evFinal
+	evSpeechEnd
+)
+
+type timedEvent struct {
+	text  string
+	delay time.Duration
+	typ   eventKind
+}
+
+// fakeEvents returns two utterances with realistic timing to stress-test the
+// DECSC/DECRC approach across multiple speech-start/end cycles.
+func fakeEvents() []timedEvent {
+	ev := func(typ eventKind, delay time.Duration, text string) timedEvent {
+		return timedEvent{typ: typ, delay: delay, text: text}
+	}
+	return []timedEvent{
+		// Utterance 1.
+		ev(evSpeechStart, 500*time.Millisecond, ""),
+		ev(evPartial, 150*time.Millisecond, "hell"),
+		ev(evPartial, 120*time.Millisecond, "hello"),
+		ev(evPartial, 130*time.Millisecond, "hello wo"),
+		ev(evPartial, 110*time.Millisecond, "hello world"),
+		ev(evPartial, 120*time.Millisecond, "hello world how"),
+		ev(evPartial, 130*time.Millisecond, "hello world how are"),
+		ev(evPartial, 110*time.Millisecond, "hello world how are you"),
+		ev(evFinal, 300*time.Millisecond, "hello world how are you"),
+		ev(evSpeechEnd, 100*time.Millisecond, ""),
+
+		// Pause between utterances.
+		ev(evSpeechStart, 1500*time.Millisecond, ""),
+
+		// Utterance 2.
+		ev(evPartial, 150*time.Millisecond, "this"),
+		ev(evPartial, 130*time.Millisecond, "this is"),
+		ev(evPartial, 120*time.Millisecond, "this is a"),
+		ev(evPartial, 140*time.Millisecond, "this is a test"),
+		ev(evFinal, 300*time.Millisecond, "this is a test"),
+		ev(evSpeechEnd, 100*time.Millisecond, ""),
+
+		// Give the user 3s to observe the final state before the goroutine exits.
+		ev(evSpeechEnd, 3*time.Second, ""),
+	}
+}
+
+// isTerminal reports whether the file is connected to a terminal.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}

--- a/voice/stt/BUILD.bazel
+++ b/voice/stt/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "stt",
     srcs = [
         "audio.go",
+        "fake_session.go",
         "stt.go",
         "types.go",
     ],

--- a/voice/stt/fake_session.go
+++ b/voice/stt/fake_session.go
@@ -1,0 +1,69 @@
+package stt
+
+import (
+	"time"
+)
+
+// FakeSession is a Session that replays a canned sequence of events with
+// configurable timing. It is intended for use in tests and manual spikes that
+// need a working Session without a real STT provider.
+//
+// Usage:
+//
+//	sess := stt.NewFakeSession([]stt.Event{
+//	    {Type: stt.EventSpeechStart},
+//	    {Type: stt.EventPartialText, Text: "hello"},
+//	    {Type: stt.EventFinalText, Text: "hello world", IsFinal: true, Confidence: 0.99},
+//	    {Type: stt.EventSpeechEnd},
+//	}, 150*time.Millisecond)
+type FakeSession struct {
+	ch       chan Event
+	done     chan struct{}
+	events   []Event
+	interval time.Duration
+}
+
+// NewFakeSession creates a FakeSession that emits each event after interval.
+// The Events() channel closes after all events are sent or Close() is called.
+// Timestamps are set to time.Now() at emission time.
+func NewFakeSession(events []Event, interval time.Duration) *FakeSession {
+	fs := &FakeSession{
+		events:   events,
+		interval: interval,
+		ch:       make(chan Event, len(events)+1),
+		done:     make(chan struct{}),
+	}
+	go fs.run()
+	return fs
+}
+
+func (fs *FakeSession) run() {
+	defer close(fs.ch)
+	ticker := time.NewTicker(fs.interval)
+	defer ticker.Stop()
+	for _, evt := range fs.events {
+		select {
+		case <-fs.done:
+			return
+		case <-ticker.C:
+			evt.Timestamp = time.Now()
+			fs.ch <- evt
+		}
+	}
+}
+
+// SendAudio is a no-op for FakeSession; the event stream is driven by timing.
+func (fs *FakeSession) SendAudio(_ []byte) error { return nil }
+
+// Events returns the channel of pre-programmed events.
+func (fs *FakeSession) Events() <-chan Event { return fs.ch }
+
+// Close stops event emission and closes the Events() channel.
+func (fs *FakeSession) Close() error {
+	select {
+	case <-fs.done:
+	default:
+		close(fs.done)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `voice/stt` package with a provider-agnostic speech-to-text interface (Session, AudioFormat, Transcript types)
- Implement Deepgram streaming provider with WebSocket-based real-time transcription
- Add audio format utilities (WAV header generation, format validation, duration calculation)
- Add structured logging package for voice subsystem
- Add FakeSession for testing and a readline-voice-spike demo integrating STT with bramble's readline
- Include voicetest CLI tool for manual Deepgram integration testing

## Test plan
- [x] All 37 tests pass (`bazel test //...`)
- [x] Lint passes (`scripts/lint.sh`)
- [ ] Manual testing with `voicetest` CLI against live Deepgram API
- [ ] Manual testing of `readline-voice-spike` demo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new manual terminal spike binary and a test-focused `FakeSession` implementation; no changes to production STT provider logic, so impact is limited to new code paths used explicitly in tests/manual runs.
> 
> **Overview**
> Adds a manual `readline-voice-spike` Bazel target to validate that streaming voice partials can be rendered *below* an `ergochat/readline` prompt using DECSC/DECRC cursor save/restore without corrupting interactive input.
> 
> Extends `voice/stt` with `FakeSession` (`NewFakeSession`) that replays a canned sequence of `stt.Event`s on a timer (with timestamps set at emission time), enabling deterministic tests/manual demos without a real STT provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f98881efd222a05285b256e5923d325c52e474aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->