### PR TITLE
jiradozer: fix plan handoff — single comment, approval race, waiting log

### DIFF
--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -129,6 +129,10 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 	resolved := w.config.ResolveStep(stepCfg)
 	totalRounds := len(stepCfg.Rounds)
 
+	// Reset lastCommentAt so transitionToReview uses the server timestamp from
+	// this step's result comment rather than a stale value from a prior review cycle.
+	w.lastCommentAt = time.Time{}
+
 	feedback := w.feedback
 	w.feedback = ""
 
@@ -178,6 +182,10 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepConfig, reviewStep WorkflowStep, trigger string) {
 	currentStep := w.state.Current()
 	sessionID := w.sessionIDs[currentStep]
+
+	// Reset lastCommentAt so transitionToReview uses the server timestamp from
+	// this step's result comment rather than a stale value from a prior review cycle.
+	w.lastCommentAt = time.Time{}
 
 	feedback := w.feedback
 	w.feedback = ""

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -34,22 +34,25 @@ type Workflow struct {
 	// OnRoundProgress is called during multi-round steps to report round progress.
 	// roundIndex is 0-based current round; roundTotal is len(rounds).
 	OnRoundProgress func(roundIndex, roundTotal int)
-	lastCommentAt   time.Time
-	plan            string
-	buildOutput     string
-	feedback        string
+	// runStepAgent is the agent runner, overridable in tests.
+	runStepAgent  func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, logger *slog.Logger) (string, string, error)
+	lastCommentAt time.Time
+	plan          string
+	buildOutput   string
+	feedback      string
 }
 
 // NewWorkflow creates a new workflow for the given issue.
 func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logger *slog.Logger) *Workflow {
 	return &Workflow{
-		tracker:    t,
-		issue:      issue,
-		state:      NewStateMachine(),
-		config:     cfg,
-		logger:     logger,
-		stateIDs:   make(map[string]string),
-		sessionIDs: make(map[WorkflowStep]string),
+		tracker:      t,
+		issue:        issue,
+		state:        NewStateMachine(),
+		config:       cfg,
+		logger:       logger,
+		stateIDs:     make(map[string]string),
+		sessionIDs:   make(map[WorkflowStep]string),
+		runStepAgent: RunStepAgent,
 	}
 }
 
@@ -157,7 +160,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 			w.OnRoundProgress(i, totalRounds)
 		}
 
