### PR TITLE
bramble: fix new session from overlay landing on wrong repo

### DIFF
--- a/bramble/app/BUILD.bazel
+++ b/bramble/app/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "filetree_open_test.go",
         "helpoverlay_test.go",
         "merge_test.go",
+        "new_session_cross_repo_test.go",
         "output_test.go",
         "playback_test.go",
         "quick_switch_test.go",

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -757,6 +757,7 @@ type (
 		prompt       string
 		model        string
 		worktreePath string // if set, starts on this path instead of selected worktree
+		repoName     string // if set and != m.repoName, starts on that repo's manager
 	}
 	createWorktreeMsg struct{ branch string }
 	editorResultMsg   struct{ err error }

--- a/bramble/app/new_session_cross_repo_test.go
+++ b/bramble/app/new_session_cross_repo_test.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/bramble/session"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+// injectSecondRepo adds a second repo to the Model's repos map with its own
+// session.Manager, so tests can exercise cross-repo overlay flows without
+// going through openRepo's filesystem checks.
+func injectSecondRepo(t *testing.T, m *Model, repoName string) *session.Manager {
+	t.Helper()
+	mgr := session.NewManagerWithConfig(session.ManagerConfig{
+		SessionMode: session.SessionModeTUI,
+		RepoName:    repoName,
+	})
+	t.Cleanup(func() { mgr.Close() })
+	m.repos[repoName] = &RepoContext{
+		sessionManager:   mgr,
+		worktreeDropdown: NewDropdown(nil),
+		sessionDropdown:  NewDropdown(nil),
+		scrollPositions:  make(map[session.SessionID]int),
+	}
+	m.openedRepos = append(m.openedRepos, repoName)
+	return mgr
+}
+
+func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	m.worktreeDropdown.SelectIndex(0)
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+
+	repoBSess := session.SessionInfo{
+		ID:           "b1",
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/repoB-feature",
+		WorktreeName: "feature",
+		RepoName:     "repoB",
+	}
+	m.allSessionsOverlay.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
+	m.focus = FocusAllSessions
+
+	// Capture the active worktree dropdown selection before the keypress so we
+	// can assert it was not mutated by the overlay handler.
+	dropdownBefore := m.worktreeDropdown.SelectedItem()
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "repoA", m2.repoName, "main view must stay on repoA")
+	assert.True(t, m2.inputMode, "should be in input mode waiting for prompt")
+	if dropdownBefore != nil {
+		after := m2.worktreeDropdown.SelectedItem()
+		require.NotNil(t, after)
+		assert.Equal(t, dropdownBefore.ID, after.ID, "worktree dropdown must not change for cross-repo")
+	}
+
+	// Drive the prompt submission. The handler returns a tea.Cmd that yields a
+	// startSessionMsg — inspect it before dispatching to verify the target repo
+	// and worktree were captured correctly.
+	newModel2, cmd := m2.Update(promptInputMsg{value: "do the thing"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd, "promptInputMsg must return a cmd")
+	msg := cmd()
+	startMsg, ok := msg.(startSessionMsg)
+	require.True(t, ok, "expected startSessionMsg, got %T", msg)
+	assert.Equal(t, "repoB", startMsg.repoName)
+	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.worktreePath)
+
+	// Dispatch the startSessionMsg and assert the new session landed on repoB's
+	// manager with the correct metadata, while repoA stays untouched.
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	assert.Equal(t, "repoA", m4.repoName, "main view must still be on repoA")
+
+	bSessions := mgrB.GetAllSessions()
+	require.Len(t, bSessions, 1, "new session should be on repoB's manager")
+	assert.Equal(t, "repoB", bSessions[0].RepoName)
+	assert.Equal(t, "/tmp/wt/repoB-feature", bSessions[0].WorktreePath)
+
+	aSessions := m4.sessionManager.GetAllSessions()
+	assert.Empty(t, aSessions, "repoA manager must not receive the new session")
+}
+
+func TestNewSessionFromCommandCenter_CrossRepo_UsesTargetManager(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	m.worktreeDropdown.SelectIndex(0)
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+
+	repoBSess := session.SessionInfo{
+		ID:           "b1",
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/repoB-feature",
+		WorktreeName: "feature",
+		RepoName:     "repoB",
+	}
+	m.commandCenter.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('p'))
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "repoA", m2.repoName)
+	assert.True(t, m2.inputMode)
+
+	newModel2, cmd := m2.Update(promptInputMsg{value: "plan something"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd)
+	startMsg, ok := cmd().(startSessionMsg)
+	require.True(t, ok)
+	assert.Equal(t, "repoB", startMsg.repoName)
+	assert.Equal(t, session.SessionTypePlanner, startMsg.sessionType)
+	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.worktreePath)
+
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	assert.Equal(t, "repoA", m4.repoName)
+	assert.Len(t, mgrB.GetAllSessions(), 1)
+	assert.Empty(t, m4.sessionManager.GetAllSessions())
+}
+
+func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "test-repo")
+	m.worktreeDropdown.SelectIndex(0) // start on "main"
+
+	// Highlight a session on the "feature" worktree in the same repo.
+	sess := session.SessionInfo{
+		ID:           "s1",
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/feature",
+		WorktreeName: "feature",
+		RepoName:     "test-repo",
+	}
+	m.allSessionsOverlay.Show([]session.SessionInfo{sess}, m.width, m.height)
+	m.focus = FocusAllSessions
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.inputMode)
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID, "same-repo overlay must sync worktree dropdown")
+}

