### PR TITLE
jiradozer: fix plan review feedback loop and add circuit breaker

### DIFF
--- a/jiradozer/poller.go
+++ b/jiradozer/poller.go
@@ -80,15 +80,18 @@ func PollForFeedback(ctx context.Context, t tracker.IssueTracker, issueID string
 
 // ParseCommentAction determines the feedback action from a comment body.
 // Only the first line is checked for action keywords, so "approve\n\nsome notes"
-// is correctly recognized as an approval.
+// is correctly recognized as an approval. Trailing punctuation (., !, ?) is
+// stripped before matching, so "lgtm!", "approved.", "ship it!" all work.
 func ParseCommentAction(body string) FeedbackAction {
 	firstLine := strings.TrimSpace(body)
 	if idx := strings.IndexAny(firstLine, "\r\n"); idx >= 0 {
 		firstLine = strings.TrimSpace(firstLine[:idx])
 	}
 	lower := strings.ToLower(firstLine)
+	// Strip trailing punctuation for keyword matching.
+	normalized := strings.TrimRight(lower, ".!?")
 	switch {
-	case lower == "approve" || lower == "lgtm" || lower == "ship it" || lower == "approved":
+	case normalized == "approve" || normalized == "lgtm" || normalized == "ship it" || normalized == "approved":
 		return FeedbackApprove
 	case strings.HasPrefix(lower, "redo") || strings.HasPrefix(lower, "retry"):
 		return FeedbackRedo

--- a/jiradozer/poller_test.go
+++ b/jiradozer/poller_test.go
@@ -29,10 +29,21 @@ func TestParseCommentAction(t *testing.T) {
 		{"Ship It", FeedbackApprove},
 		{"SHIP IT", FeedbackApprove},
 
-		// Approve with trailing text on first line (exact match required).
-		{"lgtm!", FeedbackComment},        // "lgtm!" is not an exact match
+		// Approve with trailing punctuation (stripped before matching).
+		{"lgtm!", FeedbackApprove},
+		{"lgtm.", FeedbackApprove},
+		{"lgtm?", FeedbackApprove},
+		{"LGTM!", FeedbackApprove},
+		{"approved!", FeedbackApprove},
+		{"approved.", FeedbackApprove},
+		{"approve!", FeedbackApprove},
+		{"ship it!", FeedbackApprove},
+		{"ship it!!", FeedbackApprove},
+
+		// Approve with trailing text on first line (not just punctuation — still rejected).
 		{"approve this", FeedbackComment}, // "approve this" is not "approve"
 		{"ship it now", FeedbackComment},  // "ship it now" is not "ship it"
+		{"lgtm yeah", FeedbackComment},    // "lgtm yeah" is not "lgtm"
 
 		// Redo variants.
 		{"redo", FeedbackRedo},

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -18,6 +18,11 @@ const (
 	stateKeyDone       = "done"
 )
 
+// DefaultMaxRedos is the maximum number of times a step can be re-run via
+// feedback before the workflow fails. This prevents infinite loops when
+// comments are repeatedly parsed as redo requests.
+const DefaultMaxRedos = 3
+
 // Workflow drives the issue through plan → build → create_pr → validate → ship.
 type Workflow struct {
 	lastCommentAt   time.Time
@@ -28,6 +33,7 @@ type Workflow struct {
 	logger          *slog.Logger
 	sessionIDs      map[WorkflowStep]string
 	stateIDs        map[string]string
+	redoCounts      map[WorkflowStep]int
 	OnTransition    func(step WorkflowStep)
 	OnRoundProgress func(roundIndex, roundTotal int)
 	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error)
@@ -37,6 +43,7 @@ type Workflow struct {
 	buildOutput     string
 	feedback        string
 	botCommentIDs   []string
+	maxRedos        int
 }
 
 // NewWorkflow creates a new workflow for the given issue.
@@ -49,6 +56,8 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		logger:       logger,
 		stateIDs:     make(map[string]string),
 		sessionIDs:   make(map[WorkflowStep]string),
+		redoCounts:   make(map[WorkflowStep]int),
+		maxRedos:     DefaultMaxRedos,
 		runStepAgent: RunStepAgent,
 	}
 }
@@ -376,17 +385,39 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 		w.logger.Info("feedback: redo", "step", w.state.Current())
 		w.status("Redo requested")
 		w.feedback = fb.Message
-		if err := w.transition(redoTarget, "redo"); err != nil {
+		if err := w.tryRedo(ctx, redoTarget); err != nil {
 			w.fail(ctx, err)
 		}
 	case FeedbackComment:
 		w.logger.Info("feedback: comment", "step", w.state.Current(), "message", fb.Message)
 		w.status("Feedback received")
 		w.feedback = fb.Message
-		if err := w.transition(redoTarget, "feedback"); err != nil {
-			w.fail(ctx, err)
+		// During plan review, general comments advance to build with feedback
+		// incorporated — they don't restart the planning step. For other review
+		// steps, redo is the right behavior (the user wants changes applied).
+		if w.state.Current() == StepPlanReview {
+			if err := w.transition(approveTarget, "approved_with_feedback"); err != nil {
+				w.fail(ctx, err)
+			}
+		} else {
+			if err := w.tryRedo(ctx, redoTarget); err != nil {
+				w.fail(ctx, err)
+			}
 		}
 	}
+}
+
+// tryRedo transitions to the redo target if the circuit breaker hasn't tripped.
+// Returns an error (and transitions to StepFailed) if the step has been re-run
+// maxRedos times.
+func (w *Workflow) tryRedo(ctx context.Context, redoTarget WorkflowStep) error {
+	w.redoCounts[redoTarget]++
+	count := w.redoCounts[redoTarget]
+	if count > w.maxRedos {
+		return fmt.Errorf("step %s has been re-run %d times (max %d), giving up", redoTarget, count-1, w.maxRedos)
+	}
+	w.logger.Info("redo attempt", "target", redoTarget, "attempt", count, "max", w.maxRedos)
+	return w.transition(redoTarget, "redo")
 }
 
 func (w *Workflow) transitionToReview(ctx context.Context, reviewStep WorkflowStep, trigger string) {

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -414,8 +414,9 @@ func TestWorkflow_RunReview_Redo(t *testing.T) {
 	assert.Contains(t, wf.feedback, "Please fix the tests")
 }
 
-// TestWorkflow_RunReview_Comment tests that a generic comment is treated as feedback.
-func TestWorkflow_RunReview_Comment(t *testing.T) {
+// TestWorkflow_RunReview_Comment_PlanReview tests that a generic comment during
+// plan review advances to build (approve with feedback), not back to planning.
+func TestWorkflow_RunReview_Comment_PlanReview(t *testing.T) {
 	mt := &mockWorkflowTracker{
 		commentSets: [][]tracker.Comment{
 			{{ID: "c1", Body: "Can you also handle the edge case?", IsSelf: false, CreatedAt: time.Now()}},
@@ -428,9 +429,28 @@ func TestWorkflow_RunReview_Comment(t *testing.T) {
 
 	wf.runReview(context.Background(), StepBuilding, StepPlanning)
 
-	// Generic comment also goes to redo target.
-	assert.Equal(t, StepPlanning, wf.state.Current())
+	// During plan review, generic comments advance to build with feedback.
+	assert.Equal(t, StepBuilding, wf.state.Current())
 	assert.Equal(t, "Can you also handle the edge case?", wf.feedback)
+}
+
+// TestWorkflow_RunReview_Comment_BuildReview tests that a generic comment during
+// build review goes back to redo target (existing behavior preserved).
+func TestWorkflow_RunReview_Comment_BuildReview(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		commentSets: [][]tracker.Comment{
+			{{ID: "c1", Body: "Please also fix the formatting", IsSelf: false, CreatedAt: time.Now()}},
+		},
+	}
+
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	walkTo(t, wf.state, StepBuildReview)
+
+	wf.runReview(context.Background(), StepValidating, StepBuilding)
+
+	// During build review, generic comments redo the build step.
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, "Please also fix the formatting", wf.feedback)
 }
 
 // TestWorkflow_RunReview_ApproveVariants tests all approve keywords in review context.
@@ -872,4 +892,178 @@ func TestPlanFilePath(t *testing.T) {
 	t.Parallel()
 	got := PlanFilePath("/tmp/myproject")
 	assert.Equal(t, filepath.Join("/tmp/myproject", ".jiradozer", "plan.md"), got)
+}
+
+// --- Circuit Breaker Tests ---
+
+// TestWorkflow_CircuitBreaker_RedoExceedsMax verifies that after maxRedos redo
+// attempts, the workflow transitions to StepFailed instead of looping.
+func TestWorkflow_CircuitBreaker_RedoExceedsMax(t *testing.T) {
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
+	wf.maxRedos = 2
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	// First redo — OK.
+	wf.feedback = "fix tests"
+	require.NoError(t, wf.tryRedo(context.Background(), StepPlanning))
+	assert.Equal(t, StepPlanning, wf.state.Current())
+
+	// Back to review.
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	// Second redo — OK.
+	require.NoError(t, wf.tryRedo(context.Background(), StepPlanning))
+	assert.Equal(t, StepPlanning, wf.state.Current())
+
+	// Back to review.
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	// Third redo — exceeds max, should fail.
+	err := wf.tryRedo(context.Background(), StepPlanning)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "re-run 2 times")
+	assert.Contains(t, err.Error(), "max 2")
+}
+
+// TestWorkflow_CircuitBreaker_DefaultLimit verifies the default maxRedos value.
+func TestWorkflow_CircuitBreaker_DefaultLimit(t *testing.T) {
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
+	assert.Equal(t, DefaultMaxRedos, wf.maxRedos)
+}
+
+// TestWorkflow_CircuitBreaker_IndependentPerStep verifies that redo counts
+// are tracked independently per step target.
+func TestWorkflow_CircuitBreaker_IndependentPerStep(t *testing.T) {
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
+	wf.maxRedos = 1
+
+	// One redo for planning.
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+	require.NoError(t, wf.tryRedo(context.Background(), StepPlanning))
+
+	// Advance through to build review.
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+	require.NoError(t, wf.state.Transition(StepBuilding, "approved"))
+	require.NoError(t, wf.state.Transition(StepCreatingPR, "build_done"))
+	require.NoError(t, wf.state.Transition(StepBuildReview, "pr_created"))
+
+	// One redo for building — should be allowed (independent counter).
+	require.NoError(t, wf.tryRedo(context.Background(), StepBuilding))
+	assert.Equal(t, StepBuilding, wf.state.Current())
+}
+
+// --- FeedbackComment Per-Step Tests ---
+
+// TestWorkflow_RunReview_CommentPerStep verifies FeedbackComment transitions
+// correctly for each review step: PlanReview advances, others redo.
+func TestWorkflow_RunReview_CommentPerStep(t *testing.T) {
+	tests := []struct {
+		name           string
+		reviewStep     WorkflowStep
+		approveTarget  WorkflowStep
+		redoTarget     WorkflowStep
+		expectedTarget WorkflowStep
+	}{
+		{"plan_review_advances", StepPlanReview, StepBuilding, StepPlanning, StepBuilding},
+		{"build_review_redoes", StepBuildReview, StepValidating, StepBuilding, StepBuilding},
+		{"validate_review_redoes", StepValidateReview, StepShipping, StepValidating, StepValidating},
+		{"ship_review_redoes", StepShipReview, StepDone, StepShipping, StepShipping},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt := &mockWorkflowTracker{
+				commentSets: [][]tracker.Comment{
+					{{ID: "c1", Body: "some general feedback", IsSelf: false, CreatedAt: time.Now()}},
+				},
+			}
+
+			wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+			walkTo(t, wf.state, tt.reviewStep)
+
+			wf.runReview(context.Background(), tt.approveTarget, tt.redoTarget)
+
+			assert.Equal(t, tt.expectedTarget, wf.state.Current(),
+				"FeedbackComment at %s should go to %s", tt.reviewStep, tt.expectedTarget)
+			assert.Equal(t, "some general feedback", wf.feedback)
+		})
+	}
+}
+
+// --- Full Feedback Loop Simulation ---
+
+// TestWorkflow_FullFeedbackLoop_PlanCommentAdvancesToBuild simulates the exact
+// scenario from the bug report: plan completes, user posts a general comment,
+// workflow should advance to build (not loop back to planning).
+func TestWorkflow_FullFeedbackLoop_PlanCommentAdvancesToBuild(t *testing.T) {
+	now := time.Now()
+	approveComment := tracker.Comment{ID: "human1", Body: "Looks good, but also handle error cases", IsSelf: false, CreatedAt: now.Add(3 * time.Second)}
+
+	mt := &mockWorkflowTracker{
+		workflowStates: testWorkflowStates(),
+		// First call returns bot comments only (plan result + waiting), second returns human comment.
+		commentSets: [][]tracker.Comment{
+			{
+				{ID: "bot1", Body: "## Plan Complete\n\nHere is the plan...", IsSelf: true, CreatedAt: now},
+				{ID: "bot2", Body: "**plan_review** — Waiting for review.", IsSelf: true, CreatedAt: now.Add(time.Second)},
+			},
+			{
+				{ID: "bot1", Body: "## Plan Complete\n\nHere is the plan...", IsSelf: true, CreatedAt: now},
+				{ID: "bot2", Body: "**plan_review** — Waiting for review.", IsSelf: true, CreatedAt: now.Add(time.Second)},
+				approveComment,
+			},
+		},
+	}
+
+	cfg := testConfig()
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	wf.botCommentIDs = []string{"bot1", "bot2"}
+
+	wf.runReview(context.Background(), StepBuilding, StepPlanning)
+
+	// Should advance to building, not loop back to planning.
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, "Looks good, but also handle error cases", wf.feedback)
+}
+
+// TestWorkflow_CircuitBreaker_TripsInRunReview verifies that the circuit breaker
+// integrates correctly with runReview — after maxRedos redo comments, the
+// workflow transitions to StepFailed.
+func TestWorkflow_CircuitBreaker_TripsInRunReview(t *testing.T) {
+	cfg := testConfig()
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), cfg, discardLogger())
+	wf.maxRedos = 1
+
+	// First redo cycle.
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	mt1 := &mockWorkflowTracker{
+		commentSets: [][]tracker.Comment{
+			{{ID: "c1", Body: "redo: fix approach", IsSelf: false, CreatedAt: time.Now()}},
+		},
+	}
+	wf.tracker = mt1
+	wf.runReview(context.Background(), StepBuilding, StepPlanning)
+	assert.Equal(t, StepPlanning, wf.state.Current(), "first redo should succeed")
+
+	// Back to review.
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	// Second redo cycle — should trip circuit breaker.
+	mt2 := &mockWorkflowTracker{
+		commentSets: [][]tracker.Comment{
+			{{ID: "c2", Body: "redo: try again", IsSelf: false, CreatedAt: time.Now()}},
+		},
+	}
+	wf.tracker = mt2
+	wf.runReview(context.Background(), StepBuilding, StepPlanning)
+	assert.Equal(t, StepFailed, wf.state.Current(), "second redo should trip circuit breaker")
+	assert.Contains(t, wf.lastError.Error(), "re-run")
 }


