### PR TITLE
jiradozer: remove truncation of round progress comments

### DIFF
--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -236,7 +236,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		allOutputs = append(allOutputs, output)
 
 		heading := capitalize(stepName)
-		comment := fmt.Sprintf("## %s Round %d/%d\n\n%s", heading, i+1, totalRounds, truncateOutput(output, 2000))
+		comment := fmt.Sprintf("## %s Round %d/%d\n\n%s", heading, i+1, totalRounds, output)
 		roundComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
 		if err != nil {
 			w.logger.Warn("failed to post round comment", "step", stepName, "round", i+1, "error", err)
@@ -331,15 +331,6 @@ func (w *Workflow) captureOutput(stepName, output string) {
 	case "build":
 		w.buildOutput = output
 	}
-}
-
-// truncateOutput shortens text that exceeds maxLen runes, appending a truncation notice.
-func truncateOutput(s string, maxLen int) string {
-	runes := []rune(s)
-	if len(runes) > maxLen {
-		return string(runes[:maxLen]) + "\n\n... (truncated)"
-	}
-	return s
 }
 
 // capitalize returns s with the first letter uppercased.


### PR DESCRIPTION
## Summary

- Remove the 2000-rune `truncateOutput()` call in `runMultiRoundStep()` so multi-round step comments post full output, matching the existing behavior of `runStep()` (single-round path)
- Delete the now-unused `truncateOutput()` function

## Why

The 2000-rune limit was making it impossible to see full build/validate output in Linear comments. `runStep()` has never truncated — this makes both paths consistent.

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel test //jiradozer/... --test_timeout=60` passes (6/6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Multi-round step comments now post unbounded output, which could hit tracker comment size limits or generate very large/noisy updates, potentially affecting reliability of comment posting.
> 
> **Overview**
> Multi-round workflow progress comments now include the *full* round output (matching single-step behavior) instead of truncating to 2000 runes.
> 
> Removes the unused `truncateOutput` helper after eliminating truncation from `runStepRounds` comment formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9fb9f0f3ce1bb95adcb1194ac51a599c1563c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->