### PR TITLE
jiradozer: add --auto-approve flag to skip human review steps

### DIFF
--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -29,6 +29,7 @@ func main() {
 		pollInterval time.Duration
 		maxBudget    float64
 		runStep      string
+		autoApprove  string
 		verbose      bool
 	)
 
@@ -45,6 +46,7 @@ func main() {
 				pollInterval: pollInterval,
 				maxBudget:    maxBudget,
 				runStep:      runStep,
+				autoApprove:  autoApprove,
 				verbose:      verbose,
 			})
 		},
@@ -57,6 +59,7 @@ func main() {
 	rootCmd.Flags().DurationVar(&pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	rootCmd.Flags().Float64Var(&maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	rootCmd.Flags().StringVar(&runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, validate, ship")
+	rootCmd.Flags().StringVar(&autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose logging")
 
 	_ = rootCmd.MarkFlagRequired("issue")
@@ -75,6 +78,7 @@ type runArgs struct {
 	workDir      string
 	modelID      string
 	runStep      string
+	autoApprove  string
 	pollInterval time.Duration
 	maxBudget    float64
 	verbose      bool
@@ -107,6 +111,24 @@ func run(ctx context.Context, args runArgs) error {
 	}
 	if args.maxBudget > 0 {
 		cfg.MaxBudgetUSD = args.maxBudget
+	}
+
+	// Apply auto-approve overrides.
+	if args.autoApprove != "" {
+		for _, s := range parseAutoApprove(args.autoApprove) {
+			switch s {
+			case "plan":
+				cfg.Plan.AutoApprove = true
+			case "build":
+				cfg.Build.AutoApprove = true
+			case "validate":
+				cfg.Validate.AutoApprove = true
+			case "ship":
+				cfg.Ship.AutoApprove = true
+			default:
+				return fmt.Errorf("unknown step %q in --auto-approve (valid: plan, build, validate, ship, all)", s)
+			}
+		}
 	}
 
 	// Validate work_dir after CLI overrides.
@@ -166,6 +188,22 @@ func createTracker(cfg *jiradozer.Config) (tracker.IssueTracker, error) {
 	default:
 		return nil, fmt.Errorf("unsupported tracker kind: %q", cfg.Tracker.Kind)
 	}
+}
+
+var allSteps = []string{"plan", "build", "validate", "ship"}
+
+func parseAutoApprove(value string) []string {
+	if strings.TrimSpace(value) == "all" {
+		return allSteps
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 func availableModels() string {

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -45,6 +45,7 @@ type StepConfig struct {
 	PermissionMode string  `yaml:"permission_mode"` // "plan", "bypass", etc.; empty = step default
 	MaxTurns       int     `yaml:"max_turns"`
 	MaxBudgetUSD   float64 `yaml:"max_budget_usd"` // override top-level; 0 = inherit
+	AutoApprove    bool    `yaml:"auto_approve"`   // skip human review after this step
 }
 
 // StatesConfig maps logical workflow states to tracker-specific state names.

--- a/jiradozer/state_test.go
+++ b/jiradozer/state_test.go
@@ -181,6 +181,35 @@ func TestStateMachineHistory(t *testing.T) {
 	assert.Equal(t, "start", sm.History()[0].Trigger)
 }
 
+func TestShouldAutoApprove(t *testing.T) {
+	cfg := &Config{}
+	w := &Workflow{config: cfg}
+
+	// No auto-approve by default.
+	for _, step := range []WorkflowStep{StepPlanReview, StepBuildReview, StepValidateReview, StepShipReview} {
+		assert.False(t, w.shouldAutoApprove(step), "step %s should not auto-approve by default", step)
+	}
+
+	// Non-review steps never auto-approve.
+	assert.False(t, w.shouldAutoApprove(StepPlanning))
+	assert.False(t, w.shouldAutoApprove(StepDone))
+
+	// Enable selectively.
+	cfg.Plan.AutoApprove = true
+	cfg.Validate.AutoApprove = true
+	assert.True(t, w.shouldAutoApprove(StepPlanReview))
+	assert.False(t, w.shouldAutoApprove(StepBuildReview))
+	assert.True(t, w.shouldAutoApprove(StepValidateReview))
+	assert.False(t, w.shouldAutoApprove(StepShipReview))
+
+	// Enable all.
+	cfg.Build.AutoApprove = true
+	cfg.Ship.AutoApprove = true
+	for _, step := range []WorkflowStep{StepPlanReview, StepBuildReview, StepValidateReview, StepShipReview} {
+		assert.True(t, w.shouldAutoApprove(step), "step %s should auto-approve", step)
+	}
+}
+
 // walkTo transitions the state machine to the target step via the happy path.
 func walkTo(t *testing.T, sm *StateMachine, target WorkflowStep) {
 	t.Helper()

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -140,6 +140,15 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 
 // runReview waits for human feedback and transitions accordingly.
 func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget WorkflowStep) {
+	if w.shouldAutoApprove(w.state.Current()) {
+		w.logger.Info("auto-approving", "step", w.state.Current())
+		w.feedback = ""
+		if err := w.state.Transition(approveTarget, "auto_approved"); err != nil {
+			w.fail(ctx, err)
+		}
+		return
+	}
+
 	fb, err := PollForFeedback(ctx, w.tracker, w.issue.ID, w.lastCommentAt, w.config.PollInterval, w.logger)
 	if err != nil {
 		w.fail(ctx, fmt.Errorf("polling for feedback: %w", err))
@@ -185,9 +194,29 @@ func (w *Workflow) transitionToReview(ctx context.Context, reviewStep WorkflowSt
 
 	w.lastCommentAt = time.Now()
 
+	if w.shouldAutoApprove(reviewStep) {
+		return
+	}
+
 	if err := PostWaitingComment(ctx, w.tracker, w.issue.ID, w.state.Current()); err != nil {
 		w.logger.Warn("failed to post waiting comment", "error", err)
 	}
+}
+
+// shouldAutoApprove returns true if the given review step should be
+// auto-approved (skipping human feedback polling).
+func (w *Workflow) shouldAutoApprove(reviewStep WorkflowStep) bool {
+	switch reviewStep {
+	case StepPlanReview:
+		return w.config.Plan.AutoApprove
+	case StepBuildReview:
+		return w.config.Build.AutoApprove
+	case StepValidateReview:
+		return w.config.Validate.AutoApprove
+	case StepShipReview:
+		return w.config.Ship.AutoApprove
+	}
+	return false
 }
 
 func (w *Workflow) fail(ctx context.Context, err error) {


### PR DESCRIPTION
## Summary

- Add `--auto-approve` CLI flag accepting comma-separated step names (`plan,build,validate,ship`) or `all` to skip human review gates
- Add `auto_approve` YAML config field on each `StepConfig` for persistent per-step configuration
- When auto-approve is enabled for a step, `runReview()` skips comment polling and transitions directly; `PostWaitingComment` is also skipped

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer/... --test_timeout=60` passes
- [x] `TestShouldAutoApprove` covers default-off, selective enable, non-review steps, and all-enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workflow control flow to bypass human approval and comment polling; misconfiguration could unintentionally advance issues through critical steps.
> 
> **Overview**
> Adds an `--auto-approve` CLI flag (steps list or `all`) and a per-step `auto_approve` YAML setting to allow skipping human review gates.
> 
> When enabled for a review step, the workflow now transitions immediately with an `auto_approved` trigger, and skips both feedback polling and posting the "waiting for approval" comment; includes a focused unit test for `shouldAutoApprove` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3d8c59a89dce97090e659d36903f81d94ed00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->