### PR TITLE
LOCAL-1: when jiradozer terminated during error, it outputs the help message in the end

### DIFF
--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -71,6 +71,7 @@ func main() {
 			})
 		},
 	}
+	rootCmd.SilenceUsage = true
 
 	rootCmd.Flags().StringVar(&issueID, "issue", "", "Issue identifier for single-issue mode (e.g. ENG-123)")
 	rootCmd.Flags().StringVar(&configPath, "config", "jiradozer.yaml", "Path to config file")


### PR DESCRIPTION
## Summary

- Set `SilenceUsage = true` on the cobra root command so the full help/usage block is not printed when jiradozer exits with an error
- Previously, any runtime error (bad flag, missing config, etc.) would dump the entire flag reference after the error message, making the actual error hard to spot

## Test plan

- [ ] Run jiradozer with a missing required flag and confirm only the error line is printed, not the usage block
- [ ] Run jiradozer normally and confirm `--help` still works as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single CLI behavior change that only affects error output formatting and does not touch workflow logic or data handling.
> 
> **Overview**
> Stops `jiradozer` from dumping the full Cobra usage/help text on execution errors by setting `rootCmd.SilenceUsage = true` in `cmd/jiradozer/main.go`, making runtime failures easier to spot while keeping `--help` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 585a802a0e7ae60b7bad4f4ea1b815f13a6cd935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->