### PR TITLE
bramble: add session creation to command center and all-sessions overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Tmux mode launches each AI session in its own tmux window. Bramble manages the w
 Key tmux features:
 - Automatic tmux window creation per session
 - Window monitoring and idle detection
-- Pane capture for inspecting session output from the TUI (`[p]` in command center)
+- Pane capture for inspecting session output from the TUI (`[v]` in command center)
 - Notifications via visual bell when sessions need attention
 - Windows remain open on error for debugging
 
@@ -92,7 +92,7 @@ The main view shows the selected worktree's session output with a status bar and
 
 ### Command Center (`Alt-C`)
 
-A full-screen dashboard showing all sessions across all worktrees. Press `[p]` to toggle inline preview of tmux pane content.
+A full-screen dashboard showing all sessions across all worktrees. Press `[v]` to toggle inline preview of tmux pane content, or `[p/b/c]` to start a new planner/builder/codetalk session on the selected worktree.
 
 ![Command center](docs/screenshots/command-center.png)
 <!-- TODO: Add screenshot of command center with session list and preview panel -->

--- a/bramble/app/allsessions.go
+++ b/bramble/app/allsessions.go
@@ -283,7 +283,7 @@ func (o *AllSessionsOverlay) View(s *Styles) string {
 	lines = append(lines, "")
 
 	// Footer
-	footer := s.Dim.Render("[↑/↓] Navigate  [Enter] Switch  [1-9] Quick select  [Esc] Close")
+	footer := s.Dim.Render("[↑/↓] Navigate  [Enter] Switch  [p/b/c] New session  [1-9] Quick select  [Esc] Close")
 	if len(o.sessions) > 0 {
 		maxSessionRows := contentHeight - 6
 		if maxSessionRows < 1 {
@@ -292,7 +292,7 @@ func (o *AllSessionsOverlay) View(s *Styles) string {
 		start, end := o.visibleSessionRange(maxSessionRows)
 		if start > 0 || end < len(o.sessions) {
 			footer = s.Dim.Render(fmt.Sprintf(
-				"[↑/↓] Navigate  [Enter] Switch  [1-9] Quick select  [Esc] Close   (%d-%d/%d)",
+				"[↑/↓] Navigate  [Enter] Switch  [p/b/c] New session  [1-9] Quick select  [Esc] Close   (%d-%d/%d)",
 				start+1, end, len(o.sessions),
 			))
 		}

--- a/bramble/app/commandcenter.go
+++ b/bramble/app/commandcenter.go
@@ -425,9 +425,9 @@ func (cc *CommandCenter) renderHeader(s *Styles) string {
 
 // renderFooter renders the footer keybinding hints.
 func (cc *CommandCenter) renderFooter(s *Styles) string {
-	previewKey := "[p] Preview pane"
+	previewKey := "[v] Preview pane"
 	if cc.previewIdx >= 0 {
-		previewKey = "[p] Close preview"
+		previewKey = "[v] Close preview"
 	}
 	keys := []string{
 		"[←/→/↑/↓] Navigate",
@@ -436,6 +436,7 @@ func (cc *CommandCenter) renderFooter(s *Styles) string {
 		previewKey,
 		"[f] Follow-up",
 		"[a] Approve plan",
+		"[p/b/c] New session",
 		"[Esc] Close",
 	}
 	return "\n" + s.Dim.Render(strings.Join(keys, "  "))

--- a/bramble/app/commandcenter_test.go
+++ b/bramble/app/commandcenter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bazelment/yoloswe/bramble/session"
+	"github.com/bazelment/yoloswe/wt"
 )
 
 func makeSessions() []session.SessionInfo {
@@ -293,4 +294,57 @@ func TestSessionPriority(t *testing.T) {
 	assert.Less(t, sessionPriority(idle), sessionPriority(running))
 	assert.Less(t, sessionPriority(running), sessionPriority(pending))
 	assert.Less(t, sessionPriority(pending), sessionPriority(completed))
+}
+
+func TestCommandCenter_NewSession_PBC(t *testing.T) {
+	for _, tc := range []struct {
+		promptSub   string
+		sessionType session.SessionType
+		key         rune
+	}{
+		{"Plan prompt", session.SessionTypePlanner, 'p'},
+		{"Build prompt", session.SessionTypeBuilder, 'b'},
+		{"CodeTalk prompt", session.SessionTypeCodeTalk, 'c'},
+	} {
+		t.Run(string(tc.key), func(t *testing.T) {
+			m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+				{Branch: "main", Path: "/tmp/wt/main"},
+			}, "test-repo")
+			m.worktreeDropdown.SelectIndex(0)
+
+			sessions := []session.SessionInfo{
+				{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main", WorktreeName: "main"},
+			}
+			m.commandCenter.Show(sessions, m.width, m.height)
+			m.focus = FocusCommandCenter
+
+			newModel, _ := m.handleCommandCenter(keyPress(tc.key))
+			m2 := newModel.(Model)
+
+			assert.False(t, m2.commandCenter.IsVisible())
+			assert.Equal(t, FocusInput, m2.focus)
+			assert.True(t, m2.inputMode)
+			assert.Contains(t, m2.inputPrompt, tc.promptSub)
+			assert.Equal(t, tc.sessionType, m2.pendingSessionType)
+		})
+	}
+}
+
+func TestCommandCenter_NewSession_NoSession(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Show with no sessions
+	m.commandCenter.Show(nil, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('p'))
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "No session selected")
+	// Command center should stay visible on error
+	assert.True(t, m2.commandCenter.IsVisible())
 }

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -757,6 +757,12 @@ type (
 		prompt      string
 		model       string
 	}
+	startSessionOnPathMsg struct {
+		sessionType  session.SessionType
+		prompt       string
+		model        string
+		worktreePath string
+	}
 	createWorktreeMsg struct{ branch string }
 	editorResultMsg   struct{ err error }
 	taskRouteMsg      struct{ prompt string }

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -753,15 +753,10 @@ type (
 	sessionsUpdated struct{}
 	promptInputMsg  struct{ value string }
 	startSessionMsg struct {
-		sessionType session.SessionType
-		prompt      string
-		model       string
-	}
-	startSessionOnPathMsg struct {
 		sessionType  session.SessionType
 		prompt       string
 		model        string
-		worktreePath string
+		worktreePath string // if set, starts on this path instead of selected worktree
 	}
 	createWorktreeMsg struct{ branch string }
 	editorResultMsg   struct{ err error }

--- a/bramble/app/show_all_sessions_test.go
+++ b/bramble/app/show_all_sessions_test.go
@@ -292,3 +292,80 @@ func TestAllSessionsOverlay_VisibleSessionRange_FollowsSelection(t *testing.T) {
 	assert.Equal(t, 8, start)
 	assert.Equal(t, 14, end)
 }
+
+func TestAllSessionsOverlay_NewSession_PBC(t *testing.T) {
+	for _, tc := range []struct {
+		promptSub   string
+		sessionType session.SessionType
+		key         rune
+	}{
+		{"Plan prompt", session.SessionTypePlanner, 'p'},
+		{"Build prompt", session.SessionTypeBuilder, 'b'},
+		{"CodeTalk prompt", session.SessionTypeCodeTalk, 'c'},
+	} {
+		t.Run(string(tc.key), func(t *testing.T) {
+			m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+				{Branch: "main", Path: "/tmp/wt/main"},
+			}, "test-repo")
+			m.worktreeDropdown.SelectIndex(0)
+
+			sessions := []session.SessionInfo{
+				{ID: "s1", Status: session.StatusRunning, WorktreePath: "/tmp/wt/main", WorktreeName: "main"},
+			}
+			m.allSessionsOverlay.Show(sessions, m.width, m.height)
+			m.focus = FocusAllSessions
+
+			newModel, _ := m.handleAllSessionsOverlay(keyPress(tc.key))
+			m2 := newModel.(Model)
+
+			// Overlay should be hidden and focus should move to input
+			assert.False(t, m2.allSessionsOverlay.IsVisible())
+			assert.Equal(t, FocusInput, m2.focus)
+			assert.True(t, m2.inputMode)
+			assert.Contains(t, m2.inputPrompt, tc.promptSub)
+			assert.Equal(t, tc.sessionType, m2.pendingSessionType)
+		})
+	}
+}
+
+func TestAllSessionsOverlay_NewSession_NoSession(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Show overlay with no sessions
+	m.allSessionsOverlay.Show(nil, m.width, m.height)
+	m.focus = FocusAllSessions
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('p'))
+	m2 := newModel.(Model)
+
+	// Should show toast error and overlay stays visible (focus-state bug fix)
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "No session selected")
+	// Overlay should NOT have been hidden
+	assert.True(t, m2.allSessionsOverlay.IsVisible())
+}
+
+func TestAllSessionsOverlay_NewSession_NoWorktree(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0)
+
+	// Session with no worktree path
+	sessions := []session.SessionInfo{
+		{ID: "s1", Status: session.StatusRunning, WorktreePath: ""},
+	}
+	m.allSessionsOverlay.Show(sessions, m.width, m.height)
+	m.focus = FocusAllSessions
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "no worktree")
+	// Overlay should NOT have been hidden
+	assert.True(t, m2.allSessionsOverlay.IsVisible())
+}

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -384,6 +384,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m.startSession(msg.sessionType, msg.prompt, msg.model)
 
