### PR TITLE
jiradozer: fix --run-step to use config-defined rounds

### DIFF
--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -451,16 +451,23 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 
 		output, sessionID, err := jiradozer.RunStepAgent(ctx, stepName, data, roundCfg, workDir, "", "", logger)
 		if err != nil {
-			return fmt.Errorf("%s round %d/%d: %w", stepName, i+1, totalRounds, err)
+			return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
 		}
 		allOutputs = append(allOutputs, output)
 		sessionIDs = append(sessionIDs, sessionID)
 	}
 
-	combined := strings.Join(allOutputs, "\n\n---\n\n")
-	if combined == "" {
+	hasOutput := false
+	for _, o := range allOutputs {
+		if o != "" {
+			hasOutput = true
+			break
+		}
+	}
+	if !hasOutput {
 		logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)
 	} else {
+		combined := strings.Join(allOutputs, "\n\n---\n\n")
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- `--run-step` with multi-round steps (using `rounds:` in config) was ignoring the configured rounds and falling back to the built-in default prompt
- Root cause: `runSingleStep()` passed the empty top-level `Prompt` field to `RunStepAgent()`, which fell back to `DefaultPromptForStep()`
- Added `runSingleStepRounds()` that iterates over configured rounds via `ResolveRound()`, mirroring `Workflow.runStepRounds()` without state machine overhead

## Test plan
- [x] `bazel build //jiradozer/...` passes
- [x] `bazel test //jiradozer/...` passes (4/4)
- [ ] Manual: `jiradozer --config ~/jiradozer.yaml --description fix --run-step validate --verbose` uses config rounds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to the `--run-step` debug path and mainly alters control flow to iterate configured rounds, with minimal impact on core workflow execution.
> 
> **Overview**
> `--run-step` now **executes multi-round steps as defined in config** (via `rounds:`) instead of running a single default-prompt session.
> 
> Adds `runSingleStepRounds()` to iterate rounds using `ResolveRound()`, collect per-round outputs/session IDs, and print a combined result (or warn if all rounds produced no text output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6022ac1bc5d16e2b31417dfa8efa4ab54d61877f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->