### PR TITLE
claude SDK: fix stuck session when cancelled bg tasks suppress turn completion

### DIFF
--- a/agent-cli-wrapper/claude/BUILD.bazel
+++ b/agent-cli-wrapper/claude/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "recorder_test.go",
         "sdk_mcp_test.go",
         "sdk_mcp_typed_test.go",
+        "session_bg_test.go",
         "turn_test.go",
     ],
     embed = [":claude"],

--- a/agent-cli-wrapper/claude/integration/session_test.go
+++ b/agent-cli-wrapper/claude/integration/session_test.go
@@ -624,6 +624,86 @@ func TestSession_Integration_BackgroundTask(t *testing.T) {
 	t.Log("All assertions passed for Background Task scenario")
 }
 
+// ============================================================================
+// Scenario 6: Background Task Cancellation (parallel tool failure)
+// ============================================================================
+
+// TestSession_Integration_BackgroundTaskCancelled verifies that the session
+// does NOT hang when background tasks are cancelled due to a sibling parallel
+// tool call failing.
+//
+// This reproduces the exact bug from jiradozer's validate step:
+//  1. Agent calls 3 Bash tools in parallel
+//  2. First tool fails (exit 1)
+//  3. CLI cancels the other two (which had run_in_background: true)
+//  4. Session must complete the turn normally, not hang waiting for
+//     task-notifications that will never arrive.
+func TestSession_Integration_BackgroundTaskCancelled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	testDir, err := os.MkdirTemp("", "claude-go-test-bgcancel-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(testDir)
+	t.Logf("Test artifacts directory: %s", testDir)
+
+	session := claude.NewSession(
+		claude.WithModel("haiku"),
+		claude.WithWorkDir(testDir),
+		claude.WithPermissionMode(claude.PermissionModeBypass),
+		claude.WithDisablePlugins(),
+		claude.WithRecording(testDir),
+	)
+
+	if err := session.Start(ctx); err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+	defer session.Stop()
+
+	// Ask the agent to run 3 parallel Bash commands. The first one must fail,
+	// which should cause the CLI to cancel the other two background tasks.
+	t.Log("Sending parallel-failure prompt...")
+	_, err = session.SendMessage(ctx,
+		"Run these THREE bash commands in PARALLEL (all in one response, using multiple tool calls):\n"+
+			"1. `exit 1` (this will fail)\n"+
+			"2. `sleep 5 && echo SECOND_DONE` with run_in_background: true\n"+
+			"3. `sleep 5 && echo THIRD_DONE` with run_in_background: true\n\n"+
+			"You MUST call all three Bash tools in the same response so they run in parallel. "+
+			"Commands 2 and 3 MUST use run_in_background: true.")
+	if err != nil {
+		t.Fatalf("SendMessage failed: %v", err)
+	}
+
+	events, err := CollectTurnEvents(ctx, session)
+	if err != nil {
+		t.Fatalf("CollectTurnEvents failed (session may have hung): %v", err)
+	}
+
+	if events.TurnComplete == nil {
+		t.Fatal("Expected TurnCompleteEvent — session hung or no events received")
+	}
+
+	t.Logf("Turn completed: success=%v, cost=$%.6f",
+		events.TurnComplete.Success, events.TurnComplete.Usage.CostUSD)
+
+	// Check that we had tool results with errors (cancelled bg tasks).
+	cancelledCount := 0
+	for _, tr := range events.ToolResults {
+		if tr.IsError {
+			cancelledCount++
+		}
+	}
+	t.Logf("Tool results with errors: %d", cancelledCount)
+	if cancelledCount == 0 {
+		t.Log("WARNING: No cancelled tool results — agent may not have used parallel tools. " +
+			"Test may not exercise the cancelled-bg-task path.")
+	}
+
+	t.Log("All assertions passed for Background Task Cancellation scenario")
+}
+
 // containsAny reports whether s contains any of the given substrings (case-insensitive).
 func containsAny(s string, subs ...string) bool {
 	lower := strings.ToLower(s)

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -43,37 +43,20 @@ type Session struct {
 	pendingControlResponses map[string]chan protocol.ControlResponsePayload
 	cancel                  context.CancelFunc
 
-	// bgSafetyTimer fires if a suppressed background-task turn never receives
-	// a continuation ResultMessage. Prevents indefinite blocking.
-	// Protected by mu.
-	bgSafetyTimer *time.Timer
-
 	config            SessionConfig
 	cumulativeCostUSD float64
 	mu                sync.RWMutex
+	pendingMu         sync.Mutex
+	started           bool
+	stopping          bool
 
-	// bgTaskAccumulatedUsage holds token/cost totals from intermediate
-	// ResultMessages that were suppressed due to background task continuation.
-	// These are added to the final ResultMessage's usage so callers see the
-	// full cost of the logical turn. Protected by mu.
-	bgTaskAccumulatedUsage TurnUsage
-
-	pendingMu sync.Mutex
-
-	// bgTasksPendingSinceLastResult counts successful (non-error) background
-	// task launches since the last ResultMessage. Only suppress turn completion
-	// when > 0. Cancelled/errored tool results with run_in_background are not
-	// counted because the CLI never actually launched the background task.
-	// Protected by mu.
-	bgTasksPendingSinceLastResult int
-
-	started  bool
-	stopping bool
-
-	// bgTurnSuppressionActive guards against double-completion when the
-	// safety timer and a continuation ResultMessage race.
-	// Protected by mu.
-	bgTurnSuppressionActive bool
+	// Background-task turn suppression state (all protected by mu).
+	// When a tool with run_in_background succeeds, we suppress the
+	// intermediate ResultMessage and wait for a continuation turn.
+	bgTasksPendingSinceLastResult int       // successful bg launches since last result; only suppress when > 0
+	bgTaskAccumulatedUsage        TurnUsage // token/cost totals from suppressed intermediate results
+	bgTurnSuppressionActive       bool      // guards against double-completion (timer vs normal path race)
+	bgSafetyTimer                 *time.Timer
 }
 
 // NewSession creates a new Claude session with options.
@@ -957,15 +940,16 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		result.Success = false
 	}
 
