### PR TITLE
claude SDK: fix stuck session on mixed bg/non-bg tools

### DIFF
--- a/agent-cli-wrapper/claude/integration/session_test.go
+++ b/agent-cli-wrapper/claude/integration/session_test.go
@@ -704,6 +704,93 @@ func TestSession_Integration_BackgroundTaskCancelled(t *testing.T) {
 	t.Log("All assertions passed for Background Task Cancellation scenario")
 }
 
+// ============================================================================
+// Scenario 7: Mixed Background + Non-Background Tools
+// ============================================================================
+
+// TestSession_Integration_BackgroundTaskMixed verifies that the session
+// completes normally when a turn contains BOTH background and non-background
+// tools. This reproduces the jiradozer stuck-session bug where the SDK
+// incorrectly suppressed the turn when 2× bg + 1× non-bg tools were present.
+//
+// The ResultMessage for a mixed turn represents completion of the synchronous
+// (non-bg) work, so it must NOT be suppressed.
+func TestSession_Integration_BackgroundTaskMixed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	testDir, err := os.MkdirTemp("", "claude-go-test-bgmixed-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(testDir)
+	t.Logf("Test artifacts directory: %s", testDir)
+
+	session := claude.NewSession(
+		claude.WithModel("haiku"),
+		claude.WithWorkDir(testDir),
+		claude.WithPermissionMode(claude.PermissionModeBypass),
+		claude.WithDisablePlugins(),
+		claude.WithRecording(testDir),
+	)
+
+	if err := session.Start(ctx); err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+	defer session.Stop()
+
+	// Ask the agent to run 3 tools in one response: 2 background + 1 blocking.
+	// This is the exact pattern that caused the jiradozer stuck session.
+	t.Log("Sending mixed bg/non-bg prompt...")
+	_, err = session.SendMessage(ctx,
+		"Run these THREE bash commands in PARALLEL (all in one response, using multiple tool calls):\n"+
+			"1. `sleep 1 && echo BG1_DONE` with run_in_background: true\n"+
+			"2. `sleep 1 && echo BG2_DONE` with run_in_background: true\n"+
+			"3. `echo BLOCKING_DONE` (NO run_in_background, this is a normal blocking command)\n\n"+
+			"You MUST call all three Bash tools in the same response so they run in parallel. "+
+			"Commands 1 and 2 MUST use run_in_background: true. "+
+			"Command 3 MUST NOT use run_in_background.")
+	if err != nil {
+		t.Fatalf("SendMessage failed: %v", err)
+	}
+
+	events, err := CollectTurnEvents(ctx, session)
+	if err != nil {
+		t.Fatalf("CollectTurnEvents failed (session may have hung — this is the mixed bg/non-bg bug): %v", err)
+	}
+
+	if events.TurnComplete == nil {
+		t.Fatal("Expected TurnCompleteEvent — session hung or no events received")
+	}
+	if !events.TurnComplete.Success {
+		t.Errorf("Expected successful turn, got error")
+	}
+
+	// Verify the tool mix: at least one bg and one non-bg tool.
+	bgCount := 0
+	nonBgCount := 0
+	for _, tc := range events.ToolComplete {
+		if tc.Name == "Bash" {
+			if rib, ok := tc.Input["run_in_background"]; ok {
+				if b, ok := rib.(bool); ok && b {
+					bgCount++
+					continue
+				}
+			}
+			nonBgCount++
+		}
+	}
+	t.Logf("Tool mix: %d bg, %d non-bg", bgCount, nonBgCount)
+	if bgCount == 0 || nonBgCount == 0 {
+		t.Log("WARNING: Agent did not produce the expected mix of bg + non-bg tools. " +
+			"Test may not exercise the mixed-tool path.")
+	}
+
+	t.Logf("Turn completed: success=%v, cost=$%.6f",
+		events.TurnComplete.Success, events.TurnComplete.Usage.CostUSD)
+	t.Log("All assertions passed for Mixed Background Task scenario")
+}
+
 // containsAny reports whether s contains any of the given substrings (case-insensitive).
 func containsAny(s string, subs ...string) bool {
 	lower := strings.ToLower(s)

--- a/agent-cli-wrapper/claude/integration/session_test.go
+++ b/agent-cli-wrapper/claude/integration/session_test.go
@@ -782,8 +782,9 @@ func TestSession_Integration_BackgroundTaskMixed(t *testing.T) {
 	}
 	t.Logf("Tool mix: %d bg, %d non-bg", bgCount, nonBgCount)
 	if bgCount == 0 || nonBgCount == 0 {
-		t.Log("WARNING: Agent did not produce the expected mix of bg + non-bg tools. " +
-			"Test may not exercise the mixed-tool path.")
+		t.Skipf("Agent did not produce the expected mix of bg + non-bg tools "+
+			"(bg=%d, non-bg=%d); cannot exercise the mixed-tool suppression path",
+			bgCount, nonBgCount)
 	}
 
 	t.Logf("Turn completed: success=%v, cost=$%.6f",

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -782,22 +782,16 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 	}
 }
 
-// shouldSuppressForBgTasks inspects the current turn's ContentBlocks to decide
-// whether the ResultMessage should be suppressed (waiting for background task
-// continuations). Returns true only when ALL non-cancelled tool_use blocks in
-// the turn had run_in_background: true — meaning the ResultMessage arrived
-// because bg tools returned immediately, and the real work is still in progress.
-//
-// When non-bg tools are present, the ResultMessage represents the completion of
+// shouldSuppressForBgTasks returns true when ALL non-cancelled tool_use blocks
+// in the turn had run_in_background: true, meaning the ResultMessage arrived
+// because bg tools returned immediately and the real work is still in progress.
+// When non-bg tools are present, the ResultMessage represents completion of
 // synchronous work and must not be suppressed.
