### PR TITLE
jiradozer: use user's CLI settings and plugins

### DIFF
--- a/agent-cli-wrapper/claude/process.go
+++ b/agent-cli-wrapper/claude/process.go
@@ -120,13 +120,16 @@ func (pm *processManager) BuildCLIArgs() ([]string, error) {
 	args = append(args, pm.config.ExtraArgs...)
 
 	// Always include partial messages for tool progress tracking.
-	// Disable external setting sources (matching Python SDK behavior).
 	// Input format must come last (matching Python SDK).
-	args = append(args,
-		"--include-partial-messages",
-		"--setting-sources", "",
-		"--input-format", "stream-json",
-	)
+	args = append(args, "--include-partial-messages")
+
+	// By default, disable external setting sources (matching Python SDK behavior).
+	// When KeepUserSettings is true, skip this so the CLI loads user/project settings.
+	if !pm.config.KeepUserSettings {
+		args = append(args, "--setting-sources", "")
+	}
+
+	args = append(args, "--input-format", "stream-json")
 
 	return args, nil
 }

--- a/agent-cli-wrapper/claude/session_options.go
+++ b/agent-cli-wrapper/claude/session_options.go
@@ -48,6 +48,7 @@ type SessionConfig struct {
 	MaxBudgetUSD               float64
 	EventBufferSize            int
 	DisablePlugins             bool
+	KeepUserSettings           bool
 	RecordMessages             bool
 	DangerouslySkipPermissions bool
 	PermissionPromptToolStdio  bool
@@ -84,10 +85,20 @@ func WithCLIPath(path string) SessionOption {
 	}
 }
 
-// WithDisablePlugins disables CLI plugins.
+// WithDisablePlugins disables CLI plugins by pointing --plugin-dir to /dev/null.
 func WithDisablePlugins() SessionOption {
 	return func(c *SessionConfig) {
 		c.DisablePlugins = true
+	}
+}
+
+// WithKeepUserSettings preserves the user's CLI settings and plugins.
+// By default, SDK sessions disable external setting sources (--setting-sources "")
+// and respect the DisablePlugins flag. When KeepUserSettings is true, the session
+// behaves like an interactive CLI session, loading user/project settings and plugins.
+func WithKeepUserSettings() SessionOption {
+	return func(c *SessionConfig) {
+		c.KeepUserSettings = true
 	}
 }
 

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -147,6 +147,7 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 		agent.WithProviderWorkDir(workDir),
 		agent.WithProviderPermissionMode(cfg.PermissionMode),
 		agent.WithProviderModel(cfg.Model),
+		agent.WithProviderKeepUserSettings(),
 	)
 	if cfg.SystemPrompt != "" {
 		opts = append(opts, agent.WithProviderSystemPrompt(cfg.SystemPrompt))

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -37,8 +37,10 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	sessionOpts := append([]claude.SessionOption{}, p.sessionOpts...)
 	sessionOpts = append(sessionOpts,
 		claude.WithModel(cfg.Model),
-		claude.WithDisablePlugins(),
 	)
+	if cfg.KeepUserSettings {
+		sessionOpts = append(sessionOpts, claude.WithKeepUserSettings())
+	}
 	if cfg.WorkDir != "" {
 		sessionOpts = append(sessionOpts, claude.WithWorkDir(cfg.WorkDir))
 	}

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -153,14 +153,15 @@ type ExecuteOption func(*ExecuteConfig)
 
 // ExecuteConfig holds execution configuration.
 type ExecuteConfig struct {
-	EventHandler    EventHandler
-	Model           string
-	WorkDir         string
-	SystemPrompt    string
-	PermissionMode  string
-	ResumeSessionID string
-	MaxTurns        int
-	MaxBudgetUSD    float64
+	EventHandler     EventHandler
+	Model            string
+	WorkDir          string
+	SystemPrompt     string
+	PermissionMode   string
+	ResumeSessionID  string
+	MaxTurns         int
+	MaxBudgetUSD     float64
+	KeepUserSettings bool
 }
 
 // WithProviderModel sets the model for a provider execution.
@@ -196,6 +197,13 @@ func WithProviderMaxTurns(n int) ExecuteOption {
 // WithProviderMaxBudgetUSD sets the maximum budget in USD for a provider execution.
 func WithProviderMaxBudgetUSD(budget float64) ExecuteOption {
 	return func(c *ExecuteConfig) { c.MaxBudgetUSD = budget }
+}
+
+// WithProviderKeepUserSettings preserves the user's CLI settings and plugins.
+// When set, the session loads user/project settings and plugins instead of
+// running in isolated SDK mode.
+func WithProviderKeepUserSettings() ExecuteOption {
+	return func(c *ExecuteConfig) { c.KeepUserSettings = true }
 }
 
 // WithProviderResumeSessionID sets a session ID to resume instead of starting fresh.


### PR DESCRIPTION
## Summary
- Add `WithKeepUserSettings()` session option that skips `--setting-sources ""`, allowing the CLI to load user/project settings normally
- Remove hardcoded `WithDisablePlugins()` from `ClaudeProvider.Execute()` — callers that want isolated mode must opt in explicitly
- Wire `KeepUserSettings` through the agent `ExecuteConfig` layer so jiradozer sessions behave like the user's own interactive Claude

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel test //agent-cli-wrapper/claude:claude_test` passes
- [x] `bazel test //multiagent/agent:agent_test` passes
- [x] `bazel test //jiradozer:jiradozer_test` passes
- [ ] Manual: run jiradozer and verify it picks up user settings/plugins

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Claude CLI invocation to optionally load user/project settings and plugins, which can alter runtime behavior and tool availability depending on local configuration.
> 
> **Overview**
> Adds a new `KeepUserSettings`/`WithKeepUserSettings()` option and threads it through provider execution so callers can choose between isolated SDK mode and interactive-like behavior that loads user/project settings and plugins.
> 
> Updates Claude CLI arg construction to only pass `--setting-sources ""` when *not* keeping user settings, and removes the provider’s hardcoded plugin disabling so plugin isolation becomes opt-in rather than forced (with `jiradozer` now explicitly enabling keep-user-settings for its runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d3db3b259d76b5e513b4546e090703cd4afe79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->