### PR TITLE
jiradozer: retry turns that end with unresolved tool errors

### DIFF
--- a/agent-cli-wrapper/claude/BUILD.bazel
+++ b/agent-cli-wrapper/claude/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "session_bg_test.go",
         "session_dispatch_test.go",
         "session_monitor_test.go",
+        "turn_retry_test.go",
         "turn_test.go",
     ],
     embed = [":claude"],

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -2,9 +2,124 @@ package claude
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
+
+// toolUseErrorMarker is the sentinel substring Claude emits inside a
+// tool_result.content when a parallel tool batch sibling errored and the
+// CLI cancelled this tool before it ran. Detected by FinalTurnToolError
+// even when IsError is not set, to protect against upstream format drift.
+const toolUseErrorMarker = "<tool_use_error>"
+
+// toolErrorExcerptMaxRunes caps the FinalTurnToolError excerpt so log lines
+// and retry prompts stay bounded regardless of the failing tool's output.
+const toolErrorExcerptMaxRunes = 200
+
+// stringifyToolResult renders a ContentBlock.ToolResult payload as a plain
+// string for substring matching and excerpt extraction. The underlying
+// protocol.ToolResultBlock.Content may arrive as a plain string (legacy
+// shape) or as a []interface{} of {type: "text", text: "..."} blocks (the
+// normal shape that handleUser stores into ContentBlock.ToolResult).
+// Unrecognised shapes fall through to fmt.Sprint so callers still get
+// *something* to match against.
+func stringifyToolResult(result interface{}) string {
+	if result == nil {
+		return ""
+	}
+	switch v := result.(type) {
+	case string:
+		return v
+	case []interface{}:
+		var b strings.Builder
+		for _, entry := range v {
+			m, ok := entry.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if text, ok := m["text"].(string); ok {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(text)
+			}
+		}
+		if b.Len() > 0 {
+			return b.String()
+		}
+		return fmt.Sprint(v)
+	case []map[string]interface{}:
+		var b strings.Builder
+		for _, m := range v {
+			if text, ok := m["text"].(string); ok {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(text)
+			}
+		}
+		if b.Len() > 0 {
+			return b.String()
+		}
+		return fmt.Sprint(v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// excerptRunes returns the first max runes of s, with no truncation marker.
+// Used to bound error excerpts in logs and retry prompts.
+func excerptRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max])
+}
+
+// FinalTurnToolError reports whether the given content blocks contain any
+// errored tool_result (IsError or a <tool_use_error> substring), and
+// returns the failing tool's name and a short excerpt from the first such
+// result. Callers use this to decide whether to auto-retry a turn that
+// ended with unresolved tool errors.
+//
+// When multiple tool_results are errored (parallel tool batches), the first
+// one encountered in block order wins; in the parallel-cancelled case this
+// is the real cause, not the cancelled sibling (Claude's dispatcher emits
+// the errored sibling first).
+//
+// The substring check on <tool_use_error> is belt-and-braces: today IsError
+// is always set when the marker is present, but the double check costs
+// nothing and guards against upstream format drift.
+func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
+	for i, block := range blocks {
+		if block.Type != ContentBlockTypeToolResult {
+			continue
+		}
+		content := stringifyToolResult(block.ToolResult)
+		isErr := block.IsError || strings.Contains(content, toolUseErrorMarker)
+		if !isErr {
+			continue
+		}
+		name := "unknown"
+		// Look backward for the matching tool_use block in the same turn.
+		for j := i - 1; j >= 0; j-- {
+			if blocks[j].Type == ContentBlockTypeToolUse && blocks[j].ToolUseID == block.ToolUseID {
+				if blocks[j].ToolName != "" {
+					name = blocks[j].ToolName
+				}
+				break
+			}
+		}
+		return name, excerptRunes(content, toolErrorExcerptMaxRunes), true
+	}
+	return "", "", false
+}
 
 // TurnUsage contains token usage for a turn.
 type TurnUsage struct {

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -8,23 +8,13 @@ import (
 	"time"
 )
 
-// toolUseErrorMarker is the sentinel substring Claude emits inside a
-// tool_result.content when a parallel tool batch sibling errored and the
-// CLI cancelled this tool before it ran. Detected by FinalTurnToolError
-// even when IsError is not set, to protect against upstream format drift.
+// toolUseErrorMarker guards against upstream format drift where IsError
+// is unset but content still carries this sentinel (seen on parallel-
+// cancelled tool siblings).
 const toolUseErrorMarker = "<tool_use_error>"
 
-// toolErrorExcerptMaxRunes caps the FinalTurnToolError excerpt so log lines
-// and retry prompts stay bounded regardless of the failing tool's output.
 const toolErrorExcerptMaxRunes = 200
 
-// stringifyToolResult renders a ContentBlock.ToolResult payload as a plain
-// string for substring matching and excerpt extraction. The underlying
-// protocol.ToolResultBlock.Content may arrive as a plain string (legacy
-// shape) or as a []interface{} of {type: "text", text: "..."} blocks (the
-// normal shape that handleUser stores into ContentBlock.ToolResult).
-// Unrecognised shapes fall through to fmt.Sprint so callers still get
-// *something* to match against.
 func stringifyToolResult(result interface{}) string {
 	if result == nil {
 		return ""
@@ -69,52 +59,44 @@ func stringifyToolResult(result interface{}) string {
 	}
 }
 
-// excerptRunes returns the first max runes of s, with no truncation marker.
-// Used to bound error excerpts in logs and retry prompts.
+// excerptRunes returns the first max runes of s. Iterates by rune via
+// `range string` to avoid allocating a full []rune for large tool outputs.
 func excerptRunes(s string, max int) string {
 	if max <= 0 {
 		return ""
 	}
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
+	count := 0
+	for i := range s {
+		if count == max {
+			return s[:i]
+		}
+		count++
 	}
-	return string(runes[:max])
+	return s
 }
 
-// FinalTurnToolError reports whether the given content blocks contain any
-// errored tool_result (IsError or a <tool_use_error> substring), and
-// returns the failing tool's name and a short excerpt from the first such
-// result. Callers use this to decide whether to auto-retry a turn that
-// ended with unresolved tool errors.
-//
-// When multiple tool_results are errored (parallel tool batches), the first
-// one encountered in block order wins; in the parallel-cancelled case this
-// is the real cause, not the cancelled sibling (Claude's dispatcher emits
-// the errored sibling first).
-//
-// The substring check on <tool_use_error> is belt-and-braces: today IsError
-// is always set when the marker is present, but the double check costs
-// nothing and guards against upstream format drift.
+// FinalTurnToolError reports the first errored tool_result in blocks,
+// returning the failing tool's name and a bounded excerpt. On parallel
+// tool batches the first-in-order errored result wins — in the cancelled-
+// sibling case this surfaces the real cause, not the cancellation.
 func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
-	for i, block := range blocks {
+	toolNames := make(map[string]string)
+	for _, block := range blocks {
+		if block.Type == ContentBlockTypeToolUse && block.ToolUseID != "" {
+			toolNames[block.ToolUseID] = block.ToolName
+		}
+	}
+	for _, block := range blocks {
 		if block.Type != ContentBlockTypeToolResult {
 			continue
 		}
 		content := stringifyToolResult(block.ToolResult)
-		isErr := block.IsError || strings.Contains(content, toolUseErrorMarker)
-		if !isErr {
+		if !block.IsError && !strings.Contains(content, toolUseErrorMarker) {
 			continue
 		}
-		name := "unknown"
-		// Look backward for the matching tool_use block in the same turn.
-		for j := i - 1; j >= 0; j-- {
-			if blocks[j].Type == ContentBlockTypeToolUse && blocks[j].ToolUseID == block.ToolUseID {
-				if blocks[j].ToolName != "" {
-					name = blocks[j].ToolName
-				}
-				break
-			}
+		name := toolNames[block.ToolUseID]
+		if name == "" {
+			name = "unknown"
 		}
 		return name, excerptRunes(content, toolErrorExcerptMaxRunes), true
 	}

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestFinalTurnToolError_IsError(t *testing.T) {
+	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
 		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "failed", IsError: true},
@@ -23,7 +24,7 @@ func TestFinalTurnToolError_IsError(t *testing.T) {
 }
 
 func TestFinalTurnToolError_SubstringOnly(t *testing.T) {
-	// IsError is false but content carries the marker — format-drift guard.
+	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
 		{
@@ -46,9 +47,7 @@ func TestFinalTurnToolError_SubstringOnly(t *testing.T) {
 }
 
 func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
-	// Exact PLA-212 shape: two parallel Bash tool_uses; the errored sibling
-	// comes first, the cancelled sibling second. Detector returns the first
-	// errored result — the real cause, not the cancelled one.
+	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "ruff", ToolName: "Bash", ToolInput: map[string]interface{}{"command": "ruff check"}},
 		{Type: ContentBlockTypeToolUse, ToolUseID: "pytest", ToolName: "Bash", ToolInput: map[string]interface{}{"command": "pytest"}},
@@ -81,6 +80,7 @@ func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
 }
 
 func TestFinalTurnToolError_Clean(t *testing.T) {
+	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Read"},
 		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "file contents", IsError: false},
@@ -91,6 +91,7 @@ func TestFinalTurnToolError_Clean(t *testing.T) {
 }
 
 func TestFinalTurnToolError_NoToolUse(t *testing.T) {
+	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeText, Text: "hello"},
 	}
@@ -103,8 +104,7 @@ func TestFinalTurnToolError_NoToolUse(t *testing.T) {
 }
 
 func TestFinalTurnToolError_BlockShape(t *testing.T) {
-	// Wire shape from handleUser at session.go:1045 — Content is often a
-	// []interface{} of {type: "text", text: "..."} maps rather than a plain string.
+	t.Parallel()
 	wireShape := []interface{}{
 		map[string]interface{}{
 			"type": "text",
@@ -125,6 +125,7 @@ func TestFinalTurnToolError_BlockShape(t *testing.T) {
 }
 
 func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
+	t.Parallel()
 	long := strings.Repeat("x", 500)
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
@@ -140,9 +141,7 @@ func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
 }
 
 func TestFinalTurnToolError_UnknownTool(t *testing.T) {
-	// Tool_result with no matching tool_use in the same block slice — name
-	// falls back to "unknown". Shouldn't happen in practice but the detector
-	// must not panic.
+	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolResult, ToolUseID: "orphan", ToolResult: "err", IsError: true},
 	}

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -1,0 +1,156 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFinalTurnToolError_IsError(t *testing.T) {
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "failed", IsError: true},
+	}
+	name, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if name != "Bash" {
+		t.Errorf("expected tool=Bash, got %q", name)
+	}
+	if excerpt != "failed" {
+		t.Errorf("expected excerpt=failed, got %q", excerpt)
+	}
+}
+
+func TestFinalTurnToolError_SubstringOnly(t *testing.T) {
+	// IsError is false but content carries the marker — format-drift guard.
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "t1",
+			ToolResult: "<tool_use_error>Cancelled: parallel tool call</tool_use_error>",
+			IsError:    false,
+		},
+	}
+	name, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true (substring match)")
+	}
+	if name != "Bash" {
+		t.Errorf("expected tool=Bash, got %q", name)
+	}
+	if !strings.Contains(excerpt, "<tool_use_error>") {
+		t.Errorf("excerpt should contain marker, got %q", excerpt)
+	}
+}
+
+func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
+	// Exact PLA-212 shape: two parallel Bash tool_uses; the errored sibling
+	// comes first, the cancelled sibling second. Detector returns the first
+	// errored result — the real cause, not the cancelled one.
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "ruff", ToolName: "Bash", ToolInput: map[string]interface{}{"command": "ruff check"}},
+		{Type: ContentBlockTypeToolUse, ToolUseID: "pytest", ToolName: "Bash", ToolInput: map[string]interface{}{"command": "pytest"}},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "ruff",
+			ToolResult: "TC003 stdlib import in runtime",
+			IsError:    true,
+		},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "pytest",
+			ToolResult: "<tool_use_error>Cancelled: parallel tool call Bash(ruff check) errored</tool_use_error>",
+			IsError:    true,
+		},
+	}
+	name, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if name != "Bash" {
+		t.Errorf("expected Bash, got %q", name)
+	}
+	if !strings.Contains(excerpt, "TC003") {
+		t.Errorf("expected excerpt to surface the real ruff error, got %q", excerpt)
+	}
+	if strings.Contains(excerpt, "Cancelled") {
+		t.Errorf("detector should have surfaced the ruff error, not the cancelled sibling: %q", excerpt)
+	}
+}
+
+func TestFinalTurnToolError_Clean(t *testing.T) {
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Read"},
+		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "file contents", IsError: false},
+	}
+	if _, _, ok := FinalTurnToolError(blocks); ok {
+		t.Fatal("expected ok=false for clean turn")
+	}
+}
+
+func TestFinalTurnToolError_NoToolUse(t *testing.T) {
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeText, Text: "hello"},
+	}
+	if _, _, ok := FinalTurnToolError(blocks); ok {
+		t.Fatal("expected ok=false for text-only turn")
+	}
+	if _, _, ok := FinalTurnToolError(nil); ok {
+		t.Fatal("expected ok=false for nil blocks")
+	}
+}
+
+func TestFinalTurnToolError_BlockShape(t *testing.T) {
+	// Wire shape from handleUser at session.go:1045 — Content is often a
+	// []interface{} of {type: "text", text: "..."} maps rather than a plain string.
+	wireShape := []interface{}{
+		map[string]interface{}{
+			"type": "text",
+			"text": "<tool_use_error>Cancelled</tool_use_error>",
+		},
+	}
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: wireShape, IsError: true},
+	}
+	_, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true for wire-shape content")
+	}
+	if !strings.Contains(excerpt, "<tool_use_error>") {
+		t.Errorf("expected excerpt to extract text field, got %q", excerpt)
+	}
+}
+
+func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: long, IsError: true},
+	}
+	_, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if len([]rune(excerpt)) != toolErrorExcerptMaxRunes {
+		t.Errorf("expected excerpt of %d runes, got %d", toolErrorExcerptMaxRunes, len([]rune(excerpt)))
+	}
+}
+
+func TestFinalTurnToolError_UnknownTool(t *testing.T) {
+	// Tool_result with no matching tool_use in the same block slice — name
+	// falls back to "unknown". Shouldn't happen in practice but the detector
+	// must not panic.
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolResult, ToolUseID: "orphan", ToolResult: "err", IsError: true},
+	}
+	name, _, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if name != "unknown" {
+		t.Errorf("expected name=unknown, got %q", name)
+	}
+}

