### PR TITLE
jiradozer: generic --filter for flexible multi-issue queries

### DIFF
--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -115,19 +115,21 @@ jiradozer --issue ENG-123 [flags]
 jiradozer --description "task description" [flags]
 ```
 
-One of `--issue`, `--team`, or `--description`/`--description-file` is required. `--issue` and `--description` are mutually exclusive; `--issue` takes precedence over `source.team` in the config file (so you can keep `source.team` for multi-issue mode and still use `--issue` for single issues).
+One of `--issue`, `--filter`, or `--description`/`--description-file` is required. `--issue` and `--description` are mutually exclusive; `--issue` takes precedence over `source.filters` in the config file (so you can keep `source.filters` for multi-issue mode and still use `--issue` for single issues).
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--issue` | | Issue identifier (e.g. `ENG-123` or `owner/repo#42`) |
 | `--description` | | Task description for local mode (no external tracker needed) |
 | `--description-file` | | Read task description from file (use `-` for stdin) |
-| `--team` | | Team key for multi-issue mode (e.g. `ENG` or `owner/repo`) |
+| `--filter` | | Issue filter as `key=value` (repeatable, e.g. `--filter team=ENG --filter state=Todo,Backlog`) |
 | `--config` | `jiradozer.yaml` | Path to config file |
 | `--work-dir` | from config | Working directory for the agent |
 | `--model` | from config | Agent model ID (overrides config) |
 | `--poll-interval` | from config | How often to check for new comments |
 | `--max-budget` | from config | Max spend in USD |
+| `--max-concurrent` | from config | Max concurrent workflows |
+| `--branch-prefix` | from config | Worktree branch prefix |
 | `--auto-approve` | | Auto-approve review steps (`plan,build,validate,ship` or `all`) |
 | `--run-step` | | Run a single step and exit (for debugging): `plan`, `build`, `validate`, `ship` |
 | `--verbose` | `false` | Debug logging |
@@ -201,9 +203,10 @@ tracker:
   kind: github
 
 source:
-  team: "owner/repo"          # GitHub owner/repo
-  states: ["Todo"]
-  labels: ["jiradozer"]        # optional: only pick up issues with this label
+  filters:
+    team: "owner/repo"
+    state: "Todo"
+    label: "jiradozer"         # optional: only pick up issues with this label
   max_concurrent: 3
 ```
 
@@ -212,7 +215,7 @@ source:
 jiradozer --issue owner/repo#42
 
 # Multi-issue mode (discovers open issues)
-jiradozer --team owner/repo
+jiradozer --filter team=owner/repo --filter state=Todo
 ```
 
 GitHub Issues only has open/closed states, so jiradozer maps workflow states using labels:

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -80,7 +80,7 @@ func main() {
 	rootCmd.Flags().Float64Var(&maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	rootCmd.Flags().StringVar(&runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
 	rootCmd.Flags().StringVar(&autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
-	rootCmd.Flags().StringSliceVar(&sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo)")
+	rootCmd.Flags().StringArrayVar(&sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo,Backlog)")
 	rootCmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 0, "Max concurrent workflows (overrides config)")
 	rootCmd.Flags().StringVar(&branchPrefix, "branch-prefix", "", "Worktree branch prefix (overrides config)")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose logging")
@@ -353,8 +353,8 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 	// Determine repo root for worktree manager.
 	// Use WorkDir as the root for wt.Manager — it should point to
 	// the bare repo's parent directory.
-	// For GitHub, source.team is "owner/repo" which would create a nested
-	// directory. Use just the repo portion as the worktree repo name.
+	// For GitHub, source.filters.team is "owner/repo" which would create a
+	// nested directory. Use just the repo portion as the worktree repo name.
 	repoName := cfg.Source.Filters[tracker.FilterTeam]
 	if repoName == "" {
 		repoName = "jiradozer"

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -355,7 +355,7 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 	// the bare repo's parent directory.
 	// For GitHub, source.team is "owner/repo" which would create a nested
 	// directory. Use just the repo portion as the worktree repo name.
-	repoName := cfg.Source.Filters["team"]
+	repoName := cfg.Source.Filters[tracker.FilterTeam]
 	if repoName == "" {
 		repoName = "jiradozer"
 	}
@@ -407,7 +407,7 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 			if err != nil {
 				return nil, fmt.Errorf("github tracker: %w", err)
 			}
-		} else if teamKey := cfg.Source.Filters["team"]; teamKey != "" {
+		} else if teamKey := cfg.Source.Filters[tracker.FilterTeam]; teamKey != "" {
 			var err error
 			owner, repo, err = ghtracker.ParseOwnerRepo(teamKey)
 			if err != nil {

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -37,9 +37,7 @@ func main() {
 		maxBudget       float64
 		runStep         string
 		autoApprove     string
-		team            string
-		sourceStates    []string
-		sourceLabels    []string
+		sourceFilters   []string
 		maxConcurrent   int
 		branchPrefix    string
 		verbose         bool
@@ -62,9 +60,7 @@ func main() {
 				maxBudget:       maxBudget,
 				runStep:         runStep,
 				autoApprove:     autoApprove,
-				team:            team,
-				sourceStates:    sourceStates,
-				sourceLabels:    sourceLabels,
+				sourceFilters:   sourceFilters,
 				maxConcurrent:   maxConcurrent,
 				branchPrefix:    branchPrefix,
 				verbose:         verbose,
@@ -84,9 +80,7 @@ func main() {
 	rootCmd.Flags().Float64Var(&maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	rootCmd.Flags().StringVar(&runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
 	rootCmd.Flags().StringVar(&autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
-	rootCmd.Flags().StringVar(&team, "team", "", "Team key for multi-issue mode (e.g. ENG)")
-	rootCmd.Flags().StringSliceVar(&sourceStates, "source-states", nil, "Issue states to track (default: Todo)")
-	rootCmd.Flags().StringSliceVar(&sourceLabels, "source-labels", nil, "Issue label filter")
+	rootCmd.Flags().StringSliceVar(&sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo)")
 	rootCmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 0, "Max concurrent workflows (overrides config)")
 	rootCmd.Flags().StringVar(&branchPrefix, "branch-prefix", "", "Worktree branch prefix (overrides config)")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose logging")
@@ -109,14 +103,12 @@ type runArgs struct {
 	modelID         string
 	runStep         string
 	autoApprove     string
-	team            string
 	branchPrefix    string
 	description     string
 	descriptionFile string
 	planFile        string
 	planContent     string
-	sourceStates    []string
-	sourceLabels    []string
+	sourceFilters   []string
 	pollInterval    time.Duration
 	maxBudget       float64
 	maxConcurrent   int
@@ -202,7 +194,7 @@ func run(ctx context.Context, args runArgs) error {
 		// Force local tracker, clear team, and reset state names to match the
 		// local tracker's fixed states ("In Progress", "In Review", "Done").
 		cfg.Tracker.Kind = "local"
-		cfg.Source.Team = ""
+		cfg.Source.Filters = nil
 		defaults := jiradozer.DefaultConfig()
 		cfg.States = defaults.States
 		// Default all steps to auto-approve in local mode unless overridden.
@@ -235,14 +227,17 @@ func run(ctx context.Context, args runArgs) error {
 	}
 
 	// Apply source overrides.
-	if args.team != "" {
-		cfg.Source.Team = args.team
-	}
-	if len(args.sourceStates) > 0 {
-		cfg.Source.States = args.sourceStates
-	}
-	if len(args.sourceLabels) > 0 {
-		cfg.Source.Labels = args.sourceLabels
+	if len(args.sourceFilters) > 0 {
+		if cfg.Source.Filters == nil {
+			cfg.Source.Filters = make(map[string]string)
+		}
+		for _, kv := range args.sourceFilters {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				return fmt.Errorf("invalid --filter %q: expected key=value", kv)
+			}
+			cfg.Source.Filters[k] = v
+		}
 	}
 	if args.maxConcurrent > 0 {
 		cfg.Source.MaxConcurrent = args.maxConcurrent
@@ -262,14 +257,14 @@ func run(ctx context.Context, args runArgs) error {
 	if args.description != "" {
 		modeCount++
 	}
-	if modeCount == 0 && cfg.Source.Team != "" {
+	if modeCount == 0 && cfg.Source.HasSource() {
 		modeCount++
 	}
 	if modeCount > 1 {
 		return fmt.Errorf("--issue and --description/--description-file are mutually exclusive")
 	}
 	if modeCount == 0 {
-		return fmt.Errorf("either --issue, --team, or --description/--description-file is required")
+		return fmt.Errorf("either --issue, --filter, or --description/--description-file is required")
 	}
 
 	// Apply auto-approve overrides.
@@ -320,7 +315,7 @@ func run(ctx context.Context, args runArgs) error {
 	}
 
 	// Multi-issue TUI mode (only when no --issue flag was given).
-	if cfg.Source.Team != "" && args.issueID == "" {
+	if cfg.Source.HasSource() && args.issueID == "" {
 		return runMultiIssue(ctx, issueTracker, cfg, logger)
 	}
 
@@ -360,7 +355,10 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 	// the bare repo's parent directory.
 	// For GitHub, source.team is "owner/repo" which would create a nested
 	// directory. Use just the repo portion as the worktree repo name.
-	repoName := cfg.Source.Team
+	repoName := cfg.Source.Filters["team"]
+	if repoName == "" {
+		repoName = "jiradozer"
+	}
 	if cfg.Tracker.Kind == "github" {
 		if _, repo, err := ghtracker.ParseOwnerRepo(repoName); err == nil {
 			repoName = repo
@@ -409,14 +407,14 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 			if err != nil {
 				return nil, fmt.Errorf("github tracker: %w", err)
 			}
-		} else if cfg.Source.Team != "" {
+		} else if teamKey := cfg.Source.Filters["team"]; teamKey != "" {
 			var err error
-			owner, repo, err = ghtracker.ParseOwnerRepo(cfg.Source.Team)
+			owner, repo, err = ghtracker.ParseOwnerRepo(teamKey)
 			if err != nil {
-				return nil, fmt.Errorf("github tracker requires source.team as 'owner/repo': %w", err)
+				return nil, fmt.Errorf("github tracker requires filter team as 'owner/repo': %w", err)
 			}
 		} else {
-			return nil, fmt.Errorf("github tracker requires source.team or --issue as 'owner/repo#N'")
+			return nil, fmt.Errorf("github tracker requires --filter team=owner/repo or --issue owner/repo#N")
 		}
 		return ghtracker.NewClient(&wt.DefaultGHRunner{}, owner, repo), nil
 	case "local":

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -236,7 +236,11 @@ func run(ctx context.Context, args runArgs) error {
 			if !ok {
 				return fmt.Errorf("invalid --filter %q: expected key=value", kv)
 			}
-			cfg.Source.Filters[strings.TrimSpace(k)] = strings.TrimSpace(v)
+			k = strings.TrimSpace(k)
+			if k == "" {
+				return fmt.Errorf("invalid --filter %q: empty key", kv)
+			}
+			cfg.Source.Filters[k] = strings.TrimSpace(v)
 		}
 	}
 	if args.maxConcurrent > 0 {

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -247,9 +247,10 @@ func run(ctx context.Context, args runArgs) error {
 	}
 
 	// Validate mutual exclusivity. CLI flags (--issue, --description) take
-	// precedence over config-file values (source.team). Only count source.team
-	// as a mode when no CLI flag is given, so users can have source.team in
-	// their config for multi-issue mode and still use --issue for single-issue.
+	// precedence over config-file values (source.filters). Only count
+	// source.filters as a mode when no CLI flag is given, so users can have
+	// source.filters in their config for multi-issue mode and still use
+	// --issue for single-issue.
 	modeCount := 0
 	if args.issueID != "" {
 		modeCount++
@@ -264,7 +265,7 @@ func run(ctx context.Context, args runArgs) error {
 		return fmt.Errorf("--issue and --description/--description-file are mutually exclusive")
 	}
 	if modeCount == 0 {
-		return fmt.Errorf("either --issue, --filter, or --description/--description-file is required")
+		return fmt.Errorf("either --issue, --filter, --description/--description-file, or source.filters in config is required")
 	}
 
 	// Apply auto-approve overrides.

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -236,7 +236,7 @@ func run(ctx context.Context, args runArgs) error {
 			if !ok {
 				return fmt.Errorf("invalid --filter %q: expected key=value", kv)
 			}
-			cfg.Source.Filters[k] = v
+			cfg.Source.Filters[strings.TrimSpace(k)] = strings.TrimSpace(v)
 		}
 	}
 	if args.maxConcurrent > 0 {

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -43,20 +43,20 @@ type AgentConfig struct {
 
 // SourceConfig specifies how to discover issues for multi-issue mode.
 type SourceConfig struct {
-	Team          string   `yaml:"team"`           // Team or repo identifier (e.g. "ENG" for Linear, "owner/repo" for GitHub)
-	BranchPrefix  string   `yaml:"branch_prefix"`  // Worktree branch prefix (default: "jiradozer")
-	States        []string `yaml:"states"`         // Issue states to pick up (default: ["Todo"])
-	Labels        []string `yaml:"labels"`         // Optional label filter
-	MaxConcurrent int      `yaml:"max_concurrent"` // Max parallel workflows (default: 3)
+	Filters       map[string]string `yaml:"filters"`        // Generic key-value filters (see tracker.IssueFilter)
+	BranchPrefix  string            `yaml:"branch_prefix"`  // Worktree branch prefix (default: "jiradozer")
+	MaxConcurrent int               `yaml:"max_concurrent"` // Max parallel workflows (default: 3)
 }
 
 // ToFilter converts the source config to a tracker.IssueFilter.
 func (s SourceConfig) ToFilter() tracker.IssueFilter {
-	return tracker.IssueFilter{
-		TeamKey: s.Team,
-		States:  s.States,
-		Labels:  s.Labels,
-	}
+	return tracker.IssueFilter{Filters: s.Filters}
+}
+
+// HasSource reports whether the source config specifies enough to enter
+// multi-issue mode (at least one filter key must be set).
+func (s SourceConfig) HasSource() bool {
+	return len(s.Filters) > 0
 }
 
 // StepConfig configures a single workflow step (plan or build).
@@ -137,7 +137,6 @@ func defaultConfig() Config {
 		Tracker: TrackerConfig{Kind: "linear"},
 		Agent:   AgentConfig{Model: "sonnet"},
 		Source: SourceConfig{
-			States:        []string{"Todo"},
 			MaxConcurrent: 3,
 			BranchPrefix:  "jiradozer",
 		},

--- a/jiradozer/discovery_test.go
+++ b/jiradozer/discovery_test.go
@@ -64,7 +64,7 @@ func TestDiscovery_DeduplicatesIssues(t *testing.T) {
 		},
 	}
 
-	filter := tracker.IssueFilter{TeamKey: "ENG", States: []string{"Todo"}}
+	filter := tracker.IssueFilter{Filters: map[string]string{"team": "ENG", "state": "Todo"}}
 	d := NewDiscovery(mt, filter, 10*time.Millisecond, testLogger(t))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -115,9 +115,11 @@ func TestDiscovery_PassesFilter(t *testing.T) {
 	}
 
 	filter := tracker.IssueFilter{
-		TeamKey: "INF",
-		States:  []string{"Todo", "Backlog"},
-		Labels:  []string{"automated"},
+		Filters: map[string]string{
+			"team":  "INF",
+			"state": "Todo,Backlog",
+			"label": "automated",
+		},
 	}
 	d := NewDiscovery(mt, filter, 50*time.Millisecond, testLogger(t))
 
@@ -131,9 +133,9 @@ func TestDiscovery_PassesFilter(t *testing.T) {
 	mt.mu.Lock()
 	defer mt.mu.Unlock()
 	require.NotEmpty(t, mt.callArgs)
-	require.Equal(t, "INF", mt.callArgs[0].TeamKey)
-	require.Equal(t, []string{"Todo", "Backlog"}, mt.callArgs[0].States)
-	require.Equal(t, []string{"automated"}, mt.callArgs[0].Labels)
+	require.Equal(t, "INF", mt.callArgs[0].Filters["team"])
+	require.Equal(t, "Todo,Backlog", mt.callArgs[0].Filters["state"])
+	require.Equal(t, "automated", mt.callArgs[0].Filters["label"])
 }
 
 func TestDiscovery_ContextCancellation(t *testing.T) {

--- a/jiradozer/discovery_test.go
+++ b/jiradozer/discovery_test.go
@@ -64,7 +64,7 @@ func TestDiscovery_DeduplicatesIssues(t *testing.T) {
 		},
 	}
 
-	filter := tracker.IssueFilter{Filters: map[string]string{"team": "ENG", "state": "Todo"}}
+	filter := tracker.IssueFilter{Filters: map[string]string{tracker.FilterTeam: "ENG", tracker.FilterState: "Todo"}}
 	d := NewDiscovery(mt, filter, 10*time.Millisecond, testLogger(t))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -116,9 +116,9 @@ func TestDiscovery_PassesFilter(t *testing.T) {
 
 	filter := tracker.IssueFilter{
 		Filters: map[string]string{
-			"team":  "INF",
-			"state": "Todo,Backlog",
-			"label": "automated",
+			tracker.FilterTeam:  "INF",
+			tracker.FilterState: "Todo,Backlog",
+			tracker.FilterLabel: "automated",
 		},
 	}
 	d := NewDiscovery(mt, filter, 50*time.Millisecond, testLogger(t))
@@ -133,9 +133,9 @@ func TestDiscovery_PassesFilter(t *testing.T) {
 	mt.mu.Lock()
 	defer mt.mu.Unlock()
 	require.NotEmpty(t, mt.callArgs)
-	require.Equal(t, "INF", mt.callArgs[0].Filters["team"])
-	require.Equal(t, "Todo,Backlog", mt.callArgs[0].Filters["state"])
-	require.Equal(t, "automated", mt.callArgs[0].Filters["label"])
+	require.Equal(t, "INF", mt.callArgs[0].Filters[tracker.FilterTeam])
+	require.Equal(t, "Todo,Backlog", mt.callArgs[0].Filters[tracker.FilterState])
+	require.Equal(t, "automated", mt.callArgs[0].Filters[tracker.FilterLabel])
 }
 
 func TestDiscovery_ContextCancellation(t *testing.T) {

--- a/jiradozer/integration/github_test.go
+++ b/jiradozer/integration/github_test.go
@@ -140,8 +140,8 @@ func TestGitHub_ListIssues(t *testing.T) {
 
 	issues, err := client.ListIssues(ctx, tracker.IssueFilter{
 		Filters: map[string]string{
-			"team":  repo,
-			"state": "Todo",
+			tracker.FilterTeam:  repo,
+			tracker.FilterState: "Todo",
 		},
 		Limit: 5,
 	})

--- a/jiradozer/integration/github_test.go
+++ b/jiradozer/integration/github_test.go
@@ -139,9 +139,11 @@ func TestGitHub_ListIssues(t *testing.T) {
 	defer cancel()
 
 	issues, err := client.ListIssues(ctx, tracker.IssueFilter{
-		TeamKey: repo,
-		States:  []string{"Todo"},
-		Limit:   5,
+		Filters: map[string]string{
+			"team":  repo,
+			"state": "Todo",
+		},
+		Limit: 5,
 	})
 	require.NoError(t, err)
 	t.Logf("Found %d open issues", len(issues))

--- a/jiradozer/integration/orchestrator_test.go
+++ b/jiradozer/integration/orchestrator_test.go
@@ -115,7 +115,7 @@ func (m *mockWTManager) getRemoved() []string {
 
 func testOrchestratorConfig() *jiradozer.Config {
 	cfg := jiradozer.DefaultConfig()
-	cfg.Source.Team = "ENG"
+	cfg.Source.Filters = map[string]string{"team": "ENG"}
 	cfg.Source.MaxConcurrent = 3
 	cfg.Source.BranchPrefix = "jiradozer"
 	cfg.Tracker.APIKey = "test-key"

--- a/jiradozer/integration/orchestrator_test.go
+++ b/jiradozer/integration/orchestrator_test.go
@@ -115,7 +115,7 @@ func (m *mockWTManager) getRemoved() []string {
 
 func testOrchestratorConfig() *jiradozer.Config {
 	cfg := jiradozer.DefaultConfig()
-	cfg.Source.Filters = map[string]string{"team": "ENG"}
+	cfg.Source.Filters = map[string]string{tracker.FilterTeam: "ENG"}
 	cfg.Source.MaxConcurrent = 3
 	cfg.Source.BranchPrefix = "jiradozer"
 	cfg.Tracker.APIKey = "test-key"

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -43,7 +43,7 @@ source:
     # project: "Backend Rewrite"        # Linear project name
     # cycle: current                    # Linear cycle ("current" or name)
     # milestone: "1"                     # GitHub milestone number (not title)
-    # assignee: "@me"                   # GitHub/Linear assignee
+    # assignee: "octocat"               # GitHub username or Linear display name
   branch_prefix: jiradozer              # default: "jiradozer" — worktree branch prefix
   max_concurrent: 3                     # default: 3 — max parallel workflows
 

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -4,9 +4,9 @@
 # in the inline comment and can be omitted.
 
 # --- Tracker ---
-# Issue tracker backend. Only "linear" is supported today.
+# Issue tracker backend: "linear" or "github".
 tracker:
-  kind: linear                          # [required] "linear" (future: "github", "jira")
+  kind: linear                          # [required] "linear" or "github"
   api_key: $LINEAR_API_KEY              # [required] API key; supports $ENV_VAR expansion
 
 # --- Agent ---

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -42,7 +42,7 @@ source:
     # label: backend                    # optional label filter (comma-separated, OR semantics)
     # project: "Backend Rewrite"        # Linear project name
     # cycle: current                    # Linear cycle ("current" or name)
-    # milestone: "v2.0"                 # GitHub milestone
+    # milestone: "1"                     # GitHub milestone number (not title)
     # assignee: "@me"                   # GitHub/Linear assignee
   branch_prefix: jiradozer              # default: "jiradozer" — worktree branch prefix
   max_concurrent: 3                     # default: 3 — max parallel workflows

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -27,14 +27,24 @@ states:
   in_review: "In Review"                # default: "In Review"
   done: "Done"                          # default: "Done"
 
-# --- Multi-Issue Discovery (--team mode) ---
+# --- Multi-Issue Discovery (--filter mode) ---
+# Use --filter key=value (repeatable) on the CLI, or configure here.
+# Each tracker interprets the keys it understands; unknown keys are ignored.
+#
+# Common keys:
+#   Universal:  team, state, label  (multi-value: comma-separated, e.g. state: "Todo,Backlog")
+#   GitHub:     milestone, assignee
+#   Linear:     project, cycle ("current" for active cycle), assignee
 source:
-  team: ENG                             # Linear team key; required for --team mode
+  filters:
+    team: ENG                           # Linear team key or GitHub "owner/repo"
+    state: Todo                         # issue states to pick up (comma-separated)
+    # label: backend                    # optional label filter (comma-separated, OR semantics)
+    # project: "Backend Rewrite"        # Linear project name
+    # cycle: current                    # Linear cycle ("current" or name)
+    # milestone: "v2.0"                 # GitHub milestone
+    # assignee: "@me"                   # GitHub/Linear assignee
   branch_prefix: jiradozer              # default: "jiradozer" — worktree branch prefix
-  states:                               # default: ["Todo"] — issue states to pick up
-    - Todo
-  labels:                               # default: [] — optional OR label filter
-    - backend
   max_concurrent: 3                     # default: 3 — max parallel workflows
 
 # --- Workflow Steps ---

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -53,7 +53,7 @@ func (m *mockWTManager) getCreated() map[string]string {
 
 func testOrchestratorConfig() *Config {
 	cfg := defaultConfig()
-	cfg.Source.Filters = map[string]string{"team": "ENG"}
+	cfg.Source.Filters = map[string]string{tracker.FilterTeam: "ENG"}
 	cfg.Source.MaxConcurrent = 3
 	cfg.Source.BranchPrefix = "jiradozer"
 	cfg.Tracker.APIKey = "test-key"

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -53,7 +53,7 @@ func (m *mockWTManager) getCreated() map[string]string {
 
 func testOrchestratorConfig() *Config {
 	cfg := defaultConfig()
-	cfg.Source.Team = "ENG"
+	cfg.Source.Filters = map[string]string{"team": "ENG"}
 	cfg.Source.MaxConcurrent = 3
 	cfg.Source.BranchPrefix = "jiradozer"
 	cfg.Tracker.APIKey = "test-key"

--- a/jiradozer/tracker/BUILD.bazel
+++ b/jiradozer/tracker/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tracker",
@@ -8,4 +8,11 @@ go_library(
     ],
     importpath = "github.com/bazelment/yoloswe/jiradozer/tracker",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "tracker_test",
+    srcs = ["types_test.go"],
+    embed = [":tracker"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -139,21 +139,23 @@ func (c *Client) FetchIssue(ctx context.Context, identifier string) (*tracker.Is
 func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]*tracker.Issue, error) {
 	owner := c.owner
 	repo := c.repo
-	if filter.TeamKey != "" {
+	if teamKey := filter.Filters["team"]; teamKey != "" {
 		var err error
-		owner, repo, err = ParseOwnerRepo(filter.TeamKey)
+		owner, repo, err = ParseOwnerRepo(teamKey)
 		if err != nil {
 			return nil, fmt.Errorf("invalid team key: %w", err)
 		}
 	}
 
-	// Map jiradozer state names to GitHub issue states.
+	// Map state filter to GitHub issue state.
 	ghState := "open"
-	for _, s := range filter.States {
-		lower := strings.ToLower(s)
-		if lower == "done" || lower == "closed" {
-			ghState = "closed"
-			break
+	if stateCSV := filter.Filters["state"]; stateCSV != "" {
+		for _, s := range strings.Split(stateCSV, ",") {
+			lower := strings.ToLower(strings.TrimSpace(s))
+			if lower == "done" || lower == "closed" {
+				ghState = "closed"
+				break
+			}
 		}
 	}
 
@@ -164,7 +166,10 @@ func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]
 
 	// GitHub's labels query parameter uses AND semantics, but the tracker
 	// interface specifies OR. Issue one request per label and merge results.
-	labelSets := filter.Labels
+	var labelSets []string
+	if labelCSV := filter.Filters["label"]; labelCSV != "" {
+		labelSets = strings.Split(labelCSV, ",")
+	}
 	if len(labelSets) == 0 {
 		labelSets = []string{""} // single request with no label filter
 	}
@@ -174,7 +179,13 @@ func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]
 	for _, label := range labelSets {
 		path := fmt.Sprintf("repos/%s/%s/issues?state=%s&per_page=%d", owner, repo, ghState, limit)
 		if label != "" {
-			path += "&labels=" + url.QueryEscape(label)
+			path += "&labels=" + url.QueryEscape(strings.TrimSpace(label))
+		}
+		if milestone := filter.Filters["milestone"]; milestone != "" {
+			path += "&milestone=" + url.QueryEscape(milestone)
+		}
+		if assignee := filter.Filters["assignee"]; assignee != "" {
+			path += "&assignee=" + url.QueryEscape(assignee)
 		}
 
 		result, err := c.gh.Run(ctx, []string{"api", path}, "")

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -139,7 +139,7 @@ func (c *Client) FetchIssue(ctx context.Context, identifier string) (*tracker.Is
 func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]*tracker.Issue, error) {
 	owner := c.owner
 	repo := c.repo
-	if teamKey := filter.Filters["team"]; teamKey != "" {
+	if teamKey := filter.Filters[tracker.FilterTeam]; teamKey != "" {
 		var err error
 		owner, repo, err = ParseOwnerRepo(teamKey)
 		if err != nil {
@@ -147,15 +147,13 @@ func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]
 		}
 	}
 
-	// Map state filter to GitHub issue state.
+	// GitHub only supports a single state parameter; default to "open" unless
+	// a "done"/"closed" state is explicitly requested.
 	ghState := "open"
-	if stateCSV := filter.Filters["state"]; stateCSV != "" {
-		for _, s := range strings.Split(stateCSV, ",") {
-			lower := strings.ToLower(strings.TrimSpace(s))
-			if lower == "done" || lower == "closed" {
-				ghState = "closed"
-				break
-			}
+	for _, s := range tracker.SplitCSV(filter.Filters[tracker.FilterState]) {
+		if lower := strings.ToLower(s); lower == "done" || lower == "closed" {
+			ghState = "closed"
+			break
 		}
 	}
 
@@ -166,25 +164,25 @@ func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]
 
 	// GitHub's labels query parameter uses AND semantics, but the tracker
 	// interface specifies OR. Issue one request per label and merge results.
-	var labelSets []string
-	if labelCSV := filter.Filters["label"]; labelCSV != "" {
-		labelSets = strings.Split(labelCSV, ",")
-	}
+	labelSets := tracker.SplitCSV(filter.Filters[tracker.FilterLabel])
 	if len(labelSets) == 0 {
 		labelSets = []string{""} // single request with no label filter
 	}
+
+	milestone := filter.Filters[tracker.FilterMilestone]
+	assignee := filter.Filters[tracker.FilterAssignee]
 
 	seen := make(map[int]bool)
 	var issues []*tracker.Issue
 	for _, label := range labelSets {
 		path := fmt.Sprintf("repos/%s/%s/issues?state=%s&per_page=%d", owner, repo, ghState, limit)
 		if label != "" {
-			path += "&labels=" + url.QueryEscape(strings.TrimSpace(label))
+			path += "&labels=" + url.QueryEscape(label)
 		}
-		if milestone := filter.Filters["milestone"]; milestone != "" {
+		if milestone != "" {
 			path += "&milestone=" + url.QueryEscape(milestone)
 		}
-		if assignee := filter.Filters["assignee"]; assignee != "" {
+		if assignee != "" {
 			path += "&assignee=" + url.QueryEscape(assignee)
 		}
 

--- a/jiradozer/tracker/github/client_test.go
+++ b/jiradozer/tracker/github/client_test.go
@@ -177,10 +177,12 @@ func TestListIssues(t *testing.T) {
 
 	client := NewClient(mock, "acme", "app")
 	issues, err := client.ListIssues(context.Background(), tracker.IssueFilter{
-		TeamKey: "acme/app",
-		States:  []string{"Todo"},
-		Labels:  []string{"jiradozer"},
-		Limit:   10,
+		Filters: map[string]string{
+			"team":  "acme/app",
+			"state": "Todo",
+			"label": "jiradozer",
+		},
+		Limit: 10,
 	})
 	require.NoError(t, err)
 
@@ -207,10 +209,12 @@ func TestListIssues_MultiLabel_ORSemantics(t *testing.T) {
 
 	client := NewClient(mock, "acme", "app")
 	issues, err := client.ListIssues(context.Background(), tracker.IssueFilter{
-		TeamKey: "acme/app",
-		States:  []string{"Todo"},
-		Labels:  []string{"bug", "feature"},
-		Limit:   3,
+		Filters: map[string]string{
+			"team":  "acme/app",
+			"state": "Todo",
+			"label": "bug,feature",
+		},
+		Limit: 3,
 	})
 	require.NoError(t, err)
 

--- a/jiradozer/tracker/github/client_test.go
+++ b/jiradozer/tracker/github/client_test.go
@@ -178,9 +178,9 @@ func TestListIssues(t *testing.T) {
 	client := NewClient(mock, "acme", "app")
 	issues, err := client.ListIssues(context.Background(), tracker.IssueFilter{
 		Filters: map[string]string{
-			"team":  "acme/app",
-			"state": "Todo",
-			"label": "jiradozer",
+			tracker.FilterTeam:  "acme/app",
+			tracker.FilterState: "Todo",
+			tracker.FilterLabel: "jiradozer",
 		},
 		Limit: 10,
 	})
@@ -210,9 +210,9 @@ func TestListIssues_MultiLabel_ORSemantics(t *testing.T) {
 	client := NewClient(mock, "acme", "app")
 	issues, err := client.ListIssues(context.Background(), tracker.IssueFilter{
 		Filters: map[string]string{
-			"team":  "acme/app",
-			"state": "Todo",
-			"label": "bug,feature",
+			tracker.FilterTeam:  "acme/app",
+			tracker.FilterState: "Todo",
+			tracker.FilterLabel: "bug,feature",
 		},
 		Limit: 3,
 	})

--- a/jiradozer/tracker/linear/client.go
+++ b/jiradozer/tracker/linear/client.go
@@ -63,7 +63,7 @@ func (c *Client) FetchIssue(ctx context.Context, identifier string) (*tracker.Is
 }
 
 func (c *Client) ListIssues(ctx context.Context, filter tracker.IssueFilter) ([]*tracker.Issue, error) {
-	req := listIssuesQuery(filter.TeamKey, filter.States, filter.Labels, filter.Limit)
+	req := listIssuesQuery(filter)
 	resp, err := c.execute(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("list issues: %w", err)

--- a/jiradozer/tracker/linear/queries.go
+++ b/jiradozer/tracker/linear/queries.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
 
 // graphqlRequest is the JSON body sent to the Linear GraphQL endpoint.
@@ -56,8 +58,9 @@ func fetchIssueByIdentifierQuery(identifier string) (graphqlRequest, error) {
 }
 
 // listIssuesQuery returns issues matching the given filter criteria.
-// teamKey filters by team, states filters by state name, labels filters by label name.
-func listIssuesQuery(teamKey string, states, labels []string, limit int) graphqlRequest {
+// Filter keys are read from filter.Filters; see tracker.IssueFilter for
+// documented keys.
+func listIssuesQuery(filter tracker.IssueFilter) graphqlRequest {
 	query := `query ListIssues($filter: IssueFilter!, $first: Int!) {
   issues(filter: $filter, first: $first, orderBy: createdAt) {
     nodes {
@@ -75,25 +78,48 @@ func listIssuesQuery(teamKey string, states, labels []string, limit int) graphql
 }`
 	issueFilter := map[string]any{}
 
-	if teamKey != "" {
+	if team := filter.Filters["team"]; team != "" {
 		issueFilter["team"] = map[string]any{
-			"key": map[string]any{"eq": teamKey},
+			"key": map[string]any{"eq": team},
 		}
 	}
-	if len(states) > 0 {
+	if stateCSV := filter.Filters["state"]; stateCSV != "" {
+		states := strings.Split(stateCSV, ",")
 		issueFilter["state"] = map[string]any{
 			"name": map[string]any{"in": states},
 		}
 	}
-	if len(labels) > 0 {
+	if labelCSV := filter.Filters["label"]; labelCSV != "" {
+		labels := strings.Split(labelCSV, ",")
 		issueFilter["labels"] = map[string]any{
 			"some": map[string]any{
 				"name": map[string]any{"in": labels},
 			},
 		}
 	}
+	if project := filter.Filters["project"]; project != "" {
+		issueFilter["project"] = map[string]any{
+			"name": map[string]any{"containsIgnoreCase": project},
+		}
+	}
+	if cycle := filter.Filters["cycle"]; cycle != "" {
+		if cycle == "current" {
+			issueFilter["cycle"] = map[string]any{
+				"isActive": map[string]any{"eq": true},
+			}
+		} else {
+			issueFilter["cycle"] = map[string]any{
+				"name": map[string]any{"containsIgnoreCase": cycle},
+			}
+		}
+	}
+	if assignee := filter.Filters["assignee"]; assignee != "" {
+		issueFilter["assignee"] = map[string]any{
+			"displayName": map[string]any{"containsIgnoreCase": assignee},
+		}
+	}
 
-	first := limit
+	first := filter.Limit
 	if first <= 0 {
 		first = 50
 	}

--- a/jiradozer/tracker/linear/queries.go
+++ b/jiradozer/tracker/linear/queries.go
@@ -78,31 +78,29 @@ func listIssuesQuery(filter tracker.IssueFilter) graphqlRequest {
 }`
 	issueFilter := map[string]any{}
 
-	if team := filter.Filters["team"]; team != "" {
+	if team := filter.Filters[tracker.FilterTeam]; team != "" {
 		issueFilter["team"] = map[string]any{
 			"key": map[string]any{"eq": team},
 		}
 	}
-	if stateCSV := filter.Filters["state"]; stateCSV != "" {
-		states := strings.Split(stateCSV, ",")
+	if states := tracker.SplitCSV(filter.Filters[tracker.FilterState]); len(states) > 0 {
 		issueFilter["state"] = map[string]any{
 			"name": map[string]any{"in": states},
 		}
 	}
-	if labelCSV := filter.Filters["label"]; labelCSV != "" {
-		labels := strings.Split(labelCSV, ",")
+	if labels := tracker.SplitCSV(filter.Filters[tracker.FilterLabel]); len(labels) > 0 {
 		issueFilter["labels"] = map[string]any{
 			"some": map[string]any{
 				"name": map[string]any{"in": labels},
 			},
 		}
 	}
-	if project := filter.Filters["project"]; project != "" {
+	if project := filter.Filters[tracker.FilterProject]; project != "" {
 		issueFilter["project"] = map[string]any{
 			"name": map[string]any{"containsIgnoreCase": project},
 		}
 	}
-	if cycle := filter.Filters["cycle"]; cycle != "" {
+	if cycle := filter.Filters[tracker.FilterCycle]; cycle != "" {
 		if cycle == "current" {
 			issueFilter["cycle"] = map[string]any{
 				"isActive": map[string]any{"eq": true},
@@ -113,7 +111,7 @@ func listIssuesQuery(filter tracker.IssueFilter) graphqlRequest {
 			}
 		}
 	}
-	if assignee := filter.Filters["assignee"]; assignee != "" {
+	if assignee := filter.Filters[tracker.FilterAssignee]; assignee != "" {
 		issueFilter["assignee"] = map[string]any{
 			"displayName": map[string]any{"containsIgnoreCase": assignee},
 		}

--- a/jiradozer/tracker/local/local.go
+++ b/jiradozer/tracker/local/local.go
@@ -156,9 +156,13 @@ func (t *Tracker) ListIssues(_ context.Context, filter tracker.IssueFilter) ([]*
 		return nil, err
 	}
 
-	stateSet := make(map[string]bool, len(filter.States))
-	for _, s := range filter.States {
-		stateSet[s] = true
+	var stateSet map[string]bool
+	if stateCSV := filter.Filters["state"]; stateCSV != "" {
+		states := strings.Split(stateCSV, ",")
+		stateSet = make(map[string]bool, len(states))
+		for _, s := range states {
+			stateSet[strings.TrimSpace(s)] = true
+		}
 	}
 
 	var out []*tracker.Issue

--- a/jiradozer/tracker/local/local.go
+++ b/jiradozer/tracker/local/local.go
@@ -157,11 +157,10 @@ func (t *Tracker) ListIssues(_ context.Context, filter tracker.IssueFilter) ([]*
 	}
 
 	var stateSet map[string]bool
-	if stateCSV := filter.Filters["state"]; stateCSV != "" {
-		states := strings.Split(stateCSV, ",")
+	if states := tracker.SplitCSV(filter.Filters[tracker.FilterState]); len(states) > 0 {
 		stateSet = make(map[string]bool, len(states))
 		for _, s := range states {
-			stateSet[strings.TrimSpace(s)] = true
+			stateSet[s] = true
 		}
 	}
 

--- a/jiradozer/tracker/local/local_test.go
+++ b/jiradozer/tracker/local/local_test.go
@@ -77,13 +77,13 @@ func TestListIssuesFilterByState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Filter for Todo only.
-	issues, err := tr.ListIssues(ctx, tracker.IssueFilter{Filters: map[string]string{"state": "Todo"}})
+	issues, err := tr.ListIssues(ctx, tracker.IssueFilter{Filters: map[string]string{tracker.FilterState: "Todo"}})
 	require.NoError(t, err)
 	assert.Len(t, issues, 1)
 	assert.Equal(t, "LOCAL-2", issues[0].Identifier)
 
 	// Filter for In Progress only.
-	issues, err = tr.ListIssues(ctx, tracker.IssueFilter{Filters: map[string]string{"state": "In Progress"}})
+	issues, err = tr.ListIssues(ctx, tracker.IssueFilter{Filters: map[string]string{tracker.FilterState: "In Progress"}})
 	require.NoError(t, err)
 	assert.Len(t, issues, 1)
 	assert.Equal(t, "LOCAL-1", issues[0].Identifier)

--- a/jiradozer/tracker/local/local_test.go
+++ b/jiradozer/tracker/local/local_test.go
@@ -77,13 +77,13 @@ func TestListIssuesFilterByState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Filter for Todo only.
-	issues, err := tr.ListIssues(ctx, tracker.IssueFilter{States: []string{"Todo"}})
+	issues, err := tr.ListIssues(ctx, tracker.IssueFilter{Filters: map[string]string{"state": "Todo"}})
 	require.NoError(t, err)
 	assert.Len(t, issues, 1)
 	assert.Equal(t, "LOCAL-2", issues[0].Identifier)
 
 	// Filter for In Progress only.
-	issues, err = tr.ListIssues(ctx, tracker.IssueFilter{States: []string{"In Progress"}})
+	issues, err = tr.ListIssues(ctx, tracker.IssueFilter{Filters: map[string]string{"state": "In Progress"}})
 	require.NoError(t, err)
 	assert.Len(t, issues, 1)
 	assert.Equal(t, "LOCAL-1", issues[0].Identifier)

--- a/jiradozer/tracker/types.go
+++ b/jiradozer/tracker/types.go
@@ -55,15 +55,21 @@ type IssueFilter struct {
 	Limit   int               // max results; 0 = default (50)
 }
 
-// SplitCSV splits a comma-separated filter value into trimmed parts.
-// Returns nil if the value is empty.
+// SplitCSV splits a comma-separated filter value into trimmed, non-empty parts.
+// Returns nil if the value is empty or contains only commas/whitespace.
 func SplitCSV(csv string) []string {
 	if csv == "" {
 		return nil
 	}
-	parts := strings.Split(csv, ",")
-	for i, p := range parts {
-		parts[i] = strings.TrimSpace(p)
+	raw := strings.Split(csv, ",")
+	parts := raw[:0] // reuse backing array
+	for _, p := range raw {
+		if s := strings.TrimSpace(p); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) == 0 {
+		return nil
 	}
 	return parts
 }

--- a/jiradozer/tracker/types.go
+++ b/jiradozer/tracker/types.go
@@ -1,6 +1,9 @@
 package tracker
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // Issue is the normalized issue record used by the workflow engine.
 type Issue struct {
@@ -31,18 +34,36 @@ type WorkflowState struct {
 	Type string // e.g. "started", "unstarted", "completed", "canceled"
 }
 
+// Well-known filter keys for IssueFilter.Filters.
+const (
+	FilterTeam      = "team"      // team or repo identifier (e.g. "ENG", "owner/repo")
+	FilterState     = "state"     // comma-separated state names (e.g. "Todo,InProgress")
+	FilterLabel     = "label"     // comma-separated labels (OR semantics)
+	FilterProject   = "project"   // Linear project name
+	FilterCycle     = "cycle"     // Linear cycle ("current" for active cycle, or name)
+	FilterMilestone = "milestone" // GitHub milestone
+	FilterAssignee  = "assignee"  // GitHub/Linear assignee
+)
+
 // IssueFilter specifies criteria for listing issues.
 //
-// Filters is a generic key-value map; each tracker interprets the keys it
-// understands and silently ignores unknown ones. Multi-value fields use
-// comma-separated strings (e.g. "Todo,InProgress").
-//
-// Common keys:
-//
-//	Universal:  team, state, label
-//	GitHub:     milestone, assignee, search (raw GitHub search query)
-//	Linear:     project, cycle ("current" for active cycle), assignee
+// Filters is a generic key-value map keyed by the Filter* constants above.
+// Each tracker interprets the keys it understands and silently ignores unknown
+// ones. Multi-value fields use comma-separated strings.
 type IssueFilter struct {
 	Filters map[string]string // tracker-specific key-value pairs
 	Limit   int               // max results; 0 = default (50)
+}
+
+// SplitCSV splits a comma-separated filter value into trimmed parts.
+// Returns nil if the value is empty.
+func SplitCSV(csv string) []string {
+	if csv == "" {
+		return nil
+	}
+	parts := strings.Split(csv, ",")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
 }

--- a/jiradozer/tracker/types.go
+++ b/jiradozer/tracker/types.go
@@ -32,9 +32,17 @@ type WorkflowState struct {
 }
 
 // IssueFilter specifies criteria for listing issues.
+//
+// Filters is a generic key-value map; each tracker interprets the keys it
+// understands and silently ignores unknown ones. Multi-value fields use
+// comma-separated strings (e.g. "Todo,InProgress").
+//
+// Common keys:
+//
+//	Universal:  team, state, label
+//	GitHub:     milestone, assignee, search (raw GitHub search query)
+//	Linear:     project, cycle ("current" for active cycle), assignee
 type IssueFilter struct {
-	TeamKey string   // e.g. "ENG"
-	States  []string // filter by state name, e.g. ["Todo"]
-	Labels  []string // optional filter: issue must have at least one of these labels (OR)
-	Limit   int      // max results; 0 = default (50)
+	Filters map[string]string // tracker-specific key-value pairs
+	Limit   int               // max results; 0 = default (50)
 }

--- a/jiradozer/tracker/types.go
+++ b/jiradozer/tracker/types.go
@@ -41,7 +41,7 @@ const (
 	FilterLabel     = "label"     // comma-separated labels (OR semantics)
 	FilterProject   = "project"   // Linear project name
 	FilterCycle     = "cycle"     // Linear cycle ("current" for active cycle, or name)
-	FilterMilestone = "milestone" // GitHub milestone
+	FilterMilestone = "milestone" // GitHub milestone number (integer string, e.g. "1")
 	FilterAssignee  = "assignee"  // GitHub/Linear assignee
 )
 

--- a/jiradozer/tracker/types_test.go
+++ b/jiradozer/tracker/types_test.go
@@ -18,6 +18,9 @@ func TestSplitCSV(t *testing.T) {
 		{name: "multiple values", input: "Todo,Backlog", want: []string{"Todo", "Backlog"}},
 		{name: "trims spaces", input: " Todo , Backlog ", want: []string{"Todo", "Backlog"}},
 		{name: "preserves internal spaces", input: "In Progress,Todo", want: []string{"In Progress", "Todo"}},
+		{name: "skips empty segments", input: "bug,,feature", want: []string{"bug", "feature"}},
+		{name: "comma only returns nil", input: ",", want: nil},
+		{name: "trailing comma", input: "bug,", want: []string{"bug"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/jiradozer/tracker/types_test.go
+++ b/jiradozer/tracker/types_test.go
@@ -1,0 +1,29 @@
+package tracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitCSV(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "empty returns nil", input: "", want: nil},
+		{name: "single value", input: "Todo", want: []string{"Todo"}},
+		{name: "multiple values", input: "Todo,Backlog", want: []string{"Todo", "Backlog"}},
+		{name: "trims spaces", input: " Todo , Backlog ", want: []string{"Todo", "Backlog"}},
+		{name: "preserves internal spaces", input: "In Progress,Todo", want: []string{"In Progress", "Todo"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SplitCSV(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #131.

- Replace `--team`/`--source-states`/`--source-labels` with a single generic `--filter key=value` (repeatable) flag
- `IssueFilter` now uses `Filters map[string]string` instead of dedicated `TeamKey`/`States`/`Labels` fields — each tracker interprets the keys it understands, no schema changes needed for new filter dimensions
- Add Linear support for `project`, `cycle` ("current" for active cycle), `assignee` filters
- Add GitHub support for `milestone`, `assignee` filters
- Universal keys: `team`, `state`, `label` (comma-separated for multi-value)

**CLI usage:**
```
jiradozer --filter team=ENG --filter state=Todo --filter project="Backend Rewrite"
```

**YAML config:**
```yaml
source:
  filters:
    team: ENG
    state: Todo
    project: "Backend Rewrite"
    cycle: current
```

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer/...` — all 5 test targets pass
- [ ] Manual: `jiradozer --filter team=owner/repo --filter milestone=v2.0` adds milestone to GitHub query
- [ ] Manual: `jiradozer --filter team=ENG --filter project=Backend --filter cycle=current` enters multi-issue mode for Linear

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors multi-issue discovery and tracker query plumbing to a new generic filter map, which could change which issues are discovered or how GitHub/Linear queries are formed. Risk is limited by updated unit/integration tests and mostly additive filtering behavior.
> 
> **Overview**
> **Replaces multi-issue selection with a generic filter mechanism.** The CLI drops `--team`, `--source-states`, and `--source-labels` in favor of repeatable `--filter key=value`, and config switches from `source.team/states/labels` to `source.filters`.
> 
> **Tracker filtering is generalized and expanded.** `tracker.IssueFilter` now carries `Filters map[string]string` (with comma-separated multi-values via `SplitCSV`), and GitHub/Linear/local trackers are updated to consume it; GitHub adds `milestone`/`assignee` query support and Linear adds `project`/`cycle` (including `current`)/`assignee` filtering. Docs/examples and tests are updated accordingly, and a new Bazel `go_test` target covers `SplitCSV`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49344618311cc0385f659e0201691220998482eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->