### PR TITLE
jiradozer: fix retry storm and preserve worktree on successful ship

### DIFF
--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -149,6 +149,24 @@ At each review gate, comment on the issue:
 - `redo` -- re-run the current step
 - Any other text -- treated as feedback, incorporated into the next agent run
 
+### Worktree lifecycle (team mode)
+
+In team mode (`--filter`), each issue gets its own git worktree under a dedicated branch (`<branch-prefix>/<identifier>`). The worktree lifecycle is:
+
+- **Created** when the issue is picked up and `Start()` is called.
+- **Left intact** when the workflow completes successfully (`StepDone`). The ship step typically opens a PR but does not merge it — the branch must remain until the PR is reviewed and merged.
+- **Removed** only on workflow failure (`StepFailed`). Failed runs clean up the worktree and branch so a future retry starts from a clean state.
+
+After merging the PR, remove the worktree manually:
+
+```bash
+# Remove worktree and branch after merge
+git worktree remove ~/worktrees/<repo>/<branch-prefix>/<identifier>
+git branch -d <branch-prefix>/<identifier>
+```
+
+Or use `wt remove` if you have the wt tool configured.
+
 ## Supported agents
 
 Jiradozer uses the `multiagent/agent.Provider` interface, so any agent backend that bramble supports works out of the box:

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -505,12 +505,16 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 
 	// Report preserved worktrees so the user knows what's left.
 	if preserved := orch.PreservedWorktrees(); len(preserved) > 0 {
-		fmt.Fprintf(os.Stderr, "\nPreserved %d worktree(s) with in-progress work:\n", len(preserved))
+		fmt.Fprintf(os.Stderr, "\nPreserved %d worktree(s):\n", len(preserved))
 		for _, pw := range preserved {
-			fmt.Fprintf(os.Stderr, "  %s  %s  (%s)\n", pw.Issue, pw.Branch, pw.WorktreePath)
+			reason := "cancelled"
+			if pw.Step == jiradozer.StepDone {
+				reason = "shipped (PR open, not yet merged)"
+			}
+			fmt.Fprintf(os.Stderr, "  %s  %s  (%s)  [%s]\n", pw.Issue, pw.Branch, pw.WorktreePath, reason)
 		}
-		fmt.Fprintf(os.Stderr, "\nTo clean up manually: wt remove <branch>\n")
-		fmt.Fprintf(os.Stderr, "To clean up all on cancel: re-run with --force-cleanup\n")
+		fmt.Fprintf(os.Stderr, "\nTo remove after merging: wt remove <branch>\n")
+		fmt.Fprintf(os.Stderr, "To remove cancelled worktrees on next run: re-run with --force-cleanup\n")
 	}
 
 	return err