--- a/docs/design/jiradozer-tool-error-retry.md
+++ b/docs/design/jiradozer-tool-error-retry.md
@@ -1,0 +1,371 @@
+# Jiradozer: Retry on Tool Error
+
+## Problem
+
+A jiradozer round can silently complete with unresolved tool errors. The
+concrete failure is Round 3/3 of PLA-212 validate step (session
+`1d01f69c-3993-4064-8e91-ee4a785e49c7`): a parallel Bash batch hit a lint
+failure, the sibling `pytest` call was cancelled by Claude's dispatcher with
+`is_error=true` / `<tool_use_error>Cancelled: parallel tool call … errored</tool_use_error>`,
+and the assistant's turn ended immediately. The wrapper saw a clean
+`ResultMessage`, returned success to jiradozer, and the workflow advanced to
+ship with unresolved lint/tests and no commit.
+
+## Goal
+
+When a Claude turn ends while its final tool_result set contains one or more
+errored blocks, keep the session alive and send a short retry user message
+asking the model to fix the failure and continue — bounded by a configurable
+retry limit and additional runaway guardrails.
+
+Out of scope (explicit): Round 2's "I'll wait for background task" failure
+mode (needs a separate bg-bash sentinel fix), the alembic TC003 lint issue
+itself, and any change to `workflow.go`'s cross-round loop.
+
+## Design
+
+### Where the loop lives
+
+`ClaudeProvider.Execute` in `multiagent/agent/claude_provider.go:27` already
+creates an ephemeral `claude.Session`, calls `session.Ask(ctx, prompt)` once
+at line 93, and returns. The retry loop belongs **here**, not inside the
+Claude SDK:
+
+- `claude.Session` already exposes a multi-turn API — `Ask` is a convenience
+  wrapper; the underlying `SendMessage` (session.go:261) + `WaitForTurn` pair
+  lets us inject follow-up user turns on the same session. We don't need
+  `--resume` or a new session.
+- Keeping the logic in `ClaudeProvider.Execute` avoids pushing
+  jiradozer-specific policy into the SDK turn loop. The SDK stays
+  agnostic; the provider enforces the retry budget.
+- It also sidesteps the `bgSuppressionState` machinery entirely: by the time
+  `Ask` returns a `TurnResult`, `finalizeTurn` has already run and all bg
+  suppression has been resolved (normal release, timer fire, or continuation).
+  There is no double-trigger risk with the Monitor fix.
+
+### Detection
+
+Inspect `TurnResult.ContentBlocks` (already populated via turn.go:355
+`AppendContentBlock`, carried into `TurnResult` in the finalize path). A turn
+"needs retry" if **any** `ContentBlock` with
+`Type == ContentBlockTypeToolResult` has:
+
+- `block.IsError == true`, **or**
+- `block.ToolResult` stringifies to content that contains the literal
+  substring `<tool_use_error>` (belt-and-braces — in practice `IsError` is
+  always set when this substring is present, but the double check costs
+  nothing and protects against upstream format drift).
+
+Helper to add in `agent-cli-wrapper/claude/turn.go` (near
+`cancelledToolIDs`, ~line 79):
+
+```go
+// FinalTurnToolError returns a short description of the first errored
+// tool_result in the turn's content blocks, or "" if none. Used by callers
+// that want to auto-retry after a turn ends with unresolved tool errors.
+func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) { … }
+```
+
+It walks `blocks` once, finds the first block where `Type ==
+ContentBlockTypeToolResult && (IsError || strings.Contains(stringify(ToolResult), "<tool_use_error>"))`,
+then looks backward for the matching `ToolUseID`'s `ToolUse` block to recover
+the tool name. `excerpt` is the first ~200 chars of the stringified result.
+
+Exporting a free function (not a method on `*turnState`) keeps the internal
+turn manager private while giving the provider a clean dependency.
+
+> **Note on the Round 2 "no tool_use in final message" signal.** The plan
+> does not use this as a secondary trigger. Round 2 needs Monitor/bg-bash
+> sentinel work, not retry: re-prompting "please continue" when the model is
+> already waiting on a bg task is counterproductive (the model will just say
+> "I'll keep waiting"). Leave that case to the separate fix. The plan does,
+> however, structure the retry code so a second detection strategy could be
+> plugged into the same loop later.
+
+### Retry action
+
+In `ClaudeProvider.Execute` (claude_provider.go:93), replace the single
+`session.Ask` call with a short loop:
+
+```go
+result, err := session.Ask(ctx, fullPrompt)
+if err != nil { return nil, err }
+
+for attempt := 1; attempt <= cfg.MaxToolErrorRetries; attempt++ {
+    name, excerpt, hasErr := claude.FinalTurnToolError(result.ContentBlocks)
+    if !hasErr { break }
+    if ctx.Err() != nil { break }
+
+    // Runaway guardrails (see below)
+    if !retryBudgetOK(attempt, start, prevExcerpt, excerpt) { break }
+    prevExcerpt = excerpt
+
+    retryMsg := buildRetryPrompt(name, excerpt)
+    // emit a synthetic status event so loggers/renderer see the retry
+    emitRetryStatus(cfg.EventHandler, attempt, cfg.MaxToolErrorRetries, name)
+
+    next, askErr := session.Ask(ctx, retryMsg)
+    if askErr != nil { return nil, askErr }
+    result = next
+}
+```
+
+`session.Ask` internally calls `SendMessage` (starts a new turn on the same
+live session) then `WaitForTurn`, so the session context, worktree, tool
+history, and file state are all preserved. No `--resume` needed.
+
+### Retry prompt wording
+
+Keep it terse and specific. Draft:
+
+```
+Your previous turn ended with a tool error that was not addressed:
+
+  tool: {name}
+  result: {excerpt}
+
+This is the source of the failure — if a sibling tool in a parallel batch
+was cancelled, the real error is in the *other* sibling. Fix the underlying
+problem and continue the task. Do not stop until the task is complete or
+you have a concrete blocker to report.
+```
+
+Rationale for including the excerpt verbatim: the model's history already
+contains it, but restating it in the user turn (a) makes the "this is
+important, act on it" signal unambiguous, (b) works even if the excerpt was
+clipped in the assistant's own view, and (c) the parallel-cancellation
+footnote matches the exact PLA-212 failure shape — without it, a naive
+model will try to "fix" the cancelled pytest call rather than the ruff
+error that actually triggered the cancellation.
+
+### Retry limit and runaway protection
+
+Four guardrails, in order of authority:
+
+1. **Count limit** — `cfg.MaxToolErrorRetries` from `StepConfig` (default
+   `0` = feature disabled, matching current behavior). Validate step should
+   opt in with `2` in the example config; users can raise it per-step.
+
+2. **Wall-clock budget** — hard cap at `max(10min, stepCfg.MaxTurns * 60s)`
+   elapsed since the *original* `Ask` started. Beyond this, stop retrying
+   even if the count budget is not exhausted. Prevents a runaway where each
+   retry takes 5+ minutes of agent work.
+
+3. **No-progress detector** — if `excerpt` for retry N+1 equals
+   `excerpt` for retry N (byte-exact, first 200 chars), abort: the model is
+   stuck on the same error and further retries are wasted. Emit a distinct
+   log line so this is visible in triage.
+
+4. **Context cancellation** — `ctx.Err()` short-circuits everything.
+
+The jiradozer outer cross-round loop is unchanged. When retries are
+exhausted and the round still has a tool error, the round returns
+successfully from a jiradozer perspective (we do *not* convert the tool
+error into a Go error — that would cause `fail(ctx, …)` to trip the whole
+workflow). Instead the round output gets a trailing marker line
+(`[unresolved tool error after N retries: {name}: {excerpt}]`) which the
+next round's review step and any downstream reader can surface.
+
+> **Alternative considered:** bubble up as an error. Rejected — it would
+> short-circuit `runStepRounds` mid-sequence, bypassing the remaining
+> rounds and the review step. We want the existing cross-round loop to
+> stay in charge of "this step is broken" decisions.
+
+### Observability
+
+1. In the existing `logEventHandler` (jiradozer/agent.go:187), add a new
+   method `OnRetry(attempt, max int, tool, excerpt string)` to
+   `agent.EventHandler` (check whether the interface already has an
+   extension shape like `SessionInitHandler` at agent.go:354 — use the same
+   optional-interface pattern so renderer/other handlers don't break).
+2. `logEventHandler.OnRetry` logs at INFO with fields `{step, attempt,
+   max, tool, excerpt}`.
+3. `rendererEventHandler.OnRetry` calls `h.r.Status(fmt.Sprintf("Retry
+   %d/%d: tool error in %s", attempt, max, tool))` so it appears above the
+   streaming output.
+4. `compositeEventHandler` fans out via the same optional-interface check
+   as `OnSessionInit`.
+5. In the provider loop, emit the retry status *before* the follow-up
+   `Ask` so the log/renderer shows the decision and the tool name, even if
+   the retry subsequently panics or hangs.
+
+The jiradozer log output will then include lines like:
+
+```
+[INFO ] retry on tool error  step=validate attempt=1 max=2 tool=Bash excerpt="<tool_use_error>Cancelled: parallel tool call Bash(uv run ruff check services/python/api-ga…) errored</tool_use_error>"
+```
+
+### Config surface
+
+Changes in `jiradozer/config.go`:
+
+- Add `MaxToolErrorRetries int \`yaml:"max_tool_error_retries"\`` to
+  `StepConfig` at line 64 (after `MaxTurns`).
+- `RoundConfig` at line 78 also gets `MaxToolErrorRetries` for per-round
+  override. `ResolveRound` (wherever it lives — see `jiradozer/config.go`
+  for the resolver; grep for it) treats `0` as inherit-from-step.
+- `defaultConfig()` at line 136 sets `Validate.MaxToolErrorRetries = 0`
+  (default disabled). The example config `jiradozer.example.yaml` gets an
+  annotated `max_tool_error_retries: 2` on the validate step with a comment
+  explaining what it does.
+- No top-level default field — step-level only. Keeps the blast radius
+  narrow: enabling on `validate` is a single-line change, enabling globally
+  requires touching every step.
+
+Changes in `multiagent/agent` (`ExecuteConfig` + options file):
+
+- Add `MaxToolErrorRetries int` to `ExecuteConfig`.
+- Add `func WithProviderMaxToolErrorRetries(n int) ExecuteOption`.
+
+Changes in `jiradozer/agent.go` (`runAgent`, line 363):
+
+- After the existing `if cfg.MaxTurns > 0` block (~line 403), add an
+  analogous `if cfg.MaxToolErrorRetries > 0 { opts = append(opts,
+  agent.WithProviderMaxToolErrorRetries(cfg.MaxToolErrorRetries)) }`.
+
+### File/line-number summary
+
+| File | Change |
+|---|---|
+| `agent-cli-wrapper/claude/turn.go` ~L79 | New `FinalTurnToolError(blocks)` helper |
+| `agent-cli-wrapper/claude/turn.go` | Small `stringifyToolResult(interface{})` helper (private, handles string / `[]map[string]interface{}` shapes produced by `handleUser` at session.go:1005) |
+| `multiagent/agent/provider.go` `ExecuteConfig` | New field `MaxToolErrorRetries int` |
+| `multiagent/agent/provider.go` options | New `WithProviderMaxToolErrorRetries` |
+| `multiagent/agent/events.go` (or wherever `EventHandler` lives) | New optional interface `RetryHandler { OnRetry(attempt, max int, tool, excerpt string) }` |
+| `multiagent/agent/claude_provider.go:93` | Replace single `Ask` call with retry loop |
+| `jiradozer/config.go:64` | New `StepConfig.MaxToolErrorRetries` field |
+| `jiradozer/config.go:78` | New `RoundConfig.MaxToolErrorRetries` field |
+| `jiradozer/config.go` `ResolveRound` | Inherit rule for new field |
+| `jiradozer/config.go:136-158` `defaultConfig` | Leave all defaults at `0` (opt-in) |
+| `jiradozer/jiradozer.example.yaml` validate step | Annotated `max_tool_error_retries: 2` |
+| `jiradozer/agent.go:403` `runAgent` | Pass new field into `ExecuteOption` chain |
+| `jiradozer/agent.go:187` `logEventHandler` | New `OnRetry` method, INFO log |
+| `jiradozer/agent.go:280` `rendererEventHandler` | New `OnRetry` method → `r.Status(…)` |
+| `jiradozer/agent.go:312` `compositeEventHandler` | Optional-interface fan-out |
+
+## Testing
+
+### Unit — detection helper
+
+New file `agent-cli-wrapper/claude/turn_retry_test.go`:
+
+- `TestFinalTurnToolError_IsError` — single tool_result with
+  `IsError: true`, no `<tool_use_error>` substring → detected, tool name
+  recovered.
+- `TestFinalTurnToolError_SubstringOnly` — synthetic block with
+  `IsError: false` but content containing `<tool_use_error>` → detected
+  (defends against upstream format drift).
+- `TestFinalTurnToolError_ParallelCancelled` — two tool_use blocks, one
+  errored; returns the errored one's name, not the cancelled sibling. This
+  is the exact PLA-212 shape.
+- `TestFinalTurnToolError_Clean` — all tool_results succeed → `ok=false`.
+- `TestFinalTurnToolError_NoToolUse` — empty or text-only turn → `ok=false`.
+- `TestFinalTurnToolError_NonStringResult` — content is
+  `[]map[string]interface{}{{"type":"text","text":"<tool_use_error>…"}}`
+  (the shape that actually comes off the wire in `handleUser`).
+
+### Unit — provider retry loop
+
+New file `multiagent/agent/claude_provider_retry_test.go`. Pattern: use a
+fake `claude.Session` — the simplest form is a thin interface extraction
+around the two methods the provider needs (`Ask`, `Info`, `Stop`,
+`Events`) wired behind a package-private constructor so tests can inject a
+stub. If that's too invasive, fall back to the integration test (next
+section) and drop this unit level.
+
+Cases:
+
+- `retries_until_clean` — stub returns errored result twice then clean;
+  verify 3 total calls and final result is the clean one.
+- `respects_count_limit` — MaxToolErrorRetries=1, stub always errors;
+  verify exactly 2 calls (initial + 1 retry) and the final errored result
+  is returned with the unresolved marker appended.
+- `no_progress_aborts` — same excerpt twice in a row; verify exits after
+  detecting the duplicate even though count budget remains.
+- `ctx_cancelled` — cancel ctx between retries; verify no extra `Ask`.
+- `disabled_by_default` — MaxToolErrorRetries=0, errored result → single
+  call, returns errored result as-is (no marker, no retries — preserves
+  today's behavior).
+
+### Integration — full round
+
+New test in `agent-cli-wrapper/claude/integration/` (check existing tests
+for harness conventions — there's a fake CLI fixture pattern used by the
+Monitor tests). Structure:
+
+- Start a session against a fake CLI that, on turn 1, emits an assistant
+  message with a Bash tool_use, a user message with
+  `tool_result { is_error: true, content: "<tool_use_error>Cancelled…" }`,
+  and a clean `ResultMessage`. On turn 2 it emits a clean text turn with
+  no tool use and a clean `ResultMessage`.
+- Drive via `ClaudeProvider.Execute` with
+  `WithProviderMaxToolErrorRetries(2)`.
+- Assert: 2 turns issued, final `AgentResult.Text` matches turn 2,
+  `EventHandler.OnRetry` was called exactly once with attempt=1.
+
+This fixture is also the regression test for PLA-212 specifically.
+
+### Integration — jiradozer validate step
+
+Extend (don't duplicate) an existing `jiradozer/integration` test if one
+covers the validate step — same pattern as the existing session-resumption
+test described in `memory/jiradozer-testing-approach.md`. If validate is
+not yet covered in integration, skip this and rely on the wrapper-level
+integration test above.
+
+## Rollout
+
+1. **Disabled by default.** `MaxToolErrorRetries: 0` everywhere. No
+   behavior change for existing users unless they opt in.
+2. **Example config opts validate in** with `max_tool_error_retries: 2`
+   and a comment explaining what it does and what wall-clock cost looks
+   like (each retry is a full agent turn — budget accordingly).
+3. **Monitor via existing jiradozer logs.** The new INFO line is grepable;
+   after a week of running, review how often it fires and whether the
+   no-progress abort is hitting. If retries are consistently succeeding,
+   consider bumping the example default to 3. If the no-progress abort is
+   firing often, consider adding the errored tool's *history* to the
+   prompt (not just the latest excerpt).
+4. **Kill switch**: setting the step's `max_tool_error_retries` back to
+   `0` disables the feature per step without a code change.
+
+## Open questions
+
+1. **`session.Ask` vs `SendMessage` + `WaitForTurn`.** The plan assumes
+   `Ask` can be called a second time on the same live session after the
+   first call returns. Need to confirm (a) `Ask` doesn't internally call
+   `Stop` on the first turn, and (b) the session's `done` channel isn't
+   closed by the first `ResultMessage`. If either assumption is wrong, the
+   retry loop must drop down to `SendMessage` + `WaitForTurn` directly,
+   and `ClaudeProvider.Execute`'s `defer session.Stop()` stays as the only
+   shutdown path. Spot-check required before implementation.
+
+2. **`ContentBlock.ToolResult` shape.** `handleUser` in session.go:1005
+   stores whatever the CLI sent — usually `[]map[string]interface{}`
+   blocks with `{type: "text", text: "…"}`. `stringifyToolResult` must
+   handle this shape plus plain strings. Confirm by inspecting a real
+   recorded session jsonl (the PLA-212 recording under
+   `~/.claude/projects/-home-ubuntu-worktrees-kernel-feature-PLA-212/` has
+   the exact fixture we need — copy a trimmed version into testdata).
+
+3. **Multi-round feedback injection.** `runStepRounds` starts a *fresh*
+   session per round. The retry loop lives inside one round's session,
+   so retries are scoped to that round — good, matches the design. But
+   when round N fails retries and emits the unresolved marker, should
+   round N+1's prompt include that marker automatically? Currently
+   `runStepRounds` concatenates round outputs (`allOutputs`) but does not
+   forward them into the next round's prompt. Out of scope for this fix;
+   worth a follow-up note.
+
+4. **Cost accounting.** Retry turns bill against the session's cumulative
+   cost, which is already enforced by `SessionConfig.MaxBudgetUSD`
+   (session.go:1280). No new budget field needed — a runaway retry will
+   hit the existing `ErrBudgetExceeded` first. Confirm this in the
+   integration test by setting a tiny budget and verifying the retry loop
+   exits cleanly on budget error.
+
+5. **The synthetic status event / `OnRetry` callback**. The
+   `agent.EventHandler` interface lives in `multiagent/agent`; renderer
+   already tolerates optional-interface extensions (see `SessionInitHandler`
+   at jiradozer/agent.go:354). Confirm the same pattern applies to the
+   renderer and external consumers before adding the method.

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -282,6 +282,28 @@ func (h *logEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
 		"attempt", attempt,
 		"max", max,
 		"tool", tool,
+	)
+	// Excerpt is derived from raw tool output and may contain paths,
+	// command lines, or other sensitive material, so keep it at Debug.
+	h.logger.Debug("retry on tool error excerpt",
+		"step", h.step,
+		"attempt", attempt,
+		"tool", tool,
+		"excerpt", excerpt,
+	)
+}
+
+func (h *logEventHandler) OnRetryAbort(reason, tool, excerpt string) {
+	h.flushText()
+	h.logger.Info("retry loop aborted",
+		"step", h.step,
+		"reason", reason,
+		"tool", tool,
+	)
+	h.logger.Debug("retry loop aborted excerpt",
+		"step", h.step,
+		"reason", reason,
+		"tool", tool,
 		"excerpt", excerpt,
 	)
 }
@@ -321,6 +343,10 @@ func (h *rendererEventHandler) OnError(err error, ctx string) {
 
 func (h *rendererEventHandler) OnRetry(attempt, max int, tool, _ string) {
 	h.r.Status(fmt.Sprintf("Retry %d/%d: tool error in %s", attempt, max, tool))
+}
+
+func (h *rendererEventHandler) OnRetryAbort(reason, tool, _ string) {
+	h.r.Status(fmt.Sprintf("Retry loop aborted (%s) on tool %s", reason, tool))
 }
 
 // compositeEventHandler fans out events to multiple handlers.
@@ -376,6 +402,14 @@ func (c *compositeEventHandler) OnRetry(attempt, max int, tool, excerpt string) 
 	for _, h := range c.handlers {
 		if rh, ok := h.(agent.RetryHandler); ok {
 			rh.OnRetry(attempt, max, tool, excerpt)
+		}
+	}
+}
+
+func (c *compositeEventHandler) OnRetryAbort(reason, tool, excerpt string) {
+	for _, h := range c.handlers {
+		if rh, ok := h.(agent.RetryHandler); ok {
+			rh.OnRetryAbort(reason, tool, excerpt)
 		}
 	}
 }
@@ -465,13 +499,11 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	output := resolveOutput(result.Text, logHandler, logger)
 	// If the provider recorded an unresolved tool error, make sure the
 	// marker survives any plan-file substitution performed by resolveOutput.
-	if e := result.UnresolvedToolError; e != nil && !strings.Contains(output, "unresolved tool error") {
-		marker := agent.FormatUnresolvedToolErrorMarker(*e)
-		if output == "" {
-			output = marker
-		} else {
-			output = output + "\n\n" + marker
-		}
+	// Match on the stable marker prefix rather than a loose substring so
+	// plan files that happen to mention "unresolved tool error" don't
+	// suppress re-append.
+	if e := result.UnresolvedToolError; e != nil && !strings.Contains(output, agent.UnresolvedToolErrorMarkerPrefix) {
+		output = agent.AppendUnresolvedToolErrorMarker(output, *e)
 	}
 	return output, result.SessionID, nil
 }

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -462,7 +462,18 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	}
 
 	logHandler.flushText()
