### PR TITLE
claude SDK: handle Monitor tool as background task

### DIFF
--- a/agent-cli-wrapper/claude/BUILD.bazel
+++ b/agent-cli-wrapper/claude/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "sdk_mcp_typed_test.go",
         "session_bg_test.go",
         "session_dispatch_test.go",
+        "session_monitor_test.go",
         "turn_test.go",
     ],
     embed = [":claude"],

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -41,6 +41,8 @@ const (
 	EventTypeTaskProgress
 	// EventTypeTaskNotification fires when a background task completes/fails/stops.
 	EventTypeTaskNotification
+	// EventTypeTaskUpdated fires when a background task's state patch is emitted.
+	EventTypeTaskUpdated
 	// EventTypeHookLifecycle fires for hook_started/progress/response.
 	EventTypeHookLifecycle
 	// EventTypeRateLimit fires when the server's rate-limit state changes.
@@ -285,6 +287,25 @@ type TaskNotificationEvent struct {
 
 // Type returns the event type.
 func (e TaskNotificationEvent) Type() EventType { return EventTypeTaskNotification }
+
+// TaskUpdatedEvent fires on a background-task state patch. Status and
+// description are pointers because the upstream patch only carries fields
+// that actually changed — an unchanged description is nil, not "". Terminal
+// Status values are "completed", "failed", or "killed"; non-terminal values
+// are "pending" and "running".
+type TaskUpdatedEvent struct {
+	Status         *string
+	Description    *string
+	EndTime        *int64
+	TotalPausedMs  *int64
+	Error          *string
+	IsBackgrounded *bool
+	TaskID         string
+	TurnNumber     int
+}
+
+// Type returns the event type.
+func (e TaskUpdatedEvent) Type() EventType { return EventTypeTaskUpdated }
 
 // HookLifecycleEvent is a unified event for hook_started/hook_progress/
 // hook_response system subtypes. Phase selects which stage this event

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -39,7 +39,7 @@ const (
 	EventTypeTaskStarted
 	// EventTypeTaskProgress fires on background task progress updates.
 	EventTypeTaskProgress
-	// EventTypeTaskNotification fires when a background task completes/fails/stops.
+	// EventTypeTaskNotification fires when a background task completes/fails/is killed.
 	EventTypeTaskNotification
 	// EventTypeTaskUpdated fires when a background task's state patch is emitted.
 	EventTypeTaskUpdated

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -274,7 +274,7 @@ type TaskProgressEvent struct {
 func (e TaskProgressEvent) Type() EventType { return EventTypeTaskProgress }
 
 // TaskNotificationEvent fires when a background task completes. Status is
-// "completed", "failed", or "stopped".
+// "completed", "failed", or "killed".
 type TaskNotificationEvent struct {
 	ToolUseID  *string
 	TaskID     string

--- a/agent-cli-wrapper/claude/integration/BUILD.bazel
+++ b/agent-cli-wrapper/claude/integration/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     srcs = [
         "config_test.go",
         "content_blocks_test.go",
+        "monitor_test.go",
         "query_test.go",
         "sdk_mcp_test.go",
         "sdk_mcp_typed_test.go",

--- a/agent-cli-wrapper/claude/integration/monitor_test.go
+++ b/agent-cli-wrapper/claude/integration/monitor_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+// +build integration
+
+// Integration tests for the Claude Code Monitor tool.
+//
+// Monitor is a built-in CLI tool that spawns a detached bash subprocess and
+// returns immediately with a synchronous tool_result ("Monitor started ...
+// keep working, do not poll"). Unlike Bash(run_in_background:true), its
+// tool_use.input does NOT carry run_in_background — the CLI treats it as
+// background work via task_started/task_updated lifecycle events.
+//
+// Before the fix, the SDK wrapper's suppression logic keyed only off
+// run_in_background, so Monitor turns finalized immediately on end_turn
+// while the underlying bash subprocess was still running. Headless harnesses
+// like jiradozer then advanced rounds with incomplete results.
+//
+// These tests exercise the Monitor flow end-to-end against the real Claude
+// CLI: the session must block on Ask() until the Monitor task reaches
+// terminal state, then return the final TurnResult that reflects the full
+// observation window.
+
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
+)
+
+// MonitorTurnEvents collects events from a Monitor-bearing turn. Unlike
+// the shared TurnEvents helper in session_test.go, this tracks the task
+// lifecycle events that prove suppression/release actually worked.
+type MonitorTurnEvents struct {
+	TurnComplete      *claude.TurnCompleteEvent
+	TaskStarted       []claude.TaskStartedEvent
+	TaskUpdated       []claude.TaskUpdatedEvent
+	TaskNotifications []claude.TaskNotificationEvent
+	ToolStarts        []claude.ToolStartEvent
+	ToolComplete      []claude.ToolCompleteEvent
+	TextEvents        []claude.TextEvent
+	Errors            []claude.ErrorEvent
+}
+
+// collectMonitorTurnEvents drains events until TurnCompleteEvent. It records
+// task-lifecycle events alongside the usual text/tool events so tests can
+// assert on the full Monitor flow.
+func collectMonitorTurnEvents(ctx context.Context, s *claude.Session) (*MonitorTurnEvents, error) {
+	events := &MonitorTurnEvents{}
+	for {
+		select {
+		case <-ctx.Done():
+			return events, ctx.Err()
+		case event, ok := <-s.Events():
+			if !ok {
+				return events, context.Canceled
+			}
+			switch e := event.(type) {
+			case claude.TextEvent:
+				events.TextEvents = append(events.TextEvents, e)
+			case claude.ToolStartEvent:
+				events.ToolStarts = append(events.ToolStarts, e)
+			case claude.ToolCompleteEvent:
+				events.ToolComplete = append(events.ToolComplete, e)
+			case claude.TaskStartedEvent:
+				events.TaskStarted = append(events.TaskStarted, e)
+			case claude.TaskUpdatedEvent:
+				events.TaskUpdated = append(events.TaskUpdated, e)
+			case claude.TaskNotificationEvent:
+				events.TaskNotifications = append(events.TaskNotifications, e)
+			case claude.TurnCompleteEvent:
+				events.TurnComplete = &e
+				return events, nil
+			case claude.ErrorEvent:
+				events.Errors = append(events.Errors, e)
+			}
+		}
+	}
+}
+
+// hasMonitorTool reports whether any Monitor tool_use appeared in the turn.
+func (me *MonitorTurnEvents) hasMonitorTool() bool {
+	for _, tc := range me.ToolComplete {
+		if tc.Name == "Monitor" {
+			return true
+		}
+	}
+	return false
+}
+
+// fullText joins all streamed text chunks for the turn.
+func (me *MonitorTurnEvents) fullText() string {
+	var b strings.Builder
+	for _, te := range me.TextEvents {
+		b.WriteString(te.Text)
+	}
+	return b.String()
+}
+
+// TestSession_Integration_MonitorTool verifies the core fix: when the
+// agent uses the Monitor tool, the SDK must block Ask()/CollectResponse()
+// until the Monitor task reaches terminal state — NOT finalize the turn
+// on the intermediate end_turn stop_reason.
+//
+// The marker string written by the monitored bash subprocess must appear
+// in the final TurnResult text. If it does not, the session finalized
+// before the subprocess completed — that's the exact jiradozer bug.
+func TestSession_Integration_MonitorTool(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	testDir, err := os.MkdirTemp("", "claude-go-test-monitor-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	keepArtifacts := os.Getenv("KEEP_ARTIFACTS") != ""
+	if !keepArtifacts {
+		defer os.RemoveAll(testDir)
+	}
+	t.Logf("Test artifacts directory: %s (keep=%v)", testDir, keepArtifacts)
+
+	session := claude.NewSession(
+		claude.WithModel("haiku"),
+		claude.WithWorkDir(testDir),
+		claude.WithPermissionMode(claude.PermissionModeBypass),
+		claude.WithDisablePlugins(),
+		claude.WithRecording(testDir),
+	)
+
+	if err := session.Start(ctx); err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+	defer session.Stop()
+
+	// Ask the agent to launch a short Monitor command and report its output.
+	// The sentinel file trick guarantees the subprocess runs to completion:
+	// we ask the agent to read the file after the Monitor task is done, which
+	// only works if the SDK correctly blocked until the subprocess actually
+	// finished writing.
+	t.Log("Sending Monitor prompt...")
+	_, err = session.SendMessage(ctx,
+		"Use the Monitor tool (NOT plain Bash, NOT run_in_background) to run this exact command:\n"+
+			"`sleep 3 && echo MONITOR_MARKER_XYZ > "+testDir+"/monitor_output.txt`\n\n"+
+			"You MUST call the Monitor tool. After calling Monitor, wait for it to finish, "+
+			"then read the file `"+testDir+"/monitor_output.txt` and tell me its exact contents. "+
+			"Do not guess — read the file.")
+	if err != nil {
+		t.Fatalf("SendMessage failed: %v", err)
+	}
+
+	events, err := collectMonitorTurnEvents(ctx, session)
+	if err != nil {
+		t.Fatalf("collectMonitorTurnEvents failed (session may have hung waiting for Monitor): %v", err)
+	}
+
+	if events.TurnComplete == nil {
+		t.Fatal("Expected TurnCompleteEvent — session hung or no events received")
+	}
+	if !events.TurnComplete.Success {
+		t.Errorf("Expected successful turn, got error")
+	}
+
+	t.Logf("Turn completed: success=%v, cost=$%.6f, turn=%d",
+		events.TurnComplete.Success, events.TurnComplete.Usage.CostUSD, events.TurnComplete.TurnNumber)
+	t.Logf("Task events: started=%d updated=%d notifications=%d",
+		len(events.TaskStarted), len(events.TaskUpdated), len(events.TaskNotifications))
+
+	// If the agent didn't use Monitor, the test doesn't exercise the fix —
+	// log and skip the behavioral assertions rather than false-failing.
+	if !events.hasMonitorTool() {
+		t.Skip("Agent did not use the Monitor tool — cannot exercise the fix. " +
+			"This can happen with smaller models that pick plain Bash instead.")
+	}
+
+	// task_started must have fired at least once — proves the CLI registered
+	// the Monitor command as a background task and the SDK received the event.
+	if len(events.TaskStarted) == 0 {
+		t.Error("Expected at least one TaskStartedEvent when Monitor is used")
+	}
+
+	// The terminal release path is either task_updated with a terminal status
+	// (completed/failed/killed) OR task_notification. At least one must be
+	// present or the turn could not have been released from suppression.
+	hasTerminal := false
+	for _, tu := range events.TaskUpdated {
+		if tu.Status != nil {
+			switch *tu.Status {
+			case "completed", "failed", "killed":
+				hasTerminal = true
+			}
+		}
+	}
+	if !hasTerminal && len(events.TaskNotifications) == 0 {
+		t.Error("Expected at least one terminal TaskUpdatedEvent or TaskNotificationEvent — " +
+			"without one, the turn could not have released from suppression")
+	}
+
+	// The actual proof-of-fix: the monitored subprocess wrote a marker file,
+	// and the agent read it back. If the SDK had finalized the turn on
+	// end_turn (the bug), the subprocess would still be sleeping when Ask
+	// returned — the file would be empty and the marker absent from output.
+	markerFile := testDir + "/monitor_output.txt"
+	if _, statErr := os.Stat(markerFile); statErr != nil {
+		t.Errorf("Marker file not created: %v — Monitor subprocess did not complete", statErr)
+	} else {
+		data, readErr := os.ReadFile(markerFile)
+		if readErr != nil {
+			t.Errorf("Failed to read marker file: %v", readErr)
+		} else if !strings.Contains(string(data), "MONITOR_MARKER_XYZ") {
+			t.Errorf("Marker file missing expected content, got: %q", string(data))
+		}
+	}
+
+	// The final response text should include the marker the agent read from
+	// the file. This proves Ask() waited for the full Monitor cycle — the
+	// agent had to observe the subprocess's completed output to report it.
+	text := events.fullText()
+	t.Logf("Final response text (%d bytes):\n%s", len(text), text)
+	if !strings.Contains(text, "MONITOR_MARKER_XYZ") {
+		t.Error("Expected final response text to contain MONITOR_MARKER_XYZ — " +
+			"the agent did not observe the Monitor subprocess's output, " +
+			"suggesting the SDK finalized the turn before the subprocess completed")
+	}
+
+	t.Log("Monitor tool scenario passed — SDK correctly blocked until task terminal state")
+}

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1191,11 +1191,16 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				// indefinite blocking.
 				//
 				// Two release paths exist:
-				//   1. A continuation ResultMessage (auto-continued bg-Bash
-				//      path — handleResult detects bgState.active and completes).
+				//   1. A continuation ResultMessage (auto-continued bg-Bash path).
+				//      The CLI auto-starts a new assistant turn when bg work
+				//      finishes. handleResult clears bgState.active at the top,
+				//      then the new turn has no bg tools so shouldSuppressForBgTasks
+				//      returns false and the turn completes normally.
 				//   2. All registered tasks reach a terminal state via
 				//      task_updated/task_notification (Monitor path —
-				//      maybeReleaseSuppression fires from handleSystem).
+				//      maybeReleaseSuppression fires from handleSystem; or the
+				//      AllTasksCompleted fast path fires if tasks completed before
+				//      this ResultMessage arrived).
 				//
 				// The timeout is max(configured, longest bg tool timeout_ms,
 				// 1h upper clamp) so it never releases before the agent's own

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -22,14 +22,18 @@ import (
 const defaultBgTaskSafetyTimeout = 90 * time.Second
 
 // bgSuppressionState groups all background-task turn-suppression state.
-// When the CLI runs background tasks (run_in_background: true), the SDK
-// suppresses the intermediate ResultMessage and waits for continuation
-// task-notifications. This struct holds the state for that mechanism.
+// When the CLI runs background tasks (run_in_background: true or tools
+// in backgroundTools such as Monitor), the SDK suppresses the
+// intermediate ResultMessage and waits for either a continuation
+// ResultMessage (auto-continued bg-Bash path) or all registered tasks to
+// reach a terminal state via task_updated/task_notification (Monitor path).
 // Use reset() to clear all fields at turn boundaries.
 type bgSuppressionState struct {
-	timer            *time.Timer // fires if no continuation arrives; see completeSuppressedTurn
+	timer            *time.Timer // fires if no release signal arrives; see completeSuppressedTurn
+	heldResult       *TurnResult // captured intermediate result, finalized by the release path
 	accumulatedUsage TurnUsage   // token/cost totals from suppressed intermediate results
-	active           bool        // true while waiting for continuation; cleared by timer or normal path
+	turnNumber       int         // turn that owns the held result (guards against stale releases)
+	active           bool        // true while waiting for release; cleared by timer, task terminal, or continuation result
 	timerFired       bool        // set by completeSuppressedTurn; cleared at start of next turn
 }
 
@@ -42,6 +46,8 @@ func (b *bgSuppressionState) reset() {
 		b.timer = nil
 	}
 	b.accumulatedUsage = TurnUsage{}
+	b.heldResult = nil
+	b.turnNumber = 0
 }
 
 // SessionInfo contains session metadata.
@@ -816,6 +822,7 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 		}
 	case protocol.SystemSubtypeTaskStarted:
 		if p, ok := msg.AsTaskStarted(); ok {
+			s.turnManager.TrackTask(p.TaskID)
 			s.emit(TaskStartedEvent{
 				ToolUseID:    p.ToolUseID,
 				WorkflowName: p.WorkflowName,
@@ -827,6 +834,28 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 			})
 		} else {
 			slog.Warn("failed to decode task_started payload")
+		}
+	case protocol.SystemSubtypeTaskUpdated:
+		if p, ok := msg.AsTaskUpdated(); ok {
+			s.emit(TaskUpdatedEvent{
+				Status:         p.Patch.Status,
+				Description:    p.Patch.Description,
+				EndTime:        p.Patch.EndTime,
+				TotalPausedMs:  p.Patch.TotalPausedMs,
+				Error:          p.Patch.Error,
+				IsBackgrounded: p.Patch.IsBackgrounded,
+				TaskID:         p.TaskID,
+				TurnNumber:     turnNum,
+			})
+			if p.Patch.Status != nil {
+				switch *p.Patch.Status {
+				case "completed", "failed", "killed":
+					s.turnManager.UntrackTask(p.TaskID)
+					s.maybeReleaseSuppression("task_updated:" + *p.Patch.Status)
+				}
+			}
+		} else {
+			slog.Warn("failed to decode task_updated payload")
 		}
 	case protocol.SystemSubtypeTaskProgress:
 		if p, ok := msg.AsTaskProgress(); ok {
@@ -853,6 +882,11 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 				Usage:      p.Usage,
 				TurnNumber: turnNum,
 			})
+			// Belt-and-suspenders: task_notification may fire without a
+			// preceding terminal task_updated (e.g. if the bg process writes
+			// stdout on exit). Drain the live set and attempt release.
+			s.turnManager.UntrackTask(p.TaskID)
+			s.maybeReleaseSuppression("task_notification")
 		} else {
 			slog.Warn("failed to decode task_notification payload")
 		}
@@ -1154,17 +1188,39 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				// are processed cleanly.
 				s.accumulator.Reset()
 
-				// Start a safety timer: if no continuation ResultMessage arrives
-				// within the timeout, complete the turn with accumulated data
-				// to prevent indefinite blocking.
+				// Start a safety timer: if no release signal arrives within the
+				// timeout, complete the turn with accumulated data to prevent
+				// indefinite blocking.
+				//
+				// Two release paths exist:
+				//   1. A continuation ResultMessage (auto-continued bg-Bash
+				//      path — handleResult detects bgState.active and completes).
+				//   2. All registered tasks reach a terminal state via
+				//      task_updated/task_notification (Monitor path —
+				//      maybeReleaseSuppression fires from handleSystem).
+				//
+				// The timeout is max(configured, longest bg tool timeout_ms,
+				// 1h upper clamp) so it never releases before the agent's own
+				// deadline (Monitor lets callers pass timeout_ms up to 1h).
 				timeout := defaultBgTaskSafetyTimeout
 				if s.config.BgTaskSafetyTimeout > 0 {
 					timeout = s.config.BgTaskSafetyTimeout
+				}
+				if toolMs := turn.longestBackgroundToolTimeoutMs(); toolMs > 0 {
+					toolTimeout := time.Duration(toolMs) * time.Millisecond
+					if toolTimeout > timeout {
+						timeout = toolTimeout
+					}
+				}
+				if maxTimeout := time.Hour; timeout > maxTimeout {
+					timeout = maxTimeout
 				}
 				safetyResult := result
 				s.mu.Lock()
 				s.bgState.active = true
 				s.bgState.timerFired = false // reset for this turn's timer
+				s.bgState.heldResult = &safetyResult
+				s.bgState.turnNumber = turnNumber
 				if s.bgState.timer != nil {
 					s.bgState.timer.Stop()
 				}
@@ -1222,8 +1278,8 @@ func (s *Session) finalizeTurn(result TurnResult) {
 }
 
 // completeSuppressedTurn is called by the background-task safety timer when
-// no continuation ResultMessage arrives within the timeout. It completes the
-// turn with whatever data was accumulated, preventing indefinite blocking.
+// no release signal arrives within the timeout. It completes the turn with
+// whatever data was accumulated, preventing indefinite blocking.
 func (s *Session) completeSuppressedTurn(result TurnResult) {
 	s.mu.Lock()
 	if !s.bgState.active {
@@ -1234,11 +1290,61 @@ func (s *Session) completeSuppressedTurn(result TurnResult) {
 	s.bgState.timerFired = true
 	s.bgState.timer = nil
 	s.bgState.accumulatedUsage = TurnUsage{}
+	s.bgState.heldResult = nil
 	s.mu.Unlock()
 
 	// Incorporate streaming updates from the correct turn only. Guard with
 	// TurnNumber to avoid cross-contaminating with a new turn that may have
 	// started between the lock release above and this read.
+	turn := s.turnManager.CurrentTurn()
+	if turn != nil && turn.Number == result.TurnNumber {
+		result.Text = turn.FullText
+		result.Thinking = turn.FullThinking
+		result.ContentBlocks = turn.ContentBlocks
+	}
+
+	s.finalizeTurn(result)
+}
+
+// maybeReleaseSuppression releases a suppressed turn when all live tasks
+// have reached a terminal state. Called from task_updated and
+// task_notification handling after a terminal state is observed. No-op if
+// suppression is not active, if the live set is still non-empty, or if the
+// held result no longer matches the current turn (stale release from a
+// prior turn's leftover task).
+//
+// Unlike completeSuppressedTurn (which is timer-driven and finalizes with a
+// captured copy), this uses bgState.heldResult so both paths surface the
+// same TurnResult.
+func (s *Session) maybeReleaseSuppression(reason string) {
+	s.mu.Lock()
+	if !s.bgState.active || s.bgState.heldResult == nil {
+		s.mu.Unlock()
+		return
+	}
+	if s.turnManager.HasLiveTasks() {
+		s.mu.Unlock()
+		return
+	}
+	result := *s.bgState.heldResult
+	if result.TurnNumber != s.bgState.turnNumber {
+		s.mu.Unlock()
+		return
+	}
+	s.bgState.active = false
+	s.bgState.heldResult = nil
+	s.bgState.turnNumber = 0
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
+		s.bgState.timer = nil
+	}
+	// Leave accumulatedUsage alone — the held result already includes
+	// accumulated usage folded into result.Usage at handleResult time.
+	s.bgState.accumulatedUsage = TurnUsage{}
+	s.mu.Unlock()
+
+	slog.Debug("releasing suppressed turn", "reason", reason, "turn", result.TurnNumber)
+
 	turn := s.turnManager.CurrentTurn()
 	if turn != nil && turn.Number == result.TurnNumber {
 		result.Text = turn.FullText

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1215,6 +1215,21 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				}
 				safetyResult := result
 				s.mu.Lock()
+				// Fast path: all bg tasks already completed before this
+				// ResultMessage arrived (task_updated/task_notification arrived
+				// first). In that case liveTasks is already empty and no future
+				// task event will call maybeReleaseSuppression, so we must
+				// finalize now rather than hanging until the safety timer fires.
+				//
+				// Only applies when tasks were actually registered (Monitor
+				// path); bg-Bash turns never register tasks and use the
+				// continuation-ResultMessage release path instead.
+				if s.turnManager.AllTasksCompleted() {
+					s.bgState.accumulatedUsage = TurnUsage{}
+					s.mu.Unlock()
+					s.finalizeTurn(safetyResult)
+					return
+				}
 				s.bgState.active = true
 				s.bgState.timerFired = false // reset for this turn's timer
 				s.bgState.heldResult = &safetyResult

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -32,7 +32,6 @@ type bgSuppressionState struct {
 	timer            *time.Timer // fires if no release signal arrives; see completeSuppressedTurn
 	heldResult       *TurnResult // captured intermediate result, finalized by the release path
 	accumulatedUsage TurnUsage   // token/cost totals from suppressed intermediate results
-	turnNumber       int         // turn that owns the held result (guards against stale releases)
 	active           bool        // true while waiting for release; cleared by timer, task terminal, or continuation result
 	timerFired       bool        // set by completeSuppressedTurn; cleared at start of next turn
 }
@@ -47,7 +46,6 @@ func (b *bgSuppressionState) reset() {
 	}
 	b.accumulatedUsage = TurnUsage{}
 	b.heldResult = nil
-	b.turnNumber = 0
 }
 
 // SessionInfo contains session metadata.
@@ -1220,7 +1218,6 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 				s.bgState.active = true
 				s.bgState.timerFired = false // reset for this turn's timer
 				s.bgState.heldResult = &safetyResult
-				s.bgState.turnNumber = turnNumber
 				if s.bgState.timer != nil {
 					s.bgState.timer.Stop()
 				}
@@ -1327,13 +1324,13 @@ func (s *Session) maybeReleaseSuppression(reason string) {
 		return
 	}
 	result := *s.bgState.heldResult
-	if result.TurnNumber != s.bgState.turnNumber {
+	currentTurnNum := s.turnManager.CurrentTurnNumber()
+	if result.TurnNumber != currentTurnNum {
 		s.mu.Unlock()
 		return
 	}
 	s.bgState.active = false
 	s.bgState.heldResult = nil
-	s.bgState.turnNumber = 0
 	if s.bgState.timer != nil {
 		s.bgState.timer.Stop()
 		s.bgState.timer = nil

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1061,7 +1061,15 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	}
 	timerAlreadyFired := s.bgState.timerFired
 	s.bgState.timerFired = false // clear; also reset by SendMessage at next turn start
+	// wasSuppressed is true when a prior ResultMessage triggered suppression and
+	// this ResultMessage is the bg-Bash continuation that releases it. In that
+	// case shouldSuppressForBgTasks would still return true (the bg-Bash tool_use
+	// remains in ContentBlocks), but we must NOT re-suppress — this IS the final
+	// result. We detect it by checking whether suppression was active when we
+	// arrive: if active was true, we just cleared it, so this is the continuation.
+	wasSuppressed := s.bgState.active
 	s.bgState.active = false
+	s.bgState.heldResult = nil
 	if timerAlreadyFired {
 		s.mu.Unlock()
 		return
@@ -1133,7 +1141,12 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	//
 	// When non-bg tools are present (mixed turn), the ResultMessage represents
 	// completion of synchronous work and must not be suppressed.
-	shouldSuppress := turn.shouldSuppressForBgTasks()
+	//
+	// When wasSuppressed is true, this ResultMessage is the bg-Bash continuation
+	// that releases prior suppression. The turn's ContentBlocks still contain the
+	// bg-Bash tool_use (so shouldSuppressForBgTasks would return true), but
+	// suppression must not be re-armed — this IS the final result for the turn.
+	shouldSuppress := !wasSuppressed && turn.shouldSuppressForBgTasks()
 
 	// costAccounted tracks whether cumulativeCostUSD has already been updated
 	// for this result (the background-task branch does it early to enable budget
@@ -1339,17 +1352,12 @@ func (s *Session) maybeReleaseSuppression(reason string) {
 		s.mu.Unlock()
 		return
 	}
-	if s.turnManager.HasLiveTasks() {
-		s.mu.Unlock()
-		return
-	}
-	// For mixed Monitor + bg-Bash turns: if the turn has uncancelled bg-Bash
-	// tools, do not release here — the continuation ResultMessage will arrive
-	// later and finalize via the normal (non-suppressed) handleResult path.
+	// AllTasksCompleted returns false when liveTasks is non-empty (Monitor task
+	// still running), when no tasks were ever registered (bg-Bash only turns
+	// that use the continuation-ResultMessage release path), or when uncancelled
+	// bg-Bash tools are present (mixed Monitor+bg-Bash must defer to the
+	// continuation-ResultMessage path).
 	if !s.turnManager.AllTasksCompleted() {
-		// AllTasksCompleted returns false when uncancelled continuation bg-Bash
-		// tools are present. Suppression remains active; the continuation
-		// ResultMessage (on a new assistant turn) will clear bgState.active.
 		s.mu.Unlock()
 		return
 	}

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1343,6 +1343,16 @@ func (s *Session) maybeReleaseSuppression(reason string) {
 		s.mu.Unlock()
 		return
 	}
+	// For mixed Monitor + bg-Bash turns: if the turn has uncancelled bg-Bash
+	// tools, do not release here — the continuation ResultMessage will arrive
+	// later and finalize via the normal (non-suppressed) handleResult path.
+	if !s.turnManager.AllTasksCompleted() {
+		// AllTasksCompleted returns false when uncancelled continuation bg-Bash
+		// tools are present. Suppression remains active; the continuation
+		// ResultMessage (on a new assistant turn) will clear bgState.active.
+		s.mu.Unlock()
+		return
+	}
 	result := *s.bgState.heldResult
 	currentTurnNum := s.turnManager.CurrentTurnNumber()
 	if result.TurnNumber != currentTurnNum {

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 )
 
+var notErr = false // reusable *bool for ToolResultBlock.IsError across tests
+
 // makeSystemMessage builds a protocol.SystemMessage from a JSON map by
 // round-tripping through UnmarshalJSON so the raw payload is captured for
 // DecodePayload to re-decode typed sub-payloads.
@@ -55,9 +57,8 @@ func TestMonitor_HappyPath(t *testing.T) {
 	}
 	simulateAssistantToolUse(s, tools)
 
-	isErrFalse := false
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started (task task-abc, timeout 300000ms).", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started (task task-abc, timeout 300000ms).", IsError: &notErr},
 	})
 
 	// task_started arrives.
@@ -89,13 +90,16 @@ func TestMonitor_HappyPath(t *testing.T) {
 
 	s.mu.RLock()
 	suppActive := s.bgState.active
-	heldTurn := s.bgState.turnNumber
+	heldTurn := 0
+	if s.bgState.heldResult != nil {
+		heldTurn = s.bgState.heldResult.TurnNumber
+	}
 	s.mu.RUnlock()
 	if !suppActive {
 		t.Error("expected suppression to be active after Monitor ResultMessage")
 	}
 	if heldTurn != turn.Number {
-		t.Errorf("bgState.turnNumber=%d, want %d", heldTurn, turn.Number)
+		t.Errorf("heldResult.TurnNumber=%d, want %d", heldTurn, turn.Number)
 	}
 
 	// Terminal task_updated releases the suppression.
@@ -134,9 +138,9 @@ func TestMonitor_FailedTaskReleases(t *testing.T) {
 		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "false"}},
 	}
 	simulateAssistantToolUse(s, tools)
-	isErrFalse := false
+
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
 	})
 	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
 		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
