### PR TITLE
jiradozer: persist plan output and add --plan-file for build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 bazel-*
 .bazel-cache/
 
+# jiradozer runtime artifacts
+.jiradozer/
+
 # Go
 *.exe
 *.exe~

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -299,7 +299,12 @@ func PlanFilePath(workDir string) string {
 }
 
 // PersistPlan writes plan output to PlanFilePath so --run-step=build can load it.
+// Empty output is silently skipped to avoid overwriting a previously valid plan.
 func PersistPlan(workDir, output string, logger *slog.Logger) {
+	if strings.TrimSpace(output) == "" {
+		logger.Warn("skipping plan persistence — output is empty")
+		return
+	}
 	planPath := PlanFilePath(workDir)
 	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
 		logger.Warn("failed to create plan directory", "error", err)

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -299,7 +299,7 @@ func PlanFilePath(workDir string) string {
 }
 
 // PersistPlan writes plan output to PlanFilePath so --run-step=build can load it.
-// Empty output is silently skipped to avoid overwriting a previously valid plan.
+// Empty output is skipped (with a warning log) to avoid overwriting a previously valid plan.
 func PersistPlan(workDir, output string, logger *slog.Logger) {
 	if strings.TrimSpace(output) == "" {
 		logger.Warn("skipping plan persistence — output is empty")

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -289,6 +290,11 @@ func NewPromptData(issue *tracker.Issue, baseBranch string) PromptData {
 		d.URL = *issue.URL
 	}
 	return d
+}
+
+// PlanFilePath returns the path to the persisted plan file within a work directory.
+func PlanFilePath(workDir string) string {
+	return filepath.Join(workDir, ".jiradozer", "plan.md")
 }
 
 // GenerateTitle creates a short title from the first words of a description,

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -292,9 +292,22 @@ func NewPromptData(issue *tracker.Issue, baseBranch string) PromptData {
 	return d
 }
 
-// PlanFilePath returns the path to the persisted plan file within a work directory.
+// PlanFilePath returns .jiradozer/plan.md within workDir, enabling plan
+// reuse across separate process invocations (e.g. plan step then build step).
 func PlanFilePath(workDir string) string {
 	return filepath.Join(workDir, ".jiradozer", "plan.md")
+}
+
+// PersistPlan writes plan output to PlanFilePath so --run-step=build can load it.
+func PersistPlan(workDir, output string, logger *slog.Logger) {
+	planPath := PlanFilePath(workDir)
+	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
+		logger.Warn("failed to create plan directory", "error", err)
+	} else if err := os.WriteFile(planPath, []byte(output), 0o644); err != nil {
+		logger.Warn("failed to persist plan", "error", err)
+	} else {
+		logger.Info("persisted plan to disk", "path", planPath)
+	}
 }
 
 // GenerateTitle creates a short title from the first words of a description,

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -151,7 +151,11 @@ func run(ctx context.Context, args runArgs) error {
 	}
 
 	// Resolve --plan-file into planContent.
+	// Only meaningful for --run-step=build; warn if used otherwise.
 	if args.planFile != "" {
+		if args.runStep != "" && args.runStep != "build" {
+			return fmt.Errorf("--plan-file is only used with --run-step=build (got --run-step=%s)", args.runStep)
+		}
 		data, err := readFileOrStdin(args.planFile)
 		if err != nil {
 			return fmt.Errorf("read plan file: %w", err)
@@ -461,7 +465,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	} else {
 		fmt.Printf("=== %s output ===\n%s\n", stepName, output)
 	}
-	if stepName == "plan" && output != "" {
+	if stepName == "plan" {
 		jiradozer.PersistPlan(cfg.WorkDir, output, logger)
 	}
 	return nil
@@ -500,9 +504,10 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 	} else {
 		combined := strings.Join(allOutputs, "\n\n---\n\n")
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
-		if stepName == "plan" {
-			jiradozer.PersistPlan(workDir, combined, logger)
-		}
+	}
+	if stepName == "plan" {
+		combined := strings.Join(allOutputs, "\n\n---\n\n")
+		jiradozer.PersistPlan(workDir, combined, logger)
 	}
 	return nil
 }

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -449,6 +449,8 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 		} else if content, err := os.ReadFile(planPath); err == nil {
 			data.Plan = strings.TrimSpace(string(content))
 			logger.Info("loaded persisted plan", "path", planPath)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("read persisted plan %s: %w", planPath, err)
 		}
 		if data.Plan == "" {
 			logger.Warn("NO PLAN AVAILABLE — build step is running without a plan; use --plan-file to provide one, or run the plan step first")

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -497,16 +497,17 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 		sessionIDs = append(sessionIDs, sessionID)
 	}
 