-	// Record turn completion
+	s.finalizeTurn(result)
+}
+
+// finalizeTurn records, emits, and completes the turn. Called from both the
+// normal handleResult path and the safety-timer path (completeSuppressedTurn).
+func (s *Session) finalizeTurn(result TurnResult) {
 	if s.recorder != nil {
-		s.recorder.CompleteTurn(turnNumber, result)
+		s.recorder.CompleteTurn(result.TurnNumber, result)
 	}
-
-	// Transition back to ready state
 	_ = s.state.Transition(TransitionResultReceived)
-
-	// Emit turn complete event
 	s.emit(TurnCompleteEvent{
 		TurnNumber: result.TurnNumber,
 		Success:    result.Success,
@@ -973,8 +957,6 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		Usage:      result.Usage,
 		Error:      result.Error,
 	})
-
-	// Complete turn (notifies waiters)
 	s.turnManager.CompleteTurn(result)
 }
 
@@ -992,8 +974,7 @@ func (s *Session) completeSuppressedTurn(result TurnResult) {
 	s.bgTaskAccumulatedUsage = TurnUsage{}
 	s.mu.Unlock()
 
-	// Refresh text/content from current turn state (may have been updated
-	// by streaming events from a partial continuation).
+	// Incorporate streaming updates that may have arrived before the timeout.
 	turn := s.turnManager.CurrentTurn()
 	if turn != nil {
 		result.Text = turn.FullText
@@ -1001,25 +982,7 @@ func (s *Session) completeSuppressedTurn(result TurnResult) {
 		result.ContentBlocks = turn.ContentBlocks
 	}
 
-	// Record turn completion
-	if s.recorder != nil {
-		s.recorder.CompleteTurn(result.TurnNumber, result)
-	}
-
-	// Transition back to ready state
-	_ = s.state.Transition(TransitionResultReceived)
-
-	// Emit turn complete event
-	s.emit(TurnCompleteEvent{
-		TurnNumber: result.TurnNumber,
-		Success:    result.Success,
-		DurationMs: result.DurationMs,
-		Usage:      result.Usage,
-		Error:      result.Error,
-	})
-
-	// Complete turn (notifies waiters)
-	s.turnManager.CompleteTurn(result)
+	s.finalizeTurn(result)
 }
 
 // handleControlResponse routes incoming control_response messages to the goroutine

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -233,6 +233,7 @@ func (s *Session) SendMessage(ctx context.Context, content string) (int, error) 
 	}
 
 	turn := s.turnManager.StartTurn(content)
+	s.bgTimerFired = false // clear stale timer state from previous turn
 
 	// Record turn start
 	if s.recorder != nil {
@@ -272,6 +273,7 @@ func (s *Session) SendToolResult(ctx context.Context, toolUseID, content string)
 	}
 
 	turn := s.turnManager.StartTurn(content)