-func (s *Session) shouldSuppressForBgTasks(turn *turnState) bool {
+func (turn *turnState) shouldSuppressForBgTasks() bool {
 	if turn == nil {
 		return false
 	}
 
-	// Build set of cancelled (errored) tool IDs from tool_result blocks.
-	// Cancelled tools never launched a background task, so they should not
-	// influence the suppression decision.
 	cancelled := make(map[string]bool)
 	for _, block := range turn.ContentBlocks {
 		if block.Type == ContentBlockTypeToolResult && block.IsError {
@@ -805,10 +799,6 @@ func (s *Session) shouldSuppressForBgTasks(turn *turnState) bool {
 		}
 	}
 
-	// Check tool_use blocks. Non-bg tools always prevent suppression (even if
-	// they errored), because their presence means the ResultMessage represents
-	// completion of synchronous work. Cancelled bg tools are skipped — they
-	// never actually launched a background task.
 	hasBgTool := false
 	for _, block := range turn.ContentBlocks {
 		if block.Type != ContentBlockTypeToolUse {
@@ -816,9 +806,8 @@ func (s *Session) shouldSuppressForBgTasks(turn *turnState) bool {
 		}
 		isBg, _ := block.ToolInput["run_in_background"].(bool)
 		if !isBg {
-			return false // non-bg tool exists → don't suppress
+			return false
 		}
-		// It's a bg tool — only count it if not cancelled.
 		if !cancelled[block.ToolUseID] {
 			hasBgTool = true
 		}
@@ -900,7 +889,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	//
 	// When non-bg tools are present (mixed turn), the ResultMessage represents
 	// completion of synchronous work and must not be suppressed.
-	shouldSuppress := s.shouldSuppressForBgTasks(turn)
+	shouldSuppress := turn.shouldSuppressForBgTasks()
 
 	// costAccounted tracks whether cumulativeCostUSD has already been updated
 	// for this result (the background-task branch does it early to enable budget

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -19,6 +19,29 @@ import (
 // accumulated data to prevent indefinite blocking.
 const defaultBgTaskSafetyTimeout = 90 * time.Second
 
+// bgSuppressionState groups all background-task turn-suppression state.
+// When the CLI runs background tasks (run_in_background: true), the SDK
+// suppresses the intermediate ResultMessage and waits for continuation
+// task-notifications. This struct holds the state for that mechanism.
+// Use reset() to clear all fields at turn boundaries.
+type bgSuppressionState struct {
+	timer            *time.Timer // fires if no continuation arrives; see completeSuppressedTurn
+	accumulatedUsage TurnUsage   // token/cost totals from suppressed intermediate results
+	active           bool        // true while waiting for continuation; cleared by timer or normal path
+	timerFired       bool        // set by completeSuppressedTurn; cleared at start of next turn
+}
+
+// reset clears all suppression state and stops any pending timer.
+func (b *bgSuppressionState) reset() {
+	b.active = false
+	b.timerFired = false
+	if b.timer != nil {
+		b.timer.Stop()
+		b.timer = nil
+	}
+	b.accumulatedUsage = TurnUsage{}
+}
+
 // SessionInfo contains session metadata.
 type SessionInfo struct {
 	SessionID      string
@@ -36,7 +59,6 @@ type Session struct {
 	// Pointer / interface / channel fields (all 8-16 bytes, contain pointers).
 	ctx                     context.Context
 	pendingControlResponses map[string]chan protocol.ControlResponsePayload
-	bgSafetyTimer           *time.Timer // fires if no bg-task continuation arrives; see completeSuppressedTurn
 	accumulator             *streamAccumulator
 	turnManager             *turnManager
 	permissionManager       *permissionManager
@@ -49,18 +71,15 @@ type Session struct {
 	cancel                  context.CancelFunc
 
 	// Value / struct fields.
-	config                 SessionConfig
-	bgTaskAccumulatedUsage TurnUsage // token/cost totals from suppressed intermediate results; protected by mu
-	cumulativeCostUSD      float64
+	config            SessionConfig
+	bgState           bgSuppressionState // background-task turn-suppression state; protected by mu
+	cumulativeCostUSD float64
 
 	// Scalar and sync fields.
-	bgTasksPendingSinceLastResult int // successful bg launches since last result; protected by mu
-	mu                            sync.RWMutex
-	pendingMu                     sync.Mutex
-	bgTurnSuppressionActive       bool // true while waiting for continuation; cleared by timer or normal path
-	bgTimerFired                  bool // set by completeSuppressedTurn; cleared at start of next turn
-	started                       bool
-	stopping                      bool
+	mu        sync.RWMutex
+	pendingMu sync.Mutex
+	started   bool
+	stopping  bool
 }
 
 // NewSession creates a new Claude session with options.
@@ -235,13 +254,7 @@ func (s *Session) SendMessage(ctx context.Context, content string) (int, error) 
 	turn := s.turnManager.StartTurn(content)
 	// Clear any stale background-task suppression state from the previous turn.
 	// A safety timer for Turn N must not fire after Turn N+1 has started.
-	s.bgTimerFired = false
-	s.bgTurnSuppressionActive = false
-	s.bgTasksPendingSinceLastResult = 0
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop()
-		s.bgSafetyTimer = nil
-	}
+	s.bgState.reset()
 
 	// Record turn start
 	if s.recorder != nil {
@@ -282,13 +295,7 @@ func (s *Session) SendToolResult(ctx context.Context, toolUseID, content string)
 
 	turn := s.turnManager.StartTurn(content)
 	// Clear any stale background-task suppression state from the previous turn.
-	s.bgTimerFired = false
-	s.bgTurnSuppressionActive = false
-	s.bgTasksPendingSinceLastResult = 0
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop()
-		s.bgSafetyTimer = nil
-	}
+	s.bgState.reset()
 
 	// Record turn start
 	if s.recorder != nil {
@@ -451,11 +458,7 @@ func (s *Session) Stop() error {
 		return nil
 	}
 	s.stopping = true
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop()
-		s.bgSafetyTimer = nil
-	}
-	s.bgTurnSuppressionActive = false
+	s.bgState.reset()
 	s.mu.Unlock()
 
 	// Cancel context for tool handler goroutines
@@ -759,23 +762,6 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 				IsError:    isError,
 			})
 
-			// Track background task launches from tool input parameters.
-			// Checking tool.Input["run_in_background"] is robust against false
-			// positives from output content (e.g., git diffs containing the
-			// background task regex pattern string).
-			//
-			// Only count non-error results: when a parallel tool call fails, the
-			// CLI cancels sibling tools (including background ones) and returns
-			// is_error=true. Those cancelled tools never actually launched a
-			// background task, so counting them would cause the session to wait
-			// for a task-notification that will never arrive.
-			if tool != nil && !isError {
-				if rib, ok := tool.Input["run_in_background"].(bool); ok && rib {
-					s.mu.Lock()
-					s.bgTasksPendingSinceLastResult++
-					s.mu.Unlock()
-				}
-			}
 		}
 	}
 
@@ -796,23 +782,64 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 	}
 }
 
+// shouldSuppressForBgTasks inspects the current turn's ContentBlocks to decide
+// whether the ResultMessage should be suppressed (waiting for background task
+// continuations). Returns true only when ALL non-cancelled tool_use blocks in
+// the turn had run_in_background: true — meaning the ResultMessage arrived
+// because bg tools returned immediately, and the real work is still in progress.
+//
+// When non-bg tools are present, the ResultMessage represents the completion of
+// synchronous work and must not be suppressed.
+func (s *Session) shouldSuppressForBgTasks(turn *turnState) bool {
+	if turn == nil {
+		return false
+	}
+
+	// Build set of cancelled (errored) tool IDs from tool_result blocks.
+	// Cancelled tools never launched a background task, so they should not
+	// influence the suppression decision.
+	cancelled := make(map[string]bool)
+	for _, block := range turn.ContentBlocks {
+		if block.Type == ContentBlockTypeToolResult && block.IsError {
+			cancelled[block.ToolUseID] = true
+		}
+	}
+
+	// Check tool_use blocks. Non-bg tools always prevent suppression (even if
+	// they errored), because their presence means the ResultMessage represents
+	// completion of synchronous work. Cancelled bg tools are skipped — they
+	// never actually launched a background task.
+	hasBgTool := false
+	for _, block := range turn.ContentBlocks {
+		if block.Type != ContentBlockTypeToolUse {
+			continue
+		}
+		isBg, _ := block.ToolInput["run_in_background"].(bool)
+		if !isBg {
+			return false // non-bg tool exists → don't suppress
+		}
+		// It's a bg tool — only count it if not cancelled.
+		if !cancelled[block.ToolUseID] {
+			hasBgTool = true
+		}
+	}
+	return hasBgTool
+}
+
 func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// Cancel any pending background-task safety timer — a normal continuation
 	// ResultMessage has arrived, so the safety path is no longer needed.
 	// If bgTimerFired is set, the safety timer already completed this turn;
 	// return early to prevent a duplicate TurnCompleteEvent.
 	s.mu.Lock()
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop()
-		s.bgSafetyTimer = nil
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
+		s.bgState.timer = nil
 	}
