### PR TITLE
jiradozer: add git commit+push to create_pr default prompt

### DIFF
--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -64,7 +64,11 @@ const defaultValidatePrompt = `Issue: {{.Identifier}} — {{.Title}}
 
 Run the project's tests and linters to validate the changes. Fix any failures you find. Report what passed and what you fixed.`
 
-const defaultCreatePRPrompt = `Check if a pull request already exists for the current branch against {{.BaseBranch}}.
+const defaultCreatePRPrompt = `First, check for any uncommitted changes (staged or unstaged, including untracked files).
+- If there are uncommitted changes: stage them, commit with a clear message referencing the work done, and push to the remote.
+- If there are no uncommitted changes but unpushed commits: push to the remote.
+
+Then, check if a pull request already exists for the current branch against {{.BaseBranch}}.
 - If a PR exists: update its description to reflect the current state of the code. Report the PR URL.
 - If no PR exists: create one against {{.BaseBranch}} with a clear title and description. Report the PR URL.`
 


### PR DESCRIPTION
## Summary
- The `create_pr` step runs after `build`, but the build agent doesn't always commit its changes
- This leaves `create_pr` with nothing to push and no PR to create
- Updated `defaultCreatePRPrompt` to instruct the agent to commit and push before creating/updating the PR

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer/...` passes
- [ ] Manual: run `jiradozer --run-step create_pr` on a branch with uncommitted changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a prompt-text change only, affecting agent instructions but not runtime logic or data handling.
> 
> **Overview**
> Improves the `create_pr` step’s default prompt to **explicitly stage/commit and push** any working-tree changes (or push unpushed commits) before checking for an existing PR and creating/updating it against `{{.BaseBranch}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95bfb86535f9e0fccce6fb5f52bdfd9752ac0e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->