-	return resolveOutput(result.Text, logHandler, logger), result.SessionID, nil
+	output := resolveOutput(result.Text, logHandler, logger)
+	// If the provider recorded an unresolved tool error, make sure the
+	// marker survives any plan-file substitution performed by resolveOutput.
+	if e := result.UnresolvedToolError; e != nil && !strings.Contains(output, "unresolved tool error") {
+		marker := agent.FormatUnresolvedToolErrorMarker(*e)
+		if output == "" {
+			output = marker
+		} else {
+			output = output + "\n\n" + marker
+		}
+	}
+	return output, result.SessionID, nil
 }
 
 // resolveOutput returns the plan file content if one was detected, otherwise the agent's text output.

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -497,12 +497,11 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 
 	logHandler.flushText()
 	output := resolveOutput(result.Text, logHandler, logger)
-	// If the provider recorded an unresolved tool error, make sure the
-	// marker survives any plan-file substitution performed by resolveOutput.
-	// Match on the stable marker prefix rather than a loose substring so
-	// plan files that happen to mention "unresolved tool error" don't
-	// suppress re-append.
-	if e := result.UnresolvedToolError; e != nil && !strings.Contains(output, agent.UnresolvedToolErrorMarkerPrefix) {
+	// The provider already appended the marker to result.Text. If
+	// resolveOutput replaced it with plan-file content, the marker is
+	// gone — detect that by comparing pointers-of-content and re-append
+	// rather than keying off a fuzzy substring match.
+	if e := result.UnresolvedToolError; e != nil && output != result.Text {
 		output = agent.AppendUnresolvedToolErrorMarker(output, *e)
 	}
 	return output, result.SessionID, nil

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -275,6 +275,19 @@ func (h *logEventHandler) OnError(err error, context string) {
 	h.logger.Debug("agent error", "step", h.step, "error", err, "context", context)
 }
 
+// OnRetry implements agent.RetryHandler: surfaces tool-error retries at INFO
+// so they're visible in jiradozer logs without enabling DEBUG.
+func (h *logEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
+	h.flushText()
+	h.logger.Info("retry on tool error",
+		"step", h.step,
+		"attempt", attempt,
+		"max", max,
+		"tool", tool,
+		"excerpt", truncate(excerpt, 200),
+	)
+}
+
 // rendererEventHandler adapts agent.EventHandler to a render.Renderer for
 // terminal display.
 type rendererEventHandler struct {
@@ -306,6 +319,12 @@ func (h *rendererEventHandler) OnTurnComplete(turnNumber int, success bool, dura
 
 func (h *rendererEventHandler) OnError(err error, ctx string) {
 	h.r.Error(err, ctx)
+}
+
+// OnRetry implements agent.RetryHandler: shows a status line above the
+// streaming output so the terminal user sees the retry decision.
+func (h *rendererEventHandler) OnRetry(attempt, max int, tool, _ string) {
+	h.r.Status(fmt.Sprintf("Retry %d/%d: tool error in %s", attempt, max, tool))
 }
 
 // compositeEventHandler fans out events to multiple handlers.
@@ -357,6 +376,15 @@ func (c *compositeEventHandler) OnSessionInit(sessionID string) {
 	}
 }
 
+// OnRetry fans RetryHandler events out to any handler that implements it.
+func (c *compositeEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
+	for _, h := range c.handlers {
+		if rh, ok := h.(agent.RetryHandler); ok {
+			rh.OnRetry(attempt, max, tool, excerpt)
+		}
+	}
+}
+
 // runAgent runs an agent with the given prompt and step configuration.
 // If renderer is non-nil, agent events are rendered to the terminal in addition
 // to being logged to the log file.
@@ -402,6 +430,9 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	}
 	if cfg.MaxTurns > 0 {
 		opts = append(opts, agent.WithProviderMaxTurns(cfg.MaxTurns))
+	}
+	if cfg.MaxToolErrorRetries > 0 {
+		opts = append(opts, agent.WithProviderMaxToolErrorRetries(cfg.MaxToolErrorRetries))
 	}
 	if cfg.MaxBudgetUSD > 0 {
 		opts = append(opts, agent.WithProviderMaxBudgetUSD(cfg.MaxBudgetUSD))

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -498,9 +498,9 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	logHandler.flushText()
 	output := resolveOutput(result.Text, logHandler, logger)
 	// The provider already appended the marker to result.Text. If
-	// resolveOutput replaced it with plan-file content, the marker is
-	// gone — detect that by comparing pointers-of-content and re-append
-	// rather than keying off a fuzzy substring match.
+	// resolveOutput returned the same string, the marker is still
+	// present; otherwise plan-file substitution replaced it and we
+	// need to re-append so the unresolved-error signal is not lost.
 	if e := result.UnresolvedToolError; e != nil && output != result.Text {
 		output = agent.AppendUnresolvedToolErrorMarker(output, *e)
 	}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -275,8 +275,6 @@ func (h *logEventHandler) OnError(err error, context string) {
 	h.logger.Debug("agent error", "step", h.step, "error", err, "context", context)
 }
 
-// OnRetry implements agent.RetryHandler: surfaces tool-error retries at INFO
-// so they're visible in jiradozer logs without enabling DEBUG.
 func (h *logEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
 	h.flushText()
 	h.logger.Info("retry on tool error",
@@ -284,7 +282,7 @@ func (h *logEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
 		"attempt", attempt,
 		"max", max,
 		"tool", tool,
-		"excerpt", truncate(excerpt, 200),
+		"excerpt", excerpt,
 	)
 }
 
@@ -321,8 +319,6 @@ func (h *rendererEventHandler) OnError(err error, ctx string) {
 	h.r.Error(err, ctx)
 }
 
-// OnRetry implements agent.RetryHandler: shows a status line above the
-// streaming output so the terminal user sees the retry decision.
 func (h *rendererEventHandler) OnRetry(attempt, max int, tool, _ string) {
 	h.r.Status(fmt.Sprintf("Retry %d/%d: tool error in %s", attempt, max, tool))
 }
@@ -376,7 +372,6 @@ func (c *compositeEventHandler) OnSessionInit(sessionID string) {
 	}
 }
 
-// OnRetry fans RetryHandler events out to any handler that implements it.
 func (c *compositeEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
 	for _, h := range c.handlers {
 		if rh, ok := h.(agent.RetryHandler); ok {

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -62,26 +62,28 @@ func (s SourceConfig) HasSource() bool {
 
 // StepConfig configures a single workflow step (plan or build).
 type StepConfig struct {
-	Prompt         string        `yaml:"prompt"`          // Go text/template; empty = built-in default
-	SystemPrompt   string        `yaml:"system_prompt"`   // optional system prompt passed to the agent
-	Model          string        `yaml:"model"`           // override agent.model; empty = inherit
-	PermissionMode string        `yaml:"permission_mode"` // "plan", "bypass", etc.; empty = step default
-	Rounds         []RoundConfig `yaml:"rounds"`          // multi-round execution; mutually exclusive with Prompt
-	MaxBudgetUSD   float64       `yaml:"max_budget_usd"`  // override top-level; 0 = inherit
-	MaxTurns       int           `yaml:"max_turns"`
-	AutoApprove    bool          `yaml:"auto_approve"` // skip human review after this step
+	Prompt              string        `yaml:"prompt"`          // Go text/template; empty = built-in default
+	SystemPrompt        string        `yaml:"system_prompt"`   // optional system prompt passed to the agent
+	Model               string        `yaml:"model"`           // override agent.model; empty = inherit
+	PermissionMode      string        `yaml:"permission_mode"` // "plan", "bypass", etc.; empty = step default
+	Rounds              []RoundConfig `yaml:"rounds"`          // multi-round execution; mutually exclusive with Prompt
+	MaxBudgetUSD        float64       `yaml:"max_budget_usd"`  // override top-level; 0 = inherit
+	MaxTurns            int           `yaml:"max_turns"`
+	MaxToolErrorRetries int           `yaml:"max_tool_error_retries"` // retries when a turn ends with an unresolved tool error; 0 = disabled
+	AutoApprove         bool          `yaml:"auto_approve"`           // skip human review after this step
 }
 
 // RoundConfig configures a single round within a multi-round step.
 // Zero-value fields inherit from the parent StepConfig.
 // Exactly one of Prompt or Command must be set.
 type RoundConfig struct {
-	Prompt       string  `yaml:"prompt"`         // Go text/template; mutually exclusive with Command
-	Command      string  `yaml:"command"`        // Shell command template (sh -c); mutually exclusive with Prompt. WARNING: tracker fields like Title/Description are user-controlled — only interpolate them when the issue source is fully trusted.
-	SystemPrompt string  `yaml:"system_prompt"`  // optional system prompt (agent rounds only)
-	Model        string  `yaml:"model"`          // override; empty = inherit from step (agent rounds only)
-	MaxTurns     int     `yaml:"max_turns"`      // override; 0 = inherit from step (agent rounds only)
-	MaxBudgetUSD float64 `yaml:"max_budget_usd"` // override; 0 = inherit from step (agent rounds only)
+	Prompt              string  `yaml:"prompt"`                 // Go text/template; mutually exclusive with Command
+	Command             string  `yaml:"command"`                // Shell command template (sh -c); mutually exclusive with Prompt. WARNING: tracker fields like Title/Description are user-controlled — only interpolate them when the issue source is fully trusted.
+	SystemPrompt        string  `yaml:"system_prompt"`          // optional system prompt (agent rounds only)
+	Model               string  `yaml:"model"`                  // override; empty = inherit from step (agent rounds only)
+	MaxTurns            int     `yaml:"max_turns"`              // override; 0 = inherit from step (agent rounds only)
+	MaxToolErrorRetries int     `yaml:"max_tool_error_retries"` // override; 0 = inherit from step (agent rounds only)
+	MaxBudgetUSD        float64 `yaml:"max_budget_usd"`         // override; 0 = inherit from step (agent rounds only)
 }
 
 // IsCommand reports whether this round runs a shell command instead of an agent session.
@@ -265,6 +267,11 @@ func ResolveRound(round RoundConfig, parent StepConfig) StepConfig {
 		resolved.MaxBudgetUSD = round.MaxBudgetUSD
 	} else {
 		resolved.MaxBudgetUSD = parent.MaxBudgetUSD
+	}
+	if round.MaxToolErrorRetries > 0 {
+		resolved.MaxToolErrorRetries = round.MaxToolErrorRetries
+	} else {
+		resolved.MaxToolErrorRetries = parent.MaxToolErrorRetries
 	}
 	return resolved
 }

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -107,6 +107,10 @@ validate:
   permission_mode: bypass               # default: "bypass" — inherited by all rounds
   max_turns: 10                         # default: 10 — inherited by rounds unless overridden
   # max_budget_usd: 0                   # default: inherits from top-level — per-round default
+  # Retry up to 3x when a turn ends with an unresolved tool error
+  # (e.g. parallel-cancelled Bash siblings). 0 disables the feature.
+  # Each retry is a full agent turn — budget wall-clock accordingly.
+  max_tool_error_retries: 3             # default: 0 (disabled)
   auto_approve: false                   # default: false — applies after ALL rounds complete
   rounds:
     - prompt: |

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -191,17 +191,14 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		}
 		if ctx.Err() != nil {
 			stopReason = RetryStopCtxCancelled
-			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 			break
 		}
 		if time.Since(start) >= budget {
 			stopReason = RetryStopBudgetExceeded
-			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 			break
 		}
 		if havePrev && excerpt == prevExcerpt {
 			stopReason = RetryStopNoProgress
-			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 			break
 		}
 		prevExcerpt = excerpt
@@ -232,6 +229,10 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			}
 			agentResult.UnresolvedToolError = unresolved
 			agentResult.Text = AppendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
+			// Fire the abort callback once per loop execution that stopped
+			// with a tool error still present. Unifies the four stop reasons
+			// (exhausted, no_progress, budget_exceeded, ctx_cancelled).
+			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 		}
 	}
 	return agentResult, nil

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -16,7 +16,12 @@ const retryPromptTemplate = `Your previous turn ended with a tool error that was
 
 This is the source of the failure — if a sibling tool in a parallel batch was cancelled, the real error is in the *other* sibling. Fix the underlying problem and continue the task. Do not stop until the task is complete or you have a concrete blocker to report.`
 
-const unresolvedToolErrorMarkerTemplate = "[unresolved tool error after %d/%d retries — tool: %s\n excerpt: %s]"
+// UnresolvedToolErrorMarkerPrefix is a stable prefix that identifies the
+// unresolved-tool-error marker in agent text output. Callers can use it to
+// detect whether the marker is already present before re-appending.
+const UnresolvedToolErrorMarkerPrefix = "[unresolved tool error after "
+
+const unresolvedToolErrorMarkerTemplate = UnresolvedToolErrorMarkerPrefix + "%d/%d retries — tool: %s\n excerpt: %s]"
 
 // FormatUnresolvedToolErrorMarker returns the marker string used to surface
 // an unresolved tool error in agent text output. Callers that replace
@@ -24,6 +29,17 @@ const unresolvedToolErrorMarkerTemplate = "[unresolved tool error after %d/%d re
 // marker so the failure is not silently dropped.
 func FormatUnresolvedToolErrorMarker(e UnresolvedToolError) string {
 	return fmt.Sprintf(unresolvedToolErrorMarkerTemplate, e.Attempts, e.Max, e.Tool, e.Excerpt)
+}
+
+// AppendUnresolvedToolErrorMarker appends the marker to text, using a blank
+// separator when text is non-empty. Exported for callers that re-append the
+// marker after downstream text substitution.
+func AppendUnresolvedToolErrorMarker(text string, e UnresolvedToolError) string {
+	marker := FormatUnresolvedToolErrorMarker(e)
+	if text == "" {
+		return marker
+	}
+	return text + "\n\n" + marker
 }
 
 const minRetryWallClockBudget = 10 * time.Minute
@@ -40,14 +56,6 @@ func buildRetryPrompt(toolName, excerpt string) string {
 	return fmt.Sprintf(retryPromptTemplate, toolName, excerpt)
 }
 
-func appendUnresolvedToolErrorMarker(text string, e UnresolvedToolError) string {
-	marker := FormatUnresolvedToolErrorMarker(e)
-	if text == "" {
-		return marker
-	}
-	return text + "\n\n" + marker
-}
-
 // emitRetry fires the hook before each follow-up Ask so logs see the
 // decision even if the retry subsequently hangs.
 func emitRetry(h EventHandler, attempt, max int, toolName, excerpt string) {
@@ -56,6 +64,15 @@ func emitRetry(h EventHandler, attempt, max int, toolName, excerpt string) {
 	}
 	if rh, ok := h.(RetryHandler); ok {
 		rh.OnRetry(attempt, max, toolName, excerpt)
+	}
+}
+
+func emitRetryAbort(h EventHandler, reason, toolName, excerpt string) {
+	if h == nil {
+		return
+	}
+	if rh, ok := h.(RetryHandler); ok {
+		rh.OnRetryAbort(reason, toolName, excerpt)
 	}
 }
 
@@ -155,10 +172,15 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	)
 	for attempts < cfg.MaxToolErrorRetries {
 		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
-		if !ok || ctx.Err() != nil || time.Since(start) >= budget {
+		if !ok || ctx.Err() != nil {
+			break
+		}
+		if time.Since(start) >= budget {
+			emitRetryAbort(cfg.EventHandler, "budget_exceeded", toolName, excerpt)
 			break
 		}
 		if attempts > 0 && excerpt == prevExcerpt {
+			emitRetryAbort(cfg.EventHandler, "no_progress", toolName, excerpt)
 			break
 		}
 		prevExcerpt = excerpt
@@ -186,7 +208,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 				Max:      cfg.MaxToolErrorRetries,
 			}
 			agentResult.UnresolvedToolError = unresolved
-			agentResult.Text = appendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
+			agentResult.Text = AppendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
 		}
 	}
 	return agentResult, nil

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -2,10 +2,70 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 	"github.com/bazelment/yoloswe/wt"
 )
