### PR TITLE
jiradozer: fix approval polling when bot and human share same API key

### DIFF
--- a/jiradozer/integration/workflow_test.go
+++ b/jiradozer/integration/workflow_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -275,5 +276,67 @@ func TestLinear_StateResolution(t *testing.T) {
 		t.Logf("in_progress → %s", id)
 	} else {
 		t.Log("WARNING: 'In Progress' state not found — team may use custom names")
+	}
+}
+
+// TestLinear_PollForFeedback_SameUser verifies the approval flow when the
+// bot and human share the same API key (IsSelf=true for all comments).
+// This is a regression test: previously PollForFeedback filtered by IsSelf,
+// which meant human comments were silently ignored when using a personal API key.
+func TestLinear_PollForFeedback_SameUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	client := getLinearClient(t)
+	issueID := getTestIssueID(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	issue, err := client.FetchIssue(ctx, issueID)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	variants := []struct {
+		body string
+		want jiradozer.FeedbackAction
+	}{
+		{"approve", jiradozer.FeedbackApprove},
+		{"lgtm", jiradozer.FeedbackApprove},
+		{"LGTM", jiradozer.FeedbackApprove},
+		{"ship it", jiradozer.FeedbackApprove},
+		{"redo", jiradozer.FeedbackRedo},
+		{"Please fix tests", jiradozer.FeedbackComment},
+	}
+
+	for _, v := range variants {
+		t.Run(v.body, func(t *testing.T) {
+			marker := time.Now().Format("20060102-150405.000")
+
+			// Post bot comments (simulating result + waiting).
+			resultComment, err := client.PostComment(ctx, issue.ID, "## Plan Complete ("+marker+")\n\nOutput.")
+			require.NoError(t, err)
+
+			waitingComment, err := client.PostComment(ctx, issue.ID, "**plan_review** — Waiting ("+marker+").")
+			require.NoError(t, err)
+
+			// Post the "human" comment (same API key, so IsSelf=true).
+			humanComment, err := client.PostComment(ctx, issue.ID, v.body)
+			require.NoError(t, err)
+			assert.True(t, humanComment.IsSelf, "same API key → IsSelf should be true")
+
+			// PollForFeedback should find the human comment by excluding bot IDs.
+			excludeIDs := []string{resultComment.ID, waitingComment.ID}
+
+			pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Second)
+			defer pollCancel()
+
+			fb, err := jiradozer.PollForFeedback(pollCtx, client, issue.ID, resultComment.CreatedAt, 500*time.Millisecond, logger, excludeIDs)
+			require.NoError(t, err, "PollForFeedback should find the human comment")
+			assert.Equal(t, v.want, fb.Action, "body=%q", v.body)
+			assert.Equal(t, v.body, fb.Message)
+		})
 	}
 }

--- a/jiradozer/poller.go
+++ b/jiradozer/poller.go
@@ -27,8 +27,16 @@ type FeedbackResult struct {
 }
 
 // PollForFeedback polls the tracker for new human comments on the issue.
-// It blocks until a non-bot comment is found, then parses the action.
-func PollForFeedback(ctx context.Context, t tracker.IssueTracker, issueID string, since time.Time, interval time.Duration, logger *slog.Logger) (*FeedbackResult, error) {
+// It blocks until a comment not in excludeIDs is found, then parses the action.
+// excludeIDs contains IDs of comments posted by the bot (e.g., step result and
+// waiting comments) so they are skipped even when the bot and human share the
+// same API key (where IsSelf would be true for both).
+func PollForFeedback(ctx context.Context, t tracker.IssueTracker, issueID string, since time.Time, interval time.Duration, logger *slog.Logger, excludeIDs []string) (*FeedbackResult, error) {
+	exclude := make(map[string]bool, len(excludeIDs))
+	for _, id := range excludeIDs {
+		exclude[id] = true
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -50,11 +58,11 @@ func PollForFeedback(ctx context.Context, t tracker.IssueTracker, issueID string
 			continue
 		}
 
-		// Use the last (most recent) non-self comment, since Linear returns
-		// comments in ascending createdAt order.
+		// Use the last (most recent) comment not posted by the bot, since
+		// Linear returns comments in ascending createdAt order.
 		var latest *tracker.Comment
 		for i := len(comments) - 1; i >= 0; i-- {
-			if !comments[i].IsSelf {
+			if !exclude[comments[i].ID] {
 				latest = &comments[i]
 				break
 			}

--- a/jiradozer/poller_test.go
+++ b/jiradozer/poller_test.go
@@ -123,7 +123,7 @@ func TestPollForFeedback_FiltersBotComments(t *testing.T) {
 	defer cancel()
 
 	logger := discardLogger()
-	fb, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 100*time.Millisecond, logger)
+	fb, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 100*time.Millisecond, logger, []string{"bot1", "bot2"})
 	require.NoError(t, err)
 	assert.Equal(t, FeedbackApprove, fb.Action)
 	assert.Equal(t, "lgtm", fb.Message)
@@ -143,9 +143,9 @@ func TestPollForFeedback_UsesLastHumanComment(t *testing.T) {
 	defer cancel()
 
 	logger := discardLogger()
-	fb, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 100*time.Millisecond, logger)
+	fb, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 100*time.Millisecond, logger, nil)
 	require.NoError(t, err)
-	// Should pick the last (most recent) non-self comment.
+	// Should pick the last (most recent) non-excluded comment.
 	assert.Equal(t, FeedbackApprove, fb.Action)
 	assert.Equal(t, "h2", fb.Comment.ID)
 }
@@ -163,7 +163,7 @@ func TestPollForFeedback_ContextCanceled(t *testing.T) {
 	}()
 
 	logger := discardLogger()
-	_, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 50*time.Millisecond, logger)
+	_, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 50*time.Millisecond, logger, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -179,10 +179,34 @@ func TestPollForFeedback_OnlyBotComments_KeepsPolling(t *testing.T) {
 	defer cancel()
 
 	logger := discardLogger()
-	_, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 50*time.Millisecond, logger)
-	// Should time out because only bot comments are present.
+	_, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 50*time.Millisecond, logger, []string{"bot1"})
+	// Should time out because only excluded bot comments are present.
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	// Should have polled multiple times.
 	assert.Greater(t, mt.calls, 1)
