### PR TITLE
jiradozer: preserve worktrees on cancellation, add --force-cleanup

### DIFF
--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -46,6 +46,7 @@ func main() {
 		descriptionFile string
 		planFile        string
 		dryRun          bool
+		forceCleanup    bool
 	)
 
 	rootCmd := &cobra.Command{
@@ -73,6 +74,7 @@ func main() {
 				planFile:        planFile,
 				dryRun:          dryRun,
 				dryRunSet:       cmd.Flags().Changed("dry-run"),
+				forceCleanup:    forceCleanup,
 			})
 		},
 	}
@@ -96,6 +98,7 @@ func main() {
 	rootCmd.Flags().StringVar(&descriptionFile, "description-file", "", "Read task description from file (use - for stdin)")
 	rootCmd.Flags().StringVar(&planFile, "plan-file", "", "Plan file for build step (use - for stdin)")
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Team mode only: for each newly-discovered issue, print the equivalent `bramble new-session` command instead of launching a workflow. TUI remains empty — look at stdout for the printed commands.")
+	rootCmd.Flags().BoolVar(&forceCleanup, "force-cleanup", false, "Team mode only: delete all worktrees on cancellation (Ctrl+C). By default, worktrees with in-progress work are preserved.")
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -126,6 +129,7 @@ type runArgs struct {
 	verbose         bool
 	dryRun          bool
 	dryRunSet       bool
+	forceCleanup    bool
 }
 
 func run(ctx context.Context, args runArgs) error {
@@ -476,6 +480,7 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 
 	orch := jiradozer.NewOrchestrator(issueTracker, cfg, &wtAdapter{mgr: wtMgr}, repoName, logger)
 	orch.SetSubprocessMode(selfPath, childArgs, logDir)
+	orch.SetForceCleanup(args.forceCleanup)
 
 	// Print status updates to stderr.
 	go func() {
@@ -486,6 +491,8 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 			case status.Step == jiradozer.StepDone:
 				elapsed := time.Since(status.StartedAt).Truncate(time.Second)
 				renderer.Status(fmt.Sprintf("[%s] completed (%s)", status.Issue.Identifier, elapsed))
+			case status.Step == jiradozer.StepCancelled:
+				renderer.Status(fmt.Sprintf("[%s] cancelled", status.Issue.Identifier))
 			case status.Step == jiradozer.StepFailed:
 				renderer.Error(status.Error, fmt.Sprintf("[%s] failed", status.Issue.Identifier))
 			}
@@ -495,6 +502,17 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 	err = orch.RunWithDiscovery(orchCtx, disc)
 	orchCancel()
 	orch.Shutdown()
+
+	// Report preserved worktrees so the user knows what's left.
+	if preserved := orch.PreservedWorktrees(); len(preserved) > 0 {
+		fmt.Fprintf(os.Stderr, "\nPreserved %d worktree(s) with in-progress work:\n", len(preserved))
+		for _, pw := range preserved {
+			fmt.Fprintf(os.Stderr, "  %s  %s  (%s)\n", pw.Issue, pw.Branch, pw.WorktreePath)
+		}
+		fmt.Fprintf(os.Stderr, "\nTo clean up manually: wt remove <branch>\n")
+		fmt.Fprintf(os.Stderr, "To clean up all on cancel: re-run with --force-cleanup\n")
+	}
+
 	return err
 }
 

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -475,7 +475,7 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 	if err != nil {
 		return fmt.Errorf("resolve config path: %w", err)
 	}
-	childArgs := buildChildArgs(args, absConfig, cfg)
+	childArgs := buildChildArgs(args, absConfig)
 	logDir := jiradozerLogDir()
 
 	orch := jiradozer.NewOrchestrator(issueTracker, cfg, &wtAdapter{mgr: wtMgr}, repoName, logger)
@@ -537,7 +537,7 @@ func resolveWTManager() (*wt.Manager, error) {
 
 // buildChildArgs constructs CLI flags to propagate from the parent
 // team-mode process to each child single-issue subprocess.
-func buildChildArgs(args runArgs, absConfigPath string, cfg *jiradozer.Config) []string {
+func buildChildArgs(args runArgs, absConfigPath string) []string {
 	var out []string
 	out = append(out, "--config", absConfigPath)
 	if args.modelID != "" {
@@ -546,13 +546,8 @@ func buildChildArgs(args runArgs, absConfigPath string, cfg *jiradozer.Config) [
 	if args.maxBudget > 0 {
 		out = append(out, "--max-budget", fmt.Sprintf("%.2f", args.maxBudget))
 	}
-	// Propagate auto-approve: prefer the explicit CLI flag, otherwise
-	// synthesize from the resolved config so that YAML-only auto_approve
-	// settings are forwarded as a CLI override to child processes.
 	if args.autoApprove != "" {
 		out = append(out, "--auto-approve", args.autoApprove)
-	} else if aa := autoApproveFromConfig(cfg); aa != "" {
-		out = append(out, "--auto-approve", aa)
 	}
 	if args.verbose {
 		out = append(out, "--verbose")
@@ -563,26 +558,6 @@ func buildChildArgs(args runArgs, absConfigPath string, cfg *jiradozer.Config) [
 		out = append(out, "--color", args.color)
 	}
 	return out
-}
-
-// autoApproveFromConfig returns a comma-separated list of steps that have
-// auto_approve enabled in the config, suitable for --auto-approve. Returns
-// empty string if no steps are auto-approved.
-func autoApproveFromConfig(cfg *jiradozer.Config) string {
-	var steps []string
-	if cfg.Plan.AutoApprove {
-		steps = append(steps, "plan")
-	}
-	if cfg.Build.AutoApprove {
-		steps = append(steps, "build")
-	}
-	if cfg.Validate.AutoApprove {
-		steps = append(steps, "validate")
-	}
-	if cfg.Ship.AutoApprove {
-		steps = append(steps, "ship")
-	}
-	return strings.Join(steps, ",")
 }
 
 // jiradozerLogDir returns the directory for jiradozer log files, creating

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -475,7 +475,7 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 	if err != nil {
 		return fmt.Errorf("resolve config path: %w", err)
 	}
-	childArgs := buildChildArgs(args, absConfig)
+	childArgs := buildChildArgs(args, absConfig, cfg)
 	logDir := jiradozerLogDir()
 
 	orch := jiradozer.NewOrchestrator(issueTracker, cfg, &wtAdapter{mgr: wtMgr}, repoName, logger)
@@ -537,7 +537,7 @@ func resolveWTManager() (*wt.Manager, error) {
 
 // buildChildArgs constructs CLI flags to propagate from the parent
 // team-mode process to each child single-issue subprocess.
-func buildChildArgs(args runArgs, absConfigPath string) []string {
+func buildChildArgs(args runArgs, absConfigPath string, cfg *jiradozer.Config) []string {
 	var out []string
 	out = append(out, "--config", absConfigPath)
 	if args.modelID != "" {
@@ -546,8 +546,13 @@ func buildChildArgs(args runArgs, absConfigPath string) []string {
 	if args.maxBudget > 0 {
 		out = append(out, "--max-budget", fmt.Sprintf("%.2f", args.maxBudget))
 	}
+	// Propagate auto-approve: prefer the explicit CLI flag, otherwise
+	// synthesize from the resolved config so that YAML-only auto_approve
+	// settings are forwarded as a CLI override to child processes.
 	if args.autoApprove != "" {
 		out = append(out, "--auto-approve", args.autoApprove)
+	} else if aa := autoApproveFromConfig(cfg); aa != "" {
+		out = append(out, "--auto-approve", aa)
 	}
 	if args.verbose {
 		out = append(out, "--verbose")
@@ -558,6 +563,26 @@ func buildChildArgs(args runArgs, absConfigPath string) []string {
 		out = append(out, "--color", args.color)
 	}
 	return out
+}
+
+// autoApproveFromConfig returns a comma-separated list of steps that have
+// auto_approve enabled in the config, suitable for --auto-approve. Returns
+// empty string if no steps are auto-approved.
+func autoApproveFromConfig(cfg *jiradozer.Config) string {
+	var steps []string
+	if cfg.Plan.AutoApprove {
+		steps = append(steps, "plan")
+	}
+	if cfg.Build.AutoApprove {
+		steps = append(steps, "build")
+	}
+	if cfg.Validate.AutoApprove {
+		steps = append(steps, "validate")
+	}
+	if cfg.Ship.AutoApprove {
+		steps = append(steps, "ship")
+	}
+	return strings.Join(steps, ",")
 }
 
 // jiradozerLogDir returns the directory for jiradozer log files, creating

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -33,28 +33,38 @@ type IssueStatus struct {
 
 // IsDone returns true if the workflow has completed (successfully or with failure).
 func (s IssueStatus) IsDone() bool {
-	return s.Step == StepDone || s.Step == StepFailed
+	return s.Step.IsTerminal()
+}
+
+// PreservedWorktree records a worktree that was not cleaned up because its
+// workflow was cancelled by the user.
+type PreservedWorktree struct {
+	Branch       string
+	WorktreePath string
+	Issue        string // issue identifier
 }
 
 // Orchestrator manages concurrent issue workflows, each in its own worktree.
 //
 //nolint:govet // fieldalignment: sync types at the end require padding
 type Orchestrator struct {
-	tracker    tracker.IssueTracker
-	wtManager  WorktreeManager
-	out        io.Writer
-	config     *Config
-	logger     *slog.Logger
-	active     map[string]*managedWorkflow
-	statusChan chan IssueStatus
-	slotFreed  chan struct{}
-	done       chan struct{}
-	childArgs  []string
-	repoName   string
-	selfPath   string
-	logDir     string
-	mu         sync.RWMutex
-	wg         sync.WaitGroup
+	tracker      tracker.IssueTracker
+	wtManager    WorktreeManager
+	out          io.Writer
+	config       *Config
+	logger       *slog.Logger
+	active       map[string]*managedWorkflow
+	statusChan   chan IssueStatus
+	slotFreed    chan struct{}
+	done         chan struct{}
+	childArgs    []string
+	repoName     string
+	selfPath     string
+	logDir       string
+	mu           sync.RWMutex
+	wg           sync.WaitGroup
+	forceCleanup bool
+	preserved    []PreservedWorktree
 }
 
 type managedWorkflow struct {
@@ -99,6 +109,14 @@ func (o *Orchestrator) SetSubprocessMode(selfPath string, childArgs []string, lo
 	o.selfPath = selfPath
 	o.childArgs = childArgs
 	o.logDir = logDir
+}
+
+// SetForceCleanup controls whether worktrees are deleted even when workflows
+// are cancelled by the user (Ctrl+C). By default, cancelled worktrees are
+// preserved so work is not lost. When force is true, all worktrees are
+// cleaned up unconditionally.
+func (o *Orchestrator) SetForceCleanup(force bool) {
+	o.forceCleanup = force
 }
 
 // StatusUpdates returns the channel that receives status updates for all workflows.
@@ -233,14 +251,21 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 		defer o.wg.Done()
 		defer logFile.Close()
 		err := cmd.Wait()
-		if err != nil {
-			o.logger.Error("subprocess failed", "issue", issue.Identifier, "error", err)
-			o.emitStatus(mw, StepFailed, err)
-		} else {
+		switch {
+		case err == nil:
 			o.logger.Info("subprocess completed", "issue", issue.Identifier)
 			o.emitStatus(mw, StepDone, nil)
+			o.cleanup(context.Background(), mw, StepDone)
+		case wfCtx.Err() != nil:
+			// The workflow context was cancelled (user pressed Ctrl+C).
+			o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
+			o.emitStatus(mw, StepCancelled, err)
+			o.cleanup(context.Background(), mw, StepCancelled)
+		default:
+			o.logger.Error("subprocess failed", "issue", issue.Identifier, "error", err)
+			o.emitStatus(mw, StepFailed, err)
+			o.cleanup(context.Background(), mw, StepFailed)
 		}
-		o.cleanup(context.Background(), mw)
 	}()
 
 	return nil
@@ -288,6 +313,17 @@ func (o *Orchestrator) Shutdown() {
 // Wait blocks until all active workflows have completed.
 func (o *Orchestrator) Wait() {
 	o.wg.Wait()
+}
+
+// PreservedWorktrees returns the list of worktrees that were preserved
+// because their workflows were cancelled. Only meaningful after Wait or
+// Shutdown has returned.
+func (o *Orchestrator) PreservedWorktrees() []PreservedWorktree {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	cp := make([]PreservedWorktree, len(o.preserved))
+	copy(cp, o.preserved)
+	return cp
 }
 
 // RunWithDiscovery consumes issues from the discovery channel and starts
@@ -407,9 +443,24 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-func (o *Orchestrator) cleanup(ctx context.Context, mw *managedWorkflow) {
-	if err := o.wtManager.RemoveWorktree(ctx, mw.branch, true); err != nil {
-		o.logger.Warn("failed to remove worktree", "branch", mw.branch, "error", err)
+func (o *Orchestrator) cleanup(ctx context.Context, mw *managedWorkflow, step WorkflowStep) {
+	if step == StepCancelled && !o.forceCleanup {
+		o.logger.Info("preserving worktree for cancelled workflow",
+			"branch", mw.branch,
+			"worktree", mw.worktreePath,
+			"issue", mw.issue.Identifier,
+		)
+		o.mu.Lock()
+		o.preserved = append(o.preserved, PreservedWorktree{
+			Branch:       mw.branch,
+			WorktreePath: mw.worktreePath,
+			Issue:        mw.issue.Identifier,
+		})
+		o.mu.Unlock()
+	} else {
+		if err := o.wtManager.RemoveWorktree(ctx, mw.branch, true); err != nil {
+			o.logger.Warn("failed to remove worktree", "branch", mw.branch, "error", err)
+		}
 	}
 	o.mu.Lock()
 	delete(o.active, mw.issue.ID)

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -331,6 +331,121 @@ func TestShellQuote(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_CancelPreservesWorktree(t *testing.T) {
+	cfg := testOrchestratorConfig()
+
+	// Script that waits for SIGINT (simulates a long-running subprocess).
+	script := writeTestScript(t, "trap 'exit 130' INT; sleep 60")
+	orch, wtm := setupSubprocessOrch(t, cfg, script)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	err := orch.Start(ctx, issue)
+	require.NoError(t, err)
+
+	// Drain StepInit.
+	select {
+	case <-orch.StatusUpdates():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for StepInit")
+	}
+
+	// Cancel the context (simulates Ctrl+C).
+	cancel()
+
+	// Should receive StepCancelled.
+	select {
+	case status := <-orch.StatusUpdates():
+		require.Equal(t, StepCancelled, status.Step)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for StepCancelled")
+	}
+
+	orch.Wait()
+
+	// Worktree should NOT have been removed.
+	wtm.mu.Lock()
+	removed := wtm.removed
+	wtm.mu.Unlock()
+	require.Empty(t, removed, "cancelled worktree should not be removed")
+
+	// Preserved worktrees should be recorded.
+	preserved := orch.PreservedWorktrees()
+	require.Len(t, preserved, 1)
+	require.Equal(t, "ENG-1", preserved[0].Issue)
+	require.Contains(t, preserved[0].Branch, "ENG-1")
+}
+
+func TestOrchestrator_CancelWithForceCleanup(t *testing.T) {
+	cfg := testOrchestratorConfig()
+
+	script := writeTestScript(t, "trap 'exit 130' INT; sleep 60")
+	orch, wtm := setupSubprocessOrch(t, cfg, script)
+	orch.SetForceCleanup(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	err := orch.Start(ctx, issue)
+	require.NoError(t, err)
+
+	// Drain StepInit.
+	select {
+	case <-orch.StatusUpdates():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for StepInit")
+	}
+
+	cancel()
+
+	// Should receive StepCancelled.
+	select {
+	case status := <-orch.StatusUpdates():
+		require.Equal(t, StepCancelled, status.Step)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for StepCancelled")
+	}
+
+	orch.Wait()
+
+	// With forceCleanup, worktree SHOULD be removed.
+	wtm.mu.Lock()
+	removed := wtm.removed
+	wtm.mu.Unlock()
+	require.Len(t, removed, 1, "cancelled worktree should be removed with --force-cleanup")
+
+	// No preserved worktrees.
+	require.Empty(t, orch.PreservedWorktrees())
+}
+
+func TestOrchestrator_FailedStillCleansUp(t *testing.T) {
+	cfg := testOrchestratorConfig()
+
+	script := writeTestScript(t, "exit 1")
+	orch, wtm := setupSubprocessOrch(t, cfg, script)
+
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	err := orch.Start(context.Background(), issue)
+	require.NoError(t, err)
+
+	// Drain StepInit + StepFailed.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-orch.StatusUpdates():
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for status")
+		}
+	}
+
+	orch.Wait()
+
+	// Failed worktrees should still be cleaned up.
+	wtm.mu.Lock()
+	removed := wtm.removed
+	wtm.mu.Unlock()
+	require.Len(t, removed, 1, "failed worktree should be removed")
+	require.Empty(t, orch.PreservedWorktrees())
+}
+
 func TestOrchestrator_Snapshot(t *testing.T) {
 	cfg := testOrchestratorConfig()
 

--- a/jiradozer/state.go
+++ b/jiradozer/state.go
@@ -22,6 +22,7 @@ const (
 	StepShipReview                  // Ship complete, waiting for CI + human feedback
 	StepDone                        // Terminal: issue marked done
 	StepFailed                      // Terminal: workflow failed
+	StepCancelled                   // Terminal: workflow interrupted by user cancellation
 )
 
 // String returns the string representation of the step.
@@ -51,6 +52,8 @@ func (s WorkflowStep) String() string {
 		return "done"
 	case StepFailed:
 		return "failed"
+	case StepCancelled:
+		return "cancelled"
 	default:
 		return fmt.Sprintf("unknown(%d)", s)
 	}
@@ -58,7 +61,7 @@ func (s WorkflowStep) String() string {
 
 // IsTerminal returns true if this is a terminal step.
 func (s WorkflowStep) IsTerminal() bool {
-	return s == StepDone || s == StepFailed
+	return s == StepDone || s == StepFailed || s == StepCancelled
 }
 
 // IsReview returns true if this step is waiting for human feedback.

--- a/jiradozer/state_test.go
+++ b/jiradozer/state_test.go
@@ -24,6 +24,7 @@ func TestWorkflowStepString(t *testing.T) {
 		{want: "ship_review", step: StepShipReview},
 		{want: "done", step: StepDone},
 		{want: "failed", step: StepFailed},
+		{want: "cancelled", step: StepCancelled},
 		{want: "unknown(99)", step: WorkflowStep(99)},
 	}
 	for _, tt := range tests {
@@ -34,6 +35,7 @@ func TestWorkflowStepString(t *testing.T) {
 func TestWorkflowStepIsTerminal(t *testing.T) {
 	assert.True(t, StepDone.IsTerminal())
 	assert.True(t, StepFailed.IsTerminal())
+	assert.True(t, StepCancelled.IsTerminal())
 	assert.False(t, StepPlanning.IsTerminal())
 	assert.False(t, StepInit.IsTerminal())
 }


### PR DESCRIPTION
## Summary
- When jiradozer team mode is cancelled (Ctrl+C), worktrees with in-progress work are now **preserved** instead of being unconditionally deleted, preventing loss of uncommitted work
- Adds `StepCancelled` workflow step to distinguish user interruption from genuine subprocess failures
- Adds `--force-cleanup` flag to opt into the old "delete everything on cancel" behavior when explicitly desired
- On cancellation, prints a list of preserved worktrees with manual cleanup instructions

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer:jiradozer_test` passes (3 new tests added)
- [ ] Manual: run `jiradozer` in team mode, press Ctrl+C, verify worktrees are preserved and listed
- [ ] Manual: run with `--force-cleanup`, press Ctrl+C, verify worktrees are deleted
- [ ] Manual: let a workflow fail (exit 1), verify worktree is still cleaned up (no regression)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes team-mode cancellation semantics to preserve worktrees by default, which could leave extra local state if mis-triggered; adds new terminal `StepCancelled` state that affects status handling and cleanup paths.
> 
> **Overview**
> In team mode, Ctrl+C cancellation now **preserves** per-issue worktrees by default (to avoid losing in-progress/uncommitted work) and introduces a new terminal workflow state `StepCancelled` to distinguish user interruption from real failures.
> 
> Adds `--force-cleanup` to opt back into deleting worktrees on cancellation, records/prints preserved worktrees with manual cleanup instructions, and extends orchestrator tests to cover cancel/preserve vs force-cleanup and failure cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62009fb2a30c907948f2e864118efcee52a74f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->