--- a/bramble/app/new_session_cross_repo_test.go
+++ b/bramble/app/new_session_cross_repo_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/bazelment/yoloswe/wt"
 )
 
-// injectSecondRepo adds a second repo to the Model's repos map with its own
-// session.Manager, so tests can exercise cross-repo overlay flows without
-// going through openRepo's filesystem checks.
 func injectSecondRepo(t *testing.T, m *Model, repoName string) *session.Manager {
 	t.Helper()
 	mgr := session.NewManagerWithConfig(session.ManagerConfig{
@@ -48,8 +45,6 @@ func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 	m.allSessionsOverlay.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
 	m.focus = FocusAllSessions
 
-	// Capture the active worktree dropdown selection before the keypress so we
-	// can assert it was not mutated by the overlay handler.
 	dropdownBefore := m.worktreeDropdown.SelectedItem()
 
 	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
@@ -63,9 +58,6 @@ func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 		assert.Equal(t, dropdownBefore.ID, after.ID, "worktree dropdown must not change for cross-repo")
 	}
 
-	// Drive the prompt submission. The handler returns a tea.Cmd that yields a
-	// startSessionMsg — inspect it before dispatching to verify the target repo
-	// and worktree were captured correctly.
 	newModel2, cmd := m2.Update(promptInputMsg{value: "do the thing"})
 	m3 := newModel2.(Model)
 	require.NotNil(t, cmd, "promptInputMsg must return a cmd")
@@ -75,8 +67,6 @@ func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 	assert.Equal(t, "repoB", startMsg.repoName)
 	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.worktreePath)
 
-	// Dispatch the startSessionMsg and assert the new session landed on repoB's
-	// manager with the correct metadata, while repoA stays untouched.
 	newModel3, _ := m3.Update(startMsg)
 	m4 := newModel3.(Model)
 
@@ -139,7 +129,6 @@ func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0) // start on "main"
 