+}
+
+// TestPollForFeedback_SameUserExcludeByID verifies that when all comments
+// have IsSelf=true (same API key for bot and human), excluding by bot comment
+// IDs still allows human comments through.
+func TestPollForFeedback_SameUserExcludeByID(t *testing.T) {
+	now := time.Now()
+	mt := &mockPollerTracker{
+		comments: []tracker.Comment{
+			{ID: "bot-result", Body: "## Plan Complete\n\nPlan output...", IsSelf: true, CreatedAt: now},
+			{ID: "bot-waiting", Body: "**plan_review** — Waiting for review.", IsSelf: true, CreatedAt: now.Add(time.Second)},
+			{ID: "human-approve", Body: "approve", IsSelf: true, CreatedAt: now.Add(2 * time.Second)},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	logger := discardLogger()
+	fb, err := PollForFeedback(ctx, mt, "issue-1", time.Time{}, 100*time.Millisecond, logger, []string{"bot-result", "bot-waiting"})
+	require.NoError(t, err)
+	assert.Equal(t, FeedbackApprove, fb.Action)
+	assert.Equal(t, "approve", fb.Message)
+	assert.Equal(t, "human-approve", fb.Comment.ID)
 }

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -19,27 +19,22 @@ const (
 
 // Workflow drives the issue through plan → build → create_pr → validate → ship.
 type Workflow struct {
-	tracker    tracker.IssueTracker
-	lastError  error
-	issue      *tracker.Issue
-	state      *StateMachine
-	config     *Config
-	logger     *slog.Logger
-	sessionIDs map[WorkflowStep]string // per-step session IDs for resume
-	stateIDs   map[string]string
-
-	// OnTransition is called after each successful state transition.
-	// The orchestrator uses this to track workflow progress without polling.
-	OnTransition func(step WorkflowStep)
-	// OnRoundProgress is called during multi-round steps to report round progress.
-	// roundIndex is 0-based current round; roundTotal is len(rounds).
+	lastCommentAt   time.Time
+	tracker         tracker.IssueTracker
+	lastError       error
+	config          *Config
+	state           *StateMachine
+	logger          *slog.Logger
+	sessionIDs      map[WorkflowStep]string
+	stateIDs        map[string]string
+	OnTransition    func(step WorkflowStep)
 	OnRoundProgress func(roundIndex, roundTotal int)
-	// runStepAgent is the agent runner, overridable in tests.
-	runStepAgent  func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, logger *slog.Logger) (string, string, error)
-	lastCommentAt time.Time
-	plan          string
-	buildOutput   string
-	feedback      string
+	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, logger *slog.Logger) (string, string, error)
+	issue           *tracker.Issue
+	plan            string
+	buildOutput     string
+	feedback        string
+	botCommentIDs   []string
 }
 
 // NewWorkflow creates a new workflow for the given issue.
@@ -132,9 +127,10 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 	resolved := w.config.ResolveStep(stepCfg)
 	totalRounds := len(stepCfg.Rounds)
 
-	// Reset lastCommentAt so transitionToReview uses the server timestamp from
-	// this step's result comment rather than a stale value from a prior review cycle.
+	// Reset lastCommentAt and botCommentIDs so transitionToReview uses
+	// fresh values from this step cycle rather than stale ones from a prior cycle.
 	w.lastCommentAt = time.Time{}
+	w.botCommentIDs = nil
 
 	feedback := w.feedback
 	w.feedback = ""
@@ -172,8 +168,13 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		roundComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
 		if err != nil {
 			w.logger.Warn("failed to post round comment", "step", stepName, "round", i+1, "error", err)
-		} else if i == totalRounds-1 && !roundComment.CreatedAt.IsZero() {
-			w.lastCommentAt = roundComment.CreatedAt
+		} else {
+			if roundComment.ID != "" {
+				w.botCommentIDs = append(w.botCommentIDs, roundComment.ID)
+			}
+			if i == totalRounds-1 && !roundComment.CreatedAt.IsZero() {
+				w.lastCommentAt = roundComment.CreatedAt
+			}
 		}
 	}
 
