### PR TITLE
jiradozer: add dual-write session logging and improve log SNR

### DIFF
--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -147,6 +147,7 @@ func RunCommand(ctx context.Context, stepName string, data PromptData, commandTm
 	out, err := cmd.CombinedOutput()
 	output := string(out)
 	if err != nil {
+		logger.Info("command failed", "step", stepName, "duration", time.Since(start), "error", err)
 		return output, fmt.Errorf("command failed: %w", err)
 	}
 
@@ -248,7 +249,7 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 		logAttrs = append(logAttrs, "resume_session_id", resumeSessionID)
 	}
 	logger.Info("running agent", logAttrs...)
-	logger.Debug("agent prompt", "step", stepName, "prompt", prompt)
+	logger.Debug("agent prompt", "step", stepName, "prompt", truncate(prompt, 500))
 
 	handler := &logEventHandler{logger: logger, step: stepName}
 	var opts []agent.ExecuteOption

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 	"github.com/bazelment/yoloswe/multiagent/agent"
@@ -140,6 +141,7 @@ func RunCommand(ctx context.Context, stepName string, data PromptData, commandTm
 
 	logger.Info("running command", "step", stepName, "command", truncate(rendered, 200), "work_dir", workDir)
 
+	start := time.Now()
 	cmd := exec.CommandContext(ctx, "sh", "-c", rendered)
 	cmd.Dir = workDir
 	out, err := cmd.CombinedOutput()
@@ -148,7 +150,7 @@ func RunCommand(ctx context.Context, stepName string, data PromptData, commandTm
 		return output, fmt.Errorf("command failed: %w", err)
 	}
 
-	logger.Info("command completed", "step", stepName, "output", truncate(output, 200))
+	logger.Info("command completed", "step", stepName, "duration", time.Since(start), "output", truncate(output, 200))
 	return output, nil
 }
 
@@ -236,15 +238,17 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	}
 	defer provider.Close()
 
-	logger.Info("running agent",
+	logAttrs := []any{
 		"step", stepName,
 		"mode", cfg.PermissionMode,
 		"model", cfg.Model,
 		"work_dir", workDir,
-		"resume", resumeSessionID != "",
-	)
+	}
+	if resumeSessionID != "" {
+		logAttrs = append(logAttrs, "resume_session_id", resumeSessionID)
+	}
+	logger.Info("running agent", logAttrs...)
 	logger.Debug("agent prompt", "step", stepName, "prompt", prompt)
-	logger.Info("agent prompt", "step", stepName, "prompt", truncate(prompt, 200))
 
 	handler := &logEventHandler{logger: logger, step: stepName}
 	var opts []agent.ExecuteOption
@@ -281,13 +285,14 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 
 	logger.Info("agent completed",
 		"step", stepName,
-		"mode", cfg.PermissionMode,
+		"session_id", result.SessionID,
 		"input_tokens", result.Usage.InputTokens,
 		"output_tokens", result.Usage.OutputTokens,
 		"cost_usd", result.Usage.CostUSD,
+		"duration_ms", result.DurationMs,
 	)
 	if result.Text != "" {
-		logger.Info("agent response", "step", stepName, "response", truncate(result.Text, 100))
+		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))
 	}
 
 	output := resolveOutput(result.Text, handler, logger)
@@ -304,7 +309,7 @@ func resolveOutput(agentText string, handler *logEventHandler, logger *slog.Logg
 		logger.Warn("could not read plan file, using agent text output", "path", handler.planFilePath, "error", err)
 		return agentText
 	}
-	logger.Info("using plan file content", "path", handler.planFilePath)
+	logger.Debug("using plan file content", "path", handler.planFilePath)
 	return string(planContent)
 }
 