-	timerAlreadyFired := s.bgTimerFired
-	s.bgTimerFired = false // clear; also reset by SendMessage at next turn start
-	s.bgTurnSuppressionActive = false
+	timerAlreadyFired := s.bgState.timerFired
+	s.bgState.timerFired = false // clear; also reset by SendMessage at next turn start
+	s.bgState.active = false
 	if timerAlreadyFired {
-		// The safety timer already finalized this turn. Clear any pending counter
-		// so it does not incorrectly suppress the next turn's result.
-		s.bgTasksPendingSinceLastResult = 0
 		s.mu.Unlock()
 		return
 	}
@@ -829,8 +856,8 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// Collect any accumulated usage from suppressed intermediate results
 	// (background task continuation turns) to report the full logical-turn cost.
 	s.mu.Lock()
-	accUsage := s.bgTaskAccumulatedUsage
-	s.bgTaskAccumulatedUsage = TurnUsage{}
+	accUsage := s.bgState.accumulatedUsage
+	s.bgState.accumulatedUsage = TurnUsage{}
 	s.mu.Unlock()
 
 	result := TurnResult{
@@ -865,22 +892,22 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		result.Error = fmt.Errorf("%s", msg.Result)
 	}
 
-	// Check if background tasks were launched since the last ResultMessage.
+	// Check if ALL non-cancelled tools in this turn were background tasks.
 	// If so, the CLI will auto-continue after the tasks complete (delivering
 	// task-notification messages and starting a new assistant turn). Suppress
 	// turn completion so callers of Ask()/WaitForTurn()/CollectResponse()
 	// block until the truly-final turn.