### PR DESCRIPTION
## Summary

- **Fix FeedbackComment during plan review**: General comments now advance to the build step with feedback incorporated, instead of looping back to re-run the planning step (which was blocked by `PermissionMode: "plan"` anyway). Other review steps (build, validate, ship) preserve existing redo behavior.
- **Add circuit breaker**: Per-step redo counter (default max 3) prevents infinite loops — workflow fails with a clear error after exceeding the limit.
- **Handle trailing punctuation in ParseCommentAction**: "lgtm!", "approved.", "ship it!" are now correctly recognized as approvals instead of being parsed as generic comments that trigger redo loops.

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer:jiradozer_test` passes
- [x] New unit tests for `ParseCommentAction` punctuation variants (9 cases)
- [x] Updated `TestWorkflow_RunReview_Comment` split into PlanReview (advances) and BuildReview (redoes) variants
- [x] Table-driven `TestWorkflow_RunReview_CommentPerStep` covering all 4 review steps
- [x] Circuit breaker tests: max exceeded, default limit, independent per-step counters
- [x] Full feedback loop simulation: bot comment filtering + general comment → build
- [x] Circuit breaker integration with `runReview` end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow state transitions in review steps and introduces a redo circuit breaker; mistakes here could prematurely advance/abort workflows or mask user intent, though scope is limited and well-covered by new tests.
> 
> **Overview**
> Fixes review feedback handling so **generic comments during `StepPlanReview` advance to build** (carrying feedback) instead of re-running planning, while other review steps keep treating non-approve comments as redo requests.
> 
> Adds a per-step **redo circuit breaker** (`DefaultMaxRedos`=3) via `tryRedo` to prevent infinite redo loops, failing the workflow with a clear error once the limit is exceeded.
> 
> Improves comment parsing by stripping trailing punctuation before keyword matching so approvals like `lgtm!`/`approved.` are recognized, and extends tests to cover punctuation, per-step comment behavior, and circuit-breaker scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e611e8528597cd56416c3a27932411c311453d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->