-		output, _, err := RunStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.logger)
+		output, _, err := w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.logger)
 		if err != nil {
 			w.fail(ctx, fmt.Errorf("%s round %d/%d: %w", stepName, i+1, totalRounds, err))
 			return
@@ -193,7 +196,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	w.logger.Info("step: "+stepName, "feedback", feedback != "", "resume", sessionID != "")
 
 	cfg := w.config.ResolveStep(stepCfg)
-	output, newSessionID, err := RunStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.logger)
+	output, newSessionID, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.logger)
 	if err != nil {
 		w.fail(ctx, fmt.Errorf("%s step: %w", stepName, err))
 		return

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -306,14 +306,21 @@ func (w *Workflow) transitionToReview(ctx context.Context, reviewStep WorkflowSt
 		return
 	}
 
-	if _, err := PostWaitingComment(ctx, w.tracker, w.issue.ID, w.state.Current()); err != nil {
+	waitingComment, err := PostWaitingComment(ctx, w.tracker, w.issue.ID, w.state.Current())
+	if err != nil {
 		w.logger.Warn("failed to post waiting comment", "error", err)
 	}
 	// lastCommentAt was set by the step result comment in runStep/runStepRounds.
 	// Do not overwrite it here — doing so would skip user comments posted between
 	// the result comment and the waiting comment.
+	// If it is zero (step comment failed or returned no server timestamp), prefer
+	// the waiting comment's server timestamp before falling back to local time.
 	if w.lastCommentAt.IsZero() {
-		w.lastCommentAt = time.Now()
+		if err == nil && !waitingComment.CreatedAt.IsZero() {
+			w.lastCommentAt = waitingComment.CreatedAt
+		} else {
+			w.lastCommentAt = time.Now()
+		}
 	}
 }
 

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -198,7 +198,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	comment := fmt.Sprintf("## %s Complete\n\n%s", heading, output)
 	resultComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
 	if err != nil {
-		w.logger.Warn("failed to post "+stepName+" comment", "error", err)
+		w.logger.Warn("failed to post step comment", "step", stepName, "error", err)
 	} else if !resultComment.CreatedAt.IsZero() {
 		w.lastCommentAt = resultComment.CreatedAt
 	}

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -162,8 +162,11 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 
 		heading := capitalize(stepName)
 		comment := fmt.Sprintf("## %s Round %d/%d\n\n%s", heading, i+1, totalRounds, truncateOutput(output, 2000))
-		if _, err := w.tracker.PostComment(ctx, w.issue.ID, comment); err != nil {
+		roundComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
+		if err != nil {
 			w.logger.Warn("failed to post round comment", "step", stepName, "round", i+1, "error", err)
+		} else if i == totalRounds-1 && !roundComment.CreatedAt.IsZero() {
+			w.lastCommentAt = roundComment.CreatedAt
 		}
 	}
 
@@ -191,19 +194,13 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	w.sessionIDs[currentStep] = newSessionID
 	w.captureOutput(stepName, output)
 
-	// For long outputs, post a summary first then the full content in a
-	// separate comment so reviewers see everything.
 	heading := capitalize(stepName)
-	if len(output) > 3000 {
-		preview := string([]rune(output)[:500])
-		summary := fmt.Sprintf("## %s Complete\n\n%s\n\n_(Full output in next comment)_", heading, preview)
-		if _, err := w.tracker.PostComment(ctx, w.issue.ID, summary); err != nil {
-			w.logger.Warn("failed to post "+stepName+" summary comment", "error", err)
-		}
-	}
 	comment := fmt.Sprintf("## %s Complete\n\n%s", heading, output)
-	if _, err := w.tracker.PostComment(ctx, w.issue.ID, comment); err != nil {
+	resultComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
+	if err != nil {
 		w.logger.Warn("failed to post "+stepName+" comment", "error", err)
+	} else if !resultComment.CreatedAt.IsZero() {
+		w.lastCommentAt = resultComment.CreatedAt
 	}
 
 	w.transitionToReview(ctx, reviewStep, trigger)
@@ -254,6 +251,8 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 		}
 		return
 	}