@@ -186,9 +187,10 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	currentStep := w.state.Current()
 	sessionID := w.sessionIDs[currentStep]
 
-	// Reset lastCommentAt so transitionToReview uses the server timestamp from
-	// this step's result comment rather than a stale value from a prior review cycle.
+	// Reset lastCommentAt and botCommentIDs so transitionToReview uses
+	// fresh values from this step cycle rather than stale ones from a prior cycle.
 	w.lastCommentAt = time.Time{}
+	w.botCommentIDs = nil
 
 	feedback := w.feedback
 	w.feedback = ""
@@ -210,8 +212,13 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	resultComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
 	if err != nil {
 		w.logger.Warn("failed to post step comment", "step", stepName, "error", err)
-	} else if !resultComment.CreatedAt.IsZero() {
-		w.lastCommentAt = resultComment.CreatedAt
+	} else {
+		if resultComment.ID != "" {
+			w.botCommentIDs = append(w.botCommentIDs, resultComment.ID)
+		}
+		if !resultComment.CreatedAt.IsZero() {
+			w.lastCommentAt = resultComment.CreatedAt
+		}
 	}
 
 	w.transitionToReview(ctx, reviewStep, trigger)
@@ -265,7 +272,7 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 
 	w.logger.Info("waiting for approval", "step", w.state.Current(), "issue", w.issue.Identifier)
 
-	fb, err := PollForFeedback(ctx, w.tracker, w.issue.ID, w.lastCommentAt, w.config.PollInterval, w.logger)
+	fb, err := PollForFeedback(ctx, w.tracker, w.issue.ID, w.lastCommentAt, w.config.PollInterval, w.logger, w.botCommentIDs)
 	if err != nil {
 		w.fail(ctx, fmt.Errorf("polling for feedback: %w", err))
 		return
@@ -320,6 +327,8 @@ func (w *Workflow) transitionToReview(ctx context.Context, reviewStep WorkflowSt
 	waitingComment, err := PostWaitingComment(ctx, w.tracker, w.issue.ID, w.state.Current())
 	if err != nil {
 		w.logger.Warn("failed to post waiting comment", "error", err)
+	} else if waitingComment.ID != "" {
+		w.botCommentIDs = append(w.botCommentIDs, waitingComment.ID)
 	}
 	// lastCommentAt was set by the step result comment in runStep/runStepRounds.
 	// Do not overwrite it here — doing so would skip user comments posted between


### PR DESCRIPTION
## Summary

- **Root cause:** `PollForFeedback` filtered comments using `IsSelf` flag. When the same Linear API key is used for both the bot and human reviewer, ALL comments have `IsSelf=true`, so human approval comments were silently ignored — the CLI looped forever at "waiting for approval."
- **Fix:** Changed `PollForFeedback` to accept `excludeIDs` (bot-posted comment IDs) instead of filtering by `IsSelf`. The workflow tracks result and waiting comment IDs and passes them to the poller.
- Added `TestPollForFeedback_SameUserExcludeByID` unit test for the same-user scenario
- Added `TestLinear_PollForFeedback_SameUser` integration test that exercises the full flow against real Linear with all approval variants (approve, lgtm, LGTM, ship it, redo, feedback)

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer:jiradozer_test` passes
- [x] `bazel build //jiradozer/integration:integration_test` compiles
- [ ] `bazel test //jiradozer/integration:integration_test --test_env=JIRADOZER_TEST_LINEAR_API_KEY=... --test_env=JIRADOZER_TEST_ISSUE_ID=...` — run with real Linear credentials
- [ ] Manual: `jiradozer --config ~/jiradozer.yaml --issue INF-240`, post "approve" in Linear, confirm CLI proceeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the workflow approval polling logic to ignore bot comments by ID rather than relying on `IsSelf`, which affects how workflow steps unblock and could alter behavior if the wrong IDs are excluded.
> 
> **Overview**
> Fixes a regression where approvals could be missed when the bot and reviewer share the same Linear API key by changing `PollForFeedback` to skip an explicit list of bot-posted comment IDs instead of filtering on `IsSelf`.
> 
> Updates the workflow to track result/waiting (and round) comment IDs per step cycle and pass them into the poller, and adds both a unit test and a real Linear integration test covering the same-user approval variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67efebccd10d914d5271254c0b8537351bc1debb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->