+
+// retryPromptTemplate is the user message sent when a turn ends with an
+// unresolved tool error. It restates the failing tool and a short excerpt
+// (the model's own history already has the full result, but restating
+// makes the "act on this" signal unambiguous) and specifically names the
+// parallel-cancellation footgun so the model doesn't try to "fix" the
+// cancelled sibling rather than the real cause.
+const retryPromptTemplate = `Your previous turn ended with a tool error that was not addressed:
+
+  tool: %s
+  result: %s
+
+This is the source of the failure — if a sibling tool in a parallel batch was cancelled, the real error is in the *other* sibling. Fix the underlying problem and continue the task. Do not stop until the task is complete or you have a concrete blocker to report.`
+
+// unresolvedToolErrorMarkerTemplate is appended to AgentResult.Text when
+// the retry loop exits with a still-errored final turn. Downstream round
+// logic sees this textually and can surface it in the round's comment.
+const unresolvedToolErrorMarkerTemplate = "\n\n[unresolved tool error after %d/%d retries — tool: %s\n excerpt: %s]"
+
+// minRetryWallClockBudget is the floor for computeRetryTimeBudget. The
+// budget is max(this, cfg.MaxTurns * 1 minute) to keep short-turn configs
+// from getting an unreasonably tight ceiling while still bounding runaway.
+const minRetryWallClockBudget = 10 * time.Minute
+
+// computeRetryTimeBudget returns the wall-clock cap for the retry loop,
+// measured from the start of the *original* Ask. Prevents runaway where
+// each retry takes 5+ minutes of agent work.
+func computeRetryTimeBudget(cfg ExecuteConfig) time.Duration {
+	turnBudget := time.Duration(cfg.MaxTurns) * time.Minute
+	if turnBudget > minRetryWallClockBudget {
+		return turnBudget
+	}
+	return minRetryWallClockBudget
+}
+
+// buildRetryPrompt renders the user message sent to the session on retry.
+func buildRetryPrompt(toolName, excerpt string) string {
+	return fmt.Sprintf(retryPromptTemplate, toolName, excerpt)
+}
+
+// appendUnresolvedToolErrorMarker annotates agent output with a marker
+// describing the unresolved tool error. Consumers (e.g. jiradozer round
+// comments) see this textually and can flag it for triage.
+func appendUnresolvedToolErrorMarker(text string, attempts, max int, toolName, excerpt string) string {
+	return text + fmt.Sprintf(unresolvedToolErrorMarkerTemplate, attempts, max, toolName, excerpt)
+}
+
+// emitRetry fires the optional RetryHandler hook on an EventHandler, if the
+// handler implements it. Called before each follow-up Ask so logs and the
+// renderer see the decision even if the retry subsequently hangs.
+func emitRetry(h EventHandler, attempt, max int, toolName, excerpt string) {
+	if h == nil {
+		return
+	}
+	if rh, ok := h.(RetryHandler); ok {
+		rh.OnRetry(attempt, max, toolName, excerpt)
+	}
+}
 
 // ClaudeProvider wraps the Claude SDK behind the Provider interface.
 type ClaudeProvider struct {
@@ -89,15 +149,66 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		}
 	}()
 