+	s.bgTimerFired = false // clear stale timer state from previous turn
 
 	// Record turn start
 	if s.recorder != nil {
@@ -780,22 +782,17 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 }
 
 func (s *Session) handleResult(msg protocol.ResultMessage) {
-	// Cancel any pending background-task safety timer — a continuation
-	// ResultMessage has arrived, so the normal completion path will run.
-	// If the timer already fired and completed the turn, return early to
-	// prevent a duplicate TurnCompleteEvent.
+	// Cancel any pending background-task safety timer — a normal continuation
+	// ResultMessage has arrived, so the safety path is no longer needed.
+	// If bgTimerFired is set, the safety timer already completed this turn;
+	// return early to prevent a duplicate TurnCompleteEvent.
 	s.mu.Lock()
 	if s.bgSafetyTimer != nil {
 		s.bgSafetyTimer.Stop()
 		s.bgSafetyTimer = nil
 	}
-	// If the state is already StateReady when we enter handleResult, the
-	// safety timer already completed the turn — skip to avoid duplicating
-	// TurnCompleteEvent and recorder entries.
-	// If the safety timer already fired and completed this turn, ignore the
-	// late continuation result to prevent a duplicate TurnCompleteEvent.
 	timerAlreadyFired := s.bgTimerFired
-	s.bgTimerFired = false // reset for next turn
+	s.bgTimerFired = false // clear; also reset by SendMessage at next turn start
 	s.bgTurnSuppressionActive = false
 	s.mu.Unlock()
 	if timerAlreadyFired {
@@ -920,6 +917,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				safetyResult := result
 				s.mu.Lock()
 				s.bgTurnSuppressionActive = true
+				s.bgTimerFired = false // reset for this turn's timer
 				if s.bgSafetyTimer != nil {
 					s.bgSafetyTimer.Stop()
 				}

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -13,6 +13,12 @@ import (
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 )
 
+// defaultBgTaskSafetyTimeout is the maximum time to wait for a continuation
+// ResultMessage after suppressing a turn due to background tasks. If no
+// continuation arrives within this duration, the turn completes with
+// accumulated data to prevent indefinite blocking.
+const defaultBgTaskSafetyTimeout = 90 * time.Second
+
 // SessionInfo contains session metadata.
 type SessionInfo struct {
 	SessionID      string
@@ -36,24 +42,38 @@ type Session struct {
 	done                    chan struct{}
 	pendingControlResponses map[string]chan protocol.ControlResponsePayload
 	cancel                  context.CancelFunc
-	config                  SessionConfig
-	cumulativeCostUSD       float64
-	mu                      sync.RWMutex
-	pendingMu               sync.Mutex
-	started                 bool
-	stopping                bool
 
-	// bgTaskLaunchedSinceLastResult is set when a tool with run_in_background
-	// is observed in a tool result, causing the next result message to suppress
-	// turn completion so callers block until the background task finishes.
+	// bgSafetyTimer fires if a suppressed background-task turn never receives
+	// a continuation ResultMessage. Prevents indefinite blocking.
 	// Protected by mu.
-	bgTaskLaunchedSinceLastResult bool
+	bgSafetyTimer *time.Timer
+
+	config            SessionConfig
+	cumulativeCostUSD float64
+	mu                sync.RWMutex
 
 	// bgTaskAccumulatedUsage holds token/cost totals from intermediate
 	// ResultMessages that were suppressed due to background task continuation.
 	// These are added to the final ResultMessage's usage so callers see the
 	// full cost of the logical turn. Protected by mu.
 	bgTaskAccumulatedUsage TurnUsage
+
+	pendingMu sync.Mutex
+
+	// bgTasksPendingSinceLastResult counts successful (non-error) background
+	// task launches since the last ResultMessage. Only suppress turn completion
+	// when > 0. Cancelled/errored tool results with run_in_background are not
+	// counted because the CLI never actually launched the background task.
+	// Protected by mu.
+	bgTasksPendingSinceLastResult int
+
+	started  bool
+	stopping bool
+
+	// bgTurnSuppressionActive guards against double-completion when the
+	// safety timer and a continuation ResultMessage race.
+	// Protected by mu.
+	bgTurnSuppressionActive bool
 }
 
 // NewSession creates a new Claude session with options.
@@ -427,6 +447,11 @@ func (s *Session) Stop() error {
 		return nil
 	}
 	s.stopping = true
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop()
+		s.bgSafetyTimer = nil
+	}
+	s.bgTurnSuppressionActive = false
 	s.mu.Unlock()
 
 	// Cancel context for tool handler goroutines
@@ -734,10 +759,16 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 			// Checking tool.Input["run_in_background"] is robust against false
 			// positives from output content (e.g., git diffs containing the
 			// background task regex pattern string).
-			if tool != nil {
+			//
+			// Only count non-error results: when a parallel tool call fails, the
+			// CLI cancels sibling tools (including background ones) and returns
+			// is_error=true. Those cancelled tools never actually launched a
+			// background task, so counting them would cause the session to wait
+			// for a task-notification that will never arrive.
+			if tool != nil && !isError {
 				if rib, ok := tool.Input["run_in_background"].(bool); ok && rib {
 					s.mu.Lock()
-					s.bgTaskLaunchedSinceLastResult = true
+					s.bgTasksPendingSinceLastResult++
 					s.mu.Unlock()
 				}
 			}
@@ -762,6 +793,16 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 }
 
 func (s *Session) handleResult(msg protocol.ResultMessage) {
+	// Cancel any pending background-task safety timer — a continuation
+	// ResultMessage has arrived, so the normal completion path will run.
+	s.mu.Lock()
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop()
+		s.bgSafetyTimer = nil
+	}
+	s.bgTurnSuppressionActive = false
+	s.mu.Unlock()
+
 	turnNumber := s.turnManager.CurrentTurnNumber()
 	turn := s.turnManager.CurrentTurn()
 
@@ -815,8 +856,8 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// turn completion so callers of Ask()/WaitForTurn()/CollectResponse()
 	// block until the truly-final turn.
 	s.mu.Lock()
-	bgLaunched := s.bgTaskLaunchedSinceLastResult
-	s.bgTaskLaunchedSinceLastResult = false
+	bgPending := s.bgTasksPendingSinceLastResult
+	s.bgTasksPendingSinceLastResult = 0
 	s.mu.Unlock()
 
 	// costAccounted tracks whether cumulativeCostUSD has already been updated
@@ -824,7 +865,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// checks mid-turn; the normal path must not double-count).
 	costAccounted := false
 
-	if bgLaunched {
+	if bgPending > 0 {
 		// If the intermediate result carries an error, propagate it now rather
 		// than silently dropping it — the background task continuation will not
 		// arrive, so the session would otherwise stay stuck in StateProcessing.
@@ -869,6 +910,24 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				// Reset accumulator so the continuation turn's streaming events
 				// are processed cleanly.
 				s.accumulator.Reset()
+
+				// Start a safety timer: if no continuation ResultMessage arrives
+				// within the timeout, complete the turn with accumulated data
+				// to prevent indefinite blocking.
+				timeout := defaultBgTaskSafetyTimeout
+				if s.config.BgTaskSafetyTimeout > 0 {
+					timeout = s.config.BgTaskSafetyTimeout
+				}
+				safetyResult := result
+				s.mu.Lock()
+				s.bgTurnSuppressionActive = true
+				if s.bgSafetyTimer != nil {
+					s.bgSafetyTimer.Stop()
+				}
+				s.bgSafetyTimer = time.AfterFunc(timeout, func() {
+					s.completeSuppressedTurn(safetyResult)
+				})
+				s.mu.Unlock()
 				return
 			}
 		}
@@ -901,6 +960,50 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// Record turn completion
 	if s.recorder != nil {
 		s.recorder.CompleteTurn(turnNumber, result)
+	}
+
+	// Transition back to ready state
+	_ = s.state.Transition(TransitionResultReceived)
+
+	// Emit turn complete event
+	s.emit(TurnCompleteEvent{
+		TurnNumber: result.TurnNumber,
+		Success:    result.Success,
+		DurationMs: result.DurationMs,
+		Usage:      result.Usage,
+		Error:      result.Error,
+	})
+
+	// Complete turn (notifies waiters)
+	s.turnManager.CompleteTurn(result)
+}
+
+// completeSuppressedTurn is called by the background-task safety timer when
+// no continuation ResultMessage arrives within the timeout. It completes the
+// turn with whatever data was accumulated, preventing indefinite blocking.
+func (s *Session) completeSuppressedTurn(result TurnResult) {
+	s.mu.Lock()
+	if !s.bgTurnSuppressionActive {
+		s.mu.Unlock()
+		return // Already completed by normal path
+	}
+	s.bgTurnSuppressionActive = false
+	s.bgSafetyTimer = nil
+	s.bgTaskAccumulatedUsage = TurnUsage{}
+	s.mu.Unlock()
+
+	// Refresh text/content from current turn state (may have been updated
+	// by streaming events from a partial continuation).
+	turn := s.turnManager.CurrentTurn()
+	if turn != nil {
+		result.Text = turn.FullText
+		result.Thinking = turn.FullThinking
+		result.ContentBlocks = turn.ContentBlocks
+	}
+
+	// Record turn completion
+	if s.recorder != nil {
+		s.recorder.CompleteTurn(result.TurnNumber, result)
 	}
 
 	// Transition back to ready state

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -233,7 +233,15 @@ func (s *Session) SendMessage(ctx context.Context, content string) (int, error) 
 	}
 
 	turn := s.turnManager.StartTurn(content)
-	s.bgTimerFired = false // clear stale timer state from previous turn
+	// Clear any stale background-task suppression state from the previous turn.
+	// A safety timer for Turn N must not fire after Turn N+1 has started.
+	s.bgTimerFired = false
+	s.bgTurnSuppressionActive = false
+	s.bgTasksPendingSinceLastResult = 0
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop()
+		s.bgSafetyTimer = nil
+	}
 
 	// Record turn start
 	if s.recorder != nil {
@@ -273,7 +281,14 @@ func (s *Session) SendToolResult(ctx context.Context, toolUseID, content string)
 	}
 
 	turn := s.turnManager.StartTurn(content)