@@ -170,10 +174,10 @@ func TestMonitor_TwoTasksReleaseRequiresBoth(t *testing.T) {
 		{ID: "tool-2", Name: "Monitor", Input: map[string]interface{}{"command": "sleep 10"}},
 	}
 	simulateAssistantToolUse(s, tools)
-	isErrFalse := false
+
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
-		{ToolUseID: "tool-2", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "Monitor started.", IsError: &notErr},
 	})
 	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
 		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
@@ -221,10 +225,10 @@ func TestMonitor_MixedWithNonBgDoesNotSuppress(t *testing.T) {
 		{ID: "tool-2", Name: "Read", Input: map[string]interface{}{"file_path": "/tmp/x"}},
 	}
 	simulateAssistantToolUse(s, tools)
-	isErrFalse := false
+
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
-		{ToolUseID: "tool-2", Content: "file contents", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "file contents", IsError: &notErr},
 	})
 	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
 		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
@@ -262,9 +266,8 @@ func TestMonitor_HonorsTimeoutMs(t *testing.T) {
 		t.Errorf("longestBackgroundToolTimeoutMs=%d, want 600000", got)
 	}
 
-	isErrFalse := false
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
 	})
 	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
 		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
@@ -294,9 +297,9 @@ func TestMonitor_NonTerminalStatusDoesNotRelease(t *testing.T) {
 		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "sleep 60"}},
 	}
 	simulateAssistantToolUse(s, tools)