-	// Highlight a session on the "feature" worktree in the same repo.
 	sess := session.SessionInfo{
 		ID:           "s1",
 		Status:       session.StatusRunning,

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -372,6 +372,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case startSessionMsg:
 		m.saveDefaultModel(msg.sessionType, msg.model)
+		if msg.repoName != "" && msg.repoName != m.repoName {
+			return m.startSessionOnRepo(msg.repoName, msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
+		}
 		if msg.worktreePath != "" {
 			return m.startSessionOnPath(msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
 		}
@@ -1363,6 +1366,28 @@ func (m Model) startSessionOnPath(sessionType session.SessionType, prompt, model
 	return m, toastCmd
 }
 
+// startSessionOnRepo starts a session on a specific repo's manager without
+// mutating the active repo context. Used by overlays that let users spawn a
+// session on a different repo's worktree while keeping the main view stable.
+func (m Model) startSessionOnRepo(repoName string, sessionType session.SessionType, prompt, model, worktreePath string) (tea.Model, tea.Cmd) {
+	if worktreePath == "" || prompt == "" {
+		return m, nil
+	}
+	rc, ok := m.repos[repoName]
+	if !ok || rc.sessionManager == nil {
+		toastCmd := m.addToast("Target repo no longer available", ToastError)
+		return m, toastCmd
+	}
+	sessionID, err := rc.sessionManager.StartSession(sessionType, worktreePath, prompt, model)
+	if err != nil {
+		toastCmd := m.addToast(err.Error(), ToastError)
+		return m, toastCmd
+	}
+	rc.sessions = rc.sessionManager.GetAllSessions()
+	toastCmd := m.addToast("Session started on "+repoName+": "+string(sessionID)[:12], ToastSuccess)
+	return m, toastCmd
+}
+
 // startNewSessionFromOverlay prompts the user for input to start a session on
 // the given session's worktree. hideOverlay is called only after validation
 // succeeds, so the overlay stays visible on error (preventing focus-state bugs).
@@ -1379,27 +1404,36 @@ func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType
 	hideOverlay()
 	m.focus = FocusOutput
 
-	// Switch repo if needed
-	if sess.RepoName != "" && sess.RepoName != m.repoName {
-		if _, ok := m.repos[sess.RepoName]; ok {
-			m.saveActiveContext()
-			m.loadContext(sess.RepoName)
-		}
+	// Capture the target repo and worktree up front. We intentionally do NOT
+	// call saveActiveContext / loadContext here — the main view stays on its
+	// current repo. The target manager is resolved at startSessionMsg dispatch
+	// time via m.repos[repoName], avoiding a race where a background message
+	// could reset the active context between prompt-open and prompt-submit.
+	targetRepo := sess.RepoName
+	if targetRepo == "" {
+		targetRepo = m.repoName
 	}
+	worktreePath := sess.WorktreePath
 
-	// Sync worktree dropdown so the UI reflects where the new session will run
-	if sess.WorktreeName != "" {
+	// Only sync the worktree dropdown when the target is the currently-viewed
+	// repo — the dropdown belongs to the active repo's context.
+	if targetRepo == m.repoName && sess.WorktreeName != "" {
 		m.worktreeDropdown.SelectByID(sess.WorktreeName)
 		m.updateSessionDropdown()
 	}
 
 	defaultModel, promptLabel, placeholder := m.sessionPromptConfig(sessionType)
-	worktreePath := sess.WorktreePath
 	m.pendingModel = defaultModel
 	m.pendingSessionType = sessionType
 	return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
 		return func() tea.Msg {
-			return startSessionMsg{sessionType, prompt, model, worktreePath}
+			return startSessionMsg{
+				sessionType:  sessionType,
+				prompt:       prompt,
+				model:        model,
+				worktreePath: worktreePath,
+				repoName:     targetRepo,
+			}
 		}
 	}, placeholder)
 }

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -1343,6 +1343,14 @@ func (m Model) startSession(sessionType session.SessionType, prompt, model strin
 	return m.startSessionOnPath(sessionType, prompt, model, wt.Path)
 }
 
+func truncateSessionID(id session.SessionID) string {
+	s := string(id)
+	if len(s) > 12 {
+		return s[:12]
+	}
+	return s
+}
+
 // startSessionOnPath starts a session of the given type on an explicit worktree path.
 func (m Model) startSessionOnPath(sessionType session.SessionType, prompt, model, worktreePath string) (tea.Model, tea.Cmd) {
 	if worktreePath == "" || prompt == "" {
@@ -1362,13 +1370,12 @@ func (m Model) startSessionOnPath(sessionType session.SessionType, prompt, model
 	m.scrollOffset = 0 // New session starts at bottom
 	m.sessions = m.sessionManager.GetAllSessions()
 	m.updateSessionDropdown()
-	toastCmd := m.addToast("Session started: "+string(sessionID)[:12], ToastSuccess)
+	toastCmd := m.addToast("Session started: "+truncateSessionID(sessionID), ToastSuccess)
 	return m, toastCmd
 }
 
-// startSessionOnRepo starts a session on a specific repo's manager without
-// mutating the active repo context. Used by overlays that let users spawn a
-// session on a different repo's worktree while keeping the main view stable.
+// startSessionOnRepo starts a session on a different repo's manager without
+// switching the active repo context.
 func (m Model) startSessionOnRepo(repoName string, sessionType session.SessionType, prompt, model, worktreePath string) (tea.Model, tea.Cmd) {
 	if worktreePath == "" || prompt == "" {
 		return m, nil
@@ -1378,13 +1385,12 @@ func (m Model) startSessionOnRepo(repoName string, sessionType session.SessionTy
 		toastCmd := m.addToast("Target repo no longer available", ToastError)
 		return m, toastCmd
 	}
-	sessionID, err := rc.sessionManager.StartSession(sessionType, worktreePath, prompt, model)
+	_, err := rc.sessionManager.StartSession(sessionType, worktreePath, prompt, model)
 	if err != nil {
 		toastCmd := m.addToast(err.Error(), ToastError)
 		return m, toastCmd
 	}
-	rc.sessions = rc.sessionManager.GetAllSessions()
-	toastCmd := m.addToast("Session started on "+repoName+": "+string(sessionID)[:12], ToastSuccess)
+	toastCmd := m.addToast("Session started on "+repoName, ToastSuccess)
 	return m, toastCmd
 }
 
@@ -1404,19 +1410,14 @@ func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType
 	hideOverlay()
 	m.focus = FocusOutput
 
-	// Capture the target repo and worktree up front. We intentionally do NOT
-	// call saveActiveContext / loadContext here — the main view stays on its
-	// current repo. The target manager is resolved at startSessionMsg dispatch
-	// time via m.repos[repoName], avoiding a race where a background message
-	// could reset the active context between prompt-open and prompt-submit.
+	// Capture target repo/worktree up front so the main view stays on its
+	// current repo (avoids race if background messages reset active context).
 	targetRepo := sess.RepoName
 	if targetRepo == "" {
 		targetRepo = m.repoName
 	}
 	worktreePath := sess.WorktreePath
 
-	// Only sync the worktree dropdown when the target is the currently-viewed
-	// repo — the dropdown belongs to the active repo's context.
 	if targetRepo == m.repoName && sess.WorktreeName != "" {
 		m.worktreeDropdown.SelectByID(sess.WorktreeName)
 		m.updateSessionDropdown()


### PR DESCRIPTION
## Summary
- New sessions created via `p`/`b`/`c` from the command center (Alt+C) or all-sessions overlay (Shift+S) could end up on the wrong repo's session manager when the highlighted session lived on a different repo than the main view.
- Root cause was a race: `startNewSessionFromOverlay` hijacked the active context via `saveActiveContext`/`loadContext` at prompt-open time, but session creation was deferred until the user submitted the prompt. Any background message arriving in between could reset the active context before `startSessionMsg` fired, causing the session to land on the wrong manager and get tagged with the wrong `RepoName` in its store. The hijack was also a UX bug — it replaced the user's entire visible state with the target repo's.
- Fix threads the target repo through `startSessionMsg` explicitly and resolves the right manager at dispatch time via `m.repos[repoName]`. A new `startSessionOnRepo` helper creates the session without touching `m.sessionManager` or the main view's dropdowns. The worktree dropdown is only synced when the target matches the currently-viewed repo.

## Test plan
- [x] New unit tests in `bramble/app/new_session_cross_repo_test.go`:
  - `TestNewSessionFromOverlay_CrossRepo_UsesTargetManager` — all-sessions overlay path, asserts main view stays on repoA, new session lands on repoB's manager with correct metadata, repoA manager untouched.
  - `TestNewSessionFromCommandCenter_CrossRepo_UsesTargetManager` — same assertions via command center.
  - `TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown` — regression guard that same-repo path still syncs the worktree dropdown.
- [x] Existing `TestAllSessionsOverlay_NewSession_PBC` still passes.
- [x] `scripts/lint.sh` clean.
- [x] `bazel test //bramble/...` — all 10 targets pass.
- [ ] Manual smoke test (post-merge): open two repos, highlight a session from repoB while on repoA, press `b`, submit prompt, verify main view stays on repoA and the new session appears under repoB in Alt+C.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-start dispatch to target a specific repo’s session manager without switching active UI context, which affects multi-repo session creation paths and could introduce regressions in session routing/toasts if repo contexts are missing or mismatched.
> 
> **Overview**
> Fixes a race where starting a new session from the all-sessions overlay or command center could create the session on the *wrong repo* by no longer switching active repo context during prompt entry.
> 
> `startSessionMsg` now carries an explicit `repoName`, `Update` dispatches cross-repo starts via a new `startSessionOnRepo` helper, and the worktree dropdown is only synced when the target repo matches the currently viewed repo.
> 
> Adds focused unit tests covering cross-repo session creation from both UI entry points plus a same-repo regression check, and refactors session-id toast formatting via `truncateSessionID`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1870958fd70fbe285b7ae855fff5f421ceef785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->