-	s.mu.Lock()
-	bgPending := s.bgTasksPendingSinceLastResult
-	s.bgTasksPendingSinceLastResult = 0
-	s.mu.Unlock()
+	//
+	// When non-bg tools are present (mixed turn), the ResultMessage represents
+	// completion of synchronous work and must not be suppressed.
+	shouldSuppress := s.shouldSuppressForBgTasks(turn)
 
 	// costAccounted tracks whether cumulativeCostUSD has already been updated
 	// for this result (the background-task branch does it early to enable budget
 	// checks mid-turn; the normal path must not double-count).
 	costAccounted := false
 
-	if bgPending > 0 {
+	if shouldSuppress {
 		// If the intermediate result carries an error, propagate it now rather
 		// than silently dropping it — the background task continuation will not
 		// arrive, so the session would otherwise stay stuck in StateProcessing.
@@ -896,11 +923,11 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 			s.mu.Lock()
 			s.cumulativeCostUSD += msg.TotalCostUSD
 			totalCostSoFar := s.cumulativeCostUSD
-			s.bgTaskAccumulatedUsage.InputTokens += msg.Usage.InputTokens + accUsage.InputTokens
-			s.bgTaskAccumulatedUsage.OutputTokens += msg.Usage.OutputTokens + accUsage.OutputTokens
-			s.bgTaskAccumulatedUsage.CacheCreationTokens += msg.Usage.CacheCreationInputTokens + accUsage.CacheCreationTokens
-			s.bgTaskAccumulatedUsage.CacheReadTokens += msg.Usage.CacheReadInputTokens + accUsage.CacheReadTokens
-			s.bgTaskAccumulatedUsage.CostUSD += msg.TotalCostUSD + accUsage.CostUSD
+			s.bgState.accumulatedUsage.InputTokens += msg.Usage.InputTokens + accUsage.InputTokens
+			s.bgState.accumulatedUsage.OutputTokens += msg.Usage.OutputTokens + accUsage.OutputTokens
+			s.bgState.accumulatedUsage.CacheCreationTokens += msg.Usage.CacheCreationInputTokens + accUsage.CacheCreationTokens
+			s.bgState.accumulatedUsage.CacheReadTokens += msg.Usage.CacheReadInputTokens + accUsage.CacheReadTokens
+			s.bgState.accumulatedUsage.CostUSD += msg.TotalCostUSD + accUsage.CostUSD
 			s.mu.Unlock()
 			costAccounted = true
 
@@ -918,7 +945,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 			if s.config.MaxBudgetUSD > 0 && totalCostSoFar >= s.config.MaxBudgetUSD {
 				result.Error = ErrBudgetExceeded
 				s.mu.Lock()
-				s.bgTaskAccumulatedUsage = TurnUsage{}
+				s.bgState.accumulatedUsage = TurnUsage{}
 				s.mu.Unlock()
 				// Fall through to normal completion path to emit TurnCompleteEvent.
 			} else {
@@ -935,12 +962,12 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				}
 				safetyResult := result
 				s.mu.Lock()
-				s.bgTurnSuppressionActive = true
-				s.bgTimerFired = false // reset for this turn's timer
-				if s.bgSafetyTimer != nil {
-					s.bgSafetyTimer.Stop()
+				s.bgState.active = true
+				s.bgState.timerFired = false // reset for this turn's timer
+				if s.bgState.timer != nil {
+					s.bgState.timer.Stop()
 				}
-				s.bgSafetyTimer = time.AfterFunc(timeout, func() {
+				s.bgState.timer = time.AfterFunc(timeout, func() {
 					s.completeSuppressedTurn(safetyResult)
 				})
 				s.mu.Unlock()
@@ -998,15 +1025,14 @@ func (s *Session) finalizeTurn(result TurnResult) {
 // turn with whatever data was accumulated, preventing indefinite blocking.
 func (s *Session) completeSuppressedTurn(result TurnResult) {
 	s.mu.Lock()
-	if !s.bgTurnSuppressionActive {
+	if !s.bgState.active {
 		s.mu.Unlock()
 		return // Already completed by normal path
 	}
-	s.bgTurnSuppressionActive = false
-	s.bgTimerFired = true
-	s.bgSafetyTimer = nil
-	s.bgTaskAccumulatedUsage = TurnUsage{}
-	s.bgTasksPendingSinceLastResult = 0 // clear stale counter; no continuation will arrive
+	s.bgState.active = false
+	s.bgState.timerFired = true
+	s.bgState.timer = nil
+	s.bgState.accumulatedUsage = TurnUsage{}
 	s.mu.Unlock()
 
 	// Incorporate streaming updates from the correct turn only. Guard with

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -782,43 +782,10 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 	}
 }
 
-// shouldSuppressForBgTasks returns true when ALL non-cancelled tool_use blocks
-// in the turn had run_in_background: true, meaning the ResultMessage arrived
-// because bg tools returned immediately and the real work is still in progress.
-// When non-bg tools are present, the ResultMessage represents completion of
-// synchronous work and must not be suppressed.
-func (turn *turnState) shouldSuppressForBgTasks() bool {
-	if turn == nil {
-		return false
-	}
-
-	cancelled := make(map[string]bool)
-	for _, block := range turn.ContentBlocks {
-		if block.Type == ContentBlockTypeToolResult && block.IsError {
-			cancelled[block.ToolUseID] = true
-		}
-	}
-
-	hasBgTool := false
-	for _, block := range turn.ContentBlocks {
-		if block.Type != ContentBlockTypeToolUse {
-			continue
-		}
-		isBg, _ := block.ToolInput["run_in_background"].(bool)
-		if !isBg {
-			return false
-		}
-		if !cancelled[block.ToolUseID] {
-			hasBgTool = true
-		}
-	}
-	return hasBgTool
-}
-
 func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// Cancel any pending background-task safety timer — a normal continuation
 	// ResultMessage has arrived, so the safety path is no longer needed.
-	// If bgTimerFired is set, the safety timer already completed this turn;
+	// If bgState.timerFired is set, the safety timer already completed this turn;
 	// return early to prevent a duplicate TurnCompleteEvent.
 	s.mu.Lock()
 	if s.bgState.timer != nil {

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -65,9 +65,8 @@ func newTestSession(t *testing.T, opts ...SessionOption) *Session {
 	return s
 }
 
-// simulateAssistantToolUse registers tool_use blocks with the session so
-// that handleUser can look them up via FindToolByID. Also appends
-// ContentBlocks so shouldSuppressForBgTasks can inspect them.
+// simulateAssistantToolUse registers tool_use blocks with the session,
+// mirroring what handleAssistant does: tracks tools and appends ContentBlocks.
 func simulateAssistantToolUse(s *Session, tools []protocol.ToolUseBlock) {
 	// Start a turn and register each tool.
 	s.turnManager.StartTurn("test")
@@ -128,7 +127,7 @@ func TestBgTask_CancelledToolsDoNotSuppressTurn(t *testing.T) {
 
 	// shouldSuppressForBgTasks must return false: all tools are cancelled.
 	turn := s.turnManager.CurrentTurn()
-	if s.shouldSuppressForBgTasks(turn) {
+	if turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return false when all tools are cancelled")
 	}
 
@@ -162,7 +161,7 @@ func TestBgTask_SuccessfulBgToolSuppressesTurn(t *testing.T) {
 
 	// shouldSuppressForBgTasks must return true: only bg tools, none cancelled.
 	turn := s.turnManager.CurrentTurn()
-	if !s.shouldSuppressForBgTasks(turn) {
+	if !turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return true for a single successful bg tool")
 	}
 
@@ -404,7 +403,7 @@ func TestBgTask_MixedSuccessAndCancelled(t *testing.T) {
 
 	// shouldSuppressForBgTasks must return true: only tool-1 is non-cancelled, and it's bg.
 	turn := s.turnManager.CurrentTurn()
-	if !s.shouldSuppressForBgTasks(turn) {
+	if !turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return true — only non-cancelled tool is bg")
 	}
 }
@@ -433,7 +432,7 @@ func TestBgTask_MixedBgAndNonBgDoesNotSuppressTurn(t *testing.T) {
 
 	// shouldSuppressForBgTasks must return false: non-bg tool exists.
 	turn := s.turnManager.CurrentTurn()
-	if s.shouldSuppressForBgTasks(turn) {
+	if turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return false when non-bg tools are present")
 	}
 
@@ -476,7 +475,7 @@ func TestBgTask_MultipleBgToolsStillSuppressTurn(t *testing.T) {
 
 	// shouldSuppressForBgTasks must return true.
 	turn := s.turnManager.CurrentTurn()
-	if !s.shouldSuppressForBgTasks(turn) {
+	if !turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return true when all tools are bg")
 	}
 
@@ -535,7 +534,7 @@ func TestBgTask_MixedBgAndNonBgWithNonBgError(t *testing.T) {
 
 	// Non-bg tool exists (even though it errored) → don't suppress.
 	turn := s.turnManager.CurrentTurn()
-	if s.shouldSuppressForBgTasks(turn) {
+	if turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return false when a non-bg tool exists (even if errored)")
 	}
 }
@@ -556,7 +555,7 @@ func TestBgTask_NoBgToolsNormalCompletion(t *testing.T) {
 	simulateUserToolResults(t, s, results)
 
 	turn := s.turnManager.CurrentTurn()
-	if s.shouldSuppressForBgTasks(turn) {
+	if turn.shouldSuppressForBgTasks() {
 		t.Error("shouldSuppressForBgTasks should return false when no bg tools exist")
 	}
 }

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -66,13 +66,20 @@ func newTestSession(t *testing.T, opts ...SessionOption) *Session {
 }
 
 // simulateAssistantToolUse registers tool_use blocks with the session so
-// that handleUser can look them up via FindToolByID.
+// that handleUser can look them up via FindToolByID. Also appends
+// ContentBlocks so shouldSuppressForBgTasks can inspect them.
 func simulateAssistantToolUse(s *Session, tools []protocol.ToolUseBlock) {
 	// Start a turn and register each tool.
 	s.turnManager.StartTurn("test")
 	for _, tb := range tools {
 		tool := s.turnManager.GetOrCreateTool(tb.ID, tb.Name)
 		tool.Input = tb.Input
+		s.turnManager.AppendContentBlock(ContentBlock{
+			Type:      ContentBlockTypeToolUse,
+			ToolUseID: tb.ID,
+			ToolName:  tb.Name,
+			ToolInput: tb.Input,
+		})
 	}
 }
 
@@ -119,17 +126,13 @@ func TestBgTask_CancelledToolsDoNotSuppressTurn(t *testing.T) {
 	}
 	simulateUserToolResults(t, s, results)
 
-	// The counter should be 0: cancelled bg tools should not be counted.
-	s.mu.RLock()
-	pending := s.bgTasksPendingSinceLastResult
-	s.mu.RUnlock()
-
-	if pending != 0 {
-		t.Errorf("expected bgTasksPendingSinceLastResult=0, got %d", pending)
+	// shouldSuppressForBgTasks must return false: all tools are cancelled.
+	turn := s.turnManager.CurrentTurn()
+	if s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return false when all tools are cancelled")
 	}
 
 	// Now simulate handleResult — should complete the turn normally, not suppress.
-	// Transition to processing first.
 	_ = s.state.Transition(TransitionUserMessageSent)
 
 	resultMsg := protocol.ResultMessage{
@@ -157,12 +160,10 @@ func TestBgTask_SuccessfulBgToolSuppressesTurn(t *testing.T) {
 	}
 	simulateUserToolResults(t, s, results)
 
-	s.mu.RLock()
-	pending := s.bgTasksPendingSinceLastResult
-	s.mu.RUnlock()
-
-	if pending != 1 {
-		t.Errorf("expected bgTasksPendingSinceLastResult=1, got %d", pending)
+	// shouldSuppressForBgTasks must return true: only bg tools, none cancelled.
+	turn := s.turnManager.CurrentTurn()
+	if !s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return true for a single successful bg tool")
 	}
 
 	// handleResult should suppress the turn (no TurnCompleteEvent).
@@ -185,21 +186,21 @@ func TestBgTask_SuccessfulBgToolSuppressesTurn(t *testing.T) {
 
 	// Verify safety timer is active.
 	s.mu.RLock()
-	timerActive := s.bgSafetyTimer != nil
-	suppActive := s.bgTurnSuppressionActive
+	timerActive := s.bgState.timer != nil
+	suppActive := s.bgState.active
 	s.mu.RUnlock()
 
 	if !timerActive {
-		t.Error("expected bgSafetyTimer to be active")
+		t.Error("expected bgState.timer to be active")
 	}
 	if !suppActive {
-		t.Error("expected bgTurnSuppressionActive to be true")
+		t.Error("expected bgState.active to be true")
 	}
 
 	// Clean up: stop the safety timer to avoid leaks.
 	s.mu.Lock()
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop()
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
 	}
 	s.mu.Unlock()
 }
@@ -256,7 +257,7 @@ func TestBgTask_SafetyTimerPreventsLateResultDoubleCompletion(t *testing.T) {
 	waitForTurnComplete(t, s.events, 2*time.Second)
 
 	// Simulate a late continuation result arriving after the timer completed the turn.
-	// handleResult must detect bgTimerFired and return early — no second TurnCompleteEvent.
+	// handleResult must detect bgState.timerFired and return early — no second TurnCompleteEvent.
 	s.handleResult(resultMsg)
 
 	// Drain events for a short window; must see at most one TurnCompleteEvent total.
@@ -305,14 +306,11 @@ func TestBgTask_SafetyTimerDoesNotPoisonNextTurn(t *testing.T) {
 	// Simulate Turn N+1 starting (replicates what SendMessage does):
 	// clear all stale suppression state so the old timer cannot fire again.
 	s.mu.Lock()
-	s.bgTimerFired = false
-	s.bgTurnSuppressionActive = false
-	s.bgTasksPendingSinceLastResult = 0
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop()
-		s.bgSafetyTimer = nil
-	}
+	s.bgState.reset()
 	s.mu.Unlock()
+
+	// Start a new turn with no bg tools.
+	s.turnManager.StartTurn("turn N+1")
 
 	// Turn N+1: transition to processing and deliver a result.
 	// This must produce a TurnCompleteEvent — not be silently dropped.
@@ -324,13 +322,13 @@ func TestBgTask_SafetyTimerDoesNotPoisonNextTurn(t *testing.T) {
 
 func TestBgTask_OldTimerCannotPoisonNextTurnAfterSendMessage(t *testing.T) {
 	// Validate that SendMessage correctly stops the old timer and clears
-	// bgTurnSuppressionActive, so even if the timer fires after SendMessage
-	// completes, it cannot set bgTimerFired and drop the new turn's result.
+	// bgState.active, so even if the timer fires after SendMessage
+	// completes, it cannot set bgState.timerFired and drop the new turn's result.
 	//
 	// Sequence:
 	//   1. Turn N suppressed, timer armed.
-	//   2. SendMessage starts Turn N+1 (clears bgTurnSuppressionActive, stops timer).
-	//   3. Old timer closure fires — completeSuppressedTurn sees bgTurnSuppressionActive=false, returns.
+	//   2. SendMessage starts Turn N+1 (clears bgState.active, stops timer).
+	//   3. Old timer closure fires — completeSuppressedTurn sees bgState.active=false, returns.
 	//   4. Turn N+1 handleResult must complete normally.
 	s := newTestSession(t, WithBgTaskSafetyTimeout(200*time.Millisecond))
 
@@ -352,22 +350,19 @@ func TestBgTask_OldTimerCannotPoisonNextTurnAfterSendMessage(t *testing.T) {
 
 	// Verify suppression is active.
 	s.mu.RLock()
-	suppActive := s.bgTurnSuppressionActive
+	suppActive := s.bgState.active
 	s.mu.RUnlock()
 	if !suppActive {
-		t.Fatal("expected bgTurnSuppressionActive to be true after suppression started")
+		t.Fatal("expected bgState.active to be true after suppression started")
 	}
 
 	// Simulate SendMessage for Turn N+1: clear all stale state and stop the old timer.
 	s.mu.Lock()
-	s.bgTimerFired = false
-	s.bgTurnSuppressionActive = false
-	s.bgTasksPendingSinceLastResult = 0
-	if s.bgSafetyTimer != nil {
-		s.bgSafetyTimer.Stop() // stops the real timer
-		s.bgSafetyTimer = nil
-	}
+	s.bgState.reset()
 	s.mu.Unlock()
+
+	// Start a new turn with no bg tools.
+	s.turnManager.StartTurn("turn N+1")
 
 	// Wait longer than the timer would have fired (200ms), ensuring no late fire.
 	time.Sleep(300 * time.Millisecond)
@@ -378,12 +373,12 @@ func TestBgTask_OldTimerCannotPoisonNextTurnAfterSendMessage(t *testing.T) {
 
 	waitForTurnComplete(t, s.events, time.Second)
 
-	// Ensure bgTimerFired was not set by the old timer closure.
+	// Ensure bgState.timerFired was not set by the old timer closure.
 	s.mu.RLock()
-	timerFired := s.bgTimerFired
+	timerFired := s.bgState.timerFired
 	s.mu.RUnlock()
 	if timerFired {
-		t.Error("bgTimerFired should be false — old timer should have been stopped by SendMessage")
+		t.Error("bgState.timerFired should be false — old timer should have been stopped by bgState.reset()")
 	}
 }
 
@@ -407,17 +402,161 @@ func TestBgTask_MixedSuccessAndCancelled(t *testing.T) {
 	}
 	simulateUserToolResults(t, s, results)
 
-	// Only tool-1 should be counted.
-	s.mu.RLock()
-	pending := s.bgTasksPendingSinceLastResult
-	s.mu.RUnlock()
+	// shouldSuppressForBgTasks must return true: only tool-1 is non-cancelled, and it's bg.
+	turn := s.turnManager.CurrentTurn()
+	if !s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return true — only non-cancelled tool is bg")
+	}
+}
 
-	if pending != 1 {
-		t.Errorf("expected bgTasksPendingSinceLastResult=1 (only non-error bg tool), got %d", pending)
+func TestBgTask_MixedBgAndNonBgDoesNotSuppressTurn(t *testing.T) {
+	// This is the core bug fix test: when a turn has both bg and non-bg tools,
+	// the ResultMessage represents completion of synchronous work and must NOT
+	// be suppressed. This was the jiradozer stuck-session scenario.
+	s := newTestSession(t)
+
+	// Simulate 3 tools: 2 bg + 1 non-bg (the exact jiradozer pattern).
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 1 && echo BG1", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 1 && echo BG2", "run_in_background": true}},
+		{ID: "tool-3", Name: "Bash", Input: map[string]interface{}{"command": "echo blocking", "timeout": 600000}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+		{ToolUseID: "tool-2", Content: "Running in background...", IsError: &isErrFalse},
+		{ToolUseID: "tool-3", Content: "blocking output", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	// shouldSuppressForBgTasks must return false: non-bg tool exists.
+	turn := s.turnManager.CurrentTurn()
+	if s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return false when non-bg tools are present")
+	}
+
+	// handleResult should complete the turn normally.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{
+		Type:    "result",
+		IsError: false,
+	}
+	s.handleResult(resultMsg)
+
+	// TurnCompleteEvent must be emitted — not suppressed.
+	waitForTurnComplete(t, s.events, time.Second)
+
+	// Safety timer must NOT be started.
+	s.mu.RLock()
+	timerActive := s.bgState.timer != nil
+	s.mu.RUnlock()
+	if timerActive {
+		t.Error("safety timer should NOT be started for mixed bg/non-bg turns")
+	}
+}
+
+func TestBgTask_MultipleBgToolsStillSuppressTurn(t *testing.T) {
+	// When ALL tools are bg, the turn should still be suppressed.
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 5 && echo BG1", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 5 && echo BG2", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+		{ToolUseID: "tool-2", Content: "Running in background...", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	// shouldSuppressForBgTasks must return true.
+	turn := s.turnManager.CurrentTurn()
+	if !s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return true when all tools are bg")
+	}
+
+	// handleResult should suppress the turn.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	resultMsg := protocol.ResultMessage{Type: "result", IsError: false}
+	s.handleResult(resultMsg)
+
+	// Should NOT get a TurnCompleteEvent.
+	select {
+	case event := <-s.events:
+		if _, ok := event.(TurnCompleteEvent); ok {
+			t.Error("TurnCompleteEvent should NOT have been emitted — all tools are bg")
+		}
+	case <-time.After(100 * time.Millisecond):
+		// Good — suppressed.
+	}
+
+	// Safety timer must be started.
+	s.mu.RLock()
+	timerActive := s.bgState.timer != nil
+	suppActive := s.bgState.active
+	s.mu.RUnlock()
+	if !timerActive {
+		t.Error("expected safety timer to be active")
+	}
+	if !suppActive {
+		t.Error("expected bgState.active to be true")
 	}
 
 	// Clean up.
 	s.mu.Lock()
-	s.bgTasksPendingSinceLastResult = 0
+	s.bgState.reset()
 	s.mu.Unlock()
+}
+
+func TestBgTask_MixedBgAndNonBgWithNonBgError(t *testing.T) {
+	// When a non-bg tool errors alongside a successful bg tool, the turn
+	// should NOT be suppressed — the non-bg tool's existence means the
+	// ResultMessage is the real completion.
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "echo bg", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "exit 1"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	isErrTrue := true
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Running in background...", IsError: &isErrFalse},
+		{ToolUseID: "tool-2", Content: "exit code 1", IsError: &isErrTrue},
+	}
+	simulateUserToolResults(t, s, results)
+
+	// Non-bg tool exists (even though it errored) → don't suppress.
+	turn := s.turnManager.CurrentTurn()
+	if s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return false when a non-bg tool exists (even if errored)")
+	}
+}
+
+func TestBgTask_NoBgToolsNormalCompletion(t *testing.T) {
+	// Baseline: no bg tools at all → normal completion.
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "echo hello"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "hello", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	turn := s.turnManager.CurrentTurn()
+	if s.shouldSuppressForBgTasks(turn) {
+		t.Error("shouldSuppressForBgTasks should return false when no bg tools exist")
+	}
 }

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -46,6 +46,39 @@ type turnState struct {
 	Number        int
 }
 
+// shouldSuppressForBgTasks returns true when ALL non-cancelled tool_use blocks
+// in the turn had run_in_background: true, meaning the ResultMessage arrived
+// because bg tools returned immediately and the real work is still in progress.
+// When non-bg tools are present, the ResultMessage represents completion of
+// synchronous work and must not be suppressed.
+func (turn *turnState) shouldSuppressForBgTasks() bool {
+	if turn == nil {
+		return false
+	}
+
+	cancelled := make(map[string]bool)
+	for _, block := range turn.ContentBlocks {
+		if block.Type == ContentBlockTypeToolResult && block.IsError {
+			cancelled[block.ToolUseID] = true
+		}
+	}
+
+	hasBgTool := false
+	for _, block := range turn.ContentBlocks {
+		if block.Type != ContentBlockTypeToolUse {
+			continue
+		}
+		isBg, _ := block.ToolInput["run_in_background"].(bool)
+		if !isBg {
+			return false
+		}
+		if !cancelled[block.ToolUseID] {
+			hasBgTool = true
+		}
+	}
+	return hasBgTool
+}
+
 // toolState tracks the state of a tool within a turn.
 type toolState struct {
 	StartTime    time.Time

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -63,6 +63,9 @@ func (turn *turnState) shouldSuppressForBgTasks() bool {
 		}
 	}
 
+	// Non-bg tools always prevent suppression (even if they errored), because
+	// their presence means the ResultMessage represents completion of synchronous
+	// work. Cancelled bg tools are skipped — they never launched a background task.
 	hasBgTool := false
 	for _, block := range turn.ContentBlocks {
 		if block.Type != ContentBlockTypeToolUse {
@@ -70,7 +73,7 @@ func (turn *turnState) shouldSuppressForBgTasks() bool {
 		}
 		isBg, _ := block.ToolInput["run_in_background"].(bool)
 		if !isBg {
-			return false
+			return false // non-bg tool → ResultMessage is real completion, never suppress
 		}
 		if !cancelled[block.ToolUseID] {
 			hasBgTool = true


### PR DESCRIPTION
## Summary

- Fix SDK incorrectly suppressing turn completion when a turn contains both background and non-background tools (e.g. jiradozer's 2× `Bash(bg=true)` + 1× `Bash(blocking)`), causing 90s hangs or indefinite stuck sessions
- Replace mutable `bgTasksPendingSinceLastResult` counter with computed `shouldSuppressForBgTasks()` that inspects `turn.ContentBlocks` — suppression only activates when ALL non-cancelled tools are background tasks
- Group 6 scattered bg fields into `bgSuppressionState` struct with single `reset()` method, reducing cleanup sites from 5+ to 1

## Test plan

- [x] 10 unit tests pass (`TestBgTask_*`), including 3 new: `MixedBgAndNonBgDoesNotSuppressTurn`, `MultipleBgToolsStillSuppressTurn`, `NoBgToolsNormalCompletion`
- [x] All 7 `agent-cli-wrapper/...` test targets pass
- [x] Lint passes
- [ ] Integration test `TestSession_Integration_BackgroundTaskMixed` (requires real CLI): `scripts/test-manual.sh --test_filter=BackgroundTaskMixed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-completion suppression logic in `Session.handleResult`, which can affect whether callers block or receive early completion; mistakes here could reintroduce hangs or premature TurnComplete events, but behavior is covered by added unit/integration tests.
> 
> **Overview**
> Fixes a stuck-session bug where turns containing *both* background (`run_in_background: true`) and normal tools were incorrectly suppressed, causing `Ask()`/`WaitForTurn()` to hang waiting for a continuation that will never represent the synchronous work.
> 
> Replaces the old “bg tools launched” counter with `turnState.shouldSuppressForBgTasks()` which inspects recorded `ContentBlocks` and only suppresses when **all non-cancelled tools are background tasks**. Background suppression/timer/usage bookkeeping is consolidated into `bgSuppressionState.reset()`.
> 
> Adds/updates unit tests for mixed/cancelled/bg-only scenarios and introduces an integration test `TestSession_Integration_BackgroundTaskMixed` to reproduce the 2×bg + 1×non-bg pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f556d91c869a700b52e43f37ccef1ff097c480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->