--- a/jiradozer/integration/orchestrator_test.go
+++ b/jiradozer/integration/orchestrator_test.go
@@ -189,10 +189,35 @@ func TestOrchestrator_WorktreeCreation(t *testing.T) {
 	// Wait for subprocesses to complete.
 	orch.Wait()
 
-	// Verify cleanup happened.
+	// On successful completion the worktree is intentionally left intact so
+	// the PR (which may not be merged yet) retains its base branch.
+	removed := wtm.getRemoved()
+	require.NotContains(t, removed, "jiradozer/ENG-1")
+	require.NotContains(t, removed, "jiradozer/ENG-2")
+}
+
+func TestOrchestrator_WorktreeRemovedOnFailure(t *testing.T) {
+	t.Parallel()
+	issues := []*tracker.Issue{
+		testIssue("1", "ENG-1", "Feature A"),
+	}
+	wtm := newMockWTManager(t)
+	cfg := testOrchestratorConfig()
+	script := writeIntegrationTestScript(t, "exit 1")
+	orch := newOrchWithScript(t, cfg, wtm, script)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := orch.Start(ctx, issues[0])
+	require.NoError(t, err)
+
+	// Wait for subprocess to complete.
+	orch.Wait()
+
+	// On failure the worktree must be cleaned up.
 	removed := wtm.getRemoved()
 	require.Contains(t, removed, "jiradozer/ENG-1")
-	require.Contains(t, removed, "jiradozer/ENG-2")
 }
 
 func TestOrchestrator_ConcurrencyLimit(t *testing.T) {
@@ -323,7 +348,9 @@ func TestOrchestrator_DiscoveryIntegration(t *testing.T) {
 	require.Contains(t, created, "jiradozer/ENG-2")
 }
 
-func TestOrchestrator_WorktreeCleanupOnCompletion(t *testing.T) {
+func TestOrchestrator_WorktreePreservedOnCompletion(t *testing.T) {
+	// On successful completion the worktree is intentionally left intact so
+	// the PR (which may not be merged yet) retains its base branch.
 	issue := testIssue("1", "ENG-1", "Feature A")
 	wtm := newMockWTManager(t)
 	cfg := testOrchestratorConfig()
@@ -339,7 +366,11 @@ func TestOrchestrator_WorktreeCleanupOnCompletion(t *testing.T) {
 	orch.Wait()
 
 	removed := wtm.getRemoved()
-	require.Contains(t, removed, "jiradozer/ENG-1", "worktree should be cleaned up after subprocess completion")
+	require.NotContains(t, removed, "jiradozer/ENG-1", "worktree must not be removed after successful completion")
+
+	preserved := orch.PreservedWorktrees()
+	require.Len(t, preserved, 1)
+	require.Equal(t, "ENG-1", preserved[0].Issue)
 }
 
 // testOrchestratorLogger returns a logger suitable for integration tests.

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -36,12 +36,13 @@ func (s IssueStatus) IsDone() bool {
 	return s.Step.IsTerminal()
 }
 
-// PreservedWorktree records a worktree that was not cleaned up because its
-// workflow was cancelled by the user.
+// PreservedWorktree records a worktree that was not cleaned up after its
+// workflow ended.
 type PreservedWorktree struct {
 	Branch       string
 	WorktreePath string
-	Issue        string // issue identifier
+	Issue        string       // issue identifier
+	Step         WorkflowStep // step at which the workflow ended
 }
 
 // Orchestrator manages concurrent issue workflows, each in its own worktree.
@@ -111,10 +112,14 @@ func (o *Orchestrator) SetSubprocessMode(selfPath string, childArgs []string, lo
 	o.logDir = logDir
 }
 
-// SetForceCleanup controls whether worktrees are deleted even when workflows
-// are cancelled by the user (Ctrl+C). By default, cancelled worktrees are
-// preserved so work is not lost. When force is true, all worktrees are
-// cleaned up unconditionally.
+// SetForceCleanup controls whether worktrees are deleted when workflows are
+// cancelled by the user (Ctrl+C). By default, cancelled worktrees are
+// preserved so in-progress work is not lost. When force is true, cancelled
+// worktrees are removed on cancellation.
+//
+// Note: worktrees for successfully completed workflows (StepDone) are always
+// preserved regardless of this flag — the ship step opens a PR but does not
+// merge it, so the branch must remain until the PR is merged.
 func (o *Orchestrator) SetForceCleanup(force bool) {
 	o.forceCleanup = force
 }
@@ -504,6 +509,7 @@ func (o *Orchestrator) cleanup(ctx context.Context, mw *managedWorkflow, step Wo
 			Branch:       mw.branch,
 			WorktreePath: mw.worktreePath,
 			Issue:        mw.issue.Identifier,
+			Step:         step,
 		})
 		o.mu.Unlock()
 	} else {

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -326,18 +326,53 @@ func (o *Orchestrator) PreservedWorktrees() []PreservedWorktree {
 	return cp
 }
 
+// maxStartFailures is the number of consecutive non-transient Start failures
+// allowed for a single issue before RunWithDiscovery gives up and stops
+// clearing it from the seen set (preventing an infinite retry storm).
+const maxStartFailures = 3
+
 // RunWithDiscovery consumes issues from the discovery channel and starts
 // workflows for them, respecting the concurrency limit.
 func (o *Orchestrator) RunWithDiscovery(ctx context.Context, discovery *Discovery) error {
 	issues := discovery.Run(ctx)
 	var pending []*tracker.Issue
+	// failCounts tracks consecutive permanent Start failures per issue ID.
+	// Transient failures (concurrency limit) are not counted here; they are
+	// handled by re-queuing into pending instead of clearing the seen set.
+	failCounts := make(map[string]int)
 
-	startOrRetry := func(issue *tracker.Issue) {
-		if err := o.Start(ctx, issue); err != nil {
-			o.logger.Warn("failed to start workflow", "issue", issue.Identifier, "error", err)
-			// Clear from discovery's seen set so the issue is re-emitted on next poll.
-			discovery.ClearSeen(issue.ID)
+	// tryStart attempts to start the issue workflow. Returns true if the issue
+	// should be removed from the pending queue (either started successfully or
+	// permanently failed). Returns false if it should stay pending (transient).
+	tryStart := func(issue *tracker.Issue) bool {
+		err := o.Start(ctx, issue)
+		if err == nil {
+			delete(failCounts, issue.ID)
+			return true
 		}
+		if strings.Contains(err.Error(), "concurrency limit") {
+			// Transient: slots are full. Keep in pending; do not clear seen.
+			return false
+		}
+		// Permanent error (worktree already exists, subprocess start failed, etc.).
+		failCounts[issue.ID]++
+		if failCounts[issue.ID] < maxStartFailures {
+			o.logger.Warn("failed to start workflow, will retry",
+				"issue", issue.Identifier,
+				"error", err,
+				"attempt", failCounts[issue.ID],
+				"max", maxStartFailures,
+			)
+			discovery.ClearSeen(issue.ID)
+		} else {
+			o.logger.Error("failed to start workflow, giving up after repeated failures",
+				"issue", issue.Identifier,
+				"error", err,
+				"failures", failCounts[issue.ID],
+			)
+			// Do NOT clear seen — leave the issue suppressed to stop the storm.
+		}
+		return true
 	}
 
 	for {
@@ -349,7 +384,10 @@ func (o *Orchestrator) RunWithDiscovery(ctx context.Context, discovery *Discover
 				remaining = append(remaining, issue)
 				continue
 			}
-			startOrRetry(issue)
+			if !tryStart(issue) {
+				remaining = append(remaining, issue)
+				continue
+			}
 			active = o.ActiveCount()
 		}
 		pending = remaining
@@ -366,7 +404,7 @@ func (o *Orchestrator) RunWithDiscovery(ctx context.Context, discovery *Discover
 				return nil
 			}
 			if o.ActiveCount() < o.config.Source.MaxConcurrent {
-				startOrRetry(issue)
+				tryStart(issue)
 			} else {
 				pending = append(pending, issue)
 			}
@@ -443,9 +481,18 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+// cleanup removes the issue from the active map and signals a free slot.
+// Worktree removal depends on how the workflow ended:
+//   - StepDone: worktree is preserved — the ship step opens a PR but does not
+//     merge it, so the branch must remain until the PR is merged.
+//   - StepCancelled: worktree is preserved by default so in-progress work is
+//     not lost; set forceCleanup to remove it unconditionally.
+//   - StepFailed: worktree is removed so a future retry starts clean.
 func (o *Orchestrator) cleanup(ctx context.Context, mw *managedWorkflow, step WorkflowStep) {
-	if step == StepCancelled && !o.forceCleanup {
-		o.logger.Info("preserving worktree for cancelled workflow",
+	preserve := step == StepDone || (step == StepCancelled && !o.forceCleanup)
+	if preserve {
+		o.logger.Info("preserving worktree",
+			"step", step,
 			"branch", mw.branch,
 			"worktree", mw.worktreePath,
 			"issue", mw.issue.Identifier,

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -404,7 +404,9 @@ func (o *Orchestrator) RunWithDiscovery(ctx context.Context, discovery *Discover
 				return nil
 			}
 			if o.ActiveCount() < o.config.Source.MaxConcurrent {
-				tryStart(issue)
+				if !tryStart(issue) {
+					pending = append(pending, issue)
+				}
 			} else {
 				pending = append(pending, issue)
 			}

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -257,15 +257,17 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 		defer logFile.Close()
 		err := cmd.Wait()
 		switch {
+		case wfCtx.Err() != nil:
+			// Context was cancelled (user pressed Ctrl+C). Check this first:
+			// a child that traps SIGINT and exits 0 would otherwise be
+			// misclassified as StepDone.
+			o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
+			o.emitStatus(mw, StepCancelled, wfCtx.Err())
+			o.cleanup(context.Background(), mw, StepCancelled)
 		case err == nil:
 			o.logger.Info("subprocess completed", "issue", issue.Identifier)
 			o.emitStatus(mw, StepDone, nil)
 			o.cleanup(context.Background(), mw, StepDone)
-		case wfCtx.Err() != nil:
-			// The workflow context was cancelled (user pressed Ctrl+C).
-			o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
-			o.emitStatus(mw, StepCancelled, err)
-			o.cleanup(context.Background(), mw, StepCancelled)
 		default:
 			o.logger.Error("subprocess failed", "issue", issue.Identifier, "error", err)
 			o.emitStatus(mw, StepFailed, err)
@@ -320,9 +322,10 @@ func (o *Orchestrator) Wait() {
 	o.wg.Wait()
 }
 
-// PreservedWorktrees returns the list of worktrees that were preserved
-// because their workflows were cancelled. Only meaningful after Wait or
-// Shutdown has returned.
+// PreservedWorktrees returns the list of worktrees that were preserved after
+// their workflows ended. This includes both successful completions (StepDone —
+// waiting for the PR to be merged) and cancellations (StepCancelled — preserving
+// in-progress work). Only meaningful after Wait or Shutdown has returned.
 func (o *Orchestrator) PreservedWorktrees() []PreservedWorktree {
 	o.mu.RLock()
 	defer o.mu.RUnlock()

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -2,6 +2,7 @@ package jiradozer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,6 +15,11 @@ import (
 
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
+
+// errConcurrencyLimit is returned by Start when all concurrency slots are full.
+// RunWithDiscovery uses errors.Is to distinguish transient (keep pending) from
+// permanent failures (retry with ClearSeen or give up).
+var errConcurrencyLimit = errors.New("concurrency limit reached")
 
 // WorktreeManager is the interface for creating and removing git worktrees.
 type WorktreeManager interface {
@@ -169,7 +175,7 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 	o.mu.Lock()
 	if o.activeCountLocked() >= o.config.Source.MaxConcurrent {
 		o.mu.Unlock()
-		return fmt.Errorf("concurrency limit reached (%d)", o.config.Source.MaxConcurrent)
+		return fmt.Errorf("%w (%d)", errConcurrencyLimit, o.config.Source.MaxConcurrent)
 	}
 	if _, exists := o.active[issue.ID]; exists {
 		o.mu.Unlock()
@@ -358,7 +364,7 @@ func (o *Orchestrator) RunWithDiscovery(ctx context.Context, discovery *Discover
 			delete(failCounts, issue.ID)
 			return true
 		}
-		if strings.Contains(err.Error(), "concurrency limit") {
+		if errors.Is(err, errConcurrencyLimit) {
 			// Transient: slots are full. Keep in pending; do not clear seen.
 			return false
 		}

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -418,6 +418,48 @@ func TestOrchestrator_CancelWithForceCleanup(t *testing.T) {
 	require.Empty(t, orch.PreservedWorktrees())
 }
 
+func TestOrchestrator_CancelWithCleanExit(t *testing.T) {
+	// Verify that a subprocess that traps SIGINT and exits 0 is still
+	// classified as StepCancelled, not StepDone.
+	t.Parallel()
+	cfg := testOrchestratorConfig()
+
+	// Script traps SIGINT and exits cleanly (exit 0).
+	script := writeTestScript(t, "trap 'exit 0' INT; sleep 60")
+	orch, wtm := setupSubprocessOrch(t, cfg, script)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	err := orch.Start(ctx, issue)
+	require.NoError(t, err)
+
+	// Drain StepInit.
+	select {
+	case <-orch.StatusUpdates():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for StepInit")
+	}
+
+	// Cancel the context (simulates Ctrl+C).
+	cancel()
+
+	// Should receive StepCancelled, not StepDone, even though exit code is 0.
+	select {
+	case status := <-orch.StatusUpdates():
+		require.Equal(t, StepCancelled, status.Step, "clean exit after SIGINT must be StepCancelled")
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for StepCancelled")
+	}
+
+	orch.Wait()
+
+	// Worktree should NOT have been removed (default: preserve on cancel).
+	wtm.mu.Lock()
+	removed := wtm.removed
+	wtm.mu.Unlock()
+	require.Empty(t, removed, "cancelled worktree should not be removed")
+}
+
 func TestOrchestrator_FailedStillCleansUp(t *testing.T) {
 	cfg := testOrchestratorConfig()
 

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -3,6 +3,7 @@ package jiradozer
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -444,6 +445,109 @@ func TestOrchestrator_FailedStillCleansUp(t *testing.T) {
 	wtm.mu.Unlock()
 	require.Len(t, removed, 1, "failed worktree should be removed")
 	require.Empty(t, orch.PreservedWorktrees())
+}
+
+// countingWTManager wraps mockWTManager and counts NewWorktree calls.
+type countingWTManager struct {
+	*mockWTManager
+	newCalls int
+	mu2      sync.Mutex
+}
+
+func (c *countingWTManager) NewWorktree(ctx context.Context, branch, base, goal string) (string, error) {
+	c.mu2.Lock()
+	c.newCalls++
+	c.mu2.Unlock()
+	return c.mockWTManager.NewWorktree(ctx, branch, base, goal)
+}
+
+func (c *countingWTManager) callCount() int {
+	c.mu2.Lock()
+	defer c.mu2.Unlock()
+	return c.newCalls
+}
+
+// TestRunWithDiscovery_PermanentErrorStopsRetrying verifies that RunWithDiscovery
+// stops clearing the seen set after maxStartFailures permanent errors for the
+// same issue, preventing an infinite retry storm.
+func TestRunWithDiscovery_PermanentErrorStopsRetrying(t *testing.T) {
+	t.Parallel()
+
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	// mockDiscoveryTracker returns the same issue on every ListIssues call.
+	mt := &mockDiscoveryTracker{
+		results: [][]*tracker.Issue{
+			{issue}, {issue}, {issue}, {issue}, {issue},
+			{issue}, {issue}, {issue}, {issue}, {issue},
+		},
+	}
+
+	cfg := testOrchestratorConfig()
+	cfg.Source.MaxConcurrent = 3
+
+	inner := newMockWTManager()
+	inner.newErr = fmt.Errorf("worktree already exists")
+	wtm := &countingWTManager{mockWTManager: inner}
+
+	logDir := t.TempDir()
+	orch := NewOrchestrator(mt, cfg, wtm, "", testLogger(t))
+	orch.SetSubprocessMode("/bin/false", nil, logDir)
+
+	d := NewDiscovery(mt, tracker.IssueFilter{}, 5*time.Millisecond, testLogger(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	_ = orch.RunWithDiscovery(ctx, d)
+
+	// After maxStartFailures attempts the retry storm must stop.
+	// Allow one extra call in case of a race at the boundary.
+	calls := wtm.callCount()
+	require.LessOrEqual(t, calls, maxStartFailures+1,
+		"NewWorktree called %d times; expected at most %d (maxStartFailures=%d)",
+		calls, maxStartFailures+1, maxStartFailures)
+}
+
+// TestRunWithDiscovery_ConcurrencyLimitKeepsPending verifies that a
+// concurrency-limit error keeps the issue in the pending queue rather than
+// triggering a ClearSeen (which would cause an infinite retry storm when slots
+// free up).
+func TestRunWithDiscovery_ConcurrencyLimitKeepsPending(t *testing.T) {
+	t.Parallel()
+
+	// Use a script that exits quickly so slots free up.
+	fastScript := writeTestScript(t, "exit 0")
+
+	issue1 := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test 1"}
+	issue2 := &tracker.Issue{ID: "2", Identifier: "ENG-2", Title: "Test 2"}
+	issue3 := &tracker.Issue{ID: "3", Identifier: "ENG-3", Title: "Test 3"}
+
+	cfg := testOrchestratorConfig()
+	cfg.Source.MaxConcurrent = 2 // Only 2 slots.
+
+	wtm := newMockWTManagerWithDir(t)
+	logDir := t.TempDir()
+
+	mt := &mockDiscoveryTracker{
+		results: [][]*tracker.Issue{
+			{issue1, issue2, issue3},
+		},
+	}
+
+	orch := NewOrchestrator(mt, cfg, wtm, "", testLogger(t))
+	orch.SetSubprocessMode(fastScript, nil, logDir)
+
+	d := NewDiscovery(mt, tracker.IssueFilter{}, time.Hour, testLogger(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = orch.RunWithDiscovery(ctx, d)
+
+	// All three issues must have been started exactly once (third issue was
+	// pending until a slot freed, then started — not duplicated via ClearSeen).
+	created := wtm.getCreated()
+	require.Len(t, created, 3, "expected all 3 issues to be started exactly once")
 }
 
 func TestOrchestrator_Snapshot(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Retry storm fix**: `RunWithDiscovery` now distinguishes transient from permanent `Start()` failures. Concurrency-limit errors keep the issue in the pending queue (no `ClearSeen`). Permanent errors (worktree already exists, subprocess start failure) allow up to `maxStartFailures` (3) retries via `ClearSeen`, then give up — leaving the issue suppressed so it stops being rediscovered every poll cycle.
- **Worktree preserved on success**: `cleanup()` now only calls `RemoveWorktree` on workflow failure. On `StepDone`, the worktree and branch are left intact because the ship step opens a PR but doesn't merge it — deleting the branch while the PR is open would break the merge.
- **Docs**: `README.md` documents the worktree lifecycle in team mode and how to manually clean up after merge.

## Test plan

- [ ] `TestRunWithDiscovery_PermanentErrorStopsRetrying` — verifies `NewWorktree` is called at most `maxStartFailures+1` times for a permanently failing issue
- [ ] `TestRunWithDiscovery_ConcurrencyLimitKeepsPending` — verifies all 3 issues start exactly once when one is initially over the concurrency limit
- [ ] `TestOrchestrator_WorktreeCreation` — updated: asserts worktrees are NOT removed after successful subprocess exit
- [ ] `TestOrchestrator_WorktreeRemovedOnFailure` — new: asserts worktrees ARE removed after subprocess failure
- [ ] `bazel test //jiradozer/...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator scheduling/retry behavior and worktree cleanup semantics in team mode; mistakes could lead to stuck issues, unintended suppression, or leaked worktrees/branches.
> 
> **Overview**
> **Team-mode orchestrator now avoids retry storms** by treating `Start()` failures differently: concurrency-limit errors are treated as transient (kept in the pending queue), while other failures retry via `ClearSeen` only up to `maxStartFailures` (3) before giving up to stop infinite rediscovery.
> 
> **Worktree lifecycle is changed to preserve successful runs**: `cleanup()` no longer deletes worktrees/branches on `StepDone` (and records preserved worktrees with the ending step); only `StepFailed` cleans up, while `StepCancelled` preserves by default unless `--force-cleanup` is set. CLI output, integration/unit tests, and `README.md` are updated to reflect the new preservation/cleanup guidance and to correctly classify cancelled subprocesses even if they exit `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2822a654a489c38f1698aea90d8c27310cda52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->