-	hasOutput := false
+	// Filter empty round outputs before joining so separator-only text
+	// is not mistaken for real content (mirrors workflow.go logic).
+	var nonEmpty []string
 	for _, o := range allOutputs {
-		if o != "" {
-			hasOutput = true
-			break
+		if strings.TrimSpace(o) != "" {
+			nonEmpty = append(nonEmpty, o)
 		}
 	}
 	var combined string
-	if hasOutput {
-		combined = strings.Join(allOutputs, "\n\n---\n\n")
+	if len(nonEmpty) > 0 {
+		combined = strings.Join(nonEmpty, "\n\n---\n\n")
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
 	} else {
 		logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -137,15 +137,10 @@ func run(ctx context.Context, args runArgs) error {
 		if args.description != "" {
 			return fmt.Errorf("--description and --description-file are mutually exclusive")
 		}
-		var (
-			data []byte
-			err  error
-		)
-		if args.descriptionFile == "-" {
-			data, err = io.ReadAll(os.Stdin)
-		} else {
-			data, err = os.ReadFile(args.descriptionFile)
+		if args.descriptionFile == "-" && args.planFile == "-" {
+			return fmt.Errorf("cannot use stdin (-) for both --description-file and --plan-file")
 		}
+		data, err := readFileOrStdin(args.descriptionFile)
 		if err != nil {
 			return fmt.Errorf("read description file: %w", err)
 		}
@@ -157,15 +152,7 @@ func run(ctx context.Context, args runArgs) error {
 
 	// Resolve --plan-file into planContent.
 	if args.planFile != "" {
-		var (
-			data []byte
-			err  error
-		)
-		if args.planFile == "-" {
-			data, err = io.ReadAll(os.Stdin)
-		} else {
-			data, err = os.ReadFile(args.planFile)
-		}
+		data, err := readFileOrStdin(args.planFile)
 		if err != nil {
 			return fmt.Errorf("read plan file: %w", err)
 		}
@@ -448,12 +435,13 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	// Inject plan into prompt data for the build step.
 	// Priority: --plan-file flag > persisted plan.md > no plan.
 	if stepName == "build" {
+		planPath := jiradozer.PlanFilePath(cfg.WorkDir)
 		if planContent != "" {
 			data.Plan = planContent
 			logger.Info("using plan from --plan-file")
-		} else if content, err := os.ReadFile(jiradozer.PlanFilePath(cfg.WorkDir)); err == nil {
+		} else if content, err := os.ReadFile(planPath); err == nil {
 			data.Plan = strings.TrimSpace(string(content))
-			logger.Info("loaded persisted plan", "path", jiradozer.PlanFilePath(cfg.WorkDir))
+			logger.Info("loaded persisted plan", "path", planPath)
 		}
 		if data.Plan == "" {
 			logger.Warn("NO PLAN AVAILABLE — build step is running without a plan; use --plan-file to provide one, or run the plan step first")
@@ -472,6 +460,9 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 		logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", sessionID)
 	} else {
 		fmt.Printf("=== %s output ===\n%s\n", stepName, output)
+	}
+	if stepName == "plan" && output != "" {
+		jiradozer.PersistPlan(cfg.WorkDir, output, logger)
 	}
 	return nil
 }
@@ -509,8 +500,19 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 	} else {
 		combined := strings.Join(allOutputs, "\n\n---\n\n")
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
+		if stepName == "plan" {
+			jiradozer.PersistPlan(workDir, combined, logger)
+		}
 	}
 	return nil
+}
+
+// readFileOrStdin reads from the given path, or from stdin if path is "-".
+func readFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
 }
 
 var allSteps = []string{"plan", "build", "create_pr", "validate", "ship"}

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -151,9 +151,12 @@ func run(ctx context.Context, args runArgs) error {
 	}
 
 	// Resolve --plan-file into planContent.
-	// Only meaningful for --run-step=build; warn if used otherwise.
+	// Only meaningful for --run-step=build.
 	if args.planFile != "" {
-		if args.runStep != "" && args.runStep != "build" {
+		if args.runStep != "build" {
+			if args.runStep == "" {
+				return fmt.Errorf("--plan-file requires --run-step=build")
+			}
 			return fmt.Errorf("--plan-file is only used with --run-step=build (got --run-step=%s)", args.runStep)
 		}
 		data, err := readFileOrStdin(args.planFile)
@@ -499,14 +502,14 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 			break
 		}
 	}
-	if !hasOutput {
-		logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)
-	} else {
-		combined := strings.Join(allOutputs, "\n\n---\n\n")
+	var combined string
+	if hasOutput {
+		combined = strings.Join(allOutputs, "\n\n---\n\n")
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
+	} else {
+		logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)
 	}
 	if stepName == "plan" {
-		combined := strings.Join(allOutputs, "\n\n---\n\n")
 		jiradozer.PersistPlan(workDir, combined, logger)
 	}
 	return nil

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -45,6 +45,7 @@ func main() {
 		verbose         bool
 		description     string
 		descriptionFile string
+		planFile        string
 	)
 
 	rootCmd := &cobra.Command{
@@ -69,6 +70,7 @@ func main() {
 				verbose:         verbose,
 				description:     description,
 				descriptionFile: descriptionFile,
+				planFile:        planFile,
 			})
 		},
 	}
@@ -90,6 +92,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose logging")
 	rootCmd.Flags().StringVar(&description, "description", "", "Task description for local mode (no external tracker needed)")
 	rootCmd.Flags().StringVar(&descriptionFile, "description-file", "", "Read task description from file (use - for stdin)")
+	rootCmd.Flags().StringVar(&planFile, "plan-file", "", "Plan file for build step (use - for stdin)")
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -110,6 +113,8 @@ type runArgs struct {
 	branchPrefix    string
 	description     string
 	descriptionFile string
+	planFile        string
+	planContent     string
 	sourceStates    []string
 	sourceLabels    []string
 	pollInterval    time.Duration
@@ -147,6 +152,26 @@ func run(ctx context.Context, args runArgs) error {
 		args.description = strings.TrimSpace(string(data))
 		if args.description == "" {
 			return fmt.Errorf("description file is empty")
+		}
+	}
+
+	// Resolve --plan-file into planContent.
+	if args.planFile != "" {
+		var (
+			data []byte
+			err  error
+		)
+		if args.planFile == "-" {
+			data, err = io.ReadAll(os.Stdin)
+		} else {
+			data, err = os.ReadFile(args.planFile)
+		}
+		if err != nil {
+			return fmt.Errorf("read plan file: %w", err)
+		}
+		args.planContent = strings.TrimSpace(string(data))
+		if args.planContent == "" {
+			return fmt.Errorf("plan file is empty")
 		}
 	}
 
@@ -278,7 +303,7 @@ func run(ctx context.Context, args runArgs) error {
 
 	// Local description mode.
 	if args.description != "" {
-		return runFromDescription(ctx, args.description, args.runStep, issueTracker, cfg, logger)
+		return runFromDescription(ctx, args.description, args.runStep, args.planContent, issueTracker, cfg, logger)
 	}
 
 	// Multi-issue TUI mode (only when no --issue flag was given).
@@ -295,7 +320,7 @@ func run(ctx context.Context, args runArgs) error {
 	logger.Info("found issue", "id", issue.ID, "title", issue.Title, "state", issue.State)
 
 	if args.runStep != "" {
-		return runSingleStep(ctx, args.runStep, issue, cfg, logger)
+		return runSingleStep(ctx, args.runStep, issue, cfg, args.planContent, logger)
 	}
 
 	// Run the full workflow.
@@ -389,7 +414,7 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 	}
 }
 
-func runFromDescription(ctx context.Context, description, runStep string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, logger *slog.Logger) error {
+func runFromDescription(ctx context.Context, description, runStep, planContent string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, logger *slog.Logger) error {
 	lt, ok := issueTracker.(*local.Tracker)
 	if !ok {
 		return fmt.Errorf("--description requires local tracker (got %T)", issueTracker)
@@ -405,20 +430,35 @@ func runFromDescription(ctx context.Context, description, runStep string, issueT
 	logger.Info("created local issue", "identifier", issue.Identifier, "title", issue.Title)
 
 	if runStep != "" {
-		return runSingleStep(ctx, runStep, issue, cfg, logger)
+		return runSingleStep(ctx, runStep, issue, cfg, planContent, logger)
 	}
 
 	wf := jiradozer.NewWorkflow(issueTracker, issue, cfg, logger)
 	return wf.Run(ctx)
 }
 
-func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, logger *slog.Logger) error {
+func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, logger *slog.Logger) error {
 	stepCfg, ok := cfg.StepByName(stepName)
 	if !ok {
 		return fmt.Errorf("unknown step %q (valid: %s)", stepName, strings.Join(allSteps, ", "))
 	}
 	resolved := cfg.ResolveStep(stepCfg)
 	data := jiradozer.NewPromptData(issue, cfg.BaseBranch)
+
+	// Inject plan into prompt data for the build step.
+	// Priority: --plan-file flag > persisted plan.md > no plan.
+	if stepName == "build" {
+		if planContent != "" {
+			data.Plan = planContent
+			logger.Info("using plan from --plan-file")
+		} else if content, err := os.ReadFile(jiradozer.PlanFilePath(cfg.WorkDir)); err == nil {
+			data.Plan = strings.TrimSpace(string(content))
+			logger.Info("loaded persisted plan", "path", jiradozer.PlanFilePath(cfg.WorkDir))
+		}
+		if data.Plan == "" {
+			logger.Warn("NO PLAN AVAILABLE — build step is running without a plan; use --plan-file to provide one, or run the plan step first")
+		}
+	}
 
 	if len(resolved.Rounds) > 0 {
 		return runSingleStepRounds(ctx, stepName, data, resolved, cfg.WorkDir, logger)

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -180,7 +180,15 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		}
 	}
 
-	w.captureOutput(stepName, strings.Join(allOutputs, "\n\n---\n\n"))
+	// Filter empty round outputs before joining so separator-only text
+	// (e.g. "\n\n---\n\n") is not mistaken for real plan content.
+	var nonEmpty []string
+	for _, o := range allOutputs {
+		if strings.TrimSpace(o) != "" {
+			nonEmpty = append(nonEmpty, o)
+		}
+	}
+	w.captureOutput(stepName, strings.Join(nonEmpty, "\n\n---\n\n"))
 	w.transitionToReview(ctx, reviewStep, trigger)
 }
 

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -85,6 +87,9 @@ func (w *Workflow) Run(ctx context.Context) error {
 			w.runReview(ctx, StepBuilding, StepPlanning)
 		case StepBuilding:
 			delete(w.sessionIDs, StepCreatingPR) // Fresh build cycle invalidates old create_pr session.
+			if w.plan == "" {
+				w.logger.Warn("NO PLAN AVAILABLE — build step is running without a plan")
+			}
 			w.runStepOrRounds(ctx, "build", w.config.Build, StepCreatingPR, "build_complete")
 		case StepCreatingPR:
 			w.runStep(ctx, "create_pr", w.config.CreatePR, StepBuildReview, "pr_created")
@@ -226,10 +231,19 @@ func (w *Workflow) promptData() PromptData {
 }
 
 // captureOutput stores step output for use by downstream steps.
+// For the plan step, it also persists to disk so it survives process restarts.
 func (w *Workflow) captureOutput(stepName, output string) {
 	switch stepName {
 	case "plan":
 		w.plan = output
+		planPath := PlanFilePath(w.config.WorkDir)
+		if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
+			w.logger.Warn("failed to create plan directory", "error", err)
+		} else if err := os.WriteFile(planPath, []byte(output), 0o644); err != nil {
+			w.logger.Warn("failed to persist plan", "error", err)
+		} else {
+			w.logger.Info("persisted plan to disk", "path", planPath)
+		}
 	case "build":
 		w.buildOutput = output
 	}

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -231,19 +229,13 @@ func (w *Workflow) promptData() PromptData {
 }
 
 // captureOutput stores step output for use by downstream steps.
-// For the plan step, it also persists to disk so it survives process restarts.
+// Plan output is also persisted to disk so the build step can load it
+// when run as a separate process invocation (--run-step=build).
 func (w *Workflow) captureOutput(stepName, output string) {
 	switch stepName {
 	case "plan":
 		w.plan = output
-		planPath := PlanFilePath(w.config.WorkDir)
-		if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
-			w.logger.Warn("failed to create plan directory", "error", err)
-		} else if err := os.WriteFile(planPath, []byte(output), 0o644); err != nil {
-			w.logger.Warn("failed to persist plan", "error", err)
-		} else {
-			w.logger.Info("persisted plan to disk", "path", planPath)
-		}
+		PersistPlan(w.config.WorkDir, output, w.logger)
 	case "build":
 		w.buildOutput = output
 	}

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -805,6 +805,28 @@ func TestCaptureOutput_BuildDoesNotPersist(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestCaptureOutput_EmptyPlanDoesNotOverwrite(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), cfg, discardLogger())
+
+	// Persist a valid plan first.
+	wf.captureOutput("plan", "valid plan content")
+	planPath := PlanFilePath(workDir)
+	content, err := os.ReadFile(planPath)
+	require.NoError(t, err)
+	assert.Equal(t, "valid plan content", string(content))
+
+	// Now capture empty plan output — should NOT overwrite.
+	wf.captureOutput("plan", "")
+	content, err = os.ReadFile(planPath)
+	require.NoError(t, err)
+	assert.Equal(t, "valid plan content", string(content), "empty output should not overwrite valid plan")
+}
+
 func TestPlanFilePath(t *testing.T) {
 	t.Parallel()
 	got := PlanFilePath("/tmp/myproject")

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -765,4 +767,46 @@ func TestWorkflow_AllReviewStepsFilterBotComments(t *testing.T) {
 			assert.Equal(t, r.approveTarget, wf.state.Current())
 		})
 	}
+}
+
+func TestCaptureOutput_PersistsPlanToDisk(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), cfg, discardLogger())
+	planText := "## Plan\n\n1. Do thing A\n2. Do thing B"
+	wf.captureOutput("plan", planText)
+
+	// Verify in-memory state.
+	assert.Equal(t, planText, wf.plan)
+
+	// Verify persisted file.
+	planPath := PlanFilePath(workDir)
+	content, err := os.ReadFile(planPath)
+	require.NoError(t, err)
+	assert.Equal(t, planText, string(content))
+}
+
+func TestCaptureOutput_BuildDoesNotPersist(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), cfg, discardLogger())
+	wf.captureOutput("build", "build output")
+
+	assert.Equal(t, "build output", wf.buildOutput)
+
+	// No plan file should be created for build output.
+	_, err := os.Stat(PlanFilePath(workDir))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestPlanFilePath(t *testing.T) {
+	t.Parallel()
+	got := PlanFilePath("/tmp/myproject")
+	assert.Equal(t, filepath.Join("/tmp/myproject", ".jiradozer", "plan.md"), got)
 }


