### PR TITLE
jiradozer: split terminal rendering from log file, add verbosity control

### DIFF
--- a/agent-cli-wrapper/agentstream/events.go
+++ b/agent-cli-wrapper/agentstream/events.go
@@ -7,6 +7,7 @@ const (
 	// KindUnknown is the zero value. Events returning KindUnknown are skipped
 	// by the generic bridge (e.g., ACP ToolCallUpdateEvent with non-terminal status).
 	KindUnknown EventKind = iota
+	KindReady
 	KindText
 	KindThinking
 	KindToolStart
@@ -20,6 +21,12 @@ const (
 // interface are silently skipped.
 type Event interface {
 	StreamEventKind() EventKind
+}
+
+// Ready provides session initialization metadata.
+type Ready interface {
+	Event
+	StreamSessionID() string
 }
 
 // Text provides streaming text deltas.

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -84,6 +84,9 @@ type ReadyEvent struct {
 // Type returns the event type.
 func (e ReadyEvent) Type() EventType { return EventTypeReady }
 
+func (e ReadyEvent) StreamEventKind() agentstream.EventKind { return agentstream.KindReady }
+func (e ReadyEvent) StreamSessionID() string                { return e.Info.SessionID }
+
 // TextEvent contains streaming text chunks.
 type TextEvent struct {
 	Text       string

--- a/agent-cli-wrapper/claude/render/format.go
+++ b/agent-cli-wrapper/claude/render/format.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// formatToolInput formats tool input for inline display after the tool name bracket.
+// FormatToolInput formats tool input for inline display after the tool name bracket.
 // Returns an empty string for tools that should be handled specially.
-func formatToolInput(name string, input map[string]interface{}) string {
+func FormatToolInput(name string, input map[string]interface{}) string {
 	switch name {
 	case "Read":
 		if path, ok := input["file_path"].(string); ok {

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -257,7 +257,7 @@ func (r *Renderer) ToolComplete(name string, input map[string]interface{}) {
 	}
 
 	if r.verbosity >= VerbosityNormal {
-		summary := formatToolInput(name, input)
+		summary := FormatToolInput(name, input)
 		if summary != "" {
 			fmt.Fprintf(r.out, "%s%s%s\n", r.color(ColorYellow), summary, r.color(ColorReset))
 		} else {

--- a/agent-cli-wrapper/claude/render/style.go
+++ b/agent-cli-wrapper/claude/render/style.go
@@ -17,6 +17,19 @@ const (
 	ColorNever
 )
 
+// ParseColorMode converts a string to a ColorMode.
+// Returns ColorAuto for unrecognized values.
+func ParseColorMode(s string) ColorMode {
+	switch s {
+	case "always":
+		return ColorAlways
+	case "never":
+		return ColorNever
+	default:
+		return ColorAuto
+	}
+}
+
 // Palette controls whether ANSI color codes are emitted.
 type Palette struct {
 	enabled bool

--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/bazelment/yoloswe/jiradozer",
     visibility = ["//visibility:public"],
     deps = [
+        "//agent-cli-wrapper/claude/render",
         "//jiradozer/tracker",
         "//multiagent/agent",
         "@in_gopkg_yaml_v3//:yaml_v3",
@@ -34,6 +35,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":jiradozer"],
     deps = [
+        "//agent-cli-wrapper/claude/render",
         "//jiradozer/tracker",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -273,11 +273,9 @@ func (h *logEventHandler) OnError(err error, context string) {
 }
 
 // rendererEventHandler adapts agent.EventHandler to a render.Renderer for
-// terminal display. It also tracks plan file writes for the plan step.
+// terminal display.
 type rendererEventHandler struct {
-	r            *render.Renderer
-	planFilePath string
-	lastWriteMD  string
+	r *render.Renderer
 }
 
 func (h *rendererEventHandler) OnText(text string) {
@@ -296,18 +294,6 @@ func (h *rendererEventHandler) OnToolComplete(name, id string, input map[string]
 	h.r.ToolComplete(name, input)
 	if result != nil || isError {
 		h.r.ToolResult(result, isError)
-	}
-
-	// Track plan file writes (same logic as logEventHandler).
-	if name == "Write" && !isError {
-		if filePath, ok := input["file_path"].(string); ok {
-			if strings.HasSuffix(filePath, ".md") {
-				h.lastWriteMD = filePath
-			}
-		}
-	}
-	if name == "ExitPlanMode" && h.lastWriteMD != "" {
-		h.planFilePath = h.lastWriteMD
 	}
 }
 
@@ -387,13 +373,11 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	logger.Debug("agent prompt", "step", stepName, "prompt", truncate(prompt, 500))
 
 	logHandler := newLogEventHandler(logger, stepName)
-	var renderHandler *rendererEventHandler
 
 	// Build the event handler: log-only or composite (log + renderer).
 	var handler agent.EventHandler = logHandler
 	if renderer != nil {
-		renderHandler = &rendererEventHandler{r: renderer}
-		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, renderHandler}}
+		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, &rendererEventHandler{r: renderer}}}
 	}
 
 	var opts []agent.ExecuteOption
@@ -440,15 +424,7 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))
 	}
 
-	// Prefer renderHandler for plan file detection (it tracks the same signals).
-	planHandler := logHandler
-	if renderHandler != nil && renderHandler.planFilePath != "" {
-		planHandler = nil
-	}
-	if planHandler != nil {
-		return resolveOutput(result.Text, logHandler, logger), result.SessionID, nil
-	}
-	return resolveOutputFromPath(result.Text, renderHandler.planFilePath, logger), result.SessionID, nil
+	return resolveOutput(result.Text, logHandler, logger), result.SessionID, nil
 }
 
 // resolveOutput returns the plan file content if one was detected, otherwise the agent's text output.

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 	"github.com/bazelment/yoloswe/multiagent/agent"
 )
@@ -114,12 +115,13 @@ func truncate(s string, maxLen int) string {
 // RunStepAgent runs an agent session for the given workflow step.
 // On first execution (resumeSessionID == ""), the prompt template is rendered with issue data.
 // On follow-up (resumeSessionID != ""), feedback is sent directly to the resumed session.
-func RunStepAgent(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, logger *slog.Logger) (string, string, error) {
+// If renderer is non-nil, agent events are streamed to the terminal.
+func RunStepAgent(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error) {
 	prompt, err := resolvePromptForExecution(cfg.Prompt, DefaultPromptForStep(stepName), data, feedback, resumeSessionID)
 	if err != nil {
 		return "", "", fmt.Errorf("render %s prompt: %w", stepName, err)
 	}
-	return runAgent(ctx, stepName, prompt, cfg, workDir, resumeSessionID, logger)
+	return runAgent(ctx, stepName, prompt, cfg, workDir, resumeSessionID, renderer, logger)
 }
 
 // RunCommand runs a shell command template for the given workflow step.
@@ -179,37 +181,72 @@ func resolvePromptForExecution(configPrompt, defaultPrompt string, data PromptDa
 	return prompt, nil
 }
 
-// logEventHandler logs agent events at debug level for verbose output.
-// It also tracks plan file writes for the plan step.
+// logEventHandler logs agent events to the log file with high signal-to-noise ratio.
+// Text is accumulated and flushed at semantic boundaries. Tool start/complete are
+// merged into a single log line with input summary and duration. Tool IDs are omitted.
 type logEventHandler struct {
 	logger       *slog.Logger
+	toolStarts   map[string]time.Time
 	step         string
-	planFilePath string // set when Claude writes a plan .md file before ExitPlanMode
-	lastWriteMD  string // tracks the most recent .md Write for ExitPlanMode correlation
+	planFilePath string
+	lastWriteMD  string
+	textBuf      strings.Builder
+}
+
+func newLogEventHandler(logger *slog.Logger, step string) *logEventHandler {
+	return &logEventHandler{
+		logger:     logger,
+		step:       step,
+		toolStarts: make(map[string]time.Time),
+	}
+}
+
+// flushText logs accumulated text and resets the buffer.
+func (h *logEventHandler) flushText() {
+	if h.textBuf.Len() > 0 {
+		h.logger.Debug("agent text", "step", h.step, "text", truncate(h.textBuf.String(), 200))
+		h.textBuf.Reset()
+	}
 }
 
 func (h *logEventHandler) OnText(text string) {
-	h.logger.Debug("agent text", "step", h.step, "text", text)
+	h.textBuf.WriteString(text)
+	// Flush at semantic boundaries: newline or buffer > 200 chars.
+	if strings.Contains(text, "\n") || h.textBuf.Len() > 200 {
+		h.flushText()
+	}
 }
 
 func (h *logEventHandler) OnThinking(thinking string) {
-	h.logger.Debug("agent thinking", "step", h.step, "thinking", thinking)
+	h.flushText()
+	h.logger.Debug("agent thinking", "step", h.step, "thinking", truncate(thinking, 200))
 }
 
 func (h *logEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
-	h.logger.Debug("agent tool start", "step", h.step, "tool", name, "id", id)
+	h.flushText()
+	h.toolStarts[id] = time.Now()
 }
 
 func (h *logEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
-	h.logger.Debug("agent tool complete", "step", h.step, "tool", name, "id", id, "is_error", isError)
+	// Single log line per tool with input summary and duration.
+	attrs := []any{"step", h.step, "tool", name}
+	if inputSummary := render.FormatToolInput(name, input); inputSummary != "" {
+		attrs = append(attrs, "input", inputSummary)
+	}
+	if start, ok := h.toolStarts[id]; ok {
+		attrs = append(attrs, "duration", time.Since(start).Round(100*time.Millisecond))
+		delete(h.toolStarts, id)
+	}
+	if isError {
+		attrs = append(attrs, "error", true)
+	}
+	h.logger.Debug("tool", attrs...)
+
 	// Track .md file writes — the last one before ExitPlanMode is the plan file.
-	// The plan file location varies: .claude/plans/, docs/plans/, etc. depending on
-	// user settings, so we track any .md Write and confirm when ExitPlanMode fires.
 	if name == "Write" && !isError {
 		if filePath, ok := input["file_path"].(string); ok {
 			if strings.HasSuffix(filePath, ".md") {
 				h.lastWriteMD = filePath
-				h.logger.Debug("tracked md write", "step", h.step, "path", filePath)
 			}
 		}
 	}
@@ -220,15 +257,113 @@ func (h *logEventHandler) OnToolComplete(name, id string, input map[string]inter
 }
 
 func (h *logEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {
-	h.logger.Debug("agent turn complete", "step", h.step, "turn", turnNumber, "success", success, "duration_ms", durationMs, "cost_usd", costUSD)
+	h.flushText()
+	h.logger.Debug("turn complete",
+		"step", h.step,
+		"turn", turnNumber,
+		"success", success,
+		"duration", fmt.Sprintf("%.1fs", float64(durationMs)/1000),
+		"cost", fmt.Sprintf("$%.4f", costUSD),
+	)
 }
 
 func (h *logEventHandler) OnError(err error, context string) {
+	h.flushText()
 	h.logger.Debug("agent error", "step", h.step, "error", err, "context", context)
 }
 
+// rendererEventHandler adapts agent.EventHandler to a render.Renderer for
+// terminal display. It also tracks plan file writes for the plan step.
+type rendererEventHandler struct {
+	r            *render.Renderer
+	planFilePath string
+	lastWriteMD  string
+}
+
+func (h *rendererEventHandler) OnText(text string) {
+	h.r.Text(text)
+}
+
+func (h *rendererEventHandler) OnThinking(thinking string) {
+	h.r.Thinking(thinking)
+}
+
+func (h *rendererEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
+	h.r.ToolStart(name, id)
+}
+
+func (h *rendererEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
+	h.r.ToolComplete(name, input)
+	if result != nil || isError {
+		h.r.ToolResult(result, isError)
+	}
+
+	// Track plan file writes (same logic as logEventHandler).
+	if name == "Write" && !isError {
+		if filePath, ok := input["file_path"].(string); ok {
+			if strings.HasSuffix(filePath, ".md") {
+				h.lastWriteMD = filePath
+			}
+		}
+	}
+	if name == "ExitPlanMode" && h.lastWriteMD != "" {
+		h.planFilePath = h.lastWriteMD
+	}
+}
+
+func (h *rendererEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {
+	h.r.TurnSummary(turnNumber, success, durationMs, costUSD)
+}
+
+func (h *rendererEventHandler) OnError(err error, ctx string) {
+	h.r.Error(err, ctx)
+}
+
+// compositeEventHandler fans out events to multiple handlers.
+type compositeEventHandler struct {
+	handlers []agent.EventHandler
+}
+
+func (c *compositeEventHandler) OnText(text string) {
+	for _, h := range c.handlers {
+		h.OnText(text)
+	}
+}
+
+func (c *compositeEventHandler) OnThinking(thinking string) {
+	for _, h := range c.handlers {
+		h.OnThinking(thinking)
+	}
+}
+
+func (c *compositeEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
+	for _, h := range c.handlers {
+		h.OnToolStart(name, id, input)
+	}
+}
+
+func (c *compositeEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
+	for _, h := range c.handlers {
+		h.OnToolComplete(name, id, input, result, isError)
+	}
+}
+
+func (c *compositeEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {
+	for _, h := range c.handlers {
+		h.OnTurnComplete(turnNumber, success, durationMs, costUSD)
+	}
+}
+
+func (c *compositeEventHandler) OnError(err error, ctx string) {
+	for _, h := range c.handlers {
+		h.OnError(err, ctx)
+	}
+}
+
 // runAgent runs an agent with the given prompt and step configuration.
-func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, logger *slog.Logger) (string, string, error) {
+// If renderer is non-nil, agent events are rendered to the terminal in addition
+// to being logged to the log file.
+func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error) {
 	model, ok := agent.ModelByID(cfg.Model)
 	if !ok {
 		return "", "", fmt.Errorf("unknown model: %q", cfg.Model)
@@ -251,7 +386,16 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	logger.Info("running agent", logAttrs...)
 	logger.Debug("agent prompt", "step", stepName, "prompt", truncate(prompt, 500))
 
-	handler := &logEventHandler{logger: logger, step: stepName}
+	logHandler := newLogEventHandler(logger, stepName)
+	var renderHandler *rendererEventHandler
+
+	// Build the event handler: log-only or composite (log + renderer).
+	var handler agent.EventHandler = logHandler
+	if renderer != nil {
+		renderHandler = &rendererEventHandler{r: renderer}
+		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, renderHandler}}
+	}
+
 	var opts []agent.ExecuteOption
 	opts = append(opts,
 		agent.WithProviderWorkDir(workDir),
@@ -296,21 +440,33 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))
 	}
 
-	output := resolveOutput(result.Text, handler, logger)
-	return output, result.SessionID, nil
+	// Prefer renderHandler for plan file detection (it tracks the same signals).
+	planHandler := logHandler
+	if renderHandler != nil && renderHandler.planFilePath != "" {
+		planHandler = nil
+	}
+	if planHandler != nil {
+		return resolveOutput(result.Text, logHandler, logger), result.SessionID, nil
+	}
+	return resolveOutputFromPath(result.Text, renderHandler.planFilePath, logger), result.SessionID, nil
 }
 
 // resolveOutput returns the plan file content if one was detected, otherwise the agent's text output.
 func resolveOutput(agentText string, handler *logEventHandler, logger *slog.Logger) string {
-	if handler.planFilePath == "" {
+	return resolveOutputFromPath(agentText, handler.planFilePath, logger)
+}
+
+// resolveOutputFromPath reads a plan file if the path is non-empty, falling back to agentText.
+func resolveOutputFromPath(agentText, planFilePath string, logger *slog.Logger) string {
+	if planFilePath == "" {
 		return agentText
 	}
-	planContent, err := os.ReadFile(handler.planFilePath)
+	planContent, err := os.ReadFile(planFilePath)
 	if err != nil {
-		logger.Warn("could not read plan file, using agent text output", "path", handler.planFilePath, "error", err)
+		logger.Warn("could not read plan file, using agent text output", "path", planFilePath, "error", err)
 		return agentText
 	}
-	logger.Debug("using plan file content", "path", handler.planFilePath)
+	logger.Debug("using plan file content", "path", planFilePath)
 	return string(planContent)
 }
 

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -188,6 +188,7 @@ type logEventHandler struct {
 	logger       *slog.Logger
 	toolStarts   map[string]time.Time
 	step         string
+	sessionID    string
 	planFilePath string
 	lastWriteMD  string
 	textBuf      strings.Builder
@@ -201,17 +202,25 @@ func newLogEventHandler(logger *slog.Logger, step string) *logEventHandler {
 	}
 }
 
+// logAttrs returns the common log attributes, including session_id when available.
+func (h *logEventHandler) logAttrs(extra ...any) []any {
+	attrs := []any{"step", h.step}
+	if h.sessionID != "" {
+		attrs = append(attrs, "session_id", h.sessionID)
+	}
+	return append(attrs, extra...)
+}
+
 // flushText logs accumulated text and resets the buffer.
 func (h *logEventHandler) flushText() {
 	if h.textBuf.Len() > 0 {
-		h.logger.Debug("agent text", "step", h.step, "text", truncate(h.textBuf.String(), 200))
+		h.logger.Debug("agent text", h.logAttrs("text", truncate(h.textBuf.String(), 200))...)
 		h.textBuf.Reset()
 	}
 }
 
 func (h *logEventHandler) OnText(text string) {
 	h.textBuf.WriteString(text)
-	// Flush at semantic boundaries: newline or buffer > 200 chars.
 	if strings.Contains(text, "\n") || h.textBuf.Len() > 200 {
 		h.flushText()
 	}
@@ -219,7 +228,7 @@ func (h *logEventHandler) OnText(text string) {
 
 func (h *logEventHandler) OnThinking(thinking string) {
 	h.flushText()
-	h.logger.Debug("agent thinking", "step", h.step, "thinking", truncate(thinking, 200))
+	h.logger.Debug("agent thinking", h.logAttrs("thinking", truncate(thinking, 200))...)
 }
 
 func (h *logEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
@@ -228,8 +237,7 @@ func (h *logEventHandler) OnToolStart(name, id string, input map[string]interfac
 }
 
 func (h *logEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
-	// Single log line per tool with input summary and duration.
-	attrs := []any{"step", h.step, "tool", name}
+	attrs := h.logAttrs("tool", name)
 	if inputSummary := render.FormatToolInput(name, input); inputSummary != "" {
 		attrs = append(attrs, "input", inputSummary)
 	}
@@ -252,24 +260,24 @@ func (h *logEventHandler) OnToolComplete(name, id string, input map[string]inter
 	}
 	if name == "ExitPlanMode" && h.lastWriteMD != "" {
 		h.planFilePath = h.lastWriteMD
-		h.logger.Debug("plan file confirmed", "step", h.step, "path", h.planFilePath)
+		h.logger.Debug("plan file confirmed", h.logAttrs("path", h.planFilePath)...)
 	}
 }
 
 func (h *logEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {
 	h.flushText()
-	h.logger.Debug("turn complete",
-		"step", h.step,
+	h.logger.Debug("turn complete", h.logAttrs(
 		"turn", turnNumber,
 		"success", success,
 		"duration", fmt.Sprintf("%.1fs", float64(durationMs)/1000),
 		"cost", fmt.Sprintf("$%.4f", costUSD),
-	)
+	)...)
 }
 
 func (h *logEventHandler) OnError(err error, context string) {
 	h.flushText()
-	h.logger.Debug("agent error", "step", h.step, "error", err, "context", context)
+	clear(h.toolStarts)
+	h.logger.Debug("agent error", h.logAttrs("error", err, "context", context)...)
 }
 
 // rendererEventHandler adapts agent.EventHandler to a render.Renderer for
@@ -373,8 +381,9 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	logger.Debug("agent prompt", "step", stepName, "prompt", truncate(prompt, 500))
 
 	logHandler := newLogEventHandler(logger, stepName)
-
-	// Build the event handler: log-only or composite (log + renderer).
+	if resumeSessionID != "" {
+		logHandler.sessionID = resumeSessionID
+	}
 	var handler agent.EventHandler = logHandler
 	if renderer != nil {
 		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, &rendererEventHandler{r: renderer}}}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -188,7 +188,6 @@ type logEventHandler struct {
 	logger       *slog.Logger
 	toolStarts   map[string]time.Time
 	step         string
-	sessionID    string
 	planFilePath string
 	lastWriteMD  string
 	textBuf      strings.Builder
@@ -202,19 +201,14 @@ func newLogEventHandler(logger *slog.Logger, step string) *logEventHandler {
 	}
 }
 
-// logAttrs returns the common log attributes, including session_id when available.
-func (h *logEventHandler) logAttrs(extra ...any) []any {
-	attrs := []any{"step", h.step}
-	if h.sessionID != "" {
-		attrs = append(attrs, "session_id", h.sessionID)
-	}
-	return append(attrs, extra...)
+func (h *logEventHandler) OnSessionInit(sessionID string) {
+	h.logger.Info("agent session init", "step", h.step, "session_id", sessionID)
 }
 
 // flushText logs accumulated text and resets the buffer.
 func (h *logEventHandler) flushText() {
 	if h.textBuf.Len() > 0 {
-		h.logger.Debug("agent text", h.logAttrs("text", truncate(h.textBuf.String(), 200))...)
+		h.logger.Debug("agent text", "step", h.step, "text", truncate(h.textBuf.String(), 200))
 		h.textBuf.Reset()
 	}
 }
@@ -228,7 +222,7 @@ func (h *logEventHandler) OnText(text string) {
 
 func (h *logEventHandler) OnThinking(thinking string) {
 	h.flushText()
-	h.logger.Debug("agent thinking", h.logAttrs("thinking", truncate(thinking, 200))...)
+	h.logger.Debug("agent thinking", "step", h.step, "thinking", truncate(thinking, 200))
 }
 
 func (h *logEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
@@ -237,7 +231,7 @@ func (h *logEventHandler) OnToolStart(name, id string, input map[string]interfac
 }
 
 func (h *logEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
-	attrs := h.logAttrs("tool", name)
+	attrs := []any{"step", h.step, "tool", name}
 	if inputSummary := render.FormatToolInput(name, input); inputSummary != "" {
 		attrs = append(attrs, "input", inputSummary)
 	}
@@ -260,24 +254,25 @@ func (h *logEventHandler) OnToolComplete(name, id string, input map[string]inter
 	}
 	if name == "ExitPlanMode" && h.lastWriteMD != "" {
 		h.planFilePath = h.lastWriteMD
-		h.logger.Debug("plan file confirmed", h.logAttrs("path", h.planFilePath)...)
+		h.logger.Debug("plan file confirmed", "step", h.step, "path", h.planFilePath)
 	}
 }
 
 func (h *logEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {
 	h.flushText()
-	h.logger.Debug("turn complete", h.logAttrs(
+	h.logger.Debug("turn complete",
+		"step", h.step,
 		"turn", turnNumber,
 		"success", success,
 		"duration", fmt.Sprintf("%.1fs", float64(durationMs)/1000),
 		"cost", fmt.Sprintf("$%.4f", costUSD),
-	)...)
+	)
 }
 
 func (h *logEventHandler) OnError(err error, context string) {
 	h.flushText()
 	clear(h.toolStarts)
-	h.logger.Debug("agent error", h.logAttrs("error", err, "context", context)...)
+	h.logger.Debug("agent error", "step", h.step, "error", err, "context", context)
 }
 
 // rendererEventHandler adapts agent.EventHandler to a render.Renderer for
@@ -354,6 +349,14 @@ func (c *compositeEventHandler) OnError(err error, ctx string) {
 	}
 }
 
+func (c *compositeEventHandler) OnSessionInit(sessionID string) {
+	for _, h := range c.handlers {
+		if sh, ok := h.(agent.SessionInitHandler); ok {
+			sh.OnSessionInit(sessionID)
+		}
+	}
+}
+
 // runAgent runs an agent with the given prompt and step configuration.
 // If renderer is non-nil, agent events are rendered to the terminal in addition
 // to being logged to the log file.
@@ -381,9 +384,6 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	logger.Debug("agent prompt", "step", stepName, "prompt", truncate(prompt, 500))
 
 	logHandler := newLogEventHandler(logger, stepName)
-	if resumeSessionID != "" {
-		logHandler.sessionID = resumeSessionID
-	}
 	var handler agent.EventHandler = logHandler
 	if renderer != nil {
 		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, &rendererEventHandler{r: renderer}}}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -410,9 +410,11 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 
 	result, err := provider.Execute(ctx, prompt, nil, opts...)
 	if err != nil {
+		logHandler.flushText()
 		return "", "", fmt.Errorf("agent execution: %w", err)
 	}
 	if !result.Success {
+		logHandler.flushText()
 		if result.Error != nil {
 			return "", "", result.Error
 		}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -295,9 +295,7 @@ func (h *rendererEventHandler) OnToolStart(name, id string, input map[string]int
 
 func (h *rendererEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	h.r.ToolComplete(name, input)
-	if isError {
-		h.r.ToolResult(result, isError)
-	}
+	h.r.ToolResult(result, isError)
 }
 
 func (h *rendererEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -295,7 +295,7 @@ func (h *rendererEventHandler) OnToolStart(name, id string, input map[string]int
 
 func (h *rendererEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	h.r.ToolComplete(name, input)
-	if result != nil || isError {
+	if isError {
 		h.r.ToolResult(result, isError)
 	}
 }
@@ -433,6 +433,7 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))
 	}
 
+	logHandler.flushText()
 	return resolveOutput(result.Text, logHandler, logger), result.SessionID, nil
 }
 
@@ -453,6 +454,17 @@ func resolveOutputFromPath(agentText, planFilePath string, logger *slog.Logger) 
 	}
 	logger.Debug("using plan file content", "path", planFilePath)
 	return string(planContent)
+}
+
+// JoinRoundOutputs filters empty outputs and joins non-empty ones with a separator.
+func JoinRoundOutputs(outputs []string) string {
+	var nonEmpty []string
+	for _, o := range outputs {
+		if strings.TrimSpace(o) != "" {
+			nonEmpty = append(nonEmpty, o)
+		}
+	}
+	return strings.Join(nonEmpty, "\n\n---\n\n")
 }
 
 func NewPromptData(issue *tracker.Issue, baseBranch string) PromptData {

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -295,7 +295,9 @@ func (h *rendererEventHandler) OnToolStart(name, id string, input map[string]int
 
 func (h *rendererEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	h.r.ToolComplete(name, input)
-	h.r.ToolResult(result, isError)
+	if result != nil || isError {
+		h.r.ToolResult(result, isError)
+	}
 }
 
 func (h *rendererEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -213,7 +213,7 @@ func TestResolvePromptForExecution_ResumeWithoutFeedback(t *testing.T) {
 }
 
 func TestLogEventHandler_TracksPlanFile_ExitPlanMode(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Write .md file, then ExitPlanMode confirms it as the plan file.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -227,7 +227,7 @@ func TestLogEventHandler_TracksPlanFile_ExitPlanMode(t *testing.T) {
 }
 
 func TestLogEventHandler_TracksPlanFile_ClaudePlansDir(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Also works with .claude/plans/ paths.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -238,7 +238,7 @@ func TestLogEventHandler_TracksPlanFile_ClaudePlansDir(t *testing.T) {
 }
 
 func TestLogEventHandler_NoExitPlanMode_NoPlanFile(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Write .md without ExitPlanMode — planFilePath stays empty.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -248,7 +248,7 @@ func TestLogEventHandler_NoExitPlanMode_NoPlanFile(t *testing.T) {
 }
 
 func TestLogEventHandler_IgnoresNonMDWrites(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Write to a non-.md path should not be tracked.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -259,7 +259,7 @@ func TestLogEventHandler_IgnoresNonMDWrites(t *testing.T) {
 }
 
 func TestLogEventHandler_IgnoresNonWriteTools(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Non-Write tool should not track .md path.
 	h.OnToolComplete("Read", "tool-1", map[string]interface{}{
@@ -270,7 +270,7 @@ func TestLogEventHandler_IgnoresNonWriteTools(t *testing.T) {
 }
 
 func TestLogEventHandler_IgnoresFailedWrites(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Failed write should not be tracked.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -281,7 +281,7 @@ func TestLogEventHandler_IgnoresFailedWrites(t *testing.T) {
 }
 
 func TestLogEventHandler_LastMDWriteWins(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 
 	// Multiple .md writes — the last one before ExitPlanMode wins.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -334,7 +334,7 @@ func TestReplay_PlanStepEventSequence(t *testing.T) {
 		{name: "ExitPlanMode", id: "t-10"},
 	}
 
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 	for _, ev := range events {
 		input := ev.input
 		if input == nil {
@@ -364,7 +364,7 @@ func TestReplay_PlanStepNoExitPlanMode(t *testing.T) {
 		// No ExitPlanMode — agent ran out of turns.
 	}
 
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 	for _, ev := range events {
 		input := ev.input
 		if input == nil {
@@ -384,7 +384,7 @@ func TestReplay_PlanStepNoExitPlanMode(t *testing.T) {
 // TestReplay_PlanFileReadFailure verifies graceful fallback when the plan file
 // cannot be read (e.g., deleted between write and read).
 func TestReplay_PlanFileReadFailure(t *testing.T) {
-	h := &logEventHandler{logger: slog.Default(), step: "plan"}
+	h := newLogEventHandler(slog.Default(), "plan")
 	h.OnToolComplete("Write", "t-1", map[string]interface{}{
 		"file_path": "/nonexistent/path/plan.md",
 	}, nil, false)

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazelment/yoloswe/jiradozer/cmd/jiradozer",
     visibility = ["//visibility:private"],
     deps = [
+        "//agent-cli-wrapper/claude/render",
         "//jiradozer",
         "//jiradozer/tracker",
         "//jiradozer/tracker/github",

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -538,6 +538,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, renderer *render.Renderer, logger *slog.Logger) error {
 	totalRounds := len(resolved.Rounds)
 	logger.Info("step: "+stepName, "rounds", totalRounds)
+	renderer.Status(fmt.Sprintf("Step: %s (%d rounds)", stepName, totalRounds))
 
 	var allOutputs []string
 	var sessionIDs []string
@@ -546,6 +547,7 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 			return fmt.Errorf("run-step %s: %w", stepName, ctx.Err())
 		}
 		logger.Info("round start", "step", stepName, "round", i+1, "total", totalRounds)
+		renderer.Status(fmt.Sprintf("Round %d/%d", i+1, totalRounds))
 
 		var output string
 		if round.IsCommand() {

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -132,6 +132,15 @@ func run(ctx context.Context, args runArgs) error {
 	}
 	colorMode := render.ParseColorMode(args.color)
 
+	// Map verbosity to a slog level for stderr fallback paths.
+	// The log file always uses LevelDebug (full detail); stderr respects --verbosity.
+	stderrLevel := slog.LevelInfo
+	if v >= render.VerbosityDebug {
+		stderrLevel = slog.LevelDebug
+	} else if v <= render.VerbosityQuiet {
+		stderrLevel = slog.LevelWarn
+	}
+
 	// Set up logger: log file gets DEBUG-level detail, terminal output goes through renderer.
 	if home, err := os.UserHomeDir(); err == nil {
 		logDir := filepath.Join(home, ".jiradozer", "logs")
@@ -144,14 +153,14 @@ func run(ctx context.Context, args runArgs) error {
 				// Log file only — all terminal output goes through the renderer.
 				slog.SetDefault(slog.New(klogfmt.New(f, klogfmt.WithLevel(slog.LevelDebug))))
 			} else {
-				klogfmt.Init(klogfmt.WithLevel(slog.LevelDebug))
+				klogfmt.Init(klogfmt.WithLevel(stderrLevel))
 				slog.Warn("failed to open log file, logging to stderr only", "path", logPath, "error", err)
 			}
 		} else {
-			klogfmt.Init(klogfmt.WithLevel(slog.LevelDebug))
+			klogfmt.Init(klogfmt.WithLevel(stderrLevel))
 		}
 	} else {
-		klogfmt.Init(klogfmt.WithLevel(slog.LevelDebug))
+		klogfmt.Init(klogfmt.WithLevel(stderrLevel))
 		slog.Warn("could not determine home directory, logging to stderr only", "error", err)
 	}
 	logger := slog.Default()

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -158,6 +158,7 @@ func run(ctx context.Context, args runArgs) error {
 			}
 		} else {
 			klogfmt.Init(klogfmt.WithLevel(stderrLevel))
+			slog.Warn("failed to create log directory, logging to stderr only", "path", logDir, "error", err)
 		}
 	} else {
 		klogfmt.Init(klogfmt.WithLevel(stderrLevel))
@@ -566,17 +567,8 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 		allOutputs = append(allOutputs, output)
 	}
 
-	// Filter empty round outputs before joining so separator-only text
-	// is not mistaken for real content (mirrors workflow.go logic).
-	var nonEmpty []string
-	for _, o := range allOutputs {
-		if strings.TrimSpace(o) != "" {
-			nonEmpty = append(nonEmpty, o)
-		}
-	}
-	var combined string
-	if len(nonEmpty) > 0 {
-		combined = strings.Join(nonEmpty, "\n\n---\n\n")
+	combined := jiradozer.JoinRoundOutputs(allOutputs)
+	if combined != "" {
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
 	} else {
 		logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -142,6 +142,7 @@ func run(ctx context.Context, args runArgs) error {
 	}
 
 	// Set up logger: log file gets DEBUG-level detail, terminal output goes through renderer.
+	var activeLogPath string
 	if home, err := os.UserHomeDir(); err == nil {
 		logDir := filepath.Join(home, ".jiradozer", "logs")
 		logPath := filepath.Join(logDir, fmt.Sprintf("jiradozer-%s-%d.log",
@@ -152,6 +153,7 @@ func run(ctx context.Context, args runArgs) error {
 				defer f.Close()
 				// Log file only — all terminal output goes through the renderer.
 				slog.SetDefault(slog.New(klogfmt.New(f, klogfmt.WithLevel(slog.LevelDebug))))
+				activeLogPath = logPath
 			} else {
 				klogfmt.Init(klogfmt.WithLevel(stderrLevel))
 				slog.Warn("failed to open log file, logging to stderr only", "path", logPath, "error", err)
@@ -171,6 +173,9 @@ func run(ctx context.Context, args runArgs) error {
 		render.WithVerbosity(v),
 		render.WithColorMode(colorMode),
 	)
+	if activeLogPath != "" {
+		renderer.Status("Logging to " + activeLogPath)
+	}
 
 	// Log invocation banner with CLI args and working directory.
 	// Redact values of flags that may contain secrets.
@@ -538,7 +543,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, renderer *render.Renderer, logger *slog.Logger) error {
 	totalRounds := len(resolved.Rounds)
 	logger.Info("step: "+stepName, "rounds", totalRounds)
-	renderer.Status(fmt.Sprintf("Step: %s (%d rounds)", stepName, totalRounds))
+	rendererStatus(renderer, fmt.Sprintf("Step: %s (%d rounds)", stepName, totalRounds))
 
 	var allOutputs []string
 	var sessionIDs []string
@@ -547,7 +552,7 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 			return fmt.Errorf("run-step %s: %w", stepName, ctx.Err())
 		}
 		logger.Info("round start", "step", stepName, "round", i+1, "total", totalRounds)
-		renderer.Status(fmt.Sprintf("Round %d/%d", i+1, totalRounds))
+		rendererStatus(renderer, fmt.Sprintf("Round %d/%d", i+1, totalRounds))
 
 		var output string
 		if round.IsCommand() {
@@ -617,6 +622,13 @@ func availableModels() string {
 var sensitiveFlags = []string{"--api-key", "--token", "--secret", "--password", "--description"}
 
 // redactArgs returns a copy of args with values of sensitive flags replaced by "***".
+// rendererStatus is a nil-safe wrapper around renderer.Status.
+func rendererStatus(r *render.Renderer, msg string) {
+	if r != nil {
+		r.Status(msg)
+	}
+}
+
 func redactArgs(args []string) []string {
 	out := make([]string, len(args))
 	copy(out, args)

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -16,6 +16,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/jiradozer"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 	ghtracker "github.com/bazelment/yoloswe/jiradozer/tracker/github"
@@ -41,6 +42,8 @@ func main() {
 		maxConcurrent   int
 		branchPrefix    string
 		verbose         bool
+		verbosity       string
+		color           string
 		description     string
 		descriptionFile string
 		planFile        string
@@ -64,6 +67,8 @@ func main() {
 				maxConcurrent:   maxConcurrent,
 				branchPrefix:    branchPrefix,
 				verbose:         verbose,
+				verbosity:       verbosity,
+				color:           color,
 				description:     description,
 				descriptionFile: descriptionFile,
 				planFile:        planFile,
@@ -83,7 +88,9 @@ func main() {
 	rootCmd.Flags().StringArrayVar(&sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo,Backlog)")
 	rootCmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 0, "Max concurrent workflows (overrides config)")
 	rootCmd.Flags().StringVar(&branchPrefix, "branch-prefix", "", "Worktree branch prefix (overrides config)")
-	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose logging")
+	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose output (shorthand for --verbosity=verbose)")
+	rootCmd.Flags().StringVar(&verbosity, "verbosity", "normal", "Output verbosity: quiet, normal, verbose, debug")
+	rootCmd.Flags().StringVar(&color, "color", "auto", "Color output: auto, always, never")
 	rootCmd.Flags().StringVar(&description, "description", "", "Task description for local mode (no external tracker needed)")
 	rootCmd.Flags().StringVar(&descriptionFile, "description-file", "", "Read task description from file (use - for stdin)")
 	rootCmd.Flags().StringVar(&planFile, "plan-file", "", "Plan file for build step (use - for stdin)")
@@ -97,17 +104,19 @@ func main() {
 }
 
 type runArgs struct {
-	issueID         string
+	description     string
+	planFile        string
 	configPath      string
 	workDir         string
 	modelID         string
 	runStep         string
 	autoApprove     string
 	branchPrefix    string
-	description     string
+	issueID         string
+	color           string
 	descriptionFile string
-	planFile        string
 	planContent     string
+	verbosity       string
 	sourceFilters   []string
 	pollInterval    time.Duration
 	maxBudget       float64
@@ -116,27 +125,42 @@ type runArgs struct {
 }
 
 func run(ctx context.Context, args runArgs) error {
-	// Set up logger with dual-write to stderr + log file.
-	level := slog.LevelInfo
-	if args.verbose {
-		level = slog.LevelDebug
+	// Resolve verbosity: --verbose is shorthand for --verbosity=verbose.
+	v := render.ParseVerbosity(args.verbosity)
+	if args.verbose && v < render.VerbosityVerbose {
+		v = render.VerbosityVerbose
 	}
+	colorMode := render.ParseColorMode(args.color)
+
+	// Set up logger: log file gets DEBUG-level detail, terminal output goes through renderer.
 	if home, err := os.UserHomeDir(); err == nil {
 		logDir := filepath.Join(home, ".jiradozer", "logs")
-		logFile := filepath.Join(logDir, fmt.Sprintf("jiradozer-%s-%d.log",
+		logPath := filepath.Join(logDir, fmt.Sprintf("jiradozer-%s-%d.log",
 			time.Now().Format("20060102-150405"), os.Getpid()))
-		closer, err := klogfmt.InitWithLogFile(logFile, klogfmt.WithLevel(level))
-		if err != nil {
-			klogfmt.Init(klogfmt.WithLevel(level))
-			slog.Warn("failed to open log file, logging to stderr only", "path", logFile, "error", err)
+		if err := os.MkdirAll(logDir, 0o755); err == nil {
+			f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+			if err == nil {
+				defer f.Close()
+				// Log file only — all terminal output goes through the renderer.
+				slog.SetDefault(slog.New(klogfmt.New(f, klogfmt.WithLevel(slog.LevelDebug))))
+			} else {
+				klogfmt.Init(klogfmt.WithLevel(slog.LevelDebug))
+				slog.Warn("failed to open log file, logging to stderr only", "path", logPath, "error", err)
+			}
 		} else {
-			defer closer()
+			klogfmt.Init(klogfmt.WithLevel(slog.LevelDebug))
 		}
 	} else {
-		klogfmt.Init(klogfmt.WithLevel(level))
+		klogfmt.Init(klogfmt.WithLevel(slog.LevelDebug))
 		slog.Warn("could not determine home directory, logging to stderr only", "error", err)
 	}
 	logger := slog.Default()
+
+	// Create the terminal renderer for headless modes (not TUI).
+	renderer := render.New(os.Stderr,
+		render.WithVerbosity(v),
+		render.WithColorMode(colorMode),
+	)
 
 	// Log invocation banner with CLI args and working directory.
 	// Redact values of flags that may contain secrets.
@@ -316,10 +340,11 @@ func run(ctx context.Context, args runArgs) error {
 
 	// Local description mode.
 	if args.description != "" {
-		return runFromDescription(ctx, args.description, args.runStep, args.planContent, issueTracker, cfg, logger)
+		return runFromDescription(ctx, args.description, args.runStep, args.planContent, issueTracker, cfg, renderer, logger)
 	}
 
 	// Multi-issue TUI mode (only when no --issue flag was given).
+	// TUI owns the terminal — don't use the renderer.
 	if cfg.Source.HasSource() && args.issueID == "" {
 		return runMultiIssue(ctx, issueTracker, cfg, logger)
 	}
@@ -333,11 +358,12 @@ func run(ctx context.Context, args runArgs) error {
 	logger.Info("found issue", "id", issue.ID, "title", issue.Title, "state", issue.State)
 
 	if args.runStep != "" {
-		return runSingleStep(ctx, args.runStep, issue, cfg, args.planContent, logger)
+		return runSingleStep(ctx, args.runStep, issue, cfg, args.planContent, renderer, logger)
 	}
 
 	// Run the full workflow.
 	wf := jiradozer.NewWorkflow(issueTracker, issue, cfg, logger)
+	wf.SetRenderer(renderer)
 	return wf.Run(ctx)
 }
 
@@ -430,7 +456,7 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 	}
 }
 
-func runFromDescription(ctx context.Context, description, runStep, planContent string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, logger *slog.Logger) error {
+func runFromDescription(ctx context.Context, description, runStep, planContent string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, renderer *render.Renderer, logger *slog.Logger) error {
 	lt, ok := issueTracker.(*local.Tracker)
 	if !ok {
 		return fmt.Errorf("--description requires local tracker (got %T)", issueTracker)
@@ -446,14 +472,15 @@ func runFromDescription(ctx context.Context, description, runStep, planContent s
 	logger.Info("created local issue", "identifier", issue.Identifier, "title", issue.Title)
 
 	if runStep != "" {
-		return runSingleStep(ctx, runStep, issue, cfg, planContent, logger)
+		return runSingleStep(ctx, runStep, issue, cfg, planContent, renderer, logger)
 	}
 
 	wf := jiradozer.NewWorkflow(issueTracker, issue, cfg, logger)
+	wf.SetRenderer(renderer)
 	return wf.Run(ctx)
 }
 
-func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, logger *slog.Logger) error {
+func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, renderer *render.Renderer, logger *slog.Logger) error {
 	stepCfg, ok := cfg.StepByName(stepName)
 	if !ok {
 		return fmt.Errorf("unknown step %q (valid: %s)", stepName, strings.Join(allSteps, ", "))
@@ -480,10 +507,10 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	}
 
 	if len(resolved.Rounds) > 0 {
-		return runSingleStepRounds(ctx, stepName, data, resolved, cfg.WorkDir, logger)
+		return runSingleStepRounds(ctx, stepName, data, resolved, cfg.WorkDir, renderer, logger)
 	}
 
-	output, sessionID, err := jiradozer.RunStepAgent(ctx, stepName, data, resolved, cfg.WorkDir, "", "", logger)
+	output, sessionID, err := jiradozer.RunStepAgent(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
 	if err != nil {
 		return fmt.Errorf("run-step %s: %w", stepName, err)
 	}
@@ -498,7 +525,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	return nil
 }
 
-func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, logger *slog.Logger) error {
+func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, renderer *render.Renderer, logger *slog.Logger) error {
 	totalRounds := len(resolved.Rounds)
 	logger.Info("step: "+stepName, "rounds", totalRounds)
 
@@ -521,7 +548,7 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 			roundCfg := jiradozer.ResolveRound(round, resolved)
 			var sessionID string
 			var err error
-			output, sessionID, err = jiradozer.RunStepAgent(ctx, stepName, data, roundCfg, workDir, "", "", logger)
+			output, sessionID, err = jiradozer.RunStepAgent(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
 			if err != nil {
 				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
 			}

--- a/jiradozer/integration/e2e_workflow_test.go
+++ b/jiradozer/integration/e2e_workflow_test.go
@@ -205,7 +205,7 @@ func TestE2E_PlanStep_Smoke(t *testing.T) {
 		MaxBudgetUSD:   1.0,
 	}
 
-	output, sessionID, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", logger)
+	output, sessionID, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err, "plan step should succeed")
 	assert.NotEmpty(t, output, "plan output should not be empty")
 	assert.NotEmpty(t, sessionID, "should return a session ID")

--- a/jiradozer/integration/session_resumption_test.go
+++ b/jiradozer/integration/session_resumption_test.go
@@ -55,7 +55,7 @@ func TestSessionResumption_PlanFeedbackLoop(t *testing.T) {
 
 	// --- Step 1: First execution (no session ID, no feedback) ---
 	t.Log("Step 1: First planning execution")
-	output1, sessionID1, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", logger)
+	output1, sessionID1, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err, "first plan execution should succeed")
 	require.NotEmpty(t, output1, "first plan output should not be empty")
 	require.NotEmpty(t, sessionID1, "first execution should return a session ID")
@@ -65,7 +65,7 @@ func TestSessionResumption_PlanFeedbackLoop(t *testing.T) {
 	// --- Step 2: Resume with feedback (same session ID) ---
 	t.Log("Step 2: Resume with feedback (redo)")
 	feedback := "Please also add validation for required fields and return typed errors instead of generic errors"
-	output2, sessionID2, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, feedback, sessionID1, logger)
+	output2, sessionID2, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, feedback, sessionID1, nil, logger)
 	require.NoError(t, err, "resumed plan execution should succeed")
 	require.NotEmpty(t, output2, "resumed plan output should not be empty")
 	require.NotEmpty(t, sessionID2, "resumed execution should return a session ID")
@@ -112,7 +112,7 @@ func TestSessionResumption_BuildAfterPlan(t *testing.T) {
 	// Plan step.
 	t.Log("Running plan step")
 	data := jiradozer.NewPromptData(issue, "main")
-	planOutput, planSessionID, err := jiradozer.RunStepAgent(ctx, "plan", data, planCfg, workDir, "", "", logger)
+	planOutput, planSessionID, err := jiradozer.RunStepAgent(ctx, "plan", data, planCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, planOutput)
 	require.NotEmpty(t, planSessionID)
@@ -128,7 +128,7 @@ func TestSessionResumption_BuildAfterPlan(t *testing.T) {
 	data.Plan = planOutput
 
 	t.Log("Running build step with plan output")
-	buildOutput, buildSessionID, err := jiradozer.RunStepAgent(ctx, "build", data, buildCfg, workDir, "", "", logger)
+	buildOutput, buildSessionID, err := jiradozer.RunStepAgent(ctx, "build", data, buildCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, buildOutput)
 	require.NotEmpty(t, buildSessionID)

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
 
@@ -29,7 +30,8 @@ type Workflow struct {
 	stateIDs        map[string]string
 	OnTransition    func(step WorkflowStep)
 	OnRoundProgress func(roundIndex, roundTotal int)
-	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, logger *slog.Logger) (string, string, error)
+	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error)
+	renderer        *render.Renderer
 	issue           *tracker.Issue
 	plan            string
 	buildOutput     string
@@ -49,6 +51,12 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		sessionIDs:   make(map[WorkflowStep]string),
 		runStepAgent: RunStepAgent,
 	}
+}
+
+// SetRenderer sets the terminal renderer for streaming output.
+// When non-nil, workflow lifecycle events and agent output are rendered to the terminal.
+func (w *Workflow) SetRenderer(r *render.Renderer) {
+	w.renderer = r
 }
 
 // Run executes the workflow loop until completion or failure.
@@ -166,6 +174,9 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 	w.feedback = ""
 
 	w.logger.Info("step: "+stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "feedback", feedback != "")
+	if w.renderer != nil {
+		w.renderer.Status(fmt.Sprintf("Step: %s (%s) %d rounds", stepName, w.issue.Identifier, totalRounds))
+	}
 	stepStart := time.Now()
 
 	data := w.promptData()
@@ -179,6 +190,9 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		}
 
 		w.logger.Info("round start", "step", stepName, "round", i+1, "total", totalRounds)
+		if w.renderer != nil {
+			w.renderer.Status(fmt.Sprintf("Round %d/%d", i+1, totalRounds))
+		}
 		if w.OnRoundProgress != nil {
 			w.OnRoundProgress(i, totalRounds)
 		}
@@ -199,7 +213,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 				feedbackInjected = true
 			}
 			var roundSessionID string
-			output, roundSessionID, err = w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.logger)
+			output, roundSessionID, err = w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.renderer, w.logger)
 			if roundSessionID != "" {
 				roundSessionIDs = append(roundSessionIDs, roundSessionID)
 			}
@@ -241,7 +255,11 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 			nonEmpty = append(nonEmpty, o)
 		}
 	}
-	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "session_ids", roundSessionIDs, "duration", time.Since(stepStart))
+	stepDuration := time.Since(stepStart)
+	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "session_ids", roundSessionIDs, "duration", stepDuration)
+	if w.renderer != nil {
+		w.renderer.Status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
+	}
 	w.captureOutput(stepName, strings.Join(nonEmpty, "\n\n---\n\n"))
 	w.transitionToReview(ctx, reviewStep, trigger)
 }
@@ -260,16 +278,23 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	w.feedback = ""
 
 	w.logger.Info("step: "+stepName, "issue", w.issue.Identifier, "feedback", feedback != "", "resume", sessionID != "")
+	if w.renderer != nil {
+		w.renderer.Status(fmt.Sprintf("Step: %s (%s)", stepName, w.issue.Identifier))
+	}
 
 	stepStart := time.Now()
 	cfg := w.config.ResolveStep(stepCfg)
-	output, newSessionID, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.logger)
+	output, newSessionID, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.renderer, w.logger)
 	if err != nil {
 		w.fail(ctx, fmt.Errorf("%s step: %w", stepName, err))
 		return
 	}
 
-	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "session_id", newSessionID, "duration", time.Since(stepStart))
+	stepDuration := time.Since(stepStart)
+	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "session_id", newSessionID, "duration", stepDuration)
+	if w.renderer != nil {
+		w.renderer.Status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
+	}
 	w.sessionIDs[currentStep] = newSessionID
 	w.captureOutput(stepName, output)
 
@@ -332,6 +357,9 @@ func capitalize(s string) string {
 func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget WorkflowStep) {
 	if w.shouldAutoApprove(w.state.Current()) {
 		w.logger.Info("auto-approving", "step", w.state.Current())
+		if w.renderer != nil {
+			w.renderer.Status(fmt.Sprintf("Auto-approved %s", w.state.Current()))
+		}
 		w.feedback = ""
 		if err := w.transition(approveTarget, "auto_approved"); err != nil {
 			w.fail(ctx, err)
@@ -340,6 +368,9 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 	}
 
 	w.logger.Info("waiting for approval", "step", w.state.Current(), "issue", w.issue.Identifier)
+	if w.renderer != nil {
+		w.renderer.Status(fmt.Sprintf("Waiting for approval on %s...", w.issue.Identifier))
+	}
 
 	fb, err := PollForFeedback(ctx, w.tracker, w.issue.ID, w.lastCommentAt, w.config.PollInterval, w.logger, w.botCommentIDs)
 	if err != nil {
@@ -352,18 +383,27 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 	switch fb.Action {
 	case FeedbackApprove:
 		w.logger.Info("feedback: approved", "step", w.state.Current())
+		if w.renderer != nil {
+			w.renderer.Status("Approved")
+		}
 		w.feedback = ""
 		if err := w.transition(approveTarget, "approved"); err != nil {
 			w.fail(ctx, err)
 		}
 	case FeedbackRedo:
 		w.logger.Info("feedback: redo", "step", w.state.Current())
+		if w.renderer != nil {
+			w.renderer.Status("Redo requested")
+		}
 		w.feedback = fb.Message
 		if err := w.transition(redoTarget, "redo"); err != nil {
 			w.fail(ctx, err)
 		}
 	case FeedbackComment:
 		w.logger.Info("feedback: comment", "step", w.state.Current(), "message", fb.Message)
+		if w.renderer != nil {
+			w.renderer.Status("Feedback received")
+		}
 		w.feedback = fb.Message
 		if err := w.transition(redoTarget, "feedback"); err != nil {
 			w.fail(ctx, err)

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -249,18 +249,10 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 			"step", stepName, "feedback", truncate(feedback, 200))
 	}
 
-	// Filter empty round outputs before joining so separator-only text
-	// (e.g. "\n\n---\n\n") is not mistaken for real plan content.
-	var nonEmpty []string
-	for _, o := range allOutputs {
-		if strings.TrimSpace(o) != "" {
-			nonEmpty = append(nonEmpty, o)
-		}
-	}
 	stepDuration := time.Since(stepStart)
 	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "session_ids", roundSessionIDs, "duration", stepDuration)
 	w.status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
-	w.captureOutput(stepName, strings.Join(nonEmpty, "\n\n---\n\n"))
+	w.captureOutput(stepName, JoinRoundOutputs(allOutputs))
 	w.transitionToReview(ctx, reviewStep, trigger)
 }
 

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -54,9 +54,15 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 }
 
 // SetRenderer sets the terminal renderer for streaming output.
-// When non-nil, workflow lifecycle events and agent output are rendered to the terminal.
 func (w *Workflow) SetRenderer(r *render.Renderer) {
 	w.renderer = r
+}
+
+// status emits a renderer status line when a renderer is configured.
+func (w *Workflow) status(msg string) {
+	if w.renderer != nil {
+		w.renderer.Status(msg)
+	}
 }
 
 // Run executes the workflow loop until completion or failure.
@@ -174,9 +180,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 	w.feedback = ""
 
 	w.logger.Info("step: "+stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "feedback", feedback != "")
-	if w.renderer != nil {
-		w.renderer.Status(fmt.Sprintf("Step: %s (%s) %d rounds", stepName, w.issue.Identifier, totalRounds))
-	}
+	w.status(fmt.Sprintf("Step: %s (%s) %d rounds", stepName, w.issue.Identifier, totalRounds))
 	stepStart := time.Now()
 
 	data := w.promptData()
@@ -190,9 +194,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		}
 
 		w.logger.Info("round start", "step", stepName, "round", i+1, "total", totalRounds)
-		if w.renderer != nil {
-			w.renderer.Status(fmt.Sprintf("Round %d/%d", i+1, totalRounds))
-		}
+		w.status(fmt.Sprintf("Round %d/%d", i+1, totalRounds))
 		if w.OnRoundProgress != nil {
 			w.OnRoundProgress(i, totalRounds)
 		}
@@ -257,9 +259,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 	}
 	stepDuration := time.Since(stepStart)
 	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "rounds", totalRounds, "session_ids", roundSessionIDs, "duration", stepDuration)
-	if w.renderer != nil {
-		w.renderer.Status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
-	}
+	w.status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
 	w.captureOutput(stepName, strings.Join(nonEmpty, "\n\n---\n\n"))
 	w.transitionToReview(ctx, reviewStep, trigger)
 }
@@ -278,9 +278,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	w.feedback = ""
 
 	w.logger.Info("step: "+stepName, "issue", w.issue.Identifier, "feedback", feedback != "", "resume", sessionID != "")
-	if w.renderer != nil {
-		w.renderer.Status(fmt.Sprintf("Step: %s (%s)", stepName, w.issue.Identifier))
-	}
+	w.status(fmt.Sprintf("Step: %s (%s)", stepName, w.issue.Identifier))
 
 	stepStart := time.Now()
 	cfg := w.config.ResolveStep(stepCfg)
@@ -292,9 +290,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 
 	stepDuration := time.Since(stepStart)
 	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "session_id", newSessionID, "duration", stepDuration)
-	if w.renderer != nil {
-		w.renderer.Status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
-	}
+	w.status(fmt.Sprintf("Step %s complete (%s)", stepName, stepDuration.Truncate(time.Second)))
 	w.sessionIDs[currentStep] = newSessionID
 	w.captureOutput(stepName, output)
 
@@ -357,9 +353,7 @@ func capitalize(s string) string {
 func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget WorkflowStep) {
 	if w.shouldAutoApprove(w.state.Current()) {
 		w.logger.Info("auto-approving", "step", w.state.Current())
-		if w.renderer != nil {
-			w.renderer.Status(fmt.Sprintf("Auto-approved %s", w.state.Current()))
-		}
+		w.status(fmt.Sprintf("Auto-approved %s", w.state.Current()))
 		w.feedback = ""
 		if err := w.transition(approveTarget, "auto_approved"); err != nil {
 			w.fail(ctx, err)
@@ -368,9 +362,7 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 	}
 
 	w.logger.Info("waiting for approval", "step", w.state.Current(), "issue", w.issue.Identifier)
-	if w.renderer != nil {
-		w.renderer.Status(fmt.Sprintf("Waiting for approval on %s...", w.issue.Identifier))
-	}
+	w.status(fmt.Sprintf("Waiting for approval on %s...", w.issue.Identifier))
 
 	fb, err := PollForFeedback(ctx, w.tracker, w.issue.ID, w.lastCommentAt, w.config.PollInterval, w.logger, w.botCommentIDs)
 	if err != nil {
@@ -383,27 +375,21 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 	switch fb.Action {
 	case FeedbackApprove:
 		w.logger.Info("feedback: approved", "step", w.state.Current())
-		if w.renderer != nil {
-			w.renderer.Status("Approved")
-		}
+		w.status("Approved")
 		w.feedback = ""
 		if err := w.transition(approveTarget, "approved"); err != nil {
 			w.fail(ctx, err)
 		}
 	case FeedbackRedo:
 		w.logger.Info("feedback: redo", "step", w.state.Current())
-		if w.renderer != nil {
-			w.renderer.Status("Redo requested")
-		}
+		w.status("Redo requested")
 		w.feedback = fb.Message
 		if err := w.transition(redoTarget, "redo"); err != nil {
 			w.fail(ctx, err)
 		}
 	case FeedbackComment:
 		w.logger.Info("feedback: comment", "step", w.state.Current(), "message", fb.Message)
-		if w.renderer != nil {
-			w.renderer.Status("Feedback received")
-		}
+		w.status("Feedback received")
 		w.feedback = fb.Message
 		if err := w.transition(redoTarget, "feedback"); err != nil {
 			w.fail(ctx, err)

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
 
@@ -612,7 +613,7 @@ func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
 	wf.lastCommentAt = staleTime
 
 	// Stub runStepAgent so runStep executes without invoking a real agent.
-	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *slog.Logger) (string, string, error) {
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (string, string, error) {
 		return "step output", "session-1", nil
 	}
 
@@ -660,7 +661,7 @@ func TestWorkflow_RunStepRounds_SetsLastCommentAtFromFinalRound(t *testing.T) {
 	wf.lastCommentAt = staleTime
 
 	// Stub runStepAgent so rounds execute without a real agent.
-	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *slog.Logger) (string, string, error) {
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (string, string, error) {
 		return "round output", "", nil
 	}
 
@@ -700,7 +701,7 @@ func TestWorkflow_RunStepRounds_CommandFirstFeedbackInjection(t *testing.T) {
 	wf.feedback = "please fix the tests"
 
 	var capturedFeedback string
-	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, feedback string, _ string, _ *slog.Logger) (string, string, error) {
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, feedback string, _ string, _ *render.Renderer, _ *slog.Logger) (string, string, error) {
 		capturedFeedback = feedback
 		return "agent output", "", nil
 	}

--- a/multiagent/agent/bridge.go
+++ b/multiagent/agent/bridge.go
@@ -68,8 +68,9 @@ func bridgeEvents[E any](
 			case agentstream.KindReady:
 				if handler != nil {
 					if sh, ok := handler.(SessionInitHandler); ok {
-						re := sev.(agentstream.Ready)
-						sh.OnSessionInit(re.StreamSessionID())
+						if re, ok := sev.(agentstream.Ready); ok {
+							sh.OnSessionInit(re.StreamSessionID())
+						}
 					}
 				}
 

--- a/multiagent/agent/bridge.go
+++ b/multiagent/agent/bridge.go
@@ -65,6 +65,14 @@ func bridgeEvents[E any](
 			}
 
 			switch kind {
+			case agentstream.KindReady:
+				if handler != nil {
+					if sh, ok := handler.(SessionInitHandler); ok {
+						re := sev.(agentstream.Ready)
+						sh.OnSessionInit(re.StreamSessionID())
+					}
+				}
+
 			case agentstream.KindText:
 				te := sev.(agentstream.Text)
 				delta := te.StreamDelta()

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -117,6 +117,13 @@ type EventHandler interface {
 	OnError(err error, context string)
 }
 
+// SessionInitHandler is an optional interface that EventHandler implementations
+// can implement to receive session initialization metadata (e.g. session ID).
+// The bridge calls OnSessionInit when the provider emits a ready/init event.
+type SessionInitHandler interface {
+	OnSessionInit(sessionID string)
+}
+
 // Provider is the pluggable interface for agent backends.
 // Adding a new backend (Gemini, Codex, etc.) means implementing this interface.
 type Provider interface {


### PR DESCRIPTION
## Summary
- **Separate terminal output from log file**: Agent events now fan out through a `compositeEventHandler` — `rendererEventHandler` streams clean output to stderr via `render.Renderer`, while `logEventHandler` writes high-SNR structured logs to the log file only
- **High-SNR log files**: Tool start/complete merged into single log line with input summary + duration (no tool IDs), agent text buffered and flushed at semantic boundaries instead of word fragments (~70% fewer log lines)
- **Verbosity and color control**: New `--verbosity` (quiet/normal/verbose/debug) and `--color` (auto/always/never) flags; `--verbose` kept as shorthand for `--verbosity=verbose`
- **Workflow status rendering**: Step start/complete, round progress, auto-approve, waiting for review, and feedback actions rendered as `[Status]` lines on the terminal

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel build //jiradozer/...` compiles
- [x] `bazel test //jiradozer/...` — all 6 test targets pass
- [ ] Manual test with `--run-step=plan --description "test task"` — verify streaming output on stderr
- [ ] Manual test with `--verbosity=quiet` — verify only errors on stderr
- [ ] Manual test with `--verbose` — verify tool results shown
- [ ] Verify log file in `~/.jiradozer/logs/` has high-SNR DEBUG detail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `jiradozer` logs and renders agent execution by separating terminal streaming from log-file output and adding new CLI flags; behavior is user-facing and touches workflow execution plumbing, but is largely additive and well-covered by tests.
> 
> **Overview**
> **Separates terminal rendering from log-file logging for agent runs.** `RunStepAgent`/workflow execution now optionally fans out events via a composite handler: a high-signal `logEventHandler` writes structured DEBUG logs (buffered text, merged tool start/complete with input summary + duration), while an optional `render.Renderer` streams clean, user-facing output to stderr.
> 
> **Adds session initialization propagation and status output.** Introduces `KindReady`/`agentstream.Ready` plus a new optional `agent.SessionInitHandler` so providers can emit session IDs on init; `jiradozer` workflow and headless single-step modes now emit `[Status]` lines for step/round progress and review actions.
> 
> **Adds CLI controls for output and color.** New `--verbosity` (quiet/normal/verbose/debug) and `--color` (auto/always/never) flags (with `--verbose` as shorthand) and updates logging initialization to always write full DEBUG detail to a per-run log file while terminal output respects verbosity/color settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ccc45c3f01bea8c26a1895d8b86e38cd4a23316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->