-	isErrFalse := false
+
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
 	})
 	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
 		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
@@ -333,9 +336,9 @@ func TestMonitor_TaskNotificationAlsoReleases(t *testing.T) {
 		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
 	}
 	simulateAssistantToolUse(s, tools)
-	isErrFalse := false
+
 	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
-		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
 	})
 	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
 		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -356,3 +356,39 @@ func TestMonitor_TaskNotificationAlsoReleases(t *testing.T) {
 
 	waitForTurnComplete(t, s.events, time.Second)
 }
+
+// TestMonitor_TaskCompletesBeforeResultMessage verifies the race where
+// task_updated:completed arrives before ResultMessage. Without the fix,
+// handleResult would activate suppression with an empty liveTasks set and
+// no future task event would call maybeReleaseSuppression, leaving the turn
+// stuck until the safety timer fires.
+func TestMonitor_TaskCompletesBeforeResultMessage(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "true"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-fast", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// task_updated:completed arrives BEFORE the ResultMessage — the fast-exit race.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-fast", "tool_use_id": "tool-1",
+		"patch": map[string]interface{}{"status": "completed"},
+	}))
+
+	// Now the ResultMessage arrives. All live tasks are already gone; suppression
+	// must finalize immediately without waiting for the safety timer.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	waitForTurnComplete(t, s.events, time.Second)
+}

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -392,3 +392,37 @@ func TestMonitor_TaskCompletesBeforeResultMessage(t *testing.T) {
 
 	waitForTurnComplete(t, s.events, time.Second)
 }
