### PR TITLE
LOCAL-1: jiradozer doesn't handle --run-step when --description is provided

### DIFF
--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -247,7 +247,7 @@ func run(ctx context.Context, args runArgs) error {
 			case "ship":
 				cfg.Ship.AutoApprove = true
 			default:
-				return fmt.Errorf("unknown step %q in --auto-approve (valid: plan, build, validate, ship, all)", s)
+				return fmt.Errorf("unknown step %q in --auto-approve (valid: %s, all)", s, strings.Join(allSteps, ", "))
 			}
 		}
 	}
@@ -276,7 +276,7 @@ func run(ctx context.Context, args runArgs) error {
 
 	// Local description mode.
 	if args.description != "" {
-		return runFromDescription(ctx, args.description, issueTracker, cfg, logger)
+		return runFromDescription(ctx, args.description, args.runStep, issueTracker, cfg, logger)
 	}
 
 	// Multi-issue TUI mode (only when no --issue flag was given).
@@ -293,22 +293,7 @@ func run(ctx context.Context, args runArgs) error {
 	logger.Info("found issue", "id", issue.ID, "title", issue.Title, "state", issue.State)
 
 	if args.runStep != "" {
-		stepCfg, ok := cfg.StepByName(args.runStep)
-		if !ok {
-			return fmt.Errorf("unknown step %q (valid: plan, build, validate, ship)", args.runStep)
-		}
-		resolved := cfg.ResolveStep(stepCfg)
-		data := jiradozer.NewPromptData(issue, cfg.BaseBranch)
-		output, sessionID, err := jiradozer.RunStepAgent(ctx, args.runStep, data, resolved, cfg.WorkDir, "", "", logger)
-		if err != nil {
-			return fmt.Errorf("run-step %s: %w", args.runStep, err)
-		}
-		if output == "" {
-			logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", args.runStep, "session_id", sessionID)
-		} else {
-			fmt.Printf("=== %s output ===\n%s\n", args.runStep, output)
-		}
-		return nil
+		return runSingleStep(ctx, args.runStep, issue, cfg, logger)
 	}
 
 	// Run the full workflow.
@@ -399,7 +384,7 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 	}
 }
 
-func runFromDescription(ctx context.Context, description string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, logger *slog.Logger) error {
+func runFromDescription(ctx context.Context, description, runStep string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, logger *slog.Logger) error {
 	lt, ok := issueTracker.(*local.Tracker)
 	if !ok {
 		return fmt.Errorf("--description requires local tracker (got %T)", issueTracker)
@@ -414,8 +399,31 @@ func runFromDescription(ctx context.Context, description string, issueTracker tr
 	}
 	logger.Info("created local issue", "identifier", issue.Identifier, "title", issue.Title)
 
+	if runStep != "" {
+		return runSingleStep(ctx, runStep, issue, cfg, logger)
+	}
+
 	wf := jiradozer.NewWorkflow(issueTracker, issue, cfg, logger)
 	return wf.Run(ctx)
+}
+
+func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, logger *slog.Logger) error {
+	stepCfg, ok := cfg.StepByName(stepName)
+	if !ok {
+		return fmt.Errorf("unknown step %q (valid: %s)", stepName, strings.Join(allSteps, ", "))
+	}
+	resolved := cfg.ResolveStep(stepCfg)
+	data := jiradozer.NewPromptData(issue, cfg.BaseBranch)
+	output, sessionID, err := jiradozer.RunStepAgent(ctx, stepName, data, resolved, cfg.WorkDir, "", "", logger)
+	if err != nil {
+		return fmt.Errorf("run-step %s: %w", stepName, err)
+	}
+	if output == "" {
+		logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", sessionID)
+	} else {
+		fmt.Printf("=== %s output ===\n%s\n", stepName, output)
+	}
+	return nil
 }
 
 var allSteps = []string{"plan", "build", "validate", "ship"}


### PR DESCRIPTION
## Summary

- Extract `runSingleStep()` helper from the issue-mode `--run-step` code path so it can be reused
- Call `runSingleStep()` from `runFromDescription()` when `--run-step` is provided, fixing the bug where `--description --run-step plan` would ignore the step flag and run the full workflow
- Normalize "unknown step" error messages to use the `allSteps` slice instead of hardcoded strings

## Test plan

- [ ] `jiradozer --description "test task" --run-step plan` runs only the plan step (previously ran full workflow)
- [ ] `jiradozer --issue FOO-1 --run-step build` still works as before
- [ ] `jiradozer --run-step bogus` produces a clear error listing valid steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small CLI control-flow refactor that fixes a flag-handling bug and standardizes error messages, with minimal impact outside the `--run-step` paths.
> 
> **Overview**
> Fixes `jiradozer --description ... --run-step <step>` so it runs **only the requested step** instead of always executing the full workflow.
> 
> Refactors the single-step execution logic into a shared `runSingleStep()` helper and standardizes “unknown step” errors to derive valid step names from `allSteps` (including `--auto-approve` validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26accad4efe28bcded357a46392245129bcd96f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->