-	s.bgTimerFired = false // clear stale timer state from previous turn
+	// Clear any stale background-task suppression state from the previous turn.
+	s.bgTimerFired = false
+	s.bgTurnSuppressionActive = false
+	s.bgTasksPendingSinceLastResult = 0
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop()
+		s.bgSafetyTimer = nil
+	}
 
 	// Record turn start
 	if s.recorder != nil {

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -29,10 +29,14 @@ type SessionInfo struct {
 }
 
 // Session manages interaction with the Claude CLI.
+//
+// Field ordering follows the fieldalignment rule: pointer/interface fields
+// first (minimises GC pointer bitmap), then value types, then small scalars.
 type Session struct {
+	// Pointer / interface / channel fields (all 8-16 bytes, contain pointers).
 	ctx                     context.Context
-	events                  chan Event
-	recorder                *sessionRecorder
+	pendingControlResponses map[string]chan protocol.ControlResponsePayload
+	bgSafetyTimer           *time.Timer // fires if no bg-task continuation arrives; see completeSuppressedTurn
 	accumulator             *streamAccumulator
 	turnManager             *turnManager
 	permissionManager       *permissionManager
@@ -40,23 +44,23 @@ type Session struct {
 	process                 *processManager
 	info                    *SessionInfo
 	done                    chan struct{}
-	pendingControlResponses map[string]chan protocol.ControlResponsePayload
+	events                  chan Event
+	recorder                *sessionRecorder
 	cancel                  context.CancelFunc
 
-	config            SessionConfig
-	cumulativeCostUSD float64
-	mu                sync.RWMutex
-	pendingMu         sync.Mutex
-	started           bool
-	stopping          bool
+	// Value / struct fields.
+	config                 SessionConfig
+	bgTaskAccumulatedUsage TurnUsage // token/cost totals from suppressed intermediate results; protected by mu
+	cumulativeCostUSD      float64
 
-	// Background-task turn suppression state (all protected by mu).
-	// When a tool with run_in_background succeeds, we suppress the
-	// intermediate ResultMessage and wait for a continuation turn.
-	bgTasksPendingSinceLastResult int       // successful bg launches since last result; only suppress when > 0
-	bgTaskAccumulatedUsage        TurnUsage // token/cost totals from suppressed intermediate results
-	bgTurnSuppressionActive       bool      // guards against double-completion (timer vs normal path race)
-	bgSafetyTimer                 *time.Timer
+	// Scalar and sync fields.
+	bgTasksPendingSinceLastResult int // successful bg launches since last result; protected by mu
+	mu                            sync.RWMutex
+	pendingMu                     sync.Mutex
+	bgTurnSuppressionActive       bool // true while waiting for continuation; cleared by timer or normal path
+	bgTimerFired                  bool // set by completeSuppressedTurn; cleared at start of next turn
+	started                       bool
+	stopping                      bool
 }
 
 // NewSession creates a new Claude session with options.
@@ -778,13 +782,25 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// Cancel any pending background-task safety timer — a continuation
 	// ResultMessage has arrived, so the normal completion path will run.
+	// If the timer already fired and completed the turn, return early to
+	// prevent a duplicate TurnCompleteEvent.
 	s.mu.Lock()
 	if s.bgSafetyTimer != nil {
 		s.bgSafetyTimer.Stop()
 		s.bgSafetyTimer = nil
 	}
+	// If the state is already StateReady when we enter handleResult, the
+	// safety timer already completed the turn — skip to avoid duplicating
+	// TurnCompleteEvent and recorder entries.
+	// If the safety timer already fired and completed this turn, ignore the
+	// late continuation result to prevent a duplicate TurnCompleteEvent.
+	timerAlreadyFired := s.bgTimerFired
+	s.bgTimerFired = false // reset for next turn
 	s.bgTurnSuppressionActive = false
 	s.mu.Unlock()
+	if timerAlreadyFired {
+		return
+	}
 
 	turnNumber := s.turnManager.CurrentTurnNumber()
 	turn := s.turnManager.CurrentTurn()
@@ -970,6 +986,7 @@ func (s *Session) completeSuppressedTurn(result TurnResult) {
 		return // Already completed by normal path
 	}
 	s.bgTurnSuppressionActive = false
+	s.bgTimerFired = true
 	s.bgSafetyTimer = nil
 	s.bgTaskAccumulatedUsage = TurnUsage{}
 	s.mu.Unlock()

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -794,10 +794,14 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	timerAlreadyFired := s.bgTimerFired
 	s.bgTimerFired = false // clear; also reset by SendMessage at next turn start
 	s.bgTurnSuppressionActive = false
-	s.mu.Unlock()
 	if timerAlreadyFired {
+		// The safety timer already finalized this turn. Clear any pending counter
+		// so it does not incorrectly suppress the next turn's result.
+		s.bgTasksPendingSinceLastResult = 0
+		s.mu.Unlock()
 		return
 	}
+	s.mu.Unlock()
 
 	turnNumber := s.turnManager.CurrentTurnNumber()
 	turn := s.turnManager.CurrentTurn()
@@ -987,11 +991,14 @@ func (s *Session) completeSuppressedTurn(result TurnResult) {
 	s.bgTimerFired = true
 	s.bgSafetyTimer = nil
 	s.bgTaskAccumulatedUsage = TurnUsage{}
+	s.bgTasksPendingSinceLastResult = 0 // clear stale counter; no continuation will arrive
 	s.mu.Unlock()
 
-	// Incorporate streaming updates that may have arrived before the timeout.
+	// Incorporate streaming updates from the correct turn only. Guard with
+	// TurnNumber to avoid cross-contaminating with a new turn that may have
+	// started between the lock release above and this read.
 	turn := s.turnManager.CurrentTurn()
-	if turn != nil {
+	if turn != nil && turn.Number == result.TurnNumber {
 		result.Text = turn.FullText
 		result.Thinking = turn.FullThinking
 		result.ContentBlocks = turn.ContentBlocks

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -59,7 +59,8 @@ func newTestSession(t *testing.T, opts ...SessionOption) *Session {
 		done:        make(chan struct{}),
 	}
 	s.accumulator = newStreamAccumulator(s)
-	// Transition to ready so handleResult can transition back.
+	// Transition to StateReady so handleResult can transition back via TransitionResultReceived.
+	_ = s.state.Transition(TransitionStarted)
 	_ = s.state.Transition(TransitionInitReceived)
 	return s
 }
@@ -229,6 +230,53 @@ func TestBgTask_SafetyTimeoutCompletesTurn(t *testing.T) {
 
 	// Wait for the safety timer to fire and complete the turn.
 	waitForTurnComplete(t, s.events, 2*time.Second)
+}
+
+func TestBgTask_SafetyTimerPreventsLateResultDoubleCompletion(t *testing.T) {
+	// When the safety timer fires and completes the turn, a late continuation
+	// ResultMessage must be ignored — not emit a second TurnCompleteEvent.
+	s := newTestSession(t, WithBgTaskSafetyTimeout(100*time.Millisecond))
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 60", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{Type: "result", IsError: false}
+	s.handleResult(resultMsg)
+
+	// Wait for the safety timer to fire.
+	waitForTurnComplete(t, s.events, 2*time.Second)
+
+	// Simulate a late continuation result arriving after the timer completed the turn.
+	// This should be a no-op; no second TurnCompleteEvent should be emitted.
+	// The session state is now StateReady, so handleResult should return early.
+	s.handleResult(resultMsg)
+
+	// Drain events for a short window; must see at most one TurnCompleteEvent total.
+	count := 0
+	deadline := time.After(200 * time.Millisecond)
+drain:
+	for {
+		select {
+		case event := <-s.events:
+			if _, ok := event.(TurnCompleteEvent); ok {
+				count++
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+	if count > 0 {
+		t.Errorf("expected no additional TurnCompleteEvent after safety timer already completed the turn, got %d", count)
+	}
 }
 
 func TestBgTask_MixedSuccessAndCancelled(t *testing.T) {

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -299,13 +299,19 @@ func TestBgTask_SafetyTimerDoesNotPoisonNextTurn(t *testing.T) {
 	resultMsg := protocol.ResultMessage{Type: "result", IsError: false}
 	s.handleResult(resultMsg)
 
-	// Wait for safety timer to fire.
+	// Wait for safety timer to fire — Turn N is now complete.
 	waitForTurnComplete(t, s.events, 2*time.Second)
 
-	// No late continuation arrives (timer already handled it).
-	// Simulate start of Turn N+1: reset bgTimerFired as SendMessage would.
+	// Simulate Turn N+1 starting (replicates what SendMessage does):
+	// clear all stale suppression state so the old timer cannot fire again.
 	s.mu.Lock()
 	s.bgTimerFired = false
+	s.bgTurnSuppressionActive = false
+	s.bgTasksPendingSinceLastResult = 0
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop()
+		s.bgSafetyTimer = nil
+	}
 	s.mu.Unlock()
 
 	// Turn N+1: transition to processing and deliver a result.
@@ -314,6 +320,71 @@ func TestBgTask_SafetyTimerDoesNotPoisonNextTurn(t *testing.T) {
 	s.handleResult(resultMsg)
 
 	waitForTurnComplete(t, s.events, time.Second)
+}
+
+func TestBgTask_OldTimerCannotPoisonNextTurnAfterSendMessage(t *testing.T) {
+	// Validate that SendMessage correctly stops the old timer and clears
+	// bgTurnSuppressionActive, so even if the timer fires after SendMessage
+	// completes, it cannot set bgTimerFired and drop the new turn's result.
+	//
+	// Sequence:
+	//   1. Turn N suppressed, timer armed.
+	//   2. SendMessage starts Turn N+1 (clears bgTurnSuppressionActive, stops timer).
+	//   3. Old timer closure fires — completeSuppressedTurn sees bgTurnSuppressionActive=false, returns.
+	//   4. Turn N+1 handleResult must complete normally.
+	s := newTestSession(t, WithBgTaskSafetyTimeout(200*time.Millisecond))
+
+	// Turn N: suppress.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 60", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{Type: "result", IsError: false}
+	s.handleResult(resultMsg)
+
+	// Verify suppression is active.
+	s.mu.RLock()
+	suppActive := s.bgTurnSuppressionActive
+	s.mu.RUnlock()
+	if !suppActive {
+		t.Fatal("expected bgTurnSuppressionActive to be true after suppression started")
+	}
+
+	// Simulate SendMessage for Turn N+1: clear all stale state and stop the old timer.
+	s.mu.Lock()
+	s.bgTimerFired = false
+	s.bgTurnSuppressionActive = false
+	s.bgTasksPendingSinceLastResult = 0
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop() // stops the real timer
+		s.bgSafetyTimer = nil
+	}
+	s.mu.Unlock()
+
+	// Wait longer than the timer would have fired (200ms), ensuring no late fire.
+	time.Sleep(300 * time.Millisecond)
+
+	// Turn N+1's handleResult: must complete the turn, not be silently dropped.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(resultMsg)
+
+	waitForTurnComplete(t, s.events, time.Second)
+
+	// Ensure bgTimerFired was not set by the old timer closure.
+	s.mu.RLock()
+	timerFired := s.bgTimerFired
+	s.mu.RUnlock()
+	if timerFired {
+		t.Error("bgTimerFired should be false — old timer should have been stopped by SendMessage")
+	}
 }
 
 func TestBgTask_MixedSuccessAndCancelled(t *testing.T) {

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1,0 +1,267 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
+)
+
+// waitForTurnComplete drains events from the channel until a TurnCompleteEvent
+// is found or the timeout expires.
+func waitForTurnComplete(t *testing.T, events <-chan Event, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case event := <-events:
+			if _, ok := event.(TurnCompleteEvent); ok {
+				return
+			}
+			// Keep draining other events (CLIToolResultEvent, etc.).
+		case <-deadline:
+			t.Fatal("turn did not complete — TurnCompleteEvent not emitted within timeout")
+		}
+	}
+}
+
+// makeFlexibleContent marshals v into a FlexibleContent.
+func makeFlexibleContent(t *testing.T, v interface{}) protocol.FlexibleContent {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fc protocol.FlexibleContent
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatal(err)
+	}
+	return fc
+}
+
+// newTestSession creates a minimal Session suitable for unit-testing
+// handleUser/handleResult without a real process. The session's state
+// machine and turn manager are initialised so the result-handling code
+// path works.
+func newTestSession(t *testing.T, opts ...SessionOption) *Session {
+	t.Helper()
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+	s := &Session{
+		config:      cfg,
+		events:      make(chan Event, 100),
+		turnManager: newTurnManager(),
+		state:       newSessionState(),
+		accumulator: nil, // set below
+		done:        make(chan struct{}),
+	}
+	s.accumulator = newStreamAccumulator(s)
+	// Transition to ready so handleResult can transition back.
+	_ = s.state.Transition(TransitionInitReceived)
+	return s
+}
+
+// simulateAssistantToolUse registers tool_use blocks with the session so
+// that handleUser can look them up via FindToolByID.
+func simulateAssistantToolUse(s *Session, tools []protocol.ToolUseBlock) {
+	// Start a turn and register each tool.
+	s.turnManager.StartTurn("test")
+	for _, tb := range tools {
+		tool := s.turnManager.GetOrCreateTool(tb.ID, tb.Name)
+		tool.Input = tb.Input
+	}
+}
+
+// simulateUserToolResults calls handleUser with a UserMessage containing
+// the given tool_result blocks.
+func simulateUserToolResults(t *testing.T, s *Session, results []protocol.ToolResultBlock) {
+	t.Helper()
+	// Convert to ContentBlock slice for JSON serialization.
+	var blocks []interface{}
+	for _, r := range results {
+		blocks = append(blocks, map[string]interface{}{
+			"type":        "tool_result",
+			"tool_use_id": r.ToolUseID,
+			"content":     r.Content,
+			"is_error":    r.IsError,
+		})
+	}
+	msg := protocol.UserMessage{
+		Message: protocol.MessageContent{
+			Role:    "user",
+			Content: makeFlexibleContent(t, blocks),
+		},
+	}
+	s.handleUser(msg)
+}
+
+func TestBgTask_CancelledToolsDoNotSuppressTurn(t *testing.T) {
+	s := newTestSession(t)
+
+	// Simulate 3 parallel tool_use blocks: first has no bg, second and third have bg.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "exit 1"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "echo bg2", "run_in_background": true}},
+		{ID: "tool-3", Name: "Bash", Input: map[string]interface{}{"command": "echo bg3", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	// Simulate tool results: tool-1 errors, tool-2 and tool-3 are cancelled (is_error=true).
+	isErrTrue := true
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "exit code 1", IsError: &isErrTrue},
+		{ToolUseID: "tool-2", Content: "Cancelled: parallel tool call errored", IsError: &isErrTrue},
+		{ToolUseID: "tool-3", Content: "Cancelled: parallel tool call errored", IsError: &isErrTrue},
+	}
+	simulateUserToolResults(t, s, results)
+
+	// The counter should be 0: cancelled bg tools should not be counted.
+	s.mu.RLock()
+	pending := s.bgTasksPendingSinceLastResult
+	s.mu.RUnlock()
+
+	if pending != 0 {
+		t.Errorf("expected bgTasksPendingSinceLastResult=0, got %d", pending)
+	}
+
+	// Now simulate handleResult — should complete the turn normally, not suppress.
+	// Transition to processing first.
+	_ = s.state.Transition(TransitionUserMessageSent)
+
+	resultMsg := protocol.ResultMessage{
+		Type:    "result",
+		IsError: false,
+	}
+	s.handleResult(resultMsg)
+
+	// Verify TurnCompleteEvent was emitted (drain other events first).
+	waitForTurnComplete(t, s.events, time.Second)
+}
+
+func TestBgTask_SuccessfulBgToolSuppressesTurn(t *testing.T) {
+	s := newTestSession(t)
+
+	// Simulate a successful bg tool.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 2 && echo done", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	s.mu.RLock()
+	pending := s.bgTasksPendingSinceLastResult
+	s.mu.RUnlock()
+
+	if pending != 1 {
+		t.Errorf("expected bgTasksPendingSinceLastResult=1, got %d", pending)
+	}
+
+	// handleResult should suppress the turn (no TurnCompleteEvent).
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{
+		Type:    "result",
+		IsError: false,
+	}
+	s.handleResult(resultMsg)
+
+	// Should NOT get a TurnCompleteEvent (turn is suppressed).
+	select {
+	case event := <-s.events:
+		if _, ok := event.(TurnCompleteEvent); ok {
+			t.Error("TurnCompleteEvent should NOT have been emitted — turn should be suppressed for bg task")
+		}
+	case <-time.After(100 * time.Millisecond):
+		// Good — no event, turn is suppressed as expected.
+	}
+
+	// Verify safety timer is active.
+	s.mu.RLock()
+	timerActive := s.bgSafetyTimer != nil
+	suppActive := s.bgTurnSuppressionActive
+	s.mu.RUnlock()
+
+	if !timerActive {
+		t.Error("expected bgSafetyTimer to be active")
+	}
+	if !suppActive {
+		t.Error("expected bgTurnSuppressionActive to be true")
+	}
+
+	// Clean up: stop the safety timer to avoid leaks.
+	s.mu.Lock()
+	if s.bgSafetyTimer != nil {
+		s.bgSafetyTimer.Stop()
+	}
+	s.mu.Unlock()
+}
+
+func TestBgTask_SafetyTimeoutCompletesTurn(t *testing.T) {
+	// Use a very short safety timeout.
+	s := newTestSession(t, WithBgTaskSafetyTimeout(200*time.Millisecond))
+
+	// Simulate a successful bg tool.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 60", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	// handleResult should suppress the turn.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{
+		Type:    "result",
+		IsError: false,
+	}
+	s.handleResult(resultMsg)
+
+	// Wait for the safety timer to fire and complete the turn.
+	waitForTurnComplete(t, s.events, 2*time.Second)
+}
+
+func TestBgTask_MixedSuccessAndCancelled(t *testing.T) {
+	s := newTestSession(t)
+
+	// Simulate 3 bg tools: one succeeds, two are cancelled.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "echo ok", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "echo bg2", "run_in_background": true}},
+		{ID: "tool-3", Name: "Bash", Input: map[string]interface{}{"command": "echo bg3", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	isErrTrue := true
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+		{ToolUseID: "tool-2", Content: "Cancelled", IsError: &isErrTrue},
+		{ToolUseID: "tool-3", Content: "Cancelled", IsError: &isErrTrue},
+	}
+	simulateUserToolResults(t, s, results)
+
+	// Only tool-1 should be counted.
+	s.mu.RLock()
+	pending := s.bgTasksPendingSinceLastResult
+	s.mu.RUnlock()
+
+	if pending != 1 {
+		t.Errorf("expected bgTasksPendingSinceLastResult=1 (only non-error bg tool), got %d", pending)
+	}
+
+	// Clean up.
+	s.mu.Lock()
+	s.bgTasksPendingSinceLastResult = 0
+	s.mu.Unlock()
+}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -256,8 +256,7 @@ func TestBgTask_SafetyTimerPreventsLateResultDoubleCompletion(t *testing.T) {
 	waitForTurnComplete(t, s.events, 2*time.Second)
 
 	// Simulate a late continuation result arriving after the timer completed the turn.
-	// This should be a no-op; no second TurnCompleteEvent should be emitted.
-	// The session state is now StateReady, so handleResult should return early.
+	// handleResult must detect bgTimerFired and return early — no second TurnCompleteEvent.
 	s.handleResult(resultMsg)
 
 	// Drain events for a short window; must see at most one TurnCompleteEvent total.
@@ -277,6 +276,44 @@ drain:
 	if count > 0 {
 		t.Errorf("expected no additional TurnCompleteEvent after safety timer already completed the turn, got %d", count)
 	}
+}
+
+func TestBgTask_SafetyTimerDoesNotPoisonNextTurn(t *testing.T) {
+	// When the safety timer fires and no late continuation arrives,
+	// the NEXT turn's handleResult must still work correctly.
+	s := newTestSession(t, WithBgTaskSafetyTimeout(100*time.Millisecond))
+
+	// Turn N: set up a suppressed bg turn.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 60", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{Type: "result", IsError: false}
+	s.handleResult(resultMsg)
+
+	// Wait for safety timer to fire.
+	waitForTurnComplete(t, s.events, 2*time.Second)
+
+	// No late continuation arrives (timer already handled it).
+	// Simulate start of Turn N+1: reset bgTimerFired as SendMessage would.
+	s.mu.Lock()
+	s.bgTimerFired = false
+	s.mu.Unlock()
+
+	// Turn N+1: transition to processing and deliver a result.
+	// This must produce a TurnCompleteEvent — not be silently dropped.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(resultMsg)
+
+	waitForTurnComplete(t, s.events, time.Second)
 }
 
 func TestBgTask_MixedSuccessAndCancelled(t *testing.T) {

--- a/agent-cli-wrapper/claude/session_options.go
+++ b/agent-cli-wrapper/claude/session_options.go
@@ -1,5 +1,7 @@
 package claude
 
+import "time"
+
 // PermissionMode controls tool execution approval.
 type PermissionMode string
 
@@ -52,6 +54,7 @@ type SessionConfig struct {
 	RecordMessages             bool
 	DangerouslySkipPermissions bool
 	PermissionPromptToolStdio  bool
+	BgTaskSafetyTimeout        time.Duration // 0 means use default (90s)
 }
 
 // SessionOption is a functional option for configuring a Session.
@@ -256,6 +259,14 @@ func WithTools(tools string) SessionOption {
 func WithExtraArgs(args ...string) SessionOption {
 	return func(c *SessionConfig) {
 		c.ExtraArgs = args
+	}
+}
+
+// WithBgTaskSafetyTimeout overrides the default safety timeout for background
+// task turn suppression. Useful for testing. 0 means use the default (90s).
+func WithBgTaskSafetyTimeout(d time.Duration) SessionOption {
+	return func(c *SessionConfig) {
+		c.BgTaskSafetyTimeout = d
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix session hanging indefinitely when parallel Bash tool calls with `run_in_background: true` are cancelled by the CLI due to a sibling tool failure
- Change `bgTaskLaunchedSinceLastResult` bool → `bgTasksPendingSinceLastResult` int counter, only counting non-error tool results
- Add 90s safety timeout (`completeSuppressedTurn`) as defense-in-depth against unknown edge cases
- Add `WithBgTaskSafetyTimeout()` session option for test configurability

**Root cause**: When the CLI cancels parallel bg tools (`is_error=true`), the SDK still detected `run_in_background: true` in their input and suppressed turn completion, waiting for task-notifications that would never arrive. Diagnosed from session log `5c423688` where jiradozer's validate step hung after `ruff check` failed and sibling bramble review bg tasks were cancelled.

## Test plan

- [x] 4 unit tests in `session_bg_test.go`: cancelled bg tools, successful bg suppression, safety timeout, mixed success/cancelled
- [x] Integration test `TestSession_Integration_BackgroundTaskCancelled`: real CLI with parallel tool failure
- [x] Existing `TestSession_Integration_BackgroundTask` still passes (happy path)
- [x] `scripts/lint.sh` passes
- [x] `bazel test //agent-cli-wrapper/claude/...` passes (125 unit tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core turn-completion logic by adding new background-task suppression state and a timer-based fallback, which could alter event ordering or prematurely complete turns if the timeout is mis-set. Mitigated by added unit + integration coverage around cancellation, late results, and next-turn interactions.
> 
> **Overview**
> Prevents `Session` turns from hanging indefinitely when parallel tool calls fail and the CLI cancels sibling `run_in_background` tools (no task-notifications will arrive), by only treating **non-error** tool results as background-task launches.
> 
> Adds a **background-task safety timeout** (default 90s, configurable via `WithBgTaskSafetyTimeout`) that finalizes a suppressed turn if no continuation `ResultMessage` arrives, plus guards to avoid double `TurnCompleteEvent` emission and to ensure old timers/state cannot affect subsequent turns. New unit tests (`session_bg_test.go`) and an integration scenario cover cancelled background tasks and the timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1560b4a0d855754642b0f9d06fe0242f16fcd522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->