+	case startSessionOnPathMsg:
+		// Save the chosen model as the new default for this session type
+		if msg.model != "" {
+			switch msg.sessionType {
+			case session.SessionTypePlanner:
+				m.defaultPlanModel = msg.model
+			case session.SessionTypeBuilder:
+				m.defaultBuildModel = msg.model
+			case session.SessionTypeCodeTalk:
+				m.defaultCodeTalkModel = msg.model
+			}
+		}
+		return m.startSessionOnPath(msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
+
 	case createWorktreeMsg:
 		return m.createWorktree(msg.branch)
 
@@ -1315,14 +1329,23 @@ func (m Model) promptInput(prompt string, handler func(value, model string, sess
 	return m, nil
 }
 
-// startSession starts a session of the given type with the specified model.
+// startSession starts a session of the given type with the specified model,
+// using the currently selected worktree.
 func (m Model) startSession(sessionType session.SessionType, prompt, model string) (tea.Model, tea.Cmd) {
 	wt := m.selectedWorktree()
-	if wt == nil || prompt == "" {
+	if wt == nil {
+		return m, nil
+	}
+	return m.startSessionOnPath(sessionType, prompt, model, wt.Path)
+}
+
+// startSessionOnPath starts a session of the given type on an explicit worktree path.
+func (m Model) startSessionOnPath(sessionType session.SessionType, prompt, model, worktreePath string) (tea.Model, tea.Cmd) {
+	if worktreePath == "" || prompt == "" {
 		return m, nil
 	}
 
-	sessionID, err := m.sessionManager.StartSession(sessionType, wt.Path, prompt, model)
+	sessionID, err := m.sessionManager.StartSession(sessionType, worktreePath, prompt, model)
 	if err != nil {
 		toastCmd := m.addToast(err.Error(), ToastError)
 		return m, toastCmd
@@ -1337,6 +1360,48 @@ func (m Model) startSession(sessionType session.SessionType, prompt, model strin
 	m.updateSessionDropdown()
 	toastCmd := m.addToast("Session started: "+string(sessionID)[:12], ToastSuccess)
 	return m, toastCmd
+}
+
+// startNewSessionFromOverlay handles session creation from command center or
+// all-sessions overlay. It hides the overlay, switches repo if needed, and
+// prompts the user for input to start a session on the highlighted session's worktree.
+func (m Model) startNewSessionFromOverlay(
+	sess *session.SessionInfo,
+	sessionType session.SessionType,
+	defaultModel string,
+	promptLabel string,
+	placeholder string,
+	hideOverlay func(),
+) (tea.Model, tea.Cmd) {
+	if sess == nil {
+		toastCmd := m.addToast("No session selected", ToastInfo)
+		return m, toastCmd
+	}
+	worktreePath := sess.WorktreePath
+	if worktreePath == "" {
+		toastCmd := m.addToast("Selected session has no worktree", ToastInfo)
+		return m, toastCmd
+	}
+	sessRepoName := sess.RepoName
+
+	hideOverlay()
+	m.focus = FocusOutput
+
+	// Switch repo if needed
+	if sessRepoName != "" && sessRepoName != m.repoName {
+		if _, ok := m.repos[sessRepoName]; ok {
+			m.saveActiveContext()
+			m.loadContext(sessRepoName)
+		}
+	}
+
+	m.pendingModel = defaultModel
+	m.pendingSessionType = sessionType
+	return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
+		return func() tea.Msg {
+			return startSessionOnPathMsg{sessionType, prompt, model, worktreePath}
+		}
+	}, placeholder)
 }
 
 // createWorktree creates a new worktree asynchronously with captured output.
@@ -1961,6 +2026,33 @@ func (m Model) handleAllSessionsOverlay(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	case "enter":
 		return m.switchToOverlaySession()
 
+	case "p":
+		sess := m.allSessionsOverlay.SelectedSession()
+		return m.startNewSessionFromOverlay(
+			sess, session.SessionTypePlanner, m.defaultPlanModel,
+			fmt.Sprintf("Plan prompt [%s]:", m.defaultPlanModel),
+			"Describe what you want to plan...",
+			func() { m.allSessionsOverlay.Hide() },
+		)
+
+	case "b":
+		sess := m.allSessionsOverlay.SelectedSession()
+		return m.startNewSessionFromOverlay(
+			sess, session.SessionTypeBuilder, m.defaultBuildModel,
+			fmt.Sprintf("Build prompt [%s]:", m.defaultBuildModel),
+			"Describe what to build...",
+			func() { m.allSessionsOverlay.Hide() },
+		)
+
+	case "c":
+		sess := m.allSessionsOverlay.SelectedSession()
+		return m.startNewSessionFromOverlay(
+			sess, session.SessionTypeCodeTalk, m.defaultCodeTalkModel,
+			fmt.Sprintf("CodeTalk prompt [%s]:", m.defaultCodeTalkModel),
+			"What code area do you want to understand?",
+			func() { m.allSessionsOverlay.Hide() },
+		)
+
 	case "q", "ctrl+c":
 		return m, tea.Quit
 
@@ -2165,6 +2257,36 @@ func (m Model) handleCommandCenter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "p":
+		// Start planner on highlighted session's worktree
+		sess := m.commandCenter.SelectedSession()
+		return m.startNewSessionFromOverlay(
+			sess, session.SessionTypePlanner, m.defaultPlanModel,
+			fmt.Sprintf("Plan prompt [%s]:", m.defaultPlanModel),
+			"Describe what you want to plan...",
+			func() { m.commandCenter.Hide() },
+		)
+
+	case "b":
+		// Start builder on highlighted session's worktree
+		sess := m.commandCenter.SelectedSession()
+		return m.startNewSessionFromOverlay(
+			sess, session.SessionTypeBuilder, m.defaultBuildModel,
+			fmt.Sprintf("Build prompt [%s]:", m.defaultBuildModel),
+			"Describe what to build...",
+			func() { m.commandCenter.Hide() },
+		)
+
+	case "c":
+		// Start codetalk on highlighted session's worktree
+		sess := m.commandCenter.SelectedSession()
+		return m.startNewSessionFromOverlay(
+			sess, session.SessionTypeCodeTalk, m.defaultCodeTalkModel,
+			fmt.Sprintf("CodeTalk prompt [%s]:", m.defaultCodeTalkModel),
+			"What code area do you want to understand?",
+			func() { m.commandCenter.Hide() },
+		)
+
+	case "v":
 		sess := m.commandCenter.TogglePreview()
 		if sess != nil {
 			// Preview opened — capture pane text.

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -696,7 +696,7 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "p", "b", "c":
-		st := map[string]session.SessionType{"p": session.SessionTypePlanner, "b": session.SessionTypeBuilder, "c": session.SessionTypeCodeTalk}[msg.String()]
+		st := sessionTypeFromKey(msg.String())
 		if m.selectedWorktree() != nil {
 			defaultModel, promptLabel, placeholder := m.sessionPromptConfig(st)
 			m.pendingModel = defaultModel
@@ -1296,6 +1296,20 @@ func (m *Model) saveDefaultModel(sessionType session.SessionType, model string) 
 	}
 }
 
+// sessionTypeFromKey maps a key press ("p", "b", "c") to a SessionType.
+func sessionTypeFromKey(key string) session.SessionType {
+	switch key {
+	case "p":
+		return session.SessionTypePlanner
+	case "b":
+		return session.SessionTypeBuilder
+	case "c":
+		return session.SessionTypeCodeTalk
+	default:
+		return session.SessionTypePlanner
+	}
+}
+
 // sessionPromptConfig returns the default model, prompt label, and placeholder
 // for a given session type. Used by all p/b/c key handlers.
 func (m *Model) sessionPromptConfig(st session.SessionType) (defaultModel, promptLabel, placeholder string) {
@@ -1350,8 +1364,9 @@ func (m Model) startSessionOnPath(sessionType session.SessionType, prompt, model
 }
 
 // startNewSessionFromOverlay prompts the user for input to start a session on
-// the given session's worktree. Caller must hide the overlay before calling.
-func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType session.SessionType) (tea.Model, tea.Cmd) {
+// the given session's worktree. hideOverlay is called only after validation
+// succeeds, so the overlay stays visible on error (preventing focus-state bugs).
+func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType session.SessionType, hideOverlay func()) (tea.Model, tea.Cmd) {
 	if sess == nil {
 		toastCmd := m.addToast("No session selected", ToastInfo)
 		return m, toastCmd
@@ -1361,12 +1376,21 @@ func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType
 		return m, toastCmd
 	}
 
+	hideOverlay()
+	m.focus = FocusOutput
+
 	// Switch repo if needed
 	if sess.RepoName != "" && sess.RepoName != m.repoName {
 		if _, ok := m.repos[sess.RepoName]; ok {
 			m.saveActiveContext()
 			m.loadContext(sess.RepoName)
 		}
+	}
+
+	// Sync worktree dropdown so the UI reflects where the new session will run
+	if sess.WorktreeName != "" {
+		m.worktreeDropdown.SelectByID(sess.WorktreeName)
+		m.updateSessionDropdown()
 	}
 
 	defaultModel, promptLabel, placeholder := m.sessionPromptConfig(sessionType)
@@ -2003,9 +2027,8 @@ func (m Model) handleAllSessionsOverlay(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		return m.switchToOverlaySession()
 
 	case "p", "b", "c":
-		m.allSessionsOverlay.Hide()
-		st := map[string]session.SessionType{"p": session.SessionTypePlanner, "b": session.SessionTypeBuilder, "c": session.SessionTypeCodeTalk}[msg.String()]
-		return m.startNewSessionFromOverlay(m.allSessionsOverlay.SelectedSession(), st)
+		st := sessionTypeFromKey(msg.String())
+		return m.startNewSessionFromOverlay(m.allSessionsOverlay.SelectedSession(), st, func() { m.allSessionsOverlay.Hide() })
 
 	case "q", "ctrl+c":
 		return m, tea.Quit
@@ -2211,9 +2234,8 @@ func (m Model) handleCommandCenter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "p", "b", "c":
-		m.commandCenter.Hide()
-		st := map[string]session.SessionType{"p": session.SessionTypePlanner, "b": session.SessionTypeBuilder, "c": session.SessionTypeCodeTalk}[msg.String()]
-		return m.startNewSessionFromOverlay(m.commandCenter.SelectedSession(), st)
+		st := sessionTypeFromKey(msg.String())
+		return m.startNewSessionFromOverlay(m.commandCenter.SelectedSession(), st, func() { m.commandCenter.Hide() })
 
 	case "v":
 		sess := m.commandCenter.TogglePreview()

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -371,32 +371,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case startSessionMsg:
-		// Save the chosen model as the new default for this session type
-		if msg.model != "" {
-			switch msg.sessionType {
-			case session.SessionTypePlanner:
-				m.defaultPlanModel = msg.model
-			case session.SessionTypeBuilder:
-				m.defaultBuildModel = msg.model
-			case session.SessionTypeCodeTalk:
-				m.defaultCodeTalkModel = msg.model
-			}
+		m.saveDefaultModel(msg.sessionType, msg.model)
+		if msg.worktreePath != "" {
+			return m.startSessionOnPath(msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
 		}
 		return m.startSession(msg.sessionType, msg.prompt, msg.model)
-
-	case startSessionOnPathMsg:
-		// Save the chosen model as the new default for this session type
-		if msg.model != "" {
-			switch msg.sessionType {
-			case session.SessionTypePlanner:
-				m.defaultPlanModel = msg.model
-			case session.SessionTypeBuilder:
-				m.defaultBuildModel = msg.model
-			case session.SessionTypeCodeTalk:
-				m.defaultCodeTalkModel = msg.model
-			}
-		}
-		return m.startSessionOnPath(msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
 
 	case createWorktreeMsg:
 		return m.createWorktree(msg.branch)
@@ -716,44 +695,17 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.focus = FocusTaskModal
 		return m, nil
 
-	case "p":
-		// Start planner
+	case "p", "b", "c":
+		st := map[string]session.SessionType{"p": session.SessionTypePlanner, "b": session.SessionTypeBuilder, "c": session.SessionTypeCodeTalk}[msg.String()]
 		if m.selectedWorktree() != nil {
-			m.pendingModel = m.defaultPlanModel
-			m.pendingSessionType = session.SessionTypePlanner
-			return m.promptInput(fmt.Sprintf("Plan prompt [%s]:", m.pendingModel), func(prompt, model string, _ session.SessionType) tea.Cmd {
+			defaultModel, promptLabel, placeholder := m.sessionPromptConfig(st)
+			m.pendingModel = defaultModel
+			m.pendingSessionType = st
+			return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
 				return func() tea.Msg {
-					return startSessionMsg{session.SessionTypePlanner, prompt, model}
+					return startSessionMsg{sessionType: st, prompt: prompt, model: model}
 				}
-			}, "Describe what you want to plan...")
-		}
-		toastCmd := m.addToast("Select a worktree first (Alt-W)", ToastInfo)
-		return m, toastCmd
-
-	case "b":
-		// Start builder
-		if m.selectedWorktree() != nil {
-			m.pendingModel = m.defaultBuildModel
-			m.pendingSessionType = session.SessionTypeBuilder
-			return m.promptInput(fmt.Sprintf("Build prompt [%s]:", m.pendingModel), func(prompt, model string, _ session.SessionType) tea.Cmd {
-				return func() tea.Msg {
-					return startSessionMsg{session.SessionTypeBuilder, prompt, model}
-				}
-			}, "Describe what to build...")
-		}
-		toastCmd := m.addToast("Select a worktree first (Alt-W)", ToastInfo)
-		return m, toastCmd
-
-	case "c":
-		// Start codetalk (code understanding)
-		if m.selectedWorktree() != nil {
-			m.pendingModel = m.defaultCodeTalkModel
-			m.pendingSessionType = session.SessionTypeCodeTalk
-			return m.promptInput(fmt.Sprintf("CodeTalk prompt [%s]:", m.pendingModel), func(prompt, model string, _ session.SessionType) tea.Cmd {
-				return func() tea.Msg {
-					return startSessionMsg{session.SessionTypeCodeTalk, prompt, model}
-				}
-			}, "What code area do you want to understand?")
+			}, placeholder)
 		}
 		toastCmd := m.addToast("Select a worktree first (Alt-W)", ToastInfo)
 		return m, toastCmd
@@ -1329,6 +1281,41 @@ func (m Model) promptInput(prompt string, handler func(value, model string, sess
 	return m, nil
 }
 
+// saveDefaultModel persists the user's model choice for future sessions of the same type.
+func (m *Model) saveDefaultModel(sessionType session.SessionType, model string) {
+	if model == "" {
+		return
+	}
+	switch sessionType {
+	case session.SessionTypePlanner:
+		m.defaultPlanModel = model
+	case session.SessionTypeBuilder:
+		m.defaultBuildModel = model
+	case session.SessionTypeCodeTalk:
+		m.defaultCodeTalkModel = model
+	}
+}
+
+// sessionPromptConfig returns the default model, prompt label, and placeholder
+// for a given session type. Used by all p/b/c key handlers.
+func (m *Model) sessionPromptConfig(st session.SessionType) (defaultModel, promptLabel, placeholder string) {
+	switch st {
+	case session.SessionTypePlanner:
+		defaultModel = m.defaultPlanModel
+		promptLabel = fmt.Sprintf("Plan prompt [%s]:", defaultModel)
+		placeholder = "Describe what you want to plan..."
+	case session.SessionTypeBuilder:
+		defaultModel = m.defaultBuildModel
+		promptLabel = fmt.Sprintf("Build prompt [%s]:", defaultModel)
+		placeholder = "Describe what to build..."
+	case session.SessionTypeCodeTalk:
+		defaultModel = m.defaultCodeTalkModel
+		promptLabel = fmt.Sprintf("CodeTalk prompt [%s]:", defaultModel)
+		placeholder = "What code area do you want to understand?"
+	}
+	return
+}
+
 // startSession starts a session of the given type with the specified model,
 // using the currently selected worktree.
 func (m Model) startSession(sessionType session.SessionType, prompt, model string) (tea.Model, tea.Cmd) {
@@ -1362,44 +1349,33 @@ func (m Model) startSessionOnPath(sessionType session.SessionType, prompt, model
 	return m, toastCmd
 }
 
-// startNewSessionFromOverlay handles session creation from command center or
-// all-sessions overlay. It hides the overlay, switches repo if needed, and
-// prompts the user for input to start a session on the highlighted session's worktree.
-func (m Model) startNewSessionFromOverlay(
-	sess *session.SessionInfo,
-	sessionType session.SessionType,
-	defaultModel string,
-	promptLabel string,
-	placeholder string,
-	hideOverlay func(),
-) (tea.Model, tea.Cmd) {
+// startNewSessionFromOverlay prompts the user for input to start a session on
+// the given session's worktree. Caller must hide the overlay before calling.
+func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType session.SessionType) (tea.Model, tea.Cmd) {
 	if sess == nil {
 		toastCmd := m.addToast("No session selected", ToastInfo)
 		return m, toastCmd
 	}
-	worktreePath := sess.WorktreePath
-	if worktreePath == "" {
+	if sess.WorktreePath == "" {
 		toastCmd := m.addToast("Selected session has no worktree", ToastInfo)
 		return m, toastCmd
 	}
-	sessRepoName := sess.RepoName
-
-	hideOverlay()
-	m.focus = FocusOutput
 
 	// Switch repo if needed
-	if sessRepoName != "" && sessRepoName != m.repoName {
-		if _, ok := m.repos[sessRepoName]; ok {
+	if sess.RepoName != "" && sess.RepoName != m.repoName {
+		if _, ok := m.repos[sess.RepoName]; ok {
 			m.saveActiveContext()
-			m.loadContext(sessRepoName)
+			m.loadContext(sess.RepoName)
 		}
 	}
 
+	defaultModel, promptLabel, placeholder := m.sessionPromptConfig(sessionType)
+	worktreePath := sess.WorktreePath
 	m.pendingModel = defaultModel
 	m.pendingSessionType = sessionType
 	return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
 		return func() tea.Msg {
-			return startSessionOnPathMsg{sessionType, prompt, model, worktreePath}
+			return startSessionMsg{sessionType, prompt, model, worktreePath}
 		}
 	}, placeholder)
 }
@@ -2026,32 +2002,10 @@ func (m Model) handleAllSessionsOverlay(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	case "enter":
 		return m.switchToOverlaySession()
 
-	case "p":
-		sess := m.allSessionsOverlay.SelectedSession()
-		return m.startNewSessionFromOverlay(
-			sess, session.SessionTypePlanner, m.defaultPlanModel,
-			fmt.Sprintf("Plan prompt [%s]:", m.defaultPlanModel),
-			"Describe what you want to plan...",
-			func() { m.allSessionsOverlay.Hide() },
-		)
-
-	case "b":
-		sess := m.allSessionsOverlay.SelectedSession()
-		return m.startNewSessionFromOverlay(
-			sess, session.SessionTypeBuilder, m.defaultBuildModel,
-			fmt.Sprintf("Build prompt [%s]:", m.defaultBuildModel),
-			"Describe what to build...",
-			func() { m.allSessionsOverlay.Hide() },
-		)
-
-	case "c":
-		sess := m.allSessionsOverlay.SelectedSession()
-		return m.startNewSessionFromOverlay(
-			sess, session.SessionTypeCodeTalk, m.defaultCodeTalkModel,
-			fmt.Sprintf("CodeTalk prompt [%s]:", m.defaultCodeTalkModel),
-			"What code area do you want to understand?",
-			func() { m.allSessionsOverlay.Hide() },
-		)
+	case "p", "b", "c":
+		m.allSessionsOverlay.Hide()
+		st := map[string]session.SessionType{"p": session.SessionTypePlanner, "b": session.SessionTypeBuilder, "c": session.SessionTypeCodeTalk}[msg.String()]
+		return m.startNewSessionFromOverlay(m.allSessionsOverlay.SelectedSession(), st)
 
 	case "q", "ctrl+c":
 		return m, tea.Quit
@@ -2256,35 +2210,10 @@ func (m Model) handleCommandCenter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.updateSessionDropdown()
 		return m, nil
 
-	case "p":
-		// Start planner on highlighted session's worktree
-		sess := m.commandCenter.SelectedSession()
-		return m.startNewSessionFromOverlay(
-			sess, session.SessionTypePlanner, m.defaultPlanModel,
-			fmt.Sprintf("Plan prompt [%s]:", m.defaultPlanModel),
-			"Describe what you want to plan...",
-			func() { m.commandCenter.Hide() },
-		)
-
-	case "b":
-		// Start builder on highlighted session's worktree
-		sess := m.commandCenter.SelectedSession()
-		return m.startNewSessionFromOverlay(
-			sess, session.SessionTypeBuilder, m.defaultBuildModel,
-			fmt.Sprintf("Build prompt [%s]:", m.defaultBuildModel),
-			"Describe what to build...",
-			func() { m.commandCenter.Hide() },
-		)
-
-	case "c":
-		// Start codetalk on highlighted session's worktree
-		sess := m.commandCenter.SelectedSession()
-		return m.startNewSessionFromOverlay(
-			sess, session.SessionTypeCodeTalk, m.defaultCodeTalkModel,
-			fmt.Sprintf("CodeTalk prompt [%s]:", m.defaultCodeTalkModel),
-			"What code area do you want to understand?",
-			func() { m.commandCenter.Hide() },
-		)
+	case "p", "b", "c":
+		m.commandCenter.Hide()
+		st := map[string]session.SessionType{"p": session.SessionTypePlanner, "b": session.SessionTypeBuilder, "c": session.SessionTypeCodeTalk}[msg.String()]
+		return m.startNewSessionFromOverlay(m.commandCenter.SelectedSession(), st)
 
 	case "v":
 		sess := m.commandCenter.TogglePreview()


### PR DESCRIPTION
## Summary
- Add `p`/`b`/`c` keybindings to command center (Alt+C) and all-sessions overlay (Alt+S) for creating planner/builder/codetalk sessions on the highlighted session's worktree
- Move command center preview key from `p` to `v` to avoid key conflict
- Add `startSessionOnPath()` and `startNewSessionFromOverlay()` helpers with cross-repo switching support

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel build //bramble/app/...` succeeds
- [x] `bazel test //bramble/app/...` passes
- [ ] Manual: open command center (Alt+C), highlight a session, press `p` → prompted for plan input on that session's worktree
- [ ] Manual: open all-sessions (Alt+S), highlight a session, press `b` → prompted for build input
- [ ] Manual: verify `v` toggles pane preview in command center
- [ ] Manual: verify cross-repo session creation works when highlighting a session from a different repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes TUI key handling and session-start routing (including cross-repo/worktree targeting), which could lead to sessions starting in the wrong context or focus/overlay state regressions.
> 
> **Overview**
> Adds `p`/`b`/`c` keybindings in both the Command Center and All Sessions overlay to start a new planner/builder/codetalk session on the *selected session’s* worktree (including switching repo/worktree context when needed).
> 
> Resolves the key conflict by moving Command Center pane preview from `[p]` to `[v]`, and updates on-screen key hints + README accordingly.
> 
> Refactors session start plumbing by introducing `saveDefaultModel`, `sessionPromptConfig`, `startSessionOnPath`, and `startNewSessionFromOverlay` so session creation can target an explicit worktree path and keep overlays open on validation errors; adds tests covering the new overlay/command-center session creation behaviors and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27bfea817da9241b1b42b0c3c5bf63d1b5fc1a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->