+
+	w.logger.Info("waiting for approval", "step", w.state.Current(), "issue", w.issue.Identifier)
 
 	fb, err := PollForFeedback(ctx, w.tracker, w.issue.ID, w.lastCommentAt, w.config.PollInterval, w.logger)
 	if err != nil {
@@ -307,16 +306,14 @@ func (w *Workflow) transitionToReview(ctx context.Context, reviewStep WorkflowSt
 		return
 	}
 
-	waitingComment, err := PostWaitingComment(ctx, w.tracker, w.issue.ID, w.state.Current())
-	if err != nil || waitingComment.CreatedAt.IsZero() {
-		if err != nil {
-			w.logger.Warn("failed to post waiting comment", "error", err)
-		} else {
-			w.logger.Warn("waiting comment has no server timestamp, falling back to local clock")
-		}
+	if _, err := PostWaitingComment(ctx, w.tracker, w.issue.ID, w.state.Current()); err != nil {
+		w.logger.Warn("failed to post waiting comment", "error", err)
+	}
+	// lastCommentAt was set by the step result comment in runStep/runStepRounds.
+	// Do not overwrite it here — doing so would skip user comments posted between
+	// the result comment and the waiting comment.
+	if w.lastCommentAt.IsZero() {
 		w.lastCommentAt = time.Now()
-	} else {
-		w.lastCommentAt = waitingComment.CreatedAt
 	}
 }
 

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -564,6 +564,36 @@ func TestWorkflow_MultipleRedoLoops(t *testing.T) {
 	assert.Len(t, sm.History(), 7)
 }
 
+// TestWorkflow_RunStep_SetsLastCommentAt verifies that runStep captures the server
+// timestamp from PostComment as the polling anchor, and that a stale lastCommentAt
+// from a prior review cycle is reset at step start rather than carried forward.
+func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
+	resultTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	mt := &mockWorkflowTracker{
+		workflowStates:   testWorkflowStates(),
+		postCommentReply: &tracker.Comment{CreatedAt: resultTime},
+	}
+
+	cfg := testConfig()
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	// Inject a stale lastCommentAt simulating a leftover from a prior review cycle.
+	staleTime := time.Date(2025, 6, 14, 10, 0, 0, 0, time.UTC)
+	wf.lastCommentAt = staleTime
+
+	// Stub runStepAgent so runStep executes without invoking a real agent.
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *slog.Logger) (string, string, error) {
+		return "step output", "session-1", nil
+	}
+
+	wf.runStep(context.Background(), "plan", cfg.Plan, StepPlanReview, "plan_complete")
+
+	// lastCommentAt should be resultTime (from the result comment), not staleTime.
+	assert.Equal(t, resultTime, wf.lastCommentAt, "lastCommentAt should be set from result comment, stale value discarded")
+}
+
 // TestWorkflow_TransitionToReview_PreservesLastCommentAt verifies that
 // transitionToReview does not overwrite a lastCommentAt that was already set
 // by the step result comment, preventing a race where user approval posted

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -23,13 +23,15 @@ type trackerCall struct {
 }
 
 type mockWorkflowTracker struct {
-	commentSets      [][]tracker.Comment // sequence of comment responses for polling
-	workflowStates   []tracker.WorkflowState
-	comments         []tracker.Comment // returned by FetchComments
-	postCommentReply *tracker.Comment  // if set, PostComment always returns this
-	calls            []trackerCall
-	mu               sync.Mutex
-	commentIdx       int // tracks which comment set to return (for polling)
+	commentSets        [][]tracker.Comment // sequence of comment responses for polling
+	workflowStates     []tracker.WorkflowState
+	comments           []tracker.Comment  // returned by FetchComments
+	postCommentReply   *tracker.Comment   // if set, PostComment always returns this
+	postCommentReplies []*tracker.Comment // if set, PostComment returns these in order (last repeated)
+	calls              []trackerCall
+	mu                 sync.Mutex
+	commentIdx         int // tracks which comment set to return (for polling)
+	postCommentIdx     int // tracks index into postCommentReplies
 }
 
 func (m *mockWorkflowTracker) FetchIssue(_ context.Context, id string) (*tracker.Issue, error) {
@@ -59,9 +61,24 @@ func (m *mockWorkflowTracker) FetchWorkflowStates(_ context.Context, teamID stri
 }
 
 func (m *mockWorkflowTracker) PostComment(_ context.Context, issueID string, body string) (tracker.Comment, error) {
-	m.recordCall("PostComment", issueID, body)
+	m.mu.Lock()
+	m.calls = append(m.calls, trackerCall{method: "PostComment", args: []string{issueID, body}})
+	var reply *tracker.Comment
 	if m.postCommentReply != nil {
-		return *m.postCommentReply, nil
+		reply = m.postCommentReply
+	} else if len(m.postCommentReplies) > 0 {
+		idx := m.postCommentIdx
+		if idx >= len(m.postCommentReplies) {
+			idx = len(m.postCommentReplies) - 1
+		} else {
+			m.postCommentIdx++
+		}
+		reply = m.postCommentReplies[idx]
+	}
+	m.mu.Unlock()
+
+	if reply != nil {
+		return *reply, nil
 	}
 	return tracker.Comment{CreatedAt: time.Now()}, nil
 }
@@ -565,13 +582,22 @@ func TestWorkflow_MultipleRedoLoops(t *testing.T) {
 }
 
 // TestWorkflow_RunStep_SetsLastCommentAt verifies that runStep captures the server
-// timestamp from PostComment as the polling anchor, and that a stale lastCommentAt
-// from a prior review cycle is reset at step start rather than carried forward.
+// timestamp from the result PostComment as the polling anchor, and that a stale
+// lastCommentAt from a prior review cycle is reset at step start. Uses distinct
+// timestamps for the result comment vs the subsequent waiting comment so that the
+// test fails if runStep stops capturing from the result comment (instead of silently
+// passing via the transitionToReview fallback).
 func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
 	resultTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	waitingTime := time.Date(2025, 6, 15, 12, 0, 5, 0, time.UTC)
+
+	// First PostComment = result comment, second = waiting comment.
 	mt := &mockWorkflowTracker{
-		workflowStates:   testWorkflowStates(),
-		postCommentReply: &tracker.Comment{CreatedAt: resultTime},
+		workflowStates: testWorkflowStates(),
+		postCommentReplies: []*tracker.Comment{
+			{CreatedAt: resultTime},
+			{CreatedAt: waitingTime},
+		},
 	}
 
 	cfg := testConfig()
@@ -590,8 +616,56 @@ func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
 
 	wf.runStep(context.Background(), "plan", cfg.Plan, StepPlanReview, "plan_complete")
 
-	// lastCommentAt should be resultTime (from the result comment), not staleTime.
-	assert.Equal(t, resultTime, wf.lastCommentAt, "lastCommentAt should be set from result comment, stale value discarded")
+	// Must be resultTime (result comment), not waitingTime (waiting comment) or staleTime.
+	assert.Equal(t, resultTime, wf.lastCommentAt, "lastCommentAt should be set from result comment, not waiting comment or stale value")
+}
+
+// TestWorkflow_RunStepRounds_SetsLastCommentAtFromFinalRound verifies that
+// runStepRounds captures the server timestamp from the final round's PostComment
+// as the polling anchor, discarding any stale value from a prior review cycle.
+// Uses distinct timestamps per round so that only the final round's timestamp
+// wins — confirming it is the final-round comment, not an earlier one.
+func TestWorkflow_RunStepRounds_SetsLastCommentAtFromFinalRound(t *testing.T) {
+	round1Time := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	round2Time := time.Date(2025, 6, 15, 12, 1, 0, 0, time.UTC)
+	waitingTime := time.Date(2025, 6, 15, 12, 2, 0, 0, time.UTC)
+
+	// Sequence: round1 result comment → round2 result comment → waiting comment.
+	mt := &mockWorkflowTracker{
+		workflowStates: testWorkflowStates(),
+		postCommentReplies: []*tracker.Comment{
+			{CreatedAt: round1Time},
+			{CreatedAt: round2Time},
+			{CreatedAt: waitingTime},
+		},
+	}
+
+	cfg := testConfig()
+	// Build a two-round step config.
+	roundsCfg := StepConfig{
+		Rounds: []RoundConfig{
+			{Prompt: "round one"},
+			{Prompt: "round two"},
+		},
+	}
+
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	// Inject a stale lastCommentAt simulating a prior review cycle.
+	staleTime := time.Date(2025, 6, 14, 10, 0, 0, 0, time.UTC)
+	wf.lastCommentAt = staleTime
+
+	// Stub runStepAgent so rounds execute without a real agent.
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *slog.Logger) (string, string, error) {
+		return "round output", "", nil
+	}
+
+	wf.runStepRounds(context.Background(), "plan", roundsCfg, StepPlanReview, "plan_complete")
+
+	// Must be round2Time (final round's result comment), not round1Time, waitingTime, or staleTime.
+	assert.Equal(t, round2Time, wf.lastCommentAt, "lastCommentAt should be set from final round's result comment")
 }
 
 // TestWorkflow_TransitionToReview_PreservesLastCommentAt verifies that

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -564,22 +564,28 @@ func TestWorkflow_MultipleRedoLoops(t *testing.T) {
 	assert.Len(t, sm.History(), 7)
 }
 