-	// Execute single turn
+	// Execute the initial turn. When MaxToolErrorRetries > 0, the retry
+	// loop below keeps the same live session alive and injects follow-up
+	// user messages for turns that end with an unresolved tool error.
+	start := time.Now()
+	budget := computeRetryTimeBudget(cfg)
+
 	result, err := session.Ask(ctx, fullPrompt)
 	if err != nil {
 		return nil, err
 	}
 
+	var (
+		prevExcerpt  string
+		lastToolName string
+		lastExcerpt  string
+		lastOK       bool
+		attempts     int
+	)
+	for attempt := 1; attempt <= cfg.MaxToolErrorRetries; attempt++ {
+		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
+		lastToolName, lastExcerpt, lastOK = toolName, excerpt, ok
+		if !ok {
+			break
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		if time.Since(start) >= budget {
+			break
+		}
+		if prevExcerpt != "" && excerpt == prevExcerpt {
+			// No-progress guard: the model is stuck on the same error, so
+			// further retries will waste turns. Exit and let the marker
+			// surface the failure.
+			break
+		}
+		prevExcerpt = excerpt
+		attempts = attempt
+
+		emitRetry(cfg.EventHandler, attempt, cfg.MaxToolErrorRetries, toolName, excerpt)
+
+		next, askErr := session.Ask(ctx, buildRetryPrompt(toolName, excerpt))
+		if askErr != nil {
+			return nil, askErr
+		}
+		result = next
+		// Recompute after the retry; if the new turn is clean we'll break
+		// on the next iteration's FinalTurnToolError check.
+		lastToolName, lastExcerpt, lastOK = claude.FinalTurnToolError(result.ContentBlocks)
+	}
+
 	agentResult := ClaudeResultToAgentResult(result)
 	if info := session.Info(); info != nil {
 		agentResult.SessionID = info.SessionID
+	}
+	// If the retry loop exited with a still-errored final turn, annotate
+	// the output so downstream round logic can surface the failure.
+	if lastOK && cfg.MaxToolErrorRetries > 0 {
+		agentResult.Text = appendUnresolvedToolErrorMarker(
+			agentResult.Text, attempts, cfg.MaxToolErrorRetries, lastToolName, lastExcerpt)
 	}
 	return agentResult, nil
 }

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -9,12 +9,6 @@ import (
 	"github.com/bazelment/yoloswe/wt"
 )
 