+
+// TestMonitor_TaskNotificationBeforeResultMessage is the symmetric race to
+// TestMonitor_TaskCompletesBeforeResultMessage: task_notification arrives
+// before ResultMessage. Both release paths (task_updated and task_notification)
+// must correctly trigger the AllTasksCompleted fast path.
+func TestMonitor_TaskNotificationBeforeResultMessage(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-fast2", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// task_notification arrives BEFORE the ResultMessage.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u2",
+		"task_id": "task-fast2", "tool_use_id": "tool-1",
+		"status": "completed",
+	}))
+
+	// ResultMessage arrives after notification; must finalize immediately.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	waitForTurnComplete(t, s.events, time.Second)
+}

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -427,6 +427,45 @@ func TestMonitor_TaskNotificationBeforeResultMessage(t *testing.T) {
 	waitForTurnComplete(t, s.events, time.Second)
 }
 
+// TestMonitor_MixedWithCancelledBgBashFastPaths verifies that a turn with a
+// Monitor task and a CANCELLED bg-Bash tool still uses the AllTasksCompleted
+// fast path when the Monitor task completes. A cancelled bg-Bash tool never
+// produces a continuation ResultMessage, so the fast path should apply.
+func TestMonitor_MixedWithCancelledBgBashFastPaths(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 2", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	// tool-2 (bg-Bash) is cancelled (IsError=true).
+	isErrTrue := true
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "Cancelled: parallel tool call errored", IsError: &isErrTrue},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-mixed2", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// Monitor completes BEFORE the ResultMessage.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-mixed2", "tool_use_id": "tool-1",
+		"patch": map[string]interface{}{"status": "completed"},
+	}))
+
+	// ResultMessage arrives — cancelled bg-Bash has no continuation, so fast
+	// path must apply and the turn must complete immediately.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	waitForTurnComplete(t, s.events, time.Second)
+}
+
 // TestMonitor_MixedWithBgBashDoesNotFastPath verifies that a turn containing
 // both a Monitor tool and a bg-Bash (run_in_background) tool does NOT use the
 // AllTasksCompleted fast path when the Monitor task completes first. The turn

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -426,3 +426,58 @@ func TestMonitor_TaskNotificationBeforeResultMessage(t *testing.T) {
 
 	waitForTurnComplete(t, s.events, time.Second)
 }
+
+// TestMonitor_MixedWithBgBashDoesNotFastPath verifies that a turn containing
+// both a Monitor tool and a bg-Bash (run_in_background) tool does NOT use the
+// AllTasksCompleted fast path when the Monitor task completes first. The turn
+// must remain suppressed (via the safety timer) waiting for the bg-Bash
+// continuation ResultMessage that the CLI will send automatically.
+func TestMonitor_MixedWithBgBashDoesNotFastPath(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 2", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "Running in background...", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-mixed", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// Monitor completes BEFORE the ResultMessage — but bg-Bash is still running.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-mixed", "tool_use_id": "tool-1",
+		"patch": map[string]interface{}{"status": "completed"},
+	}))
+
+	// ResultMessage arrives — should suppress (not fast-path) because bg-Bash is pending.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	// Turn must still be suppressed — bg-Bash continuation hasn't arrived.
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// Verify suppression is active (safety timer armed, not fast-pathed).
+	s.mu.RLock()
+	suppActive := s.bgState.active
+	s.mu.RUnlock()
+	if !suppActive {
+		t.Error("expected suppression to be active while bg-Bash continuation is pending")
+	}
+
+	// Clean up the safety timer to avoid test leaks.
+	s.mu.Lock()
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
+		s.bgState.timer = nil
+	}
+	s.bgState.active = false
+	s.mu.Unlock()
+}

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -524,6 +524,49 @@ func TestMonitor_MixedWithBgBashMonitorCompletesAfterResultMsg(t *testing.T) {
 	s.mu.Unlock()
 }
 
+// TestMonitor_MixedWithBgBashMonitorCompletesAfterResultMsg_ThenBashContinuation
+// is the end-to-end version of the reverse ordering test. It exercises the
+// full release path: ResultMessage arrives (suppresses), Monitor completes
+// (still suppressed), then bg-Bash continuation ResultMessage arrives and
+// releases the held turn, producing a TurnCompleteEvent.
+func TestMonitor_MixedWithBgBashMonitorCompletesAfterResultMsg_ThenBashContinuation(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 2", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "Running in background...", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-mixed4", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// ResultMessage arrives first — suppresses the turn.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// Monitor task completes — still suppressed, bg-Bash continuation pending.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-mixed4", "tool_use_id": "tool-1",
+		"patch": map[string]interface{}{"status": "completed"},
+	}))
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// bg-Bash continuation ResultMessage arrives (CLI auto-continues on the same
+	// turn; no new StartTurn is called). handleResult clears bgState.active and
+	// the turn finalizes normally.
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	waitForTurnComplete(t, s.events, time.Second)
+}
+
 // TestMonitor_MixedWithBgBashDoesNotFastPath verifies that a turn containing
 // both a Monitor tool and a bg-Bash (run_in_background) tool does NOT use the
 // AllTasksCompleted fast path when the Monitor task completes first. The turn
@@ -577,4 +620,44 @@ func TestMonitor_MixedWithBgBashDoesNotFastPath(t *testing.T) {
 	}
 	s.bgState.active = false
 	s.mu.Unlock()
