### PR TITLE
jiradozer: fix GitHub issue URL parsing (LOCAL-1)

### DIFF
--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -74,7 +74,7 @@ func main() {
 	}
 	rootCmd.SilenceUsage = true
 
-	rootCmd.Flags().StringVar(&issueID, "issue", "", "Issue identifier for single-issue mode (e.g. ENG-123 or owner/repo#42)")
+	rootCmd.Flags().StringVar(&issueID, "issue", "", "Issue identifier for single-issue mode (e.g. ENG-123, owner/repo#42, or https://github.com/owner/repo/issues/42)")
 	rootCmd.Flags().StringVar(&configPath, "config", "jiradozer.yaml", "Path to config file")
 	rootCmd.Flags().StringVar(&workDir, "work-dir", "", "Working directory (overrides config)")
 	rootCmd.Flags().StringVar(&modelID, "model", "", "Agent model ID (overrides config)")
@@ -362,18 +362,21 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 		// to ensure the client is bound to the same repo as the issue. This
 		// prevents mutations (comment, close) targeting a different repo than
 		// the one the issue was fetched from.
-		team := cfg.Source.Team
+		var owner, repo string
 		if issueID != "" {
-			if idx := strings.LastIndex(issueID, "#"); idx > 0 {
-				team = issueID[:idx]
+			var err error
+			owner, repo, _, err = ghtracker.ParseIdentifier(issueID)
+			if err != nil {
+				return nil, fmt.Errorf("github tracker: %w", err)
 			}
-		}
-		if team == "" {
+		} else if cfg.Source.Team != "" {
+			var err error
+			owner, repo, err = ghtracker.ParseOwnerRepo(cfg.Source.Team)
+			if err != nil {
+				return nil, fmt.Errorf("github tracker requires source.team as 'owner/repo': %w", err)
+			}
+		} else {
 			return nil, fmt.Errorf("github tracker requires source.team or --issue as 'owner/repo#N'")
-		}
-		owner, repo, err := ghtracker.ParseOwnerRepo(team)
-		if err != nil {
-			return nil, fmt.Errorf("github tracker requires source.team or --issue as 'owner/repo#N': %w", err)
 		}
 		return ghtracker.NewClient(&wt.DefaultGHRunner{}, owner, repo), nil
 	case "local":

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -51,8 +51,30 @@ func ParseOwnerRepo(s string) (owner, repo string, err error) {
 	return parts[0], parts[1], nil
 }
 
-// parseIdentifier splits "owner/repo#123" into (owner, repo, number).
-func parseIdentifier(identifier string) (owner, repo string, number int, err error) {
+// parseIssueURL parses a GitHub issue URL into (owner, repo, number).
+// Accepts URLs like https://github.com/owner/repo/issues/123 (any host).
+func parseIssueURL(rawURL string) (owner, repo string, number int, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid issue URL %q: %w", rawURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "issues" {
+		return "", "", 0, fmt.Errorf("invalid issue URL %q: expected https://github.com/owner/repo/issues/number", rawURL)
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil || n <= 0 {
+		return "", "", 0, fmt.Errorf("invalid issue number in URL %q", rawURL)
+	}
+	return parts[0], parts[1], n, nil
+}
+
+// ParseIdentifier splits "owner/repo#123" or a GitHub issue URL into (owner, repo, number).
+func ParseIdentifier(identifier string) (owner, repo string, number int, err error) {
+	if strings.HasPrefix(identifier, "https://") || strings.HasPrefix(identifier, "http://") {
+		return parseIssueURL(identifier)
+	}
+
 	hashIdx := strings.LastIndex(identifier, "#")
 	if hashIdx < 0 {
 		return "", "", 0, fmt.Errorf("invalid identifier %q: expected format owner/repo#number", identifier)
@@ -94,7 +116,7 @@ func (c *Client) ensureSelfLogin(ctx context.Context) error {
 }
 
 func (c *Client) FetchIssue(ctx context.Context, identifier string) (*tracker.Issue, error) {
-	owner, repo, number, err := parseIdentifier(identifier)
+	owner, repo, number, err := ParseIdentifier(identifier)
 	if err != nil {
 		return nil, err
 	}

--- a/jiradozer/tracker/github/client_test.go
+++ b/jiradozer/tracker/github/client_test.go
@@ -61,11 +61,21 @@ func TestParseIdentifier(t *testing.T) {
 		{"#123", "", "", 0, true},
 		{"/repo#123", "", "", 0, true},
 		{"owner/#123", "", "", 0, true},
+
+		// GitHub issue URLs.
+		{"https://github.com/owner/repo/issues/123", "owner", "repo", 123, false},
+		{"http://github.com/owner/repo/issues/456", "owner", "repo", 456, false},
+		{"https://github.com/owner/repo/issues/123#issuecomment-789", "owner", "repo", 123, false},
+		{"https://github.enterprise.com/org/my-repo/issues/7", "org", "my-repo", 7, false},
+		{"https://github.com/owner/repo/pulls/123", "", "", 0, true},
+		{"https://github.com/owner/repo/issues/abc", "", "", 0, true},
+		{"https://github.com/owner/repo/issues/0", "", "", 0, true},
+		{"https://github.com/owner/repo", "", "", 0, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			owner, repo, number, err := parseIdentifier(tt.input)
+			owner, repo, number, err := ParseIdentifier(tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
## Summary

- Fix "fetch issue: fetch issue" error when passing a full GitHub issue URL (e.g. `https://github.com/owner/repo/issues/123`) as the `--issue` identifier
- Add `parseIssueURL()` to handle full GitHub URLs alongside the existing `owner/repo#N` shorthand
- Fix `createTracker()` to use `ParseIdentifier()` for extracting owner/repo, instead of naive `#`-based string splitting that broke on URLs

## Test plan

- [x] Existing `TestParseIdentifier` tests pass
- [x] New test cases cover GitHub issue URLs: standard, HTTP, with comment anchors, enterprise hosts, and invalid URLs
- [x] `scripts/lint.sh` passes
- [x] `bazel build //jiradozer/...` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to parsing/validation of GitHub issue identifiers and tracker client initialization, with added unit coverage; main risk is edge-case URL formats causing unexpected parse failures.
> 
> **Overview**
> Adds support for passing full GitHub issue URLs (e.g. `https://github.com/owner/repo/issues/123`) anywhere an `owner/repo#N` identifier is accepted.
> 
> The GitHub tracker now exposes `ParseIdentifier()` that can parse either shorthand or URLs (via a new `parseIssueURL()`), uses it in `FetchIssue()`, and updates `createTracker()` to derive `owner/repo` from `--issue` robustly instead of `#`-based splitting. CLI help text and unit tests are updated to cover URL cases and invalid inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bcd6043ec7fb7902ecb28e412ca60f9f7fc021c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->