@@ -343,7 +348,7 @@ func PersistPlan(workDir, output string, logger *slog.Logger) {
 	} else if err := os.WriteFile(planPath, []byte(output), 0o644); err != nil {
 		logger.Warn("failed to persist plan", "error", err)
 	} else {
-		logger.Info("persisted plan to disk", "path", planPath)
+		logger.Debug("persisted plan to disk", "path", planPath)
 	}
 }
 

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "jiradozer_lib",
@@ -24,4 +24,11 @@ go_binary(
     name = "jiradozer",
     embed = [":jiradozer_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "jiradozer_test",
+    srcs = ["main_test.go"],
+    embed = [":jiradozer_lib"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -581,7 +581,7 @@ func availableModels() string {
 }
 
 // sensitiveFlags lists flag prefixes whose values should be redacted from logs.
-var sensitiveFlags = []string{"--api-key", "--token", "--secret", "--password"}
+var sensitiveFlags = []string{"--api-key", "--token", "--secret", "--password", "--description"}
 
 // redactArgs returns a copy of args with values of sensitive flags replaced by "***".
 func redactArgs(args []string) []string {

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -142,12 +142,14 @@ func run(ctx context.Context, args runArgs) error {
 		}
 	} else {
 		klogfmt.Init(klogfmt.WithLevel(level))
+		slog.Warn("could not determine home directory, logging to stderr only", "error", err)
 	}
 	logger := slog.Default()
 
 	// Log invocation banner with CLI args and working directory.
+	// Redact values of flags that may contain secrets.
 	cwd, _ := os.Getwd()
-	logger.Info("jiradozer starting", "args", os.Args[1:], "cwd", cwd, "pid", os.Getpid())
+	logger.Info("jiradozer starting", "args", redactArgs(os.Args[1:]), "cwd", cwd, "pid", os.Getpid())
 
 	// Resolve --description-file into --description.
 	if args.descriptionFile != "" {
@@ -576,4 +578,28 @@ func availableModels() string {
 		names = append(names, m.ID)
 	}
 	return fmt.Sprintf("[%s]", strings.Join(names, ", "))
+}
+
+// sensitiveFlags lists flag prefixes whose values should be redacted from logs.
+var sensitiveFlags = []string{"--api-key", "--token", "--secret", "--password"}
+
+// redactArgs returns a copy of args with values of sensitive flags replaced by "***".
+func redactArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i, arg := range out {
+		for _, prefix := range sensitiveFlags {
+			// --flag=value form
+			if strings.HasPrefix(arg, prefix+"=") {
+				out[i] = prefix + "=***"
+				break
+			}
+			// --flag value form: redact the next arg
+			if arg == prefix && i+1 < len(out) {
+				out[i+1] = "***"
+				break
+			}
+		}
+	}
+	return out
 }

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -124,13 +124,30 @@ type runArgs struct {
 }
 
 func run(ctx context.Context, args runArgs) error {
-	// Set up logger.
+	// Set up logger with dual-write to stderr + log file.
 	level := slog.LevelInfo
 	if args.verbose {
 		level = slog.LevelDebug
 	}
-	klogfmt.Init(klogfmt.WithLevel(level))
+	if home, err := os.UserHomeDir(); err == nil {
+		logDir := filepath.Join(home, ".jiradozer", "logs")
+		logFile := filepath.Join(logDir, fmt.Sprintf("jiradozer-%s-%d.log",
+			time.Now().Format("20060102-150405"), os.Getpid()))
+		closer, err := klogfmt.InitWithLogFile(logFile, klogfmt.WithLevel(level))
+		if err != nil {
+			klogfmt.Init(klogfmt.WithLevel(level))
+			slog.Warn("failed to open log file, logging to stderr only", "path", logFile, "error", err)
+		} else {
+			defer closer()
+		}
+	} else {
+		klogfmt.Init(klogfmt.WithLevel(level))
+	}
 	logger := slog.Default()
+
+	// Log invocation banner with CLI args and working directory.
+	cwd, _ := os.Getwd()
+	logger.Info("jiradozer starting", "args", os.Args[1:], "cwd", cwd, "pid", os.Getpid())
 
 	// Resolve --description-file into --description.
 	if args.descriptionFile != "" {

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "no sensitive flags",
+			args: []string{"--issue", "ENG-123", "--verbose"},
+			want: []string{"--issue", "ENG-123", "--verbose"},
+		},
+		{
+			name: "api-key equals form",
+			args: []string{"--api-key=sk-secret123", "--verbose"},
+			want: []string{"--api-key=***", "--verbose"},
+		},
+		{
+			name: "api-key space form",
+			args: []string{"--api-key", "sk-secret123", "--verbose"},
+			want: []string{"--api-key", "***", "--verbose"},
+		},
+		{
+			name: "description redacted",
+			args: []string{"--description", "my secret plan", "--verbose"},
+			want: []string{"--description", "***", "--verbose"},
+		},
+		{
+			name: "description equals form",
+			args: []string{"--description=my secret plan"},
+			want: []string{"--description=***"},
+		},
+		{
+			name: "multiple sensitive flags",
+			args: []string{"--token", "tok123", "--password=hunter2"},
+			want: []string{"--token", "***", "--password=***"},
+		},
+		{
+			name: "sensitive flag at end without value",
+			args: []string{"--verbose", "--api-key"},
+			want: []string{"--verbose", "--api-key"},
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactArgs(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -126,7 +126,6 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		case StepShipReview:
 			w.runReview(ctx, StepDone, StepShipping)
 		case StepDone:
-			w.logger.Info("workflow completed successfully")
 			if id, ok := w.stateIDs[stateKeyDone]; ok {
 				if err := w.tracker.UpdateIssueState(ctx, w.issue.ID, id); err != nil {
 					w.logger.Warn("failed to update issue state to done", "error", err)

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -52,7 +52,7 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 }
 
 // Run executes the workflow loop until completion or failure.
-func (w *Workflow) Run(ctx context.Context) error {
+func (w *Workflow) Run(ctx context.Context) (runErr error) {
 	w.logger.Info("workflow starting",
 		"issue", w.issue.Identifier,
 		"title", w.issue.Title,
@@ -64,11 +64,11 @@ func (w *Workflow) Run(ctx context.Context) error {
 	defer func() {
 		finalStep := w.state.Current().String()
 		duration := time.Since(workflowStart)
-		if w.lastError != nil {
+		if runErr != nil {
 			w.logger.Error("workflow finished",
 				"issue", w.issue.Identifier,
 				"final_step", finalStep,
-				"error", w.lastError,
+				"error", runErr,
 				"duration", duration,
 				"transitions", len(w.state.History()),
 			)
@@ -134,7 +134,6 @@ func (w *Workflow) Run(ctx context.Context) error {
 			}
 			return nil
 		case StepFailed:
-			w.logger.Error("workflow failed", "error", w.lastError)
 			return w.lastError
 		default:
 			return fmt.Errorf("workflow reached unexpected state: %s", w.state.Current())
@@ -172,6 +171,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 
 	data := w.promptData()
 	var allOutputs []string
+	var roundSessionIDs []string
 	feedbackInjected := false
 	for i, round := range stepCfg.Rounds {
 		if ctx.Err() != nil {
@@ -199,7 +199,11 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 				roundFeedback = feedback
 				feedbackInjected = true
 			}
-			output, _, err = w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.logger)
+			var roundSessionID string
+			output, roundSessionID, err = w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.logger)
+			if roundSessionID != "" {
+				roundSessionIDs = append(roundSessionIDs, roundSessionID)
+			}
 			if err != nil {
 				w.fail(ctx, fmt.Errorf("%s round %d/%d: %w", stepName, i+1, totalRounds, err))
 				return
@@ -238,7 +242,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 			nonEmpty = append(nonEmpty, o)
 		}
 	}
-	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "duration", time.Since(stepStart))
+	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "session_ids", roundSessionIDs, "duration", time.Since(stepStart))
 	w.captureOutput(stepName, strings.Join(nonEmpty, "\n\n---\n\n"))
 	w.transitionToReview(ctx, reviewStep, trigger)
 }

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -53,6 +53,35 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 
 // Run executes the workflow loop until completion or failure.
 func (w *Workflow) Run(ctx context.Context) error {
+	w.logger.Info("workflow starting",
+		"issue", w.issue.Identifier,
+		"title", w.issue.Title,
+		"model", w.config.Agent.Model,
+		"work_dir", w.config.WorkDir,
+		"base_branch", w.config.BaseBranch,
+	)
+	workflowStart := time.Now()
+	defer func() {
+		finalStep := w.state.Current().String()
+		duration := time.Since(workflowStart)
+		if w.lastError != nil {
+			w.logger.Error("workflow finished",
+				"issue", w.issue.Identifier,
+				"final_step", finalStep,
+				"error", w.lastError,
+				"duration", duration,
+				"transitions", len(w.state.History()),
+			)
+		} else {
+			w.logger.Info("workflow finished",
+				"issue", w.issue.Identifier,
+				"final_step", finalStep,
+				"duration", duration,
+				"transitions", len(w.state.History()),
+			)
+		}
+	}()
+
 	// Resolve workflow state names to IDs.
 	if err := w.resolveStateIDs(ctx); err != nil {
 		return fmt.Errorf("resolve workflow states: %w", err)
@@ -138,7 +167,8 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 	feedback := w.feedback
 	w.feedback = ""
 
-	w.logger.Info("step: "+stepName, "rounds", totalRounds, "feedback", feedback != "")
+	w.logger.Info("step: "+stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "feedback", feedback != "")
+	stepStart := time.Now()
 
 	data := w.promptData()
 	var allOutputs []string
@@ -208,6 +238,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 			nonEmpty = append(nonEmpty, o)
 		}
 	}
+	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "duration", time.Since(stepStart))
 	w.captureOutput(stepName, strings.Join(nonEmpty, "\n\n---\n\n"))
 	w.transitionToReview(ctx, reviewStep, trigger)
 }
@@ -225,8 +256,9 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	feedback := w.feedback
 	w.feedback = ""
 
-	w.logger.Info("step: "+stepName, "feedback", feedback != "", "resume", sessionID != "")
+	w.logger.Info("step: "+stepName, "issue", w.issue.Identifier, "feedback", feedback != "", "resume", sessionID != "")
 
+	stepStart := time.Now()
 	cfg := w.config.ResolveStep(stepCfg)
 	output, newSessionID, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.logger)
 	if err != nil {
@@ -234,6 +266,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 		return
 	}
 
+	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "session_id", newSessionID, "duration", time.Since(stepStart))
 	w.sessionIDs[currentStep] = newSessionID
 	w.captureOutput(stepName, output)
 

--- a/logging/klogfmt/handler_test.go
+++ b/logging/klogfmt/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -185,4 +187,49 @@ func TestInit(t *testing.T) {
 	Init(WithLevel(slog.LevelWarn))
 	// Restore default after test.
 	defer slog.SetDefault(slog.Default())
+}
+
+func TestInitWithWriter(t *testing.T) {
+	defer slog.SetDefault(slog.Default())
+
+	var extra bytes.Buffer
+	Init(WithLevel(slog.LevelInfo), WithWriter(&extra))
+
+	slog.Info("dual-write test", "key", "val")
+
+	got := extra.String()
+	if !strings.Contains(got, "dual-write test") {
+		t.Errorf("expected log in extra writer, got: %s", got)
+	}
+	if !strings.Contains(got, "key=val") {
+		t.Errorf("expected attrs in extra writer, got: %s", got)
+	}
+}
+
+func TestInitWithLogFile(t *testing.T) {
+	defer slog.SetDefault(slog.Default())
+
+	logPath := filepath.Join(t.TempDir(), "sub", "test.log")
+	closer, err := InitWithLogFile(logPath, WithLevel(slog.LevelInfo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closer()
+
+	slog.Info("file test", "foo", "bar")
+
+	// Flush by closing.
+	closer()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "file test") {
+		t.Errorf("expected log in file, got: %s", got)
+	}
+	if !strings.Contains(got, "foo=bar") {
+		t.Errorf("expected attrs in file, got: %s", got)
+	}
 }

--- a/logging/klogfmt/handler_test.go
+++ b/logging/klogfmt/handler_test.go
@@ -214,12 +214,13 @@ func TestInitWithLogFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closer()
 
 	slog.Info("file test", "foo", "bar")
 
-	// Flush by closing.
-	closer()
+	// Close to flush before reading.
+	if err := closer(); err != nil {
+		t.Fatal(err)
+	}
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {

--- a/logging/klogfmt/init.go
+++ b/logging/klogfmt/init.go
@@ -25,7 +25,8 @@ func WithWriter(w io.Writer) Option {
 	return func(o *options) { o.writer = w }
 }
 
-// Init sets slog.SetDefault with a klogfmt handler writing to stderr.
+// Init sets slog.SetDefault with a klogfmt handler writing to stderr
+// (and any extra writer added via WithWriter).
 func Init(opts ...Option) {
 	o := options{}
 	for _, opt := range opts {
@@ -48,7 +49,7 @@ func InitWithLogFile(logPath string, opts ...Option) (func() error, error) {
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/logging/klogfmt/init.go
+++ b/logging/klogfmt/init.go
@@ -1,12 +1,15 @@
 package klogfmt
 
 import (
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 )
 
 type options struct {
-	level slog.Leveler
+	level  slog.Leveler
+	writer io.Writer // extra writer for multi-writer setup
 }
 
 // Option configures a Handler.
@@ -17,7 +20,38 @@ func WithLevel(l slog.Leveler) Option {
 	return func(o *options) { o.level = l }
 }
 
+// WithWriter adds an extra writer that receives log output alongside stderr.
+func WithWriter(w io.Writer) Option {
+	return func(o *options) { o.writer = w }
+}
+
 // Init sets slog.SetDefault with a klogfmt handler writing to stderr.
 func Init(opts ...Option) {
-	slog.SetDefault(slog.New(New(os.Stderr, opts...)))
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	var w io.Writer = os.Stderr
+	if o.writer != nil {
+		w = io.MultiWriter(os.Stderr, o.writer)
+	}
+	var handlerOpts []Option
+	if o.level != nil {
+		handlerOpts = append(handlerOpts, WithLevel(o.level))
+	}
+	slog.SetDefault(slog.New(New(w, handlerOpts...)))
+}
+
+// InitWithLogFile sets up dual-write: stderr + a log file at logPath.
+// It creates parent directories as needed. Returns a closer for the log file.
+func InitWithLogFile(logPath string, opts ...Option) (func() error, error) {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	Init(append(opts, WithWriter(f))...)
+	return f.Close, nil
 }


### PR DESCRIPTION
## Summary

- Add persistent file logging via `klogfmt.InitWithLogFile()` — each jiradozer run writes to `~/.jiradozer/logs/jiradozer-YYYYMMDD-HHMMSS-<pid>.log` alongside stderr
- Improve log signal-to-noise: add invocation banner (args, cwd, pid), workflow start/end summaries with duration, step completion timing with session IDs, and agent session_id + duration_ms to completion logs
- Demote noisy Info logs to Debug: prompt echo, response preview, plan file operations

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer/... //logging/... --test_timeout=60` — all 5 test targets pass
- [ ] Manual: run `jiradozer --description "test" --run-step=plan` and verify log file created at `~/.jiradozer/logs/`
- [ ] Verify `grep session_id ~/.jiradozer/logs/*.log` shows session IDs in completion logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily logging/telemetry (new log file output, redacted invocation banner, and adjusted log levels) with minimal impact on workflow execution beyond additional file I/O.
> 
> **Overview**
> Adds **persistent dual-write logging** for `jiradozer` runs (stderr + per-run log file under `~/.jiradozer/logs/`) via new `klogfmt.WithWriter`/`klogfmt.InitWithLogFile` utilities.
> 
> Improves log *signal-to-noise* by adding workflow/step/command timing and agent `session_id`/duration fields, logging a startup banner with **redacted** sensitive CLI flags, and demoting noisy prompt/response/plan-file messages from Info to Debug. Includes new Bazel + Go tests for arg redaction and the new `klogfmt` init behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58bd27d19f210ed9714384de1a8e8c05af842f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->