+}
+
+// TestMonitor_MixedWithBgBashDoesNotFastPath_ThenBashContinuation is the
+// end-to-end version: Monitor completes before ResultMessage (no fast-path),
+// then ResultMessage suppresses, then bg-Bash continuation ResultMessage
+// arrives and releases the held turn.
+func TestMonitor_MixedWithBgBashDoesNotFastPath_ThenBashContinuation(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 2", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "Running in background...", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-mixed2", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// Monitor completes BEFORE the ResultMessage — bg-Bash is still running.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-mixed2", "tool_use_id": "tool-1",
+		"patch": map[string]interface{}{"status": "completed"},
+	}))
+
+	// ResultMessage suppresses (AllTasksCompleted returns false due to bg-Bash).
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// bg-Bash continuation ResultMessage arrives (same turn, no new StartTurn).
+	// handleResult clears bgState.active and the turn finalizes normally.
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	waitForTurnComplete(t, s.events, time.Second)
 }

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -1,0 +1,355 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
+)
+
+// makeSystemMessage builds a protocol.SystemMessage from a JSON map by
+// round-tripping through UnmarshalJSON so the raw payload is captured for
+// DecodePayload to re-decode typed sub-payloads.
+func makeSystemMessage(t *testing.T, v map[string]interface{}) protocol.SystemMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg protocol.SystemMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	return msg
+}
+
+// expectNoTurnComplete asserts no TurnCompleteEvent arrives within the window.
+func expectNoTurnComplete(t *testing.T, events <-chan Event, window time.Duration) {
+	t.Helper()
+	deadline := time.After(window)
+	for {
+		select {
+		case event := <-events:
+			if _, ok := event.(TurnCompleteEvent); ok {
+				t.Fatal("unexpected TurnCompleteEvent — turn should still be suppressed")
+			}
+		case <-deadline:
+			return
+		}
+	}
+}
+
+// TestMonitor_HappyPath verifies the end-to-end Monitor lifecycle:
+// a Monitor tool_use → task_started → ResultMessage is suppressed → terminal
+// task_updated releases the suppression and fires TurnCompleteEvent.
+func TestMonitor_HappyPath(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{
+			"command":     "sleep 60",
+			"description": "wait for reviews",
+			"timeout_ms":  float64(300000),
+		}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started (task task-abc, timeout 300000ms).", IsError: &isErrFalse},
+	})
+
+	// task_started arrives.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type":        "system",
+		"subtype":     "task_started",
+		"session_id":  "sess-1",
+		"uuid":        "evt-1",
+		"task_id":     "task-abc",
+		"tool_use_id": "tool-1",
+		"description": "wait for reviews",
+		"task_type":   "monitor",
+	}))
+
+	// shouldSuppressForBgTasks must be true — Monitor is in backgroundTools.
+	turn := s.turnManager.CurrentTurn()
+	if !turn.shouldSuppressForBgTasks() {
+		t.Error("shouldSuppressForBgTasks should return true for a Monitor tool")
+	}
+	if !s.turnManager.HasLiveTasks() {
+		t.Error("expected HasLiveTasks=true after task_started")
+	}
+
+	// ResultMessage arrives — should suppress, not emit TurnCompleteEvent.
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	expectNoTurnComplete(t, s.events, 100*time.Millisecond)
+
+	s.mu.RLock()
+	suppActive := s.bgState.active
+	heldTurn := s.bgState.turnNumber
+	s.mu.RUnlock()
+	if !suppActive {
+		t.Error("expected suppression to be active after Monitor ResultMessage")
+	}
+	if heldTurn != turn.Number {
+		t.Errorf("bgState.turnNumber=%d, want %d", heldTurn, turn.Number)
+	}
+
+	// Terminal task_updated releases the suppression.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type":       "system",
+		"subtype":    "task_updated",
+		"session_id": "sess-1",
+		"uuid":       "evt-2",
+		"task_id":    "task-abc",
+		"patch": map[string]interface{}{
+			"status":   "completed",
+			"end_time": float64(1234567890),
+		},
+	}))
+
+	// TurnCompleteEvent should now fire.
+	waitForTurnComplete(t, s.events, time.Second)
+
+	s.mu.RLock()
+	stillActive := s.bgState.active
+	s.mu.RUnlock()
+	if stillActive {
+		t.Error("bgState.active should be cleared after release")
+	}
+	if s.turnManager.HasLiveTasks() {
+		t.Error("live tasks should be empty after terminal task_updated")
+	}
+}
+
+// TestMonitor_FailedTaskReleases verifies that task_updated:failed also
+// releases suppression — a failed bg task still signals the turn is done.
+func TestMonitor_FailedTaskReleases(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "false"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-abc", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	errStr := "subprocess exited nonzero"
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-abc",
+		"patch": map[string]interface{}{
+			"status": "failed",
+			"error":  errStr,
+		},
+	}))
+
+	waitForTurnComplete(t, s.events, time.Second)
+}
+
+// TestMonitor_TwoTasksReleaseRequiresBoth verifies that when two Monitor tasks
+// are live, only the second terminal task_updated releases the suppression.
+func TestMonitor_TwoTasksReleaseRequiresBoth(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "sleep 10"}},
+		{ID: "tool-2", Name: "Monitor", Input: map[string]interface{}{"command": "sleep 10"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-2", Content: "Monitor started.", IsError: &isErrFalse},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-A", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u2",
+		"task_id": "task-B", "tool_use_id": "tool-2", "task_type": "monitor",
+	}))
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// First task completes — still suppressed.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u3",
+		"task_id": "task-A",
+		"patch":   map[string]interface{}{"status": "completed"},
+	}))
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+	if !s.turnManager.HasLiveTasks() {
+		t.Error("expected one live task remaining after first terminal")
+	}
+
+	// Second task completes — now release.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u4",
+		"task_id": "task-B",
+		"patch":   map[string]interface{}{"status": "completed"},
+	}))
+	waitForTurnComplete(t, s.events, time.Second)
+}
+
+// TestMonitor_MixedWithNonBgDoesNotSuppress verifies that when a turn has
+// both a Monitor tool and a regular non-bg tool, the ResultMessage represents
+// real completion and must not be suppressed. task_started for the Monitor
+// still registers a live task, but shouldSuppressForBgTasks short-circuits
+// on the non-bg tool.
+func TestMonitor_MixedWithNonBgDoesNotSuppress(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "sleep 60"}},
+		{ID: "tool-2", Name: "Read", Input: map[string]interface{}{"file_path": "/tmp/x"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+		{ToolUseID: "tool-2", Content: "file contents", IsError: &isErrFalse},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-A", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.shouldSuppressForBgTasks() {
+		t.Error("non-bg Read tool present → shouldSuppressForBgTasks must be false")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	waitForTurnComplete(t, s.events, time.Second)
+}
+
+// TestMonitor_HonorsTimeoutMs verifies that Monitor's tool_use.timeout_ms
+// extends the safety timer past the configured default.
+func TestMonitor_HonorsTimeoutMs(t *testing.T) {
+	// Configure a tiny default. Monitor carries a much larger explicit timeout.
+	s := newTestSession(t, WithBgTaskSafetyTimeout(10*time.Millisecond))
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{
+			"command":    "sleep 60",
+			"timeout_ms": float64(600000), // 10 minutes
+		}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	// longestBackgroundToolTimeoutMs should pick up 600000.
+	turn := s.turnManager.CurrentTurn()
+	if got := turn.longestBackgroundToolTimeoutMs(); got != 600000 {
+		t.Errorf("longestBackgroundToolTimeoutMs=%d, want 600000", got)
+	}
+
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-A", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	// If the Monitor timeout_ms were ignored, the 10ms default would fire almost
+	// instantly and emit TurnCompleteEvent. Observe a window much larger than
+	// that to confirm suppression survives.
+	expectNoTurnComplete(t, s.events, 150*time.Millisecond)
+
+	// Clean up the armed timer.
+	s.mu.Lock()
+	s.bgState.reset()
+	s.mu.Unlock()
+}
+
+// TestMonitor_NonTerminalStatusDoesNotRelease verifies task_updated with
+// non-terminal status (pending/running) does not release suppression.
+func TestMonitor_NonTerminalStatusDoesNotRelease(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "sleep 60"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-A", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	// Running status patch — must not release.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-A",
+		"patch":   map[string]interface{}{"status": "running"},
+	}))
+
+	expectNoTurnComplete(t, s.events, 100*time.Millisecond)
+
+	if !s.turnManager.HasLiveTasks() {
+		t.Error("expected task-A still live after non-terminal patch")
+	}
+
+	s.mu.Lock()
+	s.bgState.reset()
+	s.mu.Unlock()
+}
+
+// TestMonitor_TaskNotificationAlsoReleases verifies task_notification provides
+// a belt-and-suspenders release path: if task_updated:completed never arrives
+// but task_notification does, suppression still releases.
+func TestMonitor_TaskNotificationAlsoReleases(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	isErrFalse := false
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &isErrFalse},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-A", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u2",
+		"task_id": "task-A", "tool_use_id": "tool-1",
+		"status": "completed",
+	}))
+
+	waitForTurnComplete(t, s.events, time.Second)
+}

--- a/agent-cli-wrapper/claude/session_monitor_test.go
+++ b/agent-cli-wrapper/claude/session_monitor_test.go
@@ -466,6 +466,64 @@ func TestMonitor_MixedWithCancelledBgBashFastPaths(t *testing.T) {
 	waitForTurnComplete(t, s.events, time.Second)
 }
 
+// TestMonitor_MixedWithBgBashMonitorCompletesAfterResultMsg tests the reverse
+// ordering: ResultMessage arrives first (suppressing the turn), then Monitor
+// task_updated:completed arrives. maybeReleaseSuppression must NOT release
+// while the uncancelled bg-Bash continuation is still pending.
+func TestMonitor_MixedWithBgBashMonitorCompletesAfterResultMsg(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "echo done"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "sleep 2", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor started.", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "Running in background...", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-mixed3", "tool_use_id": "tool-1", "task_type": "monitor",
+	}))
+
+	// ResultMessage arrives first (normal ordering for this scenario).
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	// Turn is now suppressed (safety timer active, bgState.active=true).
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// Monitor task completes AFTER the ResultMessage. maybeReleaseSuppression
+	// must NOT fire because bg-Bash continuation is still pending.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-mixed3", "tool_use_id": "tool-1",
+		"patch": map[string]interface{}{"status": "completed"},
+	}))
+
+	// Turn must still be suppressed after Monitor completes.
+	expectNoTurnComplete(t, s.events, 50*time.Millisecond)
+
+	// Verify suppression is still active.
+	s.mu.RLock()
+	suppActive := s.bgState.active
+	s.mu.RUnlock()
+	if !suppActive {
+		t.Error("expected suppression to remain active while bg-Bash continuation is still pending")
+	}
+
+	// Clean up.
+	s.mu.Lock()
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
+		s.bgState.timer = nil
+	}
+	s.bgState.active = false
+	s.mu.Unlock()
+}
+
 // TestMonitor_MixedWithBgBashDoesNotFastPath verifies that a turn containing
 // both a Monitor tool and a bg-Bash (run_in_background) tool does NOT use the
 // AllTasksCompleted fast path when the Monitor task completes first. The turn

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -35,22 +35,54 @@ type TurnResult struct {
 	Success       bool
 }
 