-// retryPromptTemplate is the user message sent when a turn ends with an
-// unresolved tool error. It restates the failing tool and a short excerpt
-// (the model's own history already has the full result, but restating
-// makes the "act on this" signal unambiguous) and specifically names the
-// parallel-cancellation footgun so the model doesn't try to "fix" the
-// cancelled sibling rather than the real cause.
 const retryPromptTemplate = `Your previous turn ended with a tool error that was not addressed:
 
   tool: %s
@@ -22,19 +16,10 @@ const retryPromptTemplate = `Your previous turn ended with a tool error that was
 
 This is the source of the failure — if a sibling tool in a parallel batch was cancelled, the real error is in the *other* sibling. Fix the underlying problem and continue the task. Do not stop until the task is complete or you have a concrete blocker to report.`
 
-// unresolvedToolErrorMarkerTemplate is appended to AgentResult.Text when
-// the retry loop exits with a still-errored final turn. Downstream round
-// logic sees this textually and can surface it in the round's comment.
 const unresolvedToolErrorMarkerTemplate = "\n\n[unresolved tool error after %d/%d retries — tool: %s\n excerpt: %s]"
 
-// minRetryWallClockBudget is the floor for computeRetryTimeBudget. The
-// budget is max(this, cfg.MaxTurns * 1 minute) to keep short-turn configs
-// from getting an unreasonably tight ceiling while still bounding runaway.
 const minRetryWallClockBudget = 10 * time.Minute
 
-// computeRetryTimeBudget returns the wall-clock cap for the retry loop,
-// measured from the start of the *original* Ask. Prevents runaway where
-// each retry takes 5+ minutes of agent work.
 func computeRetryTimeBudget(cfg ExecuteConfig) time.Duration {
 	turnBudget := time.Duration(cfg.MaxTurns) * time.Minute
 	if turnBudget > minRetryWallClockBudget {
@@ -43,21 +28,16 @@ func computeRetryTimeBudget(cfg ExecuteConfig) time.Duration {
 	return minRetryWallClockBudget
 }
 
-// buildRetryPrompt renders the user message sent to the session on retry.
 func buildRetryPrompt(toolName, excerpt string) string {
 	return fmt.Sprintf(retryPromptTemplate, toolName, excerpt)
 }
 
-// appendUnresolvedToolErrorMarker annotates agent output with a marker
-// describing the unresolved tool error. Consumers (e.g. jiradozer round
-// comments) see this textually and can flag it for triage.
 func appendUnresolvedToolErrorMarker(text string, attempts, max int, toolName, excerpt string) string {
 	return text + fmt.Sprintf(unresolvedToolErrorMarkerTemplate, attempts, max, toolName, excerpt)
 }
 
-// emitRetry fires the optional RetryHandler hook on an EventHandler, if the
-// handler implements it. Called before each follow-up Ask so logs and the
-// renderer see the decision even if the retry subsequently hangs.
+// emitRetry fires the hook before each follow-up Ask so logs see the
+// decision even if the retry subsequently hangs.
 func emitRetry(h EventHandler, attempt, max int, toolName, excerpt string) {
 	if h == nil {
 		return
@@ -149,9 +129,6 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		}
 	}()
 
-	// Execute the initial turn. When MaxToolErrorRetries > 0, the retry
-	// loop below keeps the same live session alive and injects follow-up
-	// user messages for turns that end with an unresolved tool error.
 	start := time.Now()
 	budget := computeRetryTimeBudget(cfg)
 
@@ -161,54 +138,38 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	}
 
 	var (
-		prevExcerpt  string
-		lastToolName string
-		lastExcerpt  string
-		lastOK       bool
-		attempts     int
+		prevExcerpt string
+		attempts    int
 	)
-	for attempt := 1; attempt <= cfg.MaxToolErrorRetries; attempt++ {
+	for attempts < cfg.MaxToolErrorRetries {
 		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
-		lastToolName, lastExcerpt, lastOK = toolName, excerpt, ok
-		if !ok {
+		if !ok || ctx.Err() != nil || time.Since(start) >= budget {
 			break
 		}
-		if ctx.Err() != nil {
-			break
-		}
-		if time.Since(start) >= budget {
-			break
-		}
-		if prevExcerpt != "" && excerpt == prevExcerpt {
-			// No-progress guard: the model is stuck on the same error, so
-			// further retries will waste turns. Exit and let the marker
-			// surface the failure.
+		if attempts > 0 && excerpt == prevExcerpt {
 			break
 		}
 		prevExcerpt = excerpt
-		attempts = attempt
+		attempts++
 
-		emitRetry(cfg.EventHandler, attempt, cfg.MaxToolErrorRetries, toolName, excerpt)
+		emitRetry(cfg.EventHandler, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)
 
 		next, askErr := session.Ask(ctx, buildRetryPrompt(toolName, excerpt))
 		if askErr != nil {
 			return nil, askErr
 		}
 		result = next
-		// Recompute after the retry; if the new turn is clean we'll break
-		// on the next iteration's FinalTurnToolError check.
-		lastToolName, lastExcerpt, lastOK = claude.FinalTurnToolError(result.ContentBlocks)
 	}
 
 	agentResult := ClaudeResultToAgentResult(result)
 	if info := session.Info(); info != nil {
 		agentResult.SessionID = info.SessionID
 	}
-	// If the retry loop exited with a still-errored final turn, annotate
-	// the output so downstream round logic can surface the failure.
-	if lastOK && cfg.MaxToolErrorRetries > 0 {
-		agentResult.Text = appendUnresolvedToolErrorMarker(
-			agentResult.Text, attempts, cfg.MaxToolErrorRetries, lastToolName, lastExcerpt)
+	if cfg.MaxToolErrorRetries > 0 {
+		if toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks); ok {
+			agentResult.Text = appendUnresolvedToolErrorMarker(
+				agentResult.Text, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)
+		}
 	}
 	return agentResult, nil
 }

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -168,22 +168,28 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 
 	var (
 		prevExcerpt string
+		havePrev    bool
 		attempts    int
 	)
 	for attempts < cfg.MaxToolErrorRetries {
 		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
-		if !ok || ctx.Err() != nil {
+		if !ok {
+			break
+		}
+		if ctx.Err() != nil {
+			emitRetryAbort(cfg.EventHandler, "ctx_cancelled", toolName, excerpt)
 			break
 		}
 		if time.Since(start) >= budget {
 			emitRetryAbort(cfg.EventHandler, "budget_exceeded", toolName, excerpt)
 			break
 		}
-		if attempts > 0 && excerpt == prevExcerpt {
+		if havePrev && excerpt == prevExcerpt {
 			emitRetryAbort(cfg.EventHandler, "no_progress", toolName, excerpt)
 			break
 		}
 		prevExcerpt = excerpt
+		havePrev = true
 		attempts++
 
 		emitRetry(cfg.EventHandler, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -9,12 +9,7 @@ import (
 	"github.com/bazelment/yoloswe/wt"
 )
 
-const retryPromptTemplate = `Your previous turn ended with a tool error that was not addressed:
-
-  tool: %s
-  result: %s
-
-This is the source of the failure — if a sibling tool in a parallel batch was cancelled, the real error is in the *other* sibling. Fix the underlying problem and continue the task. Do not stop until the task is complete or you have a concrete blocker to report.`
+const retryPrompt = "retry"
 
 // UnresolvedToolErrorMarkerPrefix is a stable prefix that identifies the
 // unresolved-tool-error marker in agent text output. Callers can use it to
@@ -64,8 +59,8 @@ func computeRetryTimeBudget(cfg ExecuteConfig) time.Duration {
 	return minRetryWallClockBudget
 }
 
-func buildRetryPrompt(toolName, excerpt string) string {
-	return fmt.Sprintf(retryPromptTemplate, toolName, excerpt)
+func buildRetryPrompt() string {
+	return retryPrompt
 }
 
 // emitRetry fires the hook before each follow-up Ask so logs see the
@@ -207,7 +202,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 
 		emitRetry(cfg.EventHandler, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)
 
-		next, askErr := session.Ask(ctx, buildRetryPrompt(toolName, excerpt))
+		next, askErr := session.Ask(ctx, buildRetryPrompt())
 		if askErr != nil {
 			return nil, askErr
 		}

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -16,7 +16,15 @@ const retryPromptTemplate = `Your previous turn ended with a tool error that was
 
 This is the source of the failure — if a sibling tool in a parallel batch was cancelled, the real error is in the *other* sibling. Fix the underlying problem and continue the task. Do not stop until the task is complete or you have a concrete blocker to report.`
 
-const unresolvedToolErrorMarkerTemplate = "\n\n[unresolved tool error after %d/%d retries — tool: %s\n excerpt: %s]"
+const unresolvedToolErrorMarkerTemplate = "[unresolved tool error after %d/%d retries — tool: %s\n excerpt: %s]"
+
+// FormatUnresolvedToolErrorMarker returns the marker string used to surface
+// an unresolved tool error in agent text output. Callers that replace
+// AgentResult.Text downstream (e.g. plan-file readers) should re-append this
+// marker so the failure is not silently dropped.
+func FormatUnresolvedToolErrorMarker(e UnresolvedToolError) string {
+	return fmt.Sprintf(unresolvedToolErrorMarkerTemplate, e.Attempts, e.Max, e.Tool, e.Excerpt)
+}
 
 const minRetryWallClockBudget = 10 * time.Minute
 
@@ -32,8 +40,12 @@ func buildRetryPrompt(toolName, excerpt string) string {
 	return fmt.Sprintf(retryPromptTemplate, toolName, excerpt)
 }
 
-func appendUnresolvedToolErrorMarker(text string, attempts, max int, toolName, excerpt string) string {
-	return text + fmt.Sprintf(unresolvedToolErrorMarkerTemplate, attempts, max, toolName, excerpt)
+func appendUnresolvedToolErrorMarker(text string, e UnresolvedToolError) string {
+	marker := FormatUnresolvedToolErrorMarker(e)
+	if text == "" {
+		return marker
+	}
+	return text + "\n\n" + marker
 }
 
 // emitRetry fires the hook before each follow-up Ask so logs see the
@@ -167,8 +179,14 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	}
 	if cfg.MaxToolErrorRetries > 0 {
 		if toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks); ok {
-			agentResult.Text = appendUnresolvedToolErrorMarker(
-				agentResult.Text, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)
+			unresolved := &UnresolvedToolError{
+				Tool:     toolName,
+				Excerpt:  excerpt,
+				Attempts: attempts,
+				Max:      cfg.MaxToolErrorRetries,
+			}
+			agentResult.UnresolvedToolError = unresolved
+			agentResult.Text = appendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
 		}
 	}
 	return agentResult, nil

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -19,16 +19,28 @@ This is the source of the failure — if a sibling tool in a parallel batch was 
 // UnresolvedToolErrorMarkerPrefix is a stable prefix that identifies the
 // unresolved-tool-error marker in agent text output. Callers can use it to
 // detect whether the marker is already present before re-appending.
-const UnresolvedToolErrorMarkerPrefix = "[unresolved tool error after "
+const UnresolvedToolErrorMarkerPrefix = "[unresolved tool error ("
 
-const unresolvedToolErrorMarkerTemplate = UnresolvedToolErrorMarkerPrefix + "%d/%d retries — tool: %s\n excerpt: %s]"
+const unresolvedToolErrorMarkerTemplate = UnresolvedToolErrorMarkerPrefix + "%s) after %d/%d retries — tool: %s\n excerpt: %s]"
+
+// Abort-reason constants for UnresolvedToolError.Reason.
+const (
+	RetryStopExhausted      = "exhausted"
+	RetryStopNoProgress     = "no_progress"
+	RetryStopBudgetExceeded = "budget_exceeded"
+	RetryStopCtxCancelled   = "ctx_cancelled"
+)
 
 // FormatUnresolvedToolErrorMarker returns the marker string used to surface
 // an unresolved tool error in agent text output. Callers that replace
 // AgentResult.Text downstream (e.g. plan-file readers) should re-append this
 // marker so the failure is not silently dropped.
 func FormatUnresolvedToolErrorMarker(e UnresolvedToolError) string {
-	return fmt.Sprintf(unresolvedToolErrorMarkerTemplate, e.Attempts, e.Max, e.Tool, e.Excerpt)
+	reason := e.Reason
+	if reason == "" {
+		reason = RetryStopExhausted
+	}
+	return fmt.Sprintf(unresolvedToolErrorMarkerTemplate, reason, e.Attempts, e.Max, e.Tool, e.Excerpt)
 }
 
 // AppendUnresolvedToolErrorMarker appends the marker to text, using a blank
@@ -170,6 +182,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		prevExcerpt string
 		havePrev    bool
 		attempts    int
+		stopReason  = RetryStopExhausted
 	)
 	for attempts < cfg.MaxToolErrorRetries {
 		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
@@ -177,15 +190,18 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			break
 		}
 		if ctx.Err() != nil {
-			emitRetryAbort(cfg.EventHandler, "ctx_cancelled", toolName, excerpt)
+			stopReason = RetryStopCtxCancelled
+			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 			break
 		}
 		if time.Since(start) >= budget {
-			emitRetryAbort(cfg.EventHandler, "budget_exceeded", toolName, excerpt)
+			stopReason = RetryStopBudgetExceeded
+			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 			break
 		}
 		if havePrev && excerpt == prevExcerpt {
-			emitRetryAbort(cfg.EventHandler, "no_progress", toolName, excerpt)
+			stopReason = RetryStopNoProgress
+			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 			break
 		}
 		prevExcerpt = excerpt
@@ -210,6 +226,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			unresolved := &UnresolvedToolError{
 				Tool:     toolName,
 				Excerpt:  excerpt,
+				Reason:   stopReason,
 				Attempts: attempts,
 				Max:      cfg.MaxToolErrorRetries,
 			}

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -9,14 +9,26 @@ import (
 // AgentResult is the provider-agnostic result of an agent execution.
 // It replaces direct dependency on claude.TurnResult in the agent interfaces.
 type AgentResult struct {
-	Error         error
-	Text          string
-	Thinking      string
-	SessionID     string
-	ContentBlocks []AgentContentBlock
-	Usage         AgentUsage
-	DurationMs    int64
-	Success       bool
+	Error               error
+	UnresolvedToolError *UnresolvedToolError
+	Text                string
+	Thinking            string
+	SessionID           string
+	ContentBlocks       []AgentContentBlock
+	Usage               AgentUsage
+	DurationMs          int64
+	Success             bool
+}
+
+// UnresolvedToolError records an unresolved tool error that persisted after
+// the retry budget was exhausted. Consumers can surface it independently of
+// AgentResult.Text, which may be replaced downstream (e.g. when a plan file
+// is read instead of the agent's text).
+type UnresolvedToolError struct {
+	Tool     string
+	Excerpt  string
+	Attempts int
+	Max      int
 }
 
 // AgentContentBlock is a provider-agnostic content block.

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -124,10 +124,8 @@ type SessionInitHandler interface {
 	OnSessionInit(sessionID string)
 }
 
-// RetryHandler is an optional interface that EventHandler implementations can
-// implement to observe tool-error retries. Emitted by ClaudeProvider.Execute
-// before each follow-up turn when MaxToolErrorRetries > 0 and the previous
-// turn ended with an unresolved tool error.
+// RetryHandler is an optional EventHandler extension fired before each
+// tool-error retry turn.
 type RetryHandler interface {
 	OnRetry(attempt, max int, tool, excerpt string)
 }

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -21,12 +21,15 @@ type AgentResult struct {
 }
 
 // UnresolvedToolError records an unresolved tool error that persisted after
-// the retry budget was exhausted. Consumers can surface it independently of
+// the retry loop stopped. Consumers can surface it independently of
 // AgentResult.Text, which may be replaced downstream (e.g. when a plan file
-// is read instead of the agent's text).
+// is read instead of the agent's text). Reason distinguishes why the loop
+// stopped — "exhausted" (count budget reached), "budget_exceeded",
+// "no_progress", or "ctx_cancelled".
 type UnresolvedToolError struct {
 	Tool     string
 	Excerpt  string
+	Reason   string
 	Attempts int
 	Max      int
 }
@@ -141,9 +144,8 @@ type SessionInitHandler interface {
 type RetryHandler interface {
 	OnRetry(attempt, max int, tool, excerpt string)
 	// OnRetryAbort fires when the retry loop exits before reaching the
-	// count budget — e.g. because the no-progress guard tripped or the
-	// wall-clock budget elapsed. reason is a short, log-safe token
-	// ("no_progress", "budget_exceeded").
+	// count budget. reason is one of "no_progress", "budget_exceeded",
+	// or "ctx_cancelled".
 	OnRetryAbort(reason, tool, excerpt string)
 }
 

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -124,6 +124,14 @@ type SessionInitHandler interface {
 	OnSessionInit(sessionID string)
 }
 
+// RetryHandler is an optional interface that EventHandler implementations can
+// implement to observe tool-error retries. Emitted by ClaudeProvider.Execute
+// before each follow-up turn when MaxToolErrorRetries > 0 and the previous
+// turn ended with an unresolved tool error.
+type RetryHandler interface {
+	OnRetry(attempt, max int, tool, excerpt string)
+}
+
 // Provider is the pluggable interface for agent backends.
 // Adding a new backend (Gemini, Codex, etc.) means implementing this interface.
 type Provider interface {
@@ -160,15 +168,16 @@ type ExecuteOption func(*ExecuteConfig)
 
 // ExecuteConfig holds execution configuration.
 type ExecuteConfig struct {
-	EventHandler     EventHandler
-	Model            string
-	WorkDir          string
-	SystemPrompt     string
-	PermissionMode   string
-	ResumeSessionID  string
-	MaxTurns         int
-	MaxBudgetUSD     float64
-	KeepUserSettings bool
+	EventHandler        EventHandler
+	Model               string
+	WorkDir             string
+	SystemPrompt        string
+	PermissionMode      string
+	ResumeSessionID     string
+	MaxTurns            int
+	MaxToolErrorRetries int
+	MaxBudgetUSD        float64
+	KeepUserSettings    bool
 }
 
 // WithProviderModel sets the model for a provider execution.
@@ -216,6 +225,13 @@ func WithProviderKeepUserSettings() ExecuteOption {
 // WithProviderResumeSessionID sets a session ID to resume instead of starting fresh.
 func WithProviderResumeSessionID(id string) ExecuteOption {
 	return func(c *ExecuteConfig) { c.ResumeSessionID = id }
+}
+
+// WithProviderMaxToolErrorRetries sets the maximum number of auto-retries
+// performed when a turn ends with an unresolved tool error. Zero disables
+// the feature (the provider returns the errored result without retrying).
+func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
+	return func(c *ExecuteConfig) { c.MaxToolErrorRetries = n }
 }
 
 // applyOptions applies ExecuteOptions to a config, returning defaults for unset fields.

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -137,9 +137,14 @@ type SessionInitHandler interface {
 }
 
 // RetryHandler is an optional EventHandler extension fired before each
-// tool-error retry turn.
+// tool-error retry turn and when the retry loop aborts early.
 type RetryHandler interface {
 	OnRetry(attempt, max int, tool, excerpt string)
+	// OnRetryAbort fires when the retry loop exits before reaching the
+	// count budget — e.g. because the no-progress guard tripped or the
+	// wall-clock budget elapsed. reason is a short, log-safe token
+	// ("no_progress", "budget_exceeded").
+	OnRetryAbort(reason, tool, excerpt string)
 }
 
 // Provider is the pluggable interface for agent backends.

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -140,12 +140,16 @@ type SessionInitHandler interface {
 }
 
 // RetryHandler is an optional EventHandler extension fired before each
-// tool-error retry turn and when the retry loop aborts early.
+// tool-error retry turn and when the retry loop stops with an
+// unresolved tool error still present.
 type RetryHandler interface {
 	OnRetry(attempt, max int, tool, excerpt string)
-	// OnRetryAbort fires when the retry loop exits before reaching the
-	// count budget. reason is one of "no_progress", "budget_exceeded",
-	// or "ctx_cancelled".
+	// OnRetryAbort fires once per retry-loop execution when the loop
+	// stops while a tool error is still present. reason is one of
+	// "exhausted" (count budget reached), "no_progress",
+	// "budget_exceeded", or "ctx_cancelled". The same reason is
+	// carried on UnresolvedToolError.Reason and in the appended
+	// marker, so handlers can correlate logs with downstream output.
 	OnRetryAbort(reason, tool, excerpt string)
 }
 


### PR DESCRIPTION
## Summary
- Detect turns that end with an unresolved `<tool_use_error>` (common when a parallel tool batch sibling fails and Claude cancels the others) via new `claude.FinalTurnToolError`.
- Add an opt-in retry loop in `ClaudeProvider.Execute` that keeps the live session alive and injects a follow-up user message naming the real failing tool and excerpt. Gated by `max_tool_error_retries` (default 0 = disabled), with a wall-clock budget and a no-progress guard.
- Wire the new `max_tool_error_retries` knob through `jiradozer` `StepConfig`/`RoundConfig` and surface retries via a new optional `RetryHandler` (logged at INFO, rendered as a status line).
- Design doc: `docs/design/jiradozer-tool-error-retry.md`.

## Test plan
- [x] `scripts/lint.sh`
- [x] `bazel build //agent-cli-wrapper/claude/... //jiradozer/... //multiagent/...`
- [x] `bazel test //agent-cli-wrapper/claude/... //jiradozer/... //multiagent/...` (incl. new `turn_retry_test.go`)
- [ ] Exercise end-to-end on a real jiradozer run with `max_tool_error_retries: 3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an opt-in multi-turn retry loop to `ClaudeProvider.Execute` and propagates new config/event surfaces, which can change agent control flow, wall-clock cost, and output formatting when enabled.
> 
> **Overview**
> Prevents jiradozer rounds from silently succeeding when a turn ends with an unresolved tool failure by detecting errored `tool_result` blocks (including `<tool_use_error>` sentinel drift) via new `claude.FinalTurnToolError`.
> 
> Adds an opt-in retry loop in `ClaudeProvider.Execute` (`max_tool_error_retries`) with guardrails (context cancellation, wall-clock budget, no-progress detection), and if errors persist, appends a stable **unresolved tool error** marker to the final text plus structured metadata on `AgentResult.UnresolvedToolError`.
> 
> Wires the new knob through `StepConfig`/`RoundConfig`, introduces optional `agent.RetryHandler` callbacks for observability (logged/rendered in jiradozer), and documents the design in `docs/design/jiradozer-tool-error-retry.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13e585460bbabcc54ef088e78207505a84b1d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->