-// TestWorkflow_TransitionToReview_UsesServerTimestamp verifies lastCommentAt uses the
-// server-assigned timestamp from PostComment, not time.Now().
-func TestWorkflow_TransitionToReview_UsesServerTimestamp(t *testing.T) {
-	serverTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+// TestWorkflow_TransitionToReview_PreservesLastCommentAt verifies that
+// transitionToReview does not overwrite a lastCommentAt that was already set
+// by the step result comment, preventing a race where user approval posted
+// between the result comment and the waiting comment would be missed.
+func TestWorkflow_TransitionToReview_PreservesLastCommentAt(t *testing.T) {
+	resultTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	waitingTime := time.Date(2025, 6, 15, 12, 0, 5, 0, time.UTC)
 	mt := &mockWorkflowTracker{
 		workflowStates:   testWorkflowStates(),
-		postCommentReply: &tracker.Comment{CreatedAt: serverTime},
+		postCommentReply: &tracker.Comment{CreatedAt: waitingTime},
 	}
 
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 	require.NoError(t, wf.resolveStateIDs(context.Background()))
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
+	// Simulate runStep having set lastCommentAt from the result comment.
+	wf.lastCommentAt = resultTime
+
 	wf.transitionToReview(context.Background(), StepPlanReview, "plan_complete")
 
-	assert.Equal(t, serverTime, wf.lastCommentAt)
+	assert.Equal(t, resultTime, wf.lastCommentAt, "lastCommentAt should be preserved from step result, not overwritten by waiting comment")
 }
 
 // TestWorkflow_TransitionToReview_ZeroTimestampFallback verifies that a zero

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -23,13 +23,15 @@ type trackerCall struct {
 }
 
 type mockWorkflowTracker struct {
-	commentSets      [][]tracker.Comment // sequence of comment responses for polling
-	workflowStates   []tracker.WorkflowState
-	comments         []tracker.Comment // returned by FetchComments
-	postCommentReply *tracker.Comment  // if set, PostComment returns this instead of default
-	calls            []trackerCall
-	mu               sync.Mutex
-	commentIdx       int // tracks which comment set to return (for polling)
+	commentSets        [][]tracker.Comment // sequence of comment responses for polling
+	workflowStates     []tracker.WorkflowState
+	comments           []tracker.Comment  // returned by FetchComments
+	postCommentReply   *tracker.Comment   // if set, PostComment always returns this
+	postCommentReplies []*tracker.Comment // if set, PostComment cycles through these in order
+	calls              []trackerCall
+	mu                 sync.Mutex
+	commentIdx         int // tracks which comment set to return (for polling)
+	postCommentIdx     int // tracks which postCommentReplies entry to use
 }
 
 func (m *mockWorkflowTracker) FetchIssue(_ context.Context, id string) (*tracker.Issue, error) {
@@ -59,9 +61,26 @@ func (m *mockWorkflowTracker) FetchWorkflowStates(_ context.Context, teamID stri
 }
 
 func (m *mockWorkflowTracker) PostComment(_ context.Context, issueID string, body string) (tracker.Comment, error) {
-	m.recordCall("PostComment", issueID, body)
-	if m.postCommentReply != nil {
-		return *m.postCommentReply, nil
+	m.mu.Lock()
+	m.calls = append(m.calls, trackerCall{method: "PostComment", args: []string{issueID, body}})
+	reply := m.postCommentReply
+	var seqReply *tracker.Comment
+	if reply == nil && len(m.postCommentReplies) > 0 {
+		idx := m.postCommentIdx
+		if idx < len(m.postCommentReplies) {
+			m.postCommentIdx++
+		} else {
+			idx = len(m.postCommentReplies) - 1
+		}
+		seqReply = m.postCommentReplies[idx]
+	}
+	m.mu.Unlock()
+
+	if reply != nil {
+		return *reply, nil
+	}
+	if seqReply != nil {
+		return *seqReply, nil
 	}
 	return tracker.Comment{CreatedAt: time.Now()}, nil
 }
@@ -605,6 +624,28 @@ func TestWorkflow_TransitionToReview_ZeroTimestampFallback(t *testing.T) {
 
 	assert.False(t, wf.lastCommentAt.IsZero(), "lastCommentAt should not be zero")
 	assert.False(t, wf.lastCommentAt.Before(before), "lastCommentAt should be recent (time.Now fallback)")
+}
+
+// TestWorkflow_TransitionToReview_FallsBackToWaitingCommentTimestamp verifies that
+// when lastCommentAt is zero (step result comment failed or returned no timestamp),
+// transitionToReview uses the waiting comment's server timestamp instead of time.Now().
+func TestWorkflow_TransitionToReview_FallsBackToWaitingCommentTimestamp(t *testing.T) {
+	waitingTime := time.Date(2025, 6, 15, 12, 0, 5, 0, time.UTC)
+	mt := &mockWorkflowTracker{
+		workflowStates:   testWorkflowStates(),
+		postCommentReply: &tracker.Comment{CreatedAt: waitingTime},
+	}
+
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	// lastCommentAt is zero — simulates a failed or zero-timestamp step result comment.
+	require.True(t, wf.lastCommentAt.IsZero())
+
+	wf.transitionToReview(context.Background(), StepPlanReview, "plan_complete")
+
+	assert.Equal(t, waitingTime, wf.lastCommentAt, "should use waiting comment's server timestamp when lastCommentAt is zero")
 }
 
 // TestWorkflow_AllReviewStepsFilterBotComments verifies each review step.

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -23,15 +23,13 @@ type trackerCall struct {
 }
 
 type mockWorkflowTracker struct {
-	commentSets        [][]tracker.Comment // sequence of comment responses for polling
-	workflowStates     []tracker.WorkflowState
-	comments           []tracker.Comment  // returned by FetchComments
-	postCommentReply   *tracker.Comment   // if set, PostComment always returns this
-	postCommentReplies []*tracker.Comment // if set, PostComment cycles through these in order
-	calls              []trackerCall
-	mu                 sync.Mutex
-	commentIdx         int // tracks which comment set to return (for polling)
-	postCommentIdx     int // tracks which postCommentReplies entry to use
+	commentSets      [][]tracker.Comment // sequence of comment responses for polling
+	workflowStates   []tracker.WorkflowState
+	comments         []tracker.Comment // returned by FetchComments
+	postCommentReply *tracker.Comment  // if set, PostComment always returns this
+	calls            []trackerCall
+	mu               sync.Mutex
+	commentIdx       int // tracks which comment set to return (for polling)
 }
 
 func (m *mockWorkflowTracker) FetchIssue(_ context.Context, id string) (*tracker.Issue, error) {
@@ -61,26 +59,9 @@ func (m *mockWorkflowTracker) FetchWorkflowStates(_ context.Context, teamID stri
 }
 
 func (m *mockWorkflowTracker) PostComment(_ context.Context, issueID string, body string) (tracker.Comment, error) {
-	m.mu.Lock()
-	m.calls = append(m.calls, trackerCall{method: "PostComment", args: []string{issueID, body}})
-	reply := m.postCommentReply
-	var seqReply *tracker.Comment
-	if reply == nil && len(m.postCommentReplies) > 0 {
-		idx := m.postCommentIdx
-		if idx < len(m.postCommentReplies) {
-			m.postCommentIdx++
-		} else {
-			idx = len(m.postCommentReplies) - 1
-		}
-		seqReply = m.postCommentReplies[idx]
-	}
-	m.mu.Unlock()
-
-	if reply != nil {
-		return *reply, nil
-	}
-	if seqReply != nil {
-		return *seqReply, nil
+	m.recordCall("PostComment", issueID, body)
+	if m.postCommentReply != nil {
+		return *m.postCommentReply, nil
 	}
 	return tracker.Comment{CreatedAt: time.Now()}, nil
 }


### PR DESCRIPTION
## Summary

- **Waiting log**: Add `"waiting for approval"` CLI log in `runReview` so the user knows jiradozer is polling after a step completes
- **Single comment**: Remove the two-comment split for long plan outputs (summary + full) — now posts one complete comment
- **Approval race fix**: Anchor `lastCommentAt` to the step result comment's timestamp instead of the "Waiting for review" comment's timestamp, so user approvals posted between the two are not skipped

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer/... --test_timeout=60` passes
- [ ] Manual: run `jiradozer` on a real issue, post "approve" immediately after the plan comment appears (before the "Waiting for review" comment) — verify it is detected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts review polling anchor (`lastCommentAt`) and comment-posting behavior in the core workflow loop; mistakes could cause missed approvals or incorrect polling windows. Changes are localized and covered by new targeted tests but affect end-to-end review/approval flow.
> 
> **Overview**
> Prevents missed approvals by **anchoring `PollForFeedback` to the server timestamp of the step’s result comment**: `runStep`/`runStepRounds` now reset stale `lastCommentAt` at step start and capture `CreatedAt` from the result (final-round) `PostComment`, while `transitionToReview` no longer overwrites a non-zero `lastCommentAt` and only falls back to the waiting comment (or `time.Now()`) when needed.
> 
> Simplifies output posting by removing the long-output two-comment split (summary + full) and always posting a single “Complete” comment, and adds a `waiting for approval` log line in `runReview`. Tests were expanded with a `runStepAgent` injection point and a mock tracker that can return a sequence of `PostComment` timestamps to validate the new timing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448c11092d06a631fa91497418c48b0a3c0bbc87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->