+// backgroundTools lists tools that the CLI treats as background work even
+// though their tool_use.input does not carry `run_in_background: true`.
+// They register with the CLI's task registry and emit
+// task_started/task_updated/task_notification frames just like
+// Bash(run_in_background:true), but the CLI does NOT auto-start a
+// continuation assistant turn when they complete — wrappers must observe
+// task_updated terminal status (or task_notification) to release suppression.
+var backgroundTools = map[string]bool{
+	"Monitor": true,
+}
+
 // turnState tracks the state of a single turn.
 type turnState struct {
 	StartTime     time.Time
 	UserMessage   interface{}
 	Tools         map[string]*toolState
+	liveTasks     map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
 	FullText      string
 	FullThinking  string
 	ContentBlocks []ContentBlock
 	Number        int
 }
 
-// shouldSuppressForBgTasks returns true when ALL non-cancelled tool_use blocks
-// in the turn had run_in_background: true, meaning the ResultMessage arrived
-// because bg tools returned immediately and the real work is still in progress.
-// When non-bg tools are present, the ResultMessage represents completion of
-// synchronous work and must not be suppressed.
+// isBackgroundToolUse reports whether a tool_use block represents background
+// work. A block is "background" if its input carries run_in_background:true
+// (e.g. Bash(run_in_background)) OR its tool name is in backgroundTools
+// (e.g. Monitor, which registers a task without the explicit flag).
+func isBackgroundToolUse(block ContentBlock) bool {
+	if block.Type != ContentBlockTypeToolUse {
+		return false
+	}
+	if isBg, _ := block.ToolInput["run_in_background"].(bool); isBg {
+		return true
+	}
+	return backgroundTools[block.ToolName]
+}
+
+// shouldSuppressForBgTasks returns true when the turn has live background
+// work and must not be finalized on the intermediate ResultMessage.
+//
+// The turn is "live" if:
+//   - every non-cancelled tool_use is a background tool (run_in_background or
+//     in backgroundTools), AND
+//   - at least one such non-cancelled bg tool exists, OR the turn has
+//     registered task IDs via task_started that are still running.
+//
+// When any non-bg tool is present, the ResultMessage represents completion
+// of synchronous work and must not be suppressed.
 func (turn *turnState) shouldSuppressForBgTasks() bool {
 	if turn == nil {
 		return false
@@ -71,15 +103,58 @@ func (turn *turnState) shouldSuppressForBgTasks() bool {
 		if block.Type != ContentBlockTypeToolUse {
 			continue
 		}
-		isBg, _ := block.ToolInput["run_in_background"].(bool)
-		if !isBg {
+		if !isBackgroundToolUse(block) {
 			return false // non-bg tool → ResultMessage is real completion, never suppress
 		}
 		if !cancelled[block.ToolUseID] {
 			hasBgTool = true
 		}
 	}
-	return hasBgTool
+	// Either an uncancelled bg tool is present, or task_started has already
+	// registered a live task for this turn (e.g. task_started arrived before
+	// the bg tool's tool_use_id reached ContentBlocks). Both signal live work.
+	return hasBgTool || len(turn.liveTasks) > 0
+}
+
+// longestBackgroundToolTimeoutMs returns the largest timeout_ms value across
+// all non-cancelled background tool_use blocks in the turn. Returns 0 when
+// no bg tool carries an explicit timeout. Used to size the suppression
+// safety timer so it never releases before the agent's own deadline.
+func (turn *turnState) longestBackgroundToolTimeoutMs() int64 {
+	if turn == nil {
+		return 0
+	}
+	cancelled := make(map[string]bool)
+	for _, block := range turn.ContentBlocks {
+		if block.Type == ContentBlockTypeToolResult && block.IsError {
+			cancelled[block.ToolUseID] = true
+		}
+	}
+	var maxMs int64
+	for _, block := range turn.ContentBlocks {
+		if !isBackgroundToolUse(block) || cancelled[block.ToolUseID] {
+			continue
+		}
+		raw, ok := block.ToolInput["timeout_ms"]
+		if !ok {
+			continue
+		}
+		var ms int64
+		switch v := raw.(type) {
+		case float64:
+			ms = int64(v)
+		case int:
+			ms = int64(v)
+		case int64:
+			ms = v
+		default:
+			continue
+		}
+		if ms > maxMs {
+			maxMs = ms
+		}
+	}
+	return maxMs
 }
 
 // toolState tracks the state of a tool within a turn.
@@ -276,6 +351,48 @@ func (tm *turnManager) AppendContentBlock(block ContentBlock) {
 	if tm.currentTurn != nil {
 		tm.currentTurn.ContentBlocks = append(tm.currentTurn.ContentBlocks, block)
 	}
+}
+
+// TrackTask records a task ID as live on the current turn. Called from
+// task_started handling. No-op if there is no current turn.
+func (tm *turnManager) TrackTask(taskID string) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if tm.currentTurn == nil || taskID == "" {
+		return
+	}
+	if tm.currentTurn.liveTasks == nil {
+		tm.currentTurn.liveTasks = make(map[string]struct{})
+	}
+	tm.currentTurn.liveTasks[taskID] = struct{}{}
+}
+
+// UntrackTask removes a task ID from the current turn's live set. Returns
+// hadTask (task was previously tracked) and wasLast (live set is now empty
+// after removal). Callers can combine these to decide whether suppression
+// should release.
+func (tm *turnManager) UntrackTask(taskID string) (hadTask bool, wasLast bool) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if tm.currentTurn == nil || taskID == "" {
+		return false, false
+	}
+	if _, ok := tm.currentTurn.liveTasks[taskID]; !ok {
+		return false, false
+	}
+	delete(tm.currentTurn.liveTasks, taskID)
+	return true, len(tm.currentTurn.liveTasks) == 0
+}
+
+// HasLiveTasks reports whether the current turn has any registered live
+// tasks that have not yet reached a terminal state.
+func (tm *turnManager) HasLiveTasks() bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	if tm.currentTurn == nil {
+		return false
+	}
+	return len(tm.currentTurn.liveTasks) > 0
 }
 
 // GetTurnByNumber returns a turn by its number.

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -48,15 +48,16 @@ var backgroundTools = map[string]bool{
 
 // turnState tracks the state of a single turn.
 type turnState struct {
-	StartTime        time.Time
-	UserMessage      interface{}
-	Tools            map[string]*toolState
-	liveTasks        map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
-	FullText         string
-	FullThinking     string
-	ContentBlocks    []ContentBlock
-	tasksEverTracked int // counts task IDs ever added via TrackTask; never decremented
-	Number           int
+	StartTime              time.Time
+	UserMessage            interface{}
+	Tools                  map[string]*toolState
+	liveTasks              map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
+	FullText               string
+	FullThinking           string
+	ContentBlocks          []ContentBlock
+	tasksEverTracked       int  // counts task IDs ever added via TrackTask; never decremented
+	hasContinuationBgTools bool // true if turn has any bg-Bash (run_in_background) tools that use continuation-ResultMessage release path
+	Number                 int
 }
 
 // isBackgroundToolUse reports whether a tool_use block represents background
@@ -348,11 +349,18 @@ func (tm *turnManager) GetTurnHistory() []*turnState {
 }
 
 // AppendContentBlock appends a content block to the current turn.
+// When a bg tool_use that is not in backgroundTools (e.g. Bash with
+// run_in_background) is appended, hasContinuationBgTools is set to true so
+// AllTasksCompleted skips the fast path for mixed Monitor+bg-Bash turns.
 func (tm *turnManager) AppendContentBlock(block ContentBlock) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
-	if tm.currentTurn != nil {
-		tm.currentTurn.ContentBlocks = append(tm.currentTurn.ContentBlocks, block)
+	if tm.currentTurn == nil {
+		return
+	}
+	tm.currentTurn.ContentBlocks = append(tm.currentTurn.ContentBlocks, block)
+	if isBackgroundToolUse(block) && !backgroundTools[block.ToolName] {
+		tm.currentTurn.hasContinuationBgTools = true
 	}
 }
 
@@ -394,16 +402,24 @@ func (tm *turnManager) HasLiveTasks() bool {
 }
 
 // AllTasksCompleted reports whether the current turn had tasks registered via
-// task_started and all of them have since reached a terminal state. Returns
-// false if no tasks were ever registered (e.g. bg-Bash turns that use the
-// continuation-ResultMessage release path instead of task events).
+// task_started, all of them have since reached a terminal state, and the turn
+// contains no bg-Bash (continuation) tools.
+//
+// Background: Monitor tasks release suppression via terminal task events;
+// bg-Bash (run_in_background) releases via a continuation ResultMessage. A
+// turn that mixes both must NOT short-circuit on task completion alone —
+// the Bash continuation must still arrive. This method returns false for
+// mixed turns, deferring release to the continuation-ResultMessage path.
 func (tm *turnManager) AllTasksCompleted() bool {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
 	if tm.currentTurn == nil {
 		return false
 	}
-	return tm.currentTurn.tasksEverTracked > 0 && len(tm.currentTurn.liveTasks) == 0
+	if tm.currentTurn.tasksEverTracked == 0 || len(tm.currentTurn.liveTasks) != 0 {
+		return false
+	}
+	return !tm.currentTurn.hasContinuationBgTools
 }
 
 // GetTurnByNumber returns a turn by its number.

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -83,17 +83,24 @@ func isBackgroundToolUse(block ContentBlock) bool {
 //
 // When any non-bg tool is present, the ResultMessage represents completion
 // of synchronous work and must not be suppressed.
-func (turn *turnState) shouldSuppressForBgTasks() bool {
-	if turn == nil {
-		return false
-	}
-
+// cancelledToolIDs returns the set of tool_use IDs whose tool_result was an
+// error, meaning the tool invocation was cancelled before it ran.
+func (turn *turnState) cancelledToolIDs() map[string]bool {
 	cancelled := make(map[string]bool)
 	for _, block := range turn.ContentBlocks {
 		if block.Type == ContentBlockTypeToolResult && block.IsError {
 			cancelled[block.ToolUseID] = true
 		}
 	}
+	return cancelled
+}
+
+func (turn *turnState) shouldSuppressForBgTasks() bool {
+	if turn == nil {
+		return false
+	}
+
+	cancelled := turn.cancelledToolIDs()
 
 	// Non-bg tools always prevent suppression (even if they errored), because
 	// their presence means the ResultMessage represents completion of synchronous
@@ -124,12 +131,7 @@ func (turn *turnState) longestBackgroundToolTimeoutMs() int64 {
 	if turn == nil {
 		return 0
 	}
-	cancelled := make(map[string]bool)
-	for _, block := range turn.ContentBlocks {
-		if block.Type == ContentBlockTypeToolResult && block.IsError {
-			cancelled[block.ToolUseID] = true
-		}
-	}
+	cancelled := turn.cancelledToolIDs()
 	var maxMs int64
 	for _, block := range turn.ContentBlocks {
 		if !isBackgroundToolUse(block) || cancelled[block.ToolUseID] {

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -48,14 +48,15 @@ var backgroundTools = map[string]bool{
 
 // turnState tracks the state of a single turn.
 type turnState struct {
-	StartTime     time.Time
-	UserMessage   interface{}
-	Tools         map[string]*toolState
-	liveTasks     map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
-	FullText      string
-	FullThinking  string
-	ContentBlocks []ContentBlock
-	Number        int
+	StartTime        time.Time
+	UserMessage      interface{}
+	Tools            map[string]*toolState
+	liveTasks        map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
+	FullText         string
+	FullThinking     string
+	ContentBlocks    []ContentBlock
+	tasksEverTracked int // counts task IDs ever added via TrackTask; never decremented
+	Number           int
 }
 
 // isBackgroundToolUse reports whether a tool_use block represents background
@@ -72,17 +73,6 @@ func isBackgroundToolUse(block ContentBlock) bool {
 	return backgroundTools[block.ToolName]
 }
 
-// shouldSuppressForBgTasks returns true when the turn has live background
-// work and must not be finalized on the intermediate ResultMessage.
-//
-// The turn is "live" if:
-//   - every non-cancelled tool_use is a background tool (run_in_background or
-//     in backgroundTools), AND
-//   - at least one such non-cancelled bg tool exists, OR the turn has
-//     registered task IDs via task_started that are still running.
-//
-// When any non-bg tool is present, the ResultMessage represents completion
-// of synchronous work and must not be suppressed.
 // cancelledToolIDs returns the set of tool_use IDs whose tool_result was an
 // error, meaning the tool invocation was cancelled before it ran.
 func (turn *turnState) cancelledToolIDs() map[string]bool {
@@ -95,6 +85,17 @@ func (turn *turnState) cancelledToolIDs() map[string]bool {
 	return cancelled
 }
 
+// shouldSuppressForBgTasks returns true when the turn has live background
+// work and must not be finalized on the intermediate ResultMessage.
+//
+// The turn is "live" if:
+//   - every non-cancelled tool_use is a background tool (run_in_background or
+//     in backgroundTools), AND
+//   - at least one such non-cancelled bg tool exists, OR the turn has
+//     registered task IDs via task_started that are still running.
+//
+// When any non-bg tool is present, the ResultMessage represents completion
+// of synchronous work and must not be suppressed.
 func (turn *turnState) shouldSuppressForBgTasks() bool {
 	if turn == nil {
 		return false
@@ -367,23 +368,18 @@ func (tm *turnManager) TrackTask(taskID string) {
 		tm.currentTurn.liveTasks = make(map[string]struct{})
 	}
 	tm.currentTurn.liveTasks[taskID] = struct{}{}
+	tm.currentTurn.tasksEverTracked++
 }
 
-// UntrackTask removes a task ID from the current turn's live set. Returns
-// hadTask (task was previously tracked) and wasLast (live set is now empty
-// after removal). Callers can combine these to decide whether suppression
-// should release.
-func (tm *turnManager) UntrackTask(taskID string) (hadTask bool, wasLast bool) {
+// UntrackTask removes a task ID from the current turn's live set.
+// No-op if the task is not tracked or there is no current turn.
+func (tm *turnManager) UntrackTask(taskID string) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil || taskID == "" {
-		return false, false
-	}
-	if _, ok := tm.currentTurn.liveTasks[taskID]; !ok {
-		return false, false
+		return
 	}
 	delete(tm.currentTurn.liveTasks, taskID)
-	return true, len(tm.currentTurn.liveTasks) == 0
 }
 
 // HasLiveTasks reports whether the current turn has any registered live
@@ -395,6 +391,19 @@ func (tm *turnManager) HasLiveTasks() bool {
 		return false
 	}
 	return len(tm.currentTurn.liveTasks) > 0
+}
+
+// AllTasksCompleted reports whether the current turn had tasks registered via
+// task_started and all of them have since reached a terminal state. Returns
+// false if no tasks were ever registered (e.g. bg-Bash turns that use the
+// continuation-ResultMessage release path instead of task events).
+func (tm *turnManager) AllTasksCompleted() bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	if tm.currentTurn == nil {
+		return false
+	}
+	return tm.currentTurn.tasksEverTracked > 0 && len(tm.currentTurn.liveTasks) == 0
 }
 
 // GetTurnByNumber returns a turn by its number.

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -403,13 +403,16 @@ func (tm *turnManager) HasLiveTasks() bool {
 
 // AllTasksCompleted reports whether the current turn had tasks registered via
 // task_started, all of them have since reached a terminal state, and the turn
-// contains no bg-Bash (continuation) tools.
+// contains no uncancelled bg-Bash (continuation) tools.
 //
 // Background: Monitor tasks release suppression via terminal task events;
 // bg-Bash (run_in_background) releases via a continuation ResultMessage. A
 // turn that mixes both must NOT short-circuit on task completion alone —
 // the Bash continuation must still arrive. This method returns false for
 // mixed turns, deferring release to the continuation-ResultMessage path.
+//
+// Cancelled bg-Bash tools (IsError on their tool_result) never produce a
+// continuation, so they are excluded from the check.
 func (tm *turnManager) AllTasksCompleted() bool {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
@@ -419,7 +422,22 @@ func (tm *turnManager) AllTasksCompleted() bool {
 	if tm.currentTurn.tasksEverTracked == 0 || len(tm.currentTurn.liveTasks) != 0 {
 		return false
 	}
-	return !tm.currentTurn.hasContinuationBgTools
+	if !tm.currentTurn.hasContinuationBgTools {
+		return true
+	}
+	// hasContinuationBgTools is set conservatively on tool_use append. Check
+	// whether any such tool is actually uncancelled (i.e. has a non-error
+	// tool_result) — cancelled bg-Bash tools never produce a continuation.
+	cancelled := tm.currentTurn.cancelledToolIDs()
+	for _, block := range tm.currentTurn.ContentBlocks {
+		if block.Type == ContentBlockTypeToolUse &&
+			isBackgroundToolUse(block) &&
+			!backgroundTools[block.ToolName] &&
+			!cancelled[block.ToolUseID] {
+			return false // uncancelled bg-Bash present, wait for continuation
+		}
+	}
+	return true
 }
 
 // GetTurnByNumber returns a turn by its number.

--- a/agent-cli-wrapper/protocol/system.go
+++ b/agent-cli-wrapper/protocol/system.go
@@ -33,6 +33,7 @@ const (
 	SystemSubtypeTaskNotification    SystemSubtype = "task_notification"
 	SystemSubtypeTaskStarted         SystemSubtype = "task_started"
 	SystemSubtypeTaskProgress        SystemSubtype = "task_progress"
+	SystemSubtypeTaskUpdated         SystemSubtype = "task_updated"
 	SystemSubtypeSessionStateChanged SystemSubtype = "session_state_changed"
 	SystemSubtypeFilesPersisted      SystemSubtype = "files_persisted"
 	SystemSubtypeElicitationComplete SystemSubtype = "elicitation_complete"
@@ -212,6 +213,32 @@ type TaskProgressPayload struct {
 	Usage        TaskUsage `json:"usage"`
 }
 
+// TaskUpdatedPatch is the wire-safe subset of TaskState fields that changed
+// since the last update. All fields are optional — only the ones that
+// actually changed are present on the wire. Mirrors the upstream Zod schema
+// in the Claude Code CLI (excludes abortController, unregisterCleanup, and
+// internal message-buffer fields that are not JSON-safe).
+type TaskUpdatedPatch struct {
+	Status         *string `json:"status,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	EndTime        *int64  `json:"end_time,omitempty"`
+	TotalPausedMs  *int64  `json:"total_paused_ms,omitempty"`
+	Error          *string `json:"error,omitempty"`
+	IsBackgrounded *bool   `json:"is_backgrounded,omitempty"`
+}
+
+// TaskUpdatedPayload is emitted whenever the CLI mutates a registered
+// background task — e.g. Monitor or Bash run_in_background state machine
+// transitions (pending→running→completed/failed/killed), description
+// updates, backgrounding toggles. Unlike most system payloads this frame
+// carries no uuid/session_id: it is a state patch, not a logged event.
+//
+// Status enum on the wire: pending | running | completed | failed | killed.
+type TaskUpdatedPayload struct {
+	Patch  TaskUpdatedPatch `json:"patch"`
+	TaskID string           `json:"task_id"`
+}
+
 // SessionStateChangedPayload mirrors the CLI's own session state machine.
 // "idle" is the authoritative turn-over signal (fires after heldBackResult
 // flushes and the background-agent loop exits).
@@ -304,6 +331,8 @@ func (m SystemMessage) DecodePayload() (any, error) {
 		return decode(&TaskStartedPayload{})
 	case SystemSubtypeTaskProgress:
 		return decode(&TaskProgressPayload{})
+	case SystemSubtypeTaskUpdated:
+		return decode(&TaskUpdatedPayload{})
 	case SystemSubtypeSessionStateChanged:
 		return decode(&SessionStateChangedPayload{})
 	case SystemSubtypeFilesPersisted:
@@ -397,6 +426,13 @@ func (m SystemMessage) AsTaskStarted() (*TaskStartedPayload, bool) {
 func (m SystemMessage) AsTaskProgress() (*TaskProgressPayload, bool) {
 	p, _ := m.DecodePayload()
 	v, ok := p.(*TaskProgressPayload)
+	return v, ok
+}
+
+// AsTaskUpdated returns the task_updated payload.
+func (m SystemMessage) AsTaskUpdated() (*TaskUpdatedPayload, bool) {
+	p, _ := m.DecodePayload()
+	v, ok := p.(*TaskUpdatedPayload)
 	return v, ok
 }
 

--- a/agent-cli-wrapper/protocol/system_test.go
+++ b/agent-cli-wrapper/protocol/system_test.go
@@ -197,6 +197,48 @@ func TestSystemSubtype_TaskProgress(t *testing.T) {
 	}
 }
 
+func TestSystemSubtype_TaskUpdated(t *testing.T) {
+	raw := `{"type":"system","subtype":"task_updated","task_id":"t1","patch":{"status":"running","description":"searching","is_backgrounded":true}}`
+	m := parseSystem(t, raw)
+	p, ok := m.AsTaskUpdated()
+	if !ok {
+		t.Fatalf("AsTaskUpdated failed")
+	}
+	if p.TaskID != "t1" {
+		t.Errorf("task_id: %q", p.TaskID)
+	}
+	if p.Patch.Status == nil || *p.Patch.Status != "running" {
+		t.Errorf("patch.status: %+v", p.Patch.Status)
+	}
+	if p.Patch.Description == nil || *p.Patch.Description != "searching" {
+		t.Errorf("patch.description: %+v", p.Patch.Description)
+	}
+	if p.Patch.IsBackgrounded == nil || !*p.Patch.IsBackgrounded {
+		t.Errorf("patch.is_backgrounded: %+v", p.Patch.IsBackgrounded)
+	}
+	if p.Patch.EndTime != nil || p.Patch.TotalPausedMs != nil || p.Patch.Error != nil {
+		t.Errorf("unset fields should be nil: %+v", p.Patch)
+	}
+}
+
+func TestSystemSubtype_TaskUpdated_TerminalStatus(t *testing.T) {
+	raw := `{"type":"system","subtype":"task_updated","task_id":"t1","patch":{"status":"completed","end_time":1712800000000,"total_paused_ms":1500}}`
+	m := parseSystem(t, raw)
+	p, ok := m.AsTaskUpdated()
+	if !ok {
+		t.Fatalf("AsTaskUpdated failed")
+	}
+	if p.Patch.Status == nil || *p.Patch.Status != "completed" {
+		t.Errorf("patch.status: %+v", p.Patch.Status)
+	}
+	if p.Patch.EndTime == nil || *p.Patch.EndTime != 1712800000000 {
+		t.Errorf("patch.end_time: %+v", p.Patch.EndTime)
+	}
+	if p.Patch.TotalPausedMs == nil || *p.Patch.TotalPausedMs != 1500 {
+		t.Errorf("patch.total_paused_ms: %+v", p.Patch.TotalPausedMs)
+	}
+}
+
 func TestSystemSubtype_SessionStateChanged(t *testing.T) {
 	raw := `{"type":"system","subtype":"session_state_changed","session_id":"s1","uuid":"u1","state":"running"}`
 	m := parseSystem(t, raw)
@@ -303,6 +345,16 @@ func TestSystemDecodePayload_DispatchesAllSubtypes(t *testing.T) {
 		{subtype: "task_progress", raw: `{"type":"system","subtype":"task_progress","session_id":"s","uuid":"u","task_id":"t","description":"d","usage":{"total_tokens":0,"tool_uses":0,"duration_ms":0}}`, check: func(t *testing.T, v any) {
 			if _, ok := v.(*TaskProgressPayload); !ok {
 				t.Errorf("wrong type: %T", v)
+			}
+		}},
+		{subtype: "task_updated", raw: `{"type":"system","subtype":"task_updated","task_id":"t","patch":{"status":"failed","error":"boom"}}`, check: func(t *testing.T, v any) {
+			p, ok := v.(*TaskUpdatedPayload)
+			if !ok {
+				t.Errorf("wrong type: %T", v)
+				return
+			}
+			if p.Patch.Error == nil || *p.Patch.Error != "boom" {
+				t.Errorf("patch.error: %+v", p.Patch.Error)
 			}
 		}},
 		{subtype: "session_state_changed", raw: `{"type":"system","subtype":"session_state_changed","session_id":"s","uuid":"u","state":"idle"}`, check: func(t *testing.T, v any) {


### PR DESCRIPTION
## Summary
- Monitor is a Claude Code built-in tool that spawns a detached bash subprocess and registers it in the CLI task registry — but its `tool_use.input` does NOT carry `run_in_background:true`. The SDK's suppression logic keyed only off that flag, so Monitor turns finalized on the intermediate `end_turn` while the subprocess was still running. Jiradozer then advanced rounds with incomplete results (session `36b1b5b6-0a8c-4802-8f6a-a4e4599c73c1`).
- Fix at the `agent-cli-wrapper/claude` layer so all consumers (jiradozer, bramble, symphony, multiagent) benefit transparently.

## What changed
- **`protocol/system.go`**: decode `task_updated` system frames (patch schema with `status`, `end_time`, `total_paused_ms`, `error`, `is_backgrounded`).
- **`claude/turn.go`**: `backgroundTools={"Monitor":true}` tool-name map; `turnState.liveTasks` populated by `task_started` and drained by terminal `task_updated`; `shouldSuppressForBgTasks` now considers `run_in_background:true` inputs, tool-name map, AND live tasks; `longestBackgroundToolTimeoutMs` reads `timeout_ms` from Monitor inputs for safety-timer sizing.
- **`claude/session.go`**: `bgSuppressionState.heldResult`/`turnNumber`; new `maybeReleaseSuppression` releases the held `TurnResult` when all live tasks reach terminal state (`completed`/`failed`/`killed`), or on `task_notification` as a belt-and-suspenders fallback. `handleSystem` wires `task_started`/`task_updated`/`task_notification` to `TrackTask`/`UntrackTask`/`maybeReleaseSuppression`. Safety timer clamped to `max(configured, longest tool timeout_ms, 1h)`.
- **`claude/events.go`**: new `TaskUpdatedEvent`.
- **Tests**: 7 unit tests (`session_monitor_test.go`) + 1 real-CLI integration test (`integration/monitor_test.go`) that asserts the Monitor subprocess's marker file appears in the final turn text.

## Why jiradozer needs no changes
Jiradozer goes through `multiagent/agent.ClaudeProvider.Execute()` → `session.Ask()` → `session.WaitForTurn()`, which blocks on `CompleteTurn`. The new suppression release path delays `CompleteTurn` until terminal `task_updated`/`task_notification`, so `Ask()` transparently waits for the truly-final turn result.

## Test plan
- [x] `bazel test //agent-cli-wrapper/...` — 7 unit tests for Monitor pass
- [x] `bazel test //jiradozer/... //multiagent/agent/...` — no regressions
- [x] `bazel test //...` — 55/55 targets green
- [x] `scripts/lint.sh` — clean
- [x] Real Claude CLI integration test (`bazel test //agent-cli-wrapper/claude/integration:integration_test --test_filter='TestSession_Integration_MonitorTool$'`) — passes in ~11s. Session recording confirms `task_started` → `task_updated:completed` was the release path, agent observed `MONITOR_MARKER_XYZ` in final text, proving `Ask()` blocked for the full Monitor cycle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-finalization/suppression logic around background tasks, which can affect blocking behavior, timeouts, and cost accounting for all SDK consumers. Risk is mitigated by extensive new unit coverage plus an end-to-end integration test against the real CLI.
> 
> **Overview**
> Ensures turns using the CLI’s `Monitor` tool are treated as *background work* so `Ask()`/`WaitForTurn()` no longer completes on the intermediate `ResultMessage` and instead blocks until the underlying task reaches a terminal state.
> 
> Adds decoding and SDK surfacing of `task_updated` state patches, tracks live task IDs per turn, and introduces a new suppression release path that finalizes the held `TurnResult` when all tracked tasks report terminal `task_updated` (or `task_notification` as fallback). Safety timer sizing is updated to honor per-tool `timeout_ms` (with an upper clamp) and includes fast-path handling for races where tasks finish before the `ResultMessage` arrives.
> 
> Adds comprehensive Monitor-specific unit tests plus an integration test that proves the final response includes output produced only after the monitored subprocess completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d91af3d3d9a1f46338adc0ad8b78494005f1ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->