### PR DESCRIPTION
## Summary

- Persists plan output to `.jiradozer/plan.md` after the plan step completes, so it survives process restarts
- Adds `--plan-file` flag to provide a plan explicitly when running `--run-step build` directly
- Auto-loads persisted plan when `--run-step build` is used without `--plan-file`
- Logs a loud warning when the build step runs without any plan available (both full workflow and `--run-step` modes)

Priority: `--plan-file` flag > persisted `plan.md` > no plan (with warning).

## Test plan

- [x] `bazel test //jiradozer/...` — all tests pass
- [x] `scripts/lint.sh` — clean
- [ ] Manual: `--run-step plan` on an issue, verify `plan.md` appears in `.jiradozer/`
- [ ] Manual: `--run-step build --plan-file <path>` uses the provided plan
- [ ] Manual: `--run-step build` (no flag) auto-loads persisted `plan.md`
- [ ] Manual: `--run-step build` with no plan shows warning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workflow step plumbing and introduces new on-disk state (`.jiradozer/plan.md`) that affects how the build prompt is constructed across runs.
> 
> **Overview**
> **Adds cross-run plan reuse for `jiradozer`.** Plan output is now persisted to `cfg.WorkDir/.jiradozer/plan.md` (and `.jiradozer/` is added to `.gitignore`) so a later process invocation can pick it up.
> 
> Standalone step execution is extended with `--plan-file` (or persisted `plan.md`) to inject `PromptData.Plan` when running `--run-step=build`, with clear validation around stdin usage and *loud warnings* when build runs without any plan.
> 
> Multi-round step output handling now filters empty round outputs before joining, preventing separator-only text from being treated as real plan content, and new tests cover plan path/persistence and empty-plan overwrite prevention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42088bf2b5a296aacfecc2a92145266ca9fbe6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->