### PR TITLE
jiradozer: gate retry loop on real tool errors and bg work

### DIFF
--- a/agent-cli-wrapper/acp/events.go
+++ b/agent-cli-wrapper/acp/events.go
@@ -140,10 +140,11 @@ func (e TurnCompleteEvent) Type() EventType { return EventTypeTurnComplete }
 func (e TurnCompleteEvent) StreamEventKind() agentstream.EventKind {
 	return agentstream.KindTurnComplete
 }
-func (e TurnCompleteEvent) StreamTurnNum() int    { return e.TurnNumber }
-func (e TurnCompleteEvent) StreamIsSuccess() bool { return e.Success }
-func (e TurnCompleteEvent) StreamDuration() int64 { return e.DurationMs }
-func (e TurnCompleteEvent) StreamCost() float64   { return 0 }
+func (e TurnCompleteEvent) StreamTurnNum() int                { return e.TurnNumber }
+func (e TurnCompleteEvent) StreamIsSuccess() bool             { return e.Success }
+func (e TurnCompleteEvent) StreamDuration() int64             { return e.DurationMs }
+func (e TurnCompleteEvent) StreamCost() float64               { return 0 }
+func (e TurnCompleteEvent) StreamHasLiveBackgroundWork() bool { return false }
 
 // PlanUpdateEvent fires when the agent updates its plan.
 type PlanUpdateEvent struct {

--- a/agent-cli-wrapper/agentstream/events.go
+++ b/agent-cli-wrapper/agentstream/events.go
@@ -63,6 +63,12 @@ type TurnComplete interface {
 	StreamIsSuccess() bool
 	StreamDuration() int64
 	StreamCost() float64
+	// StreamHasLiveBackgroundWork returns true when the turn ended with live
+	// background tasks still registered (parked session, safety-timer expiry,
+	// or budget-exceeded mid-bg-turn). Callers that would otherwise restart or
+	// retry the session should skip that action when this returns true.
+	// Returns false for providers that do not support background tasks.
+	StreamHasLiveBackgroundWork() bool
 }
 
 // Error provides error information.

--- a/agent-cli-wrapper/claude/BUILD.bazel
+++ b/agent-cli-wrapper/claude/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "turn_retry_test.go",
         "turn_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":claude"],
     deps = [
         "//agent-cli-wrapper/internal/ndjson",

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -176,11 +176,12 @@ func (e CLIToolResultEvent) Type() EventType { return EventTypeCLIToolResult }
 
 // TurnCompleteEvent fires when a turn finishes.
 type TurnCompleteEvent struct {
-	Error      error
-	Usage      TurnUsage
-	TurnNumber int
-	DurationMs int64
-	Success    bool
+	Error                 error
+	Usage                 TurnUsage
+	TurnNumber            int
+	DurationMs            int64
+	Success               bool
+	HasLiveBackgroundWork bool
 }
 
 // Type returns the event type.

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -190,10 +190,11 @@ func (e TurnCompleteEvent) Type() EventType { return EventTypeTurnComplete }
 func (e TurnCompleteEvent) StreamEventKind() agentstream.EventKind {
 	return agentstream.KindTurnComplete
 }
-func (e TurnCompleteEvent) StreamTurnNum() int    { return e.TurnNumber }
-func (e TurnCompleteEvent) StreamIsSuccess() bool { return e.Success }
-func (e TurnCompleteEvent) StreamDuration() int64 { return e.DurationMs }
-func (e TurnCompleteEvent) StreamCost() float64   { return e.Usage.CostUSD }
+func (e TurnCompleteEvent) StreamTurnNum() int                { return e.TurnNumber }
+func (e TurnCompleteEvent) StreamIsSuccess() bool             { return e.Success }
+func (e TurnCompleteEvent) StreamDuration() int64             { return e.DurationMs }
+func (e TurnCompleteEvent) StreamCost() float64               { return e.Usage.CostUSD }
+func (e TurnCompleteEvent) StreamHasLiveBackgroundWork() bool { return e.HasLiveBackgroundWork }
 
 // ErrorEvent contains session errors.
 type ErrorEvent struct {

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1159,7 +1159,11 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		// arrive, so the session would otherwise stay stuck in StateProcessing.
 		// result.Error was already set above from msg.IsError; just fall through.
 		if msg.IsError {
-			// Fall through to the normal completion path below.
+			// Fall through to the normal completion path below. Mark the
+			// result as having live bg work so downstream retry loops do
+			// not interrupt the parked tasks — defer session.Stop() on a
+			// retry would orphan them.
+			result.HasLiveBackgroundWork = true
 		} else {
 			// Accumulate cost and token usage from this intermediate result so
 			// the final TurnResult reports the true total for the logical turn.
@@ -1332,6 +1336,10 @@ func (s *Session) completeSuppressedTurn(result TurnResult) {
 		result.Thinking = turn.FullThinking
 		result.ContentBlocks = turn.ContentBlocks
 	}
+	// The safety timer fired without any release signal. The bg work is
+	// still live from the session's perspective — mark so retry loops do
+	// not interrupt it.
+	result.HasLiveBackgroundWork = true
 
 	s.finalizeTurn(result)
 }

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -383,11 +383,12 @@ func (s *Session) CollectResponse(ctx context.Context) (*TurnResult, []Event, er
 			events = append(events, evt)
 			if tc, ok := evt.(TurnCompleteEvent); ok {
 				result := &TurnResult{
-					TurnNumber: tc.TurnNumber,
-					Success:    tc.Success,
-					DurationMs: tc.DurationMs,
-					Usage:      tc.Usage,
-					Error:      tc.Error,
+					TurnNumber:            tc.TurnNumber,
+					Success:               tc.Success,
+					DurationMs:            tc.DurationMs,
+					Usage:                 tc.Usage,
+					Error:                 tc.Error,
+					HasLiveBackgroundWork: tc.HasLiveBackgroundWork,
 				}
 				// Populate text/blocks from turn state
 				turn := s.turnManager.GetTurnByNumber(tc.TurnNumber)
@@ -1302,11 +1303,12 @@ func (s *Session) finalizeTurn(result TurnResult) {
 	}
 	_ = s.state.Transition(TransitionResultReceived)
 	s.emit(TurnCompleteEvent{
-		TurnNumber: result.TurnNumber,
-		Success:    result.Success,
-		DurationMs: result.DurationMs,
-		Usage:      result.Usage,
-		Error:      result.Error,
+		TurnNumber:            result.TurnNumber,
+		Success:               result.Success,
+		DurationMs:            result.DurationMs,
+		Usage:                 result.Usage,
+		Error:                 result.Error,
+		HasLiveBackgroundWork: result.HasLiveBackgroundWork,
 	})
 	s.turnManager.CompleteTurn(result)
 }

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1195,6 +1195,10 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 			// after receiving ErrBudgetExceeded if they want to halt fully.
 			if s.config.MaxBudgetUSD > 0 && totalCostSoFar >= s.config.MaxBudgetUSD {
 				result.Error = ErrBudgetExceeded
+				// The background task is still running in the CLI process. Mark
+				// so retry loops do not interrupt it (same guard as the error
+				// and safety-timer paths).
+				result.HasLiveBackgroundWork = true
 				s.mu.Lock()
 				s.bgState.accumulatedUsage = TurnUsage{}
 				s.mu.Unlock()

--- a/agent-cli-wrapper/claude/testdata/retry/nonzero_exit_bash.json
+++ b/agent-cli-wrapper/claude/testdata/retry/nonzero_exit_bash.json
@@ -10,7 +10,7 @@
   {
     "type": "tool_result",
     "tool_use_id": "toolu_017E3NKRaj3dZEWn8jStZhjR",
-    "tool_result": "Exit code 8\nForge Visual Tests\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532667425\t\nPython Tests\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532667428\t\nSecurity Scan\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532667430\t\nDocker Compose Smoke\tskipping\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532668275\t\nDetect Changes\tpass\t6s\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532641962\t\nLint & Type Check\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532642026\t",
+    "tool_result": "Exit code 8\nForge Visual Tests\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/1\t\nPython Tests\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/2\t\nSecurity Scan\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/3\t\nDocker Compose Smoke\tskipping\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/4\t\nDetect Changes\tpass\t6s\thttps://github.com/example-org/example-repo/actions/runs/1/job/5\t\nLint & Type Check\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/6\t",
     "is_error": true
   }
 ]

--- a/agent-cli-wrapper/claude/testdata/retry/nonzero_exit_bash.json
+++ b/agent-cli-wrapper/claude/testdata/retry/nonzero_exit_bash.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_017E3NKRaj3dZEWn8jStZhjR",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "gh pr checks 2286"
+    }
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_017E3NKRaj3dZEWn8jStZhjR",
+    "tool_result": "Exit code 8\nForge Visual Tests\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532667425\t\nPython Tests\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532667428\t\nSecurity Scan\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532667430\t\nDocker Compose Smoke\tskipping\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532668275\t\nDetect Changes\tpass\t6s\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532641962\t\nLint & Type Check\tpending\t0\thttps://github.com/sycamore-labs/kernel/actions/runs/24477273494/job/71532642026\t",
+    "is_error": true
+  }
+]

--- a/agent-cli-wrapper/claude/testdata/retry/parked_with_skill_error.json
+++ b/agent-cli-wrapper/claude/testdata/retry/parked_with_skill_error.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_bash_bg_1",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "sleep 120",
+      "run_in_background": true
+    }
+  },
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_bash_bg_2",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "until gh api repos/sycamore-labs/kernel/pulls/2285/reviews | jq -e '.[0]'; do sleep 10; done",
+      "run_in_background": true
+    }
+  },
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_skill_1",
+    "tool_name": "Skill",
+    "tool_input": {
+      "skill": "sy:pr-polish"
+    }
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_bash_bg_1",
+    "tool_result": "command started in background",
+    "is_error": false
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_bash_bg_2",
+    "tool_result": "command started in background",
+    "is_error": false
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_skill_1",
+    "tool_result": "<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+    "is_error": true
+  }
+]

--- a/agent-cli-wrapper/claude/testdata/retry/parked_with_skill_error.json
+++ b/agent-cli-wrapper/claude/testdata/retry/parked_with_skill_error.json
@@ -13,7 +13,7 @@
     "tool_use_id": "toolu_bash_bg_2",
     "tool_name": "Bash",
     "tool_input": {
-      "command": "until gh api repos/sycamore-labs/kernel/pulls/2285/reviews | jq -e '.[0]'; do sleep 10; done",
+      "command": "until gh api repos/example-org/example-repo/pulls/1/reviews | jq -e '.[0]'; do sleep 10; done",
       "run_in_background": true
     }
   },
@@ -22,7 +22,7 @@
     "tool_use_id": "toolu_skill_1",
     "tool_name": "Skill",
     "tool_input": {
-      "skill": "sy:pr-polish"
+      "skill": "example:pr-polish"
     }
   },
   {
@@ -40,7 +40,7 @@
   {
     "type": "tool_result",
     "tool_use_id": "toolu_skill_1",
-    "tool_result": "<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+    "tool_result": "<tool_use_error>Skill example:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
     "is_error": true
   }
 ]

--- a/agent-cli-wrapper/claude/testdata/retry/real_tool_use_error.json
+++ b/agent-cli-wrapper/claude/testdata/retry/real_tool_use_error.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_ruff",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "uv run ruff check services/python/api-gateway"
+    }
+  },
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_pytest",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "uv run pytest services/python/api-gateway"
+    }
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_ruff",
+    "tool_result": "Exit code 1\nservices/python/api-gateway/app.py:1:1: TC003 Move standard library import into TYPE_CHECKING block",
+    "is_error": true
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_pytest",
+    "tool_result": "<tool_use_error>Cancelled: parallel tool call Bash(uv run ruff check services/python/api-ga…) errored</tool_use_error>",
+    "is_error": true
+  }
+]

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -8,9 +8,12 @@ import (
 	"time"
 )
 
-// toolUseErrorMarker guards against upstream format drift where IsError
-// is unset but content still carries this sentinel (seen on parallel-
-// cancelled tool siblings).
+// toolUseErrorMarker is the sentinel the Claude CLI wraps around tool
+// invocations it refused, blocked, or cancelled (disable-model-invocation,
+// sleep block, parallel-cancelled siblings). It is NOT emitted for
+// nonzero-exit Bash the agent ran to inspect output — those carry a raw
+// "Exit code N\n<output>" string with is_error=true but no wrapper. The
+// retry detector requires both IsError and this marker.
 const toolUseErrorMarker = "<tool_use_error>"
 
 const toolErrorExcerptMaxRunes = 200
@@ -75,10 +78,16 @@ func excerptRunes(s string, max int) string {
 	return s
 }
 
-// FinalTurnToolError reports the first errored tool_result in blocks,
-// returning the failing tool's name and a bounded excerpt. On parallel
-// tool batches the first-in-order errored result wins — in the cancelled-
-// sibling case this surfaces the real cause, not the cancellation.
+// FinalTurnToolError reports the first CLI-reported tool_use_error in
+// blocks, returning the failing tool's name and a bounded excerpt. A
+// block qualifies iff IsError is set AND the content carries the
+// toolUseErrorMarker wrapper — the marker is the stable signal the CLI
+// uses for tool invocations it refused, blocked, or cancelled. Nonzero-
+// exit Bash (e.g. `gh pr checks` exit 8) sets IsError but lacks the
+// wrapper and must not trigger retry.
+//
+// On parallel batches, first-in-order wins, so a real error listed
+// before a parallel-cancelled sibling surfaces the real cause.
 func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
 	toolNames := make(map[string]string)
 	for _, block := range blocks {
@@ -87,11 +96,11 @@ func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok boo
 		}
 	}
 	for _, block := range blocks {
-		if block.Type != ContentBlockTypeToolResult {
+		if block.Type != ContentBlockTypeToolResult || !block.IsError {
 			continue
 		}
 		content := stringifyToolResult(block.ToolResult)
-		if !block.IsError && !strings.Contains(content, toolUseErrorMarker) {
+		if !strings.Contains(content, toolUseErrorMarker) {
 			continue
 		}
 		name := toolNames[block.ToolUseID]
@@ -130,6 +139,13 @@ type TurnResult struct {
 	TurnNumber    int
 	DurationMs    int64
 	Success       bool
+	// HasLiveBackgroundWork is a snapshot at finalize time: true when the
+	// turn ended with registered live Monitor tasks or uncancelled bg-Bash
+	// tools the agent parked on. Callers that would otherwise restart the
+	// session (e.g. the jiradozer retry-on-tool-error loop) must skip that
+	// action when this is true — re-Ask would interrupt the park and the
+	// ephemeral session's defer Stop() would orphan the bg work.
+	HasLiveBackgroundWork bool
 }
 
 // backgroundTools lists tools that the CLI treats as background work even

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -86,8 +86,8 @@ func excerptRunes(s string, max int) string {
 // exit Bash (e.g. `gh pr checks` exit 8) sets IsError but lacks the
 // wrapper and must not trigger retry.
 //
-// On parallel batches, first-in-order wins, so a real error listed
-// before a parallel-cancelled sibling surfaces the real cause.
+// On parallel batches, first qualifying block wins (first with both
+// IsError and the marker).
 func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
 	toolNames := make(map[string]string)
 	for _, block := range blocks {

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -17,7 +17,7 @@ func TestFinalTurnToolError_IsErrorPlusMarker(t *testing.T) {
 		{
 			Type:       ContentBlockTypeToolResult,
 			ToolUseID:  "t1",
-			ToolResult: "<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+			ToolResult: "<tool_use_error>Skill example:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
 			IsError:    true,
 		},
 	}
@@ -248,7 +248,7 @@ func TestFinalTurnToolError_Fixture_RealToolUseError(t *testing.T) {
 	if !ok {
 		t.Fatal("parallel-cancelled fixture must be detected")
 	}
-	if !strings.Contains(excerpt, "Cancelled") && !strings.Contains(excerpt, "tool_use_error") {
+	if !strings.Contains(excerpt, "Cancelled") {
 		t.Errorf("expected the wrapped sibling to be surfaced, got %q", excerpt)
 	}
 }

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -1,51 +1,101 @@
 package claude
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestFinalTurnToolError_IsError(t *testing.T) {
+// TestFinalTurnToolError_IsErrorPlusMarker: both IsError and the marker
+// are required. The canonical positive case.
+func TestFinalTurnToolError_IsErrorPlusMarker(t *testing.T) {
 	t.Parallel()
 	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "failed", IsError: true},
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Skill"},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "t1",
+			ToolResult: "<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+			IsError:    true,
+		},
 	}
 	name, excerpt, ok := FinalTurnToolError(blocks)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
-	if name != "Bash" {
-		t.Errorf("expected tool=Bash, got %q", name)
+	if name != "Skill" {
+		t.Errorf("expected tool=Skill, got %q", name)
 	}
-	if excerpt != "failed" {
-		t.Errorf("expected excerpt=failed, got %q", excerpt)
+	if !strings.Contains(excerpt, "disable-model-invocation") {
+		t.Errorf("excerpt should contain the reason, got %q", excerpt)
 	}
 }
 
-func TestFinalTurnToolError_SubstringOnly(t *testing.T) {
+// TestFinalTurnToolError_NonzeroExitBash: is_error without the marker is
+// a nonzero-exit Bash the agent ran to inspect output (gh pr checks,
+// grep, git diff). These must NOT trigger retry. Regression for the
+// evidence log 2 false positive.
+func TestFinalTurnToolError_NonzeroExitBash(t *testing.T) {
 	t.Parallel()
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
 		{
 			Type:       ContentBlockTypeToolResult,
 			ToolUseID:  "t1",
-			ToolResult: "<tool_use_error>Cancelled: parallel tool call</tool_use_error>",
-			IsError:    false,
+			ToolResult: "Exit code 8\nForge Visual Tests\tpending\nPython Tests\tpending",
+			IsError:    true,
 		},
 	}
-	name, excerpt, ok := FinalTurnToolError(blocks)
-	if !ok {
-		t.Fatal("expected ok=true (substring match)")
-	}
-	if name != "Bash" {
-		t.Errorf("expected tool=Bash, got %q", name)
-	}
-	if !strings.Contains(excerpt, "<tool_use_error>") {
-		t.Errorf("excerpt should contain marker, got %q", excerpt)
+	if _, _, ok := FinalTurnToolError(blocks); ok {
+		t.Error("nonzero-exit Bash must not be treated as a tool_use_error")
 	}
 }
 
+// TestFinalTurnToolError_WriteNotReadYet: Write tool_use_error shape
+// from evidence log 2. The CLI emits the wrapper, so retry fires.
+func TestFinalTurnToolError_WriteNotReadYet(t *testing.T) {
+	t.Parallel()
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Write"},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "t1",
+			ToolResult: "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+			IsError:    true,
+		},
+	}
+	if _, _, ok := FinalTurnToolError(blocks); !ok {
+		t.Error("Write tool_use_error must be detected")
+	}
+}
+
+// TestFinalTurnToolError_SubstringWithoutIsError: content happens to
+// contain the marker literal (e.g. a grep over a log file) but IsError
+// is false. Must not fire — the AND rule requires both.
+func TestFinalTurnToolError_SubstringWithoutIsError(t *testing.T) {
+	t.Parallel()
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "t1",
+			ToolResult: "log line mentions <tool_use_error> in text",
+			IsError:    false,
+		},
+	}
+	if _, _, ok := FinalTurnToolError(blocks); ok {
+		t.Error("IsError=false must not trigger retry even with marker in content")
+	}
+}
+
+// TestFinalTurnToolError_ParallelCancelled: the real PLA-212 wire shape.
+// The real error (ruff TC003) is a plain nonzero-exit with no wrapper;
+// the cancelled sibling carries the <tool_use_error> wrapper. Under the
+// AND rule, the cancelled sibling is the one that matches, which is
+// sufficient to trigger retry — the retry prompt is just "retry" and
+// the model sees the full history in context.
 func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
 	t.Parallel()
 	blocks := []ContentBlock{
@@ -54,7 +104,7 @@ func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
 		{
 			Type:       ContentBlockTypeToolResult,
 			ToolUseID:  "ruff",
-			ToolResult: "TC003 stdlib import in runtime",
+			ToolResult: "Exit code 1\nTC003 stdlib import in runtime",
 			IsError:    true,
 		},
 		{
@@ -66,16 +116,13 @@ func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
 	}
 	name, excerpt, ok := FinalTurnToolError(blocks)
 	if !ok {
-		t.Fatal("expected ok=true")
+		t.Fatal("expected ok=true — cancelled sibling carries the marker")
 	}
 	if name != "Bash" {
 		t.Errorf("expected Bash, got %q", name)
 	}
-	if !strings.Contains(excerpt, "TC003") {
-		t.Errorf("expected excerpt to surface the real ruff error, got %q", excerpt)
-	}
-	if strings.Contains(excerpt, "Cancelled") {
-		t.Errorf("detector should have surfaced the ruff error, not the cancelled sibling: %q", excerpt)
+	if !strings.Contains(excerpt, "Cancelled") {
+		t.Errorf("expected excerpt to surface the cancelled sibling, got %q", excerpt)
 	}
 }
 
@@ -103,6 +150,8 @@ func TestFinalTurnToolError_NoToolUse(t *testing.T) {
 	}
 }
 
+// TestFinalTurnToolError_BlockShape exercises the []interface{} wire
+// shape handleUser stores for structured tool_result content.
 func TestFinalTurnToolError_BlockShape(t *testing.T) {
 	t.Parallel()
 	wireShape := []interface{}{
@@ -126,7 +175,7 @@ func TestFinalTurnToolError_BlockShape(t *testing.T) {
 
 func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
 	t.Parallel()
-	long := strings.Repeat("x", 500)
+	long := "<tool_use_error>" + strings.Repeat("x", 500) + "</tool_use_error>"
 	blocks := []ContentBlock{
 		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
 		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: long, IsError: true},
@@ -143,7 +192,12 @@ func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
 func TestFinalTurnToolError_UnknownTool(t *testing.T) {
 	t.Parallel()
 	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolResult, ToolUseID: "orphan", ToolResult: "err", IsError: true},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "orphan",
+			ToolResult: "<tool_use_error>err</tool_use_error>",
+			IsError:    true,
+		},
 	}
 	name, _, ok := FinalTurnToolError(blocks)
 	if !ok {
@@ -152,4 +206,66 @@ func TestFinalTurnToolError_UnknownTool(t *testing.T) {
 	if name != "unknown" {
 		t.Errorf("expected name=unknown, got %q", name)
 	}
+}
+
+// TestFinalTurnToolError_Fixture_NonzeroExitBash drives the detector
+// with a wire-shape snapshot captured from evidence log 2 (gh pr checks
+// exit 8). Must not trigger retry.
+func TestFinalTurnToolError_Fixture_NonzeroExitBash(t *testing.T) {
+	t.Parallel()
+	blocks := loadRetryFixture(t, "nonzero_exit_bash.json")
+	if _, _, ok := FinalTurnToolError(blocks); ok {
+		t.Error("nonzero-exit gh pr checks fixture must not trigger retry")
+	}
+}
+
+// TestFinalTurnToolError_Fixture_ParkedWithSkillError drives the
+// detector with evidence log 1's Skill disable-model-invocation shape.
+// The Skill error carries the marker, so detection fires at the turn
+// level — the bg-work gate (G2) is what prevents the actual retry.
+func TestFinalTurnToolError_Fixture_ParkedWithSkillError(t *testing.T) {
+	t.Parallel()
+	blocks := loadRetryFixture(t, "parked_with_skill_error.json")
+	name, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("Skill disable-model-invocation must be detected at the detector level")
+	}
+	if !strings.Contains(excerpt, "disable-model-invocation") {
+		t.Errorf("expected disable-model-invocation in excerpt, got %q", excerpt)
+	}
+	if name == "" {
+		t.Error("expected non-empty tool name")
+	}
+}
+
+// TestFinalTurnToolError_Fixture_RealToolUseError is the PLA-212
+// parallel-cancelled shape — real error + cancelled sibling. Detection
+// must fire on the cancelled sibling's wrapped content.
+func TestFinalTurnToolError_Fixture_RealToolUseError(t *testing.T) {
+	t.Parallel()
+	blocks := loadRetryFixture(t, "real_tool_use_error.json")
+	_, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("parallel-cancelled fixture must be detected")
+	}
+	if !strings.Contains(excerpt, "Cancelled") && !strings.Contains(excerpt, "tool_use_error") {
+		t.Errorf("expected the wrapped sibling to be surfaced, got %q", excerpt)
+	}
+}
+
+// loadRetryFixture reads a JSON snapshot of []ContentBlock from
+// testdata/retry/. Fixtures are hand-extracted from real Claude CLI
+// session JSONL files to guard the detector against regressions.
+func loadRetryFixture(t *testing.T, name string) []ContentBlock {
+	t.Helper()
+	path := filepath.Join("testdata", "retry", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	var blocks []ContentBlock
+	if err := json.Unmarshal(data, &blocks); err != nil {
+		t.Fatalf("unmarshal fixture %s: %v", name, err)
+	}
+	return blocks
 }

--- a/agent-cli-wrapper/codex/events.go
+++ b/agent-cli-wrapper/codex/events.go
@@ -115,11 +115,12 @@ func (e TurnCompletedEvent) Type() EventType { return EventTypeTurnCompleted }
 func (e TurnCompletedEvent) StreamEventKind() agentstream.EventKind {
 	return agentstream.KindTurnComplete
 }
-func (e TurnCompletedEvent) StreamTurnNum() int    { return TurnNumberFromID(e.TurnID) }
-func (e TurnCompletedEvent) StreamIsSuccess() bool { return e.Success }
-func (e TurnCompletedEvent) StreamDuration() int64 { return e.DurationMs }
-func (e TurnCompletedEvent) StreamCost() float64   { return 0 }
-func (e TurnCompletedEvent) ScopeID() string       { return e.ThreadID }
+func (e TurnCompletedEvent) StreamTurnNum() int                { return TurnNumberFromID(e.TurnID) }
+func (e TurnCompletedEvent) StreamIsSuccess() bool             { return e.Success }
+func (e TurnCompletedEvent) StreamDuration() int64             { return e.DurationMs }
+func (e TurnCompletedEvent) StreamCost() float64               { return 0 }
+func (e TurnCompletedEvent) StreamHasLiveBackgroundWork() bool { return false }
+func (e TurnCompletedEvent) ScopeID() string                   { return e.ThreadID }
 
 // TextDeltaEvent contains streaming text chunks.
 type TextDeltaEvent struct {

--- a/agent-cli-wrapper/cursor/events.go
+++ b/agent-cli-wrapper/cursor/events.go
@@ -85,10 +85,11 @@ func (e TurnCompleteEvent) Type() EventType { return EventTypeTurnComplete }
 func (e TurnCompleteEvent) StreamEventKind() agentstream.EventKind {
 	return agentstream.KindTurnComplete
 }
-func (e TurnCompleteEvent) StreamTurnNum() int    { return 1 }
-func (e TurnCompleteEvent) StreamIsSuccess() bool { return e.Success }
-func (e TurnCompleteEvent) StreamDuration() int64 { return e.DurationMs }
-func (e TurnCompleteEvent) StreamCost() float64   { return 0 }
+func (e TurnCompleteEvent) StreamTurnNum() int                { return 1 }
+func (e TurnCompleteEvent) StreamIsSuccess() bool             { return e.Success }
+func (e TurnCompleteEvent) StreamDuration() int64             { return e.DurationMs }
+func (e TurnCompleteEvent) StreamCost() float64               { return 0 }
+func (e TurnCompleteEvent) StreamHasLiveBackgroundWork() bool { return false }
 
 // ErrorEvent contains session errors.
 type ErrorEvent struct {

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -1,0 +1,501 @@
+# Jiradozer: Tool-Error Retry v2 — Tighten the Gate
+
+## Status
+
+Follow-up to `jiradozer-tool-error-retry.md` (PR #152, commit 4d57278).
+The v1 design shipped the retry loop in `ClaudeProvider.Execute`, gated on
+`FinalTurnToolError`. In production it fires on turns that should not be
+retried, actively destroying legitimate parked work. This doc spells out the
+gate changes required to make the loop safe, plus the test coverage the v1
+doc waved off as "integration-only, out of scope."
+
+v1 stays the authoritative doc for the *shape* of the loop (where it lives,
+how `session.Ask` is reused, retry-prompt wording, runaway guardrails,
+config surface, observability). v2 is narrowly about *when* the loop is
+allowed to fire.
+
+## Problem
+
+The v1 detector, `FinalTurnToolError` in
+`agent-cli-wrapper/claude/turn.go:82`, flags any final tool_result with
+`IsError==true` **or** the `<tool_use_error>` substring. The provider loop
+in `multiagent/agent/claude_provider.go:182-210` then re-`Ask`s the session
+with the literal prompt `"retry"` up to `MaxToolErrorRetries` times.
+
+Two real jiradozer runs show the detector firing on turns where no retry
+is warranted and where the retry actively destroys work. Both logs are
+kept under `~/.jiradozer/logs/`; the relevant ContentBlock sequences should
+be extracted into testdata fixtures (see Test Plan).
+
+### Evidence 1: permanent-error Skill + live bg-Bash parking
+
+`~/.jiradozer/logs/jiradozer-20260415-202027-2762325.log`
+
+- Turn 1 launched two background Bash tools (`sleep 120`, a `gh api`
+  poll loop) and a `Skill(sy:pr-polish)` call that the CLI rejected
+  permanently with
+  `<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due
+  to disable-model-invocation</tool_use_error>`. The agent's final text
+  was *"Both background tasks are running. I'll wait for the
+  notifications when they complete."*
+- `FinalTurnToolError` flagged the Skill error. Retry fired with prompt
+  `"retry"`. Turn 2 relaunched a background poll and again said *"I'll
+  wait for the notification."*
+- Execute then returned, `defer session.Stop()` tore down the ephemeral
+  session, and every backgrounded Bash was orphaned.
+
+Two separate bugs compose here:
+
+1. A permanent-class error ("disable-model-invocation") was retried
+   despite being unrecoverable.
+2. A turn with *live background work* was interrupted even though the
+   agent had explicitly parked on that work.
+
+### Wire-level evidence from session JSONL
+
+Both bugs were cross-checked against the Claude CLI session JSONL files
+(`~/.claude/projects/<cwd-slug>/<session-id>.jsonl`) corresponding to
+each run. The wire shape is conclusive:
+
+| Case | `is_error` | Content shape | `<tool_use_error>` wrapper |
+|---|---|---|---|
+| Successful Bash | `false` | structured object `{stdout, stderr, interrupted, isImage, noOutputExpected}` | no |
+| `gh pr checks` exit 8 (informational) | `true` | string `"Error: Exit code 8\n<stdout>"` | **no** |
+| `git diff` exit 128 (real but self-inspectable) | `true` | string `"Error: Exit code 128\n<stderr>"` | **no** |
+| `sleep 120` CLI-blocked | `true` | string `"<tool_use_error>Blocked: sleep 120...</tool_use_error>"` | **yes** |
+| `Skill(sy:pr-polish)` disabled | `true` | string `"<tool_use_error>Skill ... cannot be used ... due to disable-model-invocation</tool_use_error>"` | **yes** |
+| Parallel-cancelled sibling | `true` | string `"<tool_use_error>Cancelled: parallel tool call ... errored</tool_use_error>"` | **yes** |
+
+**The `<tool_use_error>` marker is a stable sentinel the CLI uses
+exclusively for tool invocations it refused, blocked, or cancelled.**
+Nonzero-exit Bash — whether informational (`gh pr checks`) or a real
+command failure (`git diff` against a missing ref) — is indistinguishable
+on the wire from a polling check: raw `"Error: Exit code N\n<output>"`
+with `is_error: true` and no wrapper.
+
+This is actually the right boundary for the retry gate. The agent
+itself runs nonzero-exit commands to *inspect* their output — whether
+a failure is "real" or "informational" is a decision the agent makes
+in its next turn, not something the wrapper can determine from the
+wire. If the agent's session had not been torn down by the retry
+orphan, it would have handled the git-128 case in-turn and either
+fixed the command or moved on. The retry loop's job is narrower:
+recover from the case where the CLI itself aborted a tool the agent
+was counting on, after which the agent stops with nothing to act on.
+That's exactly what the `<tool_use_error>` marker signals.
+
+**Additional observations from the JSONL analysis:**
+
+- `stop_reason` did not differentiate parked-on-bg from
+  tool-error-unresolved cases — both show `"tool_use"` as the last
+  assistant stop before the terminal ResultMessage. So `stop_reason`
+  is not a usable secondary signal.
+- No `task_*` frame types appeared in the files for backgrounded
+  Bash (run_in_background:true). The bg state is conveyed purely
+  through the tool_use block's `run_in_background` input flag and
+  the presence of a `backgroundTaskId` field in the tool_result.
+  Confirms that `turnState.shouldSuppressForBgTasks()` (which keys
+  off `run_in_background` input) is the right detection point;
+  there's no separate frame type to watch.
+- No frame type carries a permanent-vs-transient error category.
+  G3 (the deny-list) remains substring-based — the CLI does not
+  emit a structured error kind field.
+- The `toolUseResult` field on user frames carries the same content
+  twice (once inside `message.content[].content`, once in
+  `toolUseResult` with an `Error: ` prefix). The wrapper already reads
+  from the first; no change needed.
+
+### Evidence 2: nonzero-exit Bash treated as tool error
+
+`~/.jiradozer/logs/jiradozer-20260415-203130-2938633.log`
+
+- Turn 1 ended with a `Write` tool_use_error ("File has not been read
+  yet") after legitimate commits had already landed; the agent was
+  waiting on CI. Retry attempt 1 fired.
+- Turn 2 ran `gh pr checks 2286`, which exits with code **8** while
+  checks are pending. The CLI surfaced this as a `tool_result` with
+  `is_error: true` even though the output was informational, not a
+  `<tool_use_error>` block. The agent launched a bg poll loop and said
+  *"Polling CI in the background. I'll evaluate exit criteria once all
+  checks complete."*
+- Retry attempt 2 fired on the `gh pr checks` nonzero exit. Turn 3 ran
+  another `gh pr checks`, then used `ScheduleWakeup(270s, prompt="retry")`
+  as a workaround to defend against the retry loop itself. The
+  no-progress abort finally caught it on attempt 3.
+- Net: 3 wasted turns and the agent's intentional park-and-wait pattern
+  was actively fought.
+
+### Root causes
+
+Three distinct bugs in the gate.
+
+**G1 — `IsError` is not a tool_use_error.** The Claude CLI sets
+`tool_result.is_error=true` on any nonzero-exit Bash, regardless of
+whether the agent ran it specifically to inspect the exit code.
+`gh pr checks` exits 8, `grep -q` exits 1, `test -f` exits 1 — all
+informational. Only the `<tool_use_error>` marker (already a constant at
+`turn.go:14`) means the CLI itself is reporting a tool invocation
+failure. The v1 detector treats the two as equivalent.
+
+Confirmed empirically against the four session JSONL files — see the
+"Wire-level evidence" table below. The `<tool_use_error>` wrapper is
+used *exclusively* by the CLI for tool invocations it refused, blocked,
+or cancelled (disable-model-invocation, sleep-block, parallel-cancel).
+Nonzero-exit Bash — whether a real command failure (`git diff` against
+a missing ref, exit 128) or an informational poll (`gh pr checks` exit
+8) — carries raw `"Error: Exit code N\n<output>"` without the wrapper.
+The wrapper cannot tell these apart from the wire, and neither can it:
+whether a nonzero exit is "real" or "informational" is a decision only
+the agent itself can make in its next turn.
+
+**G2 — Retry fires while the agent is parked on background work.** When
+a turn ends with `shouldSuppressForBgTasks()==true` OR with registered
+live tasks, the agent has explicitly deferred to background progress.
+Re-`Ask`ing "retry" interrupts the park; the follow-up turn re-launches
+bg work from scratch, then `Execute` returns and the new bg work is
+orphaned by `defer session.Stop()`. The gate currently has no visibility
+into turnState at all.
+
+**G3 — Permanent-class errors are indistinguishable from transient
+ones.** Tools rejected via `disable-model-invocation`, permissions
+denials, or "tool X cannot be used with tool Y" messages will never
+succeed on retry. These are lower priority than G1/G2 because G2 alone
+covers most occurrences in practice (permanent errors usually coexist
+with parked bg work), but worth a deny-list belt.
+
+## Design
+
+### G1 — Distinguish real tool_use_error from nonzero-exit Bash
+
+`FinalTurnToolError` should require **both** signals:
+
+1. `block.IsError == true`, AND
+2. `stringifyToolResult(block.ToolResult)` contains
+   `toolUseErrorMarker` (`<tool_use_error>`).
+
+Currently it ORs the two. The v1 doc called the substring check
+"belt-and-braces"; in the wire data we actually see, it's load-bearing
+— the substring is what distinguishes a *CLI-reported tool invocation
+failure* from a *tool that ran to completion with a nonzero exit*.
+
+Rationale for the AND (not OR, not substring-only):
+
+- `IsError=true` without the marker covers every nonzero-exit Bash the
+  agent ran on purpose. These must not retry.
+- The marker without `IsError=true` would be ambiguous content — e.g. a
+  `grep` that literally finds the string `<tool_use_error>` in a log
+  file. Requiring `IsError=true` rules that out.
+- Real CLI tool_use_errors set both. Confirmed by the
+  `SubstringOnly` case in `turn_retry_test.go:26-47` where the test
+  stubs `IsError:false` but content has the marker — that case should
+  now be **not** detected. The test was written to defend against
+  "upstream format drift" that does not exist in the wire data; remove
+  it and invert the assertion.
+
+Concrete spec (no code yet):
+
+```
+FinalTurnToolError(blocks) walks blocks once.
+For each block where Type == ContentBlockTypeToolResult:
+  content := stringifyToolResult(block.ToolResult)
+  if block.IsError && strings.Contains(content, toolUseErrorMarker):
+    return (toolName, excerpt, true)
+return ("", "", false)
+```
+
+Parallel-cancellation semantics preserved: on a parallel batch where a
+real error and a cancelled sibling both set `IsError=true`, the
+cancelled sibling's content carries the marker too ("Cancelled: parallel
+tool call ... errored"), but the real error wins because the function
+walks in content-block order — same as today. The existing
+`ParallelCancelled` test still passes (both blocks have `IsError=true`
+and both *would* match under the new rule, but the first-in-order rule
+picks the real error).
+
+### G2 — Skip retry when the turn has live bg work
+
+`turnState.shouldSuppressForBgTasks()` already encodes the "this turn
+is a deliberate park" signal. It's battle-tested via bg/Monitor tests.
+Reuse it — don't re-derive.
+
+At `finalizeTurn` time in `session.go:1149`, the code computes
+`shouldSuppress := !wasSuppressed && turn.shouldSuppressForBgTasks()`
+and, in the `msg.IsError` branch (line 1161), **falls through** to
+finalize anyway. That fall-through is exactly when the retry-loop bug
+bites: the turn finalizes with bg work still live, and the provider
+has no way to know.
+
+The fix is to carry that signal into the `TurnResult` so the provider
+can inspect it.
+
+**Chosen approach: add `HasLiveBackgroundWork bool` to `TurnResult`.**
+
+Set it in `finalizeTurn` immediately before `CompleteTurn`, computed as
+`turn != nil && turn.shouldSuppressForBgTasks()`. The provider gates
+retry on `!result.HasLiveBackgroundWork`.
+
+Also-ran approaches and why they lose:
+
+- *Pass `turnState` into `FinalTurnToolError`* — couples a pure content
+  helper to turn internals. `turnState` is private to the claude
+  package; exposing it would leak more than we need.
+- *New `turnState.ShouldRetryOnToolError()`* — conflates the "is there
+  an error" question with the "should we retry" question. The first is
+  a property of the content blocks; the second is policy that belongs
+  one layer up. Mixing them makes the helper harder to test.
+- *Session-level snapshot accessor
+  (`session.CurrentTurnHasLiveBackgroundWork()`)* — races. The provider
+  calls it after `Ask` returns; by then a new turn might be starting.
+  A field on the immutable `TurnResult` is race-free.
+- *`turnState` field in `TurnResult`* — too broad; exposes internal
+  machinery the provider doesn't need and makes the struct mutable.
+
+The field is a minimal, immutable, point-in-time snapshot.
+
+### G3 — Permanent-class error deny list (optional, lower priority)
+
+Add a package-private list of error substrings that should never
+trigger retry:
+
+```
+permanentErrorMarkers = []string{
+    "disable-model-invocation",
+    "cannot be used with",  // covers "Skill X cannot be used with Skill tool"
+}
+```
+
+`FinalTurnToolError` (or a new sibling `FinalTurnRetryableToolError`)
+returns `ok=false` when the excerpt matches any marker. Keep the list
+*tight* — each entry must correspond to a real CLI error class that
+is definitionally unrecoverable within the same session.
+
+G3 is optional. G2 alone would have caught both evidence logs, because
+in both cases live bg work was present when the retry fired. Ship G1+G2
+first; add G3 only if a repro surfaces a permanent error *without*
+concurrent bg work.
+
+### Gate combination
+
+Final retry decision in `ClaudeProvider.Execute`:
+
+```
+fire retry iff:
+  result.HasLiveBackgroundWork == false AND
+  FinalTurnToolError(blocks) returns ok==true AND
+  (G3 optional) excerpt does not match permanentErrorMarkers AND
+  // v1 guardrails unchanged:
+  attempts < cfg.MaxToolErrorRetries AND
+  time.Since(start) < budget AND
+  excerpt != prevExcerpt AND
+  ctx.Err() == nil
+```
+
+Order matters: check `HasLiveBackgroundWork` *first*, before the content
+walk. It's the cheapest check and it's the most consequential — it
+blocks the destructive case where the retry orphans bg work.
+
+When the gate blocks for bg reasons, emit a distinct
+`RetryStopReason = "bg_work_live"` via `OnRetryAbort` so triage can
+tell "we saw a tool error but chose not to retry" apart from "no tool
+error was seen at all." Without this signal the non-retry case is
+invisible in logs.
+
+## File/line summary
+
+| File | Change |
+|---|---|
+| `agent-cli-wrapper/claude/turn.go:82-104` | `FinalTurnToolError` tightens to require `IsError && marker` |
+| `agent-cli-wrapper/claude/turn.go` (TurnResult struct ~L124) | New field `HasLiveBackgroundWork bool` |
+| `agent-cli-wrapper/claude/session.go:1116-1120` | Set `result.HasLiveBackgroundWork = turn.shouldSuppressForBgTasks()` before `CompleteTurn` |
+| `multiagent/agent/claude_provider.go:182-210` | Gate retry on `!result.HasLiveBackgroundWork` first; new abort reason `bg_work_live` |
+| `multiagent/agent/claude_provider.go` const block ~L22 | `RetryStopBgWorkLive = "bg_work_live"` |
+| `agent-cli-wrapper/claude/turn_retry_test.go` | Update `SubstringOnly` (now negative); add new cases (see Test Plan) |
+| `agent-cli-wrapper/claude/testdata/` (new) | Wire-shape fixtures extracted from the two evidence logs |
+
+## Test plan
+
+The v1 doc punted provider-layer tests to "integration only." That
+position has allowed five successive PR polish rounds to ship with zero
+provider retry coverage. v2 specifies unit tests at both layers.
+
+### Unit — detection (turn_retry_test.go)
+
+Rename existing cases where the assertion inverts:
+
+- `TestFinalTurnToolError_IsError` — `IsError:true` + no marker →
+  **ok=false** (was: ok=true). This is the core G1 correction. Cover
+  both the `gh pr checks` (nonzero exit with informational output) and
+  `Write` ("File has not been read yet") shapes explicitly.
+- `TestFinalTurnToolError_SubstringOnly` — `IsError:false` + marker →
+  **ok=false** (was: ok=true). Removes the "format drift" belt.
+- `TestFinalTurnToolError_IsErrorPlusMarker` — *new*. Both set →
+  ok=true. Explicit positive case.
+- `TestFinalTurnToolError_ParallelCancelled` — unchanged behavior; real
+  error wins over cancelled sibling. Both blocks now have `IsError:true`
+  and marker in the cancelled sibling. Assert excerpt contains the real
+  error, not "Cancelled".
+- `TestFinalTurnToolError_Clean` / `_NoToolUse` / `_BlockShape` /
+  `_ExcerptLength` / `_UnknownTool` — unchanged.
+- `TestFinalTurnToolError_NonzeroExitBash_Fixture` — *new*. Loads
+  `testdata/nonzero_exit_bash.json` (extracted from evidence log 2)
+  and asserts `ok=false`. This is the regression test for G1.
+- (G3 only) `TestFinalTurnToolError_PermanentSkillError_Fixture` —
+  loads `testdata/permanent_skill_error.json` (evidence log 1) and
+  asserts `ok=false` when G3 deny list is enabled.
+
+### Unit — provider retry loop (new: claude_provider_retry_test.go)
+
+The v1 doc said a fake `claude.Session` was "too invasive." It isn't —
+`claude.NewSession` already returns a struct, and the provider uses
+exactly four entry points (`Start`, `Stop`, `Ask`, `Info`, `Events`).
+Pattern: introduce a package-private `sessionFactory` field on
+`ClaudeProvider` (default: real `claude.NewSession`). Tests set it to
+a factory that returns a fake implementing a minimal `claudeSession`
+interface. `Ask` is script-driven: the fake holds a slice of canned
+`TurnResult`s and returns them in order. `Events()` returns a closed
+channel so the bridge goroutine exits immediately.
+
+Cases:
+
+- `retries_until_clean` — fake returns [error, error, clean]; assert 3
+  Ask calls, final result is the clean one, no `UnresolvedToolError`
+  on `AgentResult`.
+- `respects_count_limit` — `MaxToolErrorRetries=1`, fake always returns
+  error; assert exactly 2 Asks, `UnresolvedToolError.Reason=exhausted`.
+- `no_progress_aborts` — identical excerpts twice; assert abort with
+  `Reason=no_progress` before count budget is hit.
+- `ctx_cancelled_between_retries` — cancel ctx after first retry
+  returns; assert no extra Ask, `Reason=ctx_cancelled`.
+- `disabled_by_default` — `MaxToolErrorRetries=0`, fake returns error;
+  single Ask, raw result returned, no marker, no
+  `UnresolvedToolError`. Preserves today's behavior for jiradozer
+  configs that did not opt in.
+- **`skips_when_bg_work_live`** — *G2 core test*. Fake returns one
+  `TurnResult` with `HasLiveBackgroundWork:true` AND the content
+  blocks of a real tool_use_error. Assert exactly 1 Ask, no retry,
+  `UnresolvedToolError.Reason=bg_work_live`, marker appended. This is
+  the regression test for evidence log 1.
+- **`skips_on_nonzero_exit_bash`** — *G1 core test*. Fake returns a
+  `TurnResult` whose blocks have `IsError:true` but no
+  `<tool_use_error>` marker. Assert exactly 1 Ask, no retry, no
+  `UnresolvedToolError` (because `FinalTurnToolError` returned
+  ok=false — nothing to mark unresolved). Regression test for
+  evidence log 2.
+- `retries_cleanly_on_real_tool_use_error` — fake returns [real
+  tool_use_error with `HasLiveBackgroundWork:false`, clean]; assert 2
+  Asks, clean final. Ensures G1+G2 tightening did not break the
+  original PLA-212 fix path.
+- `skips_when_bg_work_live_and_cancelled_sibling` — evidence-shaped:
+  one tool_use_error, one cancelled sibling, `HasLiveBackgroundWork:
+  true`. Assert no retry (G2 dominates even when G1 would allow).
+
+### Fixture-driven testing
+
+Extract from both evidence logs into
+`agent-cli-wrapper/claude/testdata/`:
+
+- `testdata/retry/nonzero_exit_bash.json` — the `gh pr checks` exit-8
+  `tool_result` from evidence log 2.
+- `testdata/retry/parked_with_skill_error.json` — the Skill
+  permanent-error + two bg-Bash tool_use blocks from evidence log 1.
+- `testdata/retry/real_tool_use_error.json` — the original PLA-212
+  parallel-cancellation fixture (already in tests inline; externalize
+  for consistency).
+
+Fixtures are JSON snapshots of `[]ContentBlock`. A shared loader in
+`turn_retry_test.go` unmarshals them. Storing the full log is
+unnecessary — only the `ContentBlock` slice that `FinalTurnToolError`
+sees matters for the detection tests, and the provider tests drive the
+fake via these same fixtures.
+
+Fixture extraction can be a one-off script; the log files have
+unambiguous JSONL framing and the ContentBlock shape matches wire
+format.
+
+### Integration — wrapper level
+
+Keep the existing v1 integration test (fake CLI + real
+`ClaudeProvider.Execute`) that covers the PLA-212 recover-on-retry
+path. Add:
+
+- `TestExecute_SkipsRetryWhenBgWorkLive_Integration` — fake CLI
+  script: turn 1 emits a Bash tool_use_error AND a bg-Bash tool_use
+  (uncancelled), then a `ResultMessage` with `is_error:true` that
+  falls through to finalize. Assert 1 turn issued, no `OnRetry`
+  callback, `UnresolvedToolError.Reason=bg_work_live`.
+
+### Integration — jiradozer validate step
+
+No change from v1's position. If validate is not yet covered in
+jiradozer integration, skip. The wrapper-level integration test above
+is the load-bearing regression coverage.
+
+## Migration notes
+
+- `MaxToolErrorRetries` default remains `0` (disabled). No existing
+  config changes.
+- Existing jiradozer configs that opted in (e.g.
+  `validate.max_tool_error_retries: 2` in the example config) keep
+  working. The fix **tightens** when retry fires — any case the old
+  code retried is a subset of what v2 retries plus strictly more cases
+  it correctly skips. No config currently in the tree relies on the
+  buggy retry behavior.
+- `HasLiveBackgroundWork` is a new field on the public `TurnResult`
+  struct. Monorepo style permits API changes; all in-tree callers are
+  exhaustively enumerated (provider, render, bramble via adapter).
+  Gazelle-regenerated BUILDs pick up the new field with no changes.
+- `RetryStopBgWorkLive` is a new abort reason string. Any log parser
+  that pattern-matches on reasons should be updated. (In tree:
+  jiradozer log consumers only; no external consumers.)
+- `OnRetryAbort` fires for `bg_work_live` even though no retry was
+  attempted. This is a semantic widening — "abort" now covers "gate
+  blocked from the start" as well as "we tried and ran out of budget."
+  `logEventHandler.OnRetryAbort` (jiradozer/agent.go) should log at
+  INFO, not WARN, when `reason == bg_work_live` since it's the
+  expected case.
+
+## Open questions for human review
+
+1. **Do we need G3 at all?** If G1+G2 land and no log shows a
+   permanent error without concurrent bg work within one week of
+   running, drop G3. Ask: should the plan land G3 as a separate PR or
+   not at all?
+
+2. **Fixture format.** JSON snapshots of `[]ContentBlock` are simple
+   but tied to struct field names. Alternative: store raw CLI wire
+   frames and parse them through the real accumulator. The wire-frame
+   route is more faithful but requires running more of the session
+   machinery in test. Recommend JSON snapshots for unit-level; defer
+   wire frames to a dedicated recorder replay test if a future bug
+   escapes the JSON path.
+
+3. **Fake session interface extraction.** The v1 doc flagged interface
+   extraction as "too invasive." It isn't — the provider uses five
+   session methods. Confirm: is there a reason the real `Session`
+   type cannot be made to satisfy a local interface
+   `claudeSession` in `multiagent/agent/`? (I believe there is none.
+   The interface lives provider-side, the real type satisfies it
+   structurally, tests inject the fake via a factory function.)
+
+4. **`HasLiveBackgroundWork` naming.** Alternatives:
+   `HadLiveBackgroundWork` (past tense — snapshot at finalize),
+   `BackgroundWorkParked`, `DeliberateFinalPark`. Pick one. I lean
+   `HasLiveBackgroundWork` as a point-in-time read at `finalizeTurn`
+   — semantically the same as "the turn that just finished was
+   parked on bg work."
+
+5. **Do we also need to gate on `result.Error != nil`?** A turn that
+   failed with `msg.IsError=true` from the CLI (not a tool_use_error,
+   a session-level error) falls through finalize. Retrying an
+   already-errored session turn is suspicious — the error is
+   already surfaced up the stack via `result.Error`. Consider:
+   if `result.Error != nil`, do not retry, return immediately. This
+   is a fourth gate (G4) not in the bug list but worth a small sweep
+   of the finalize paths (`session.go:1122-1134`, `1248`, `1290`,
+   `1336`, `1390`) before deciding.
+
+6. **Should the provider emit a synthetic event when the gate blocks
+   a retry?** Currently `OnRetryAbort(bg_work_live, ...)` covers it,
+   but event handlers that don't implement `RetryHandler` will lose
+   the signal entirely. Consider logging at provider level even when
+   no event handler is installed — at least once per Execute call.

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -295,7 +295,13 @@ func (h *logEventHandler) OnRetry(attempt, max int, tool, excerpt string) {
 
 func (h *logEventHandler) OnRetryAbort(reason, tool, excerpt string) {
 	h.flushText()
-	h.logger.Info("retry loop aborted",
+	msg := "retry loop aborted"
+	if reason == agent.RetryStopBgWorkLive {
+		// Expected-case gate: the turn ended with live bg work, so retry
+		// was intentionally skipped. Not a failure.
+		msg = "retry skipped: background work still live"
+	}
+	h.logger.Info(msg,
 		"step", h.step,
 		"reason", reason,
 		"tool", tool,
@@ -346,6 +352,10 @@ func (h *rendererEventHandler) OnRetry(attempt, max int, tool, _ string) {
 }
 
 func (h *rendererEventHandler) OnRetryAbort(reason, tool, _ string) {
+	if reason == agent.RetryStopBgWorkLive {
+		h.r.Status(fmt.Sprintf("Retry skipped: background work still live (tool %s)", tool))
+		return
+	}
 	h.r.Status(fmt.Sprintf("Retry loop aborted (%s) on tool %s", reason, tool))
 }
 

--- a/multiagent/agent/BUILD.bazel
+++ b/multiagent/agent/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
 go_test(
     name = "agent_test",
     srcs = [
+        "claude_provider_retry_test.go",
         "codex_provider_test.go",
         "config_test.go",
         "cursor_provider_test.go",

--- a/multiagent/agent/bridge.go
+++ b/multiagent/agent/bridge.go
@@ -144,16 +144,18 @@ func bridgeEvents[E any](
 				success := tc.StreamIsSuccess()
 				duration := tc.StreamDuration()
 				cost := tc.StreamCost()
+				hasLiveBg := tc.StreamHasLiveBackgroundWork()
 				if handler != nil {
 					handler.OnTurnComplete(turnNum, success, duration, cost)
 				}
 				if out != nil {
 					select {
 					case out <- TurnCompleteAgentEvent{
-						TurnNumber: turnNum,
-						Success:    success,
-						DurationMs: duration,
-						CostUSD:    cost,
+						TurnNumber:            turnNum,
+						Success:               success,
+						DurationMs:            duration,
+						CostUSD:               cost,
+						HasLiveBackgroundWork: hasLiveBg,
 					}:
 					default:
 					}

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -24,6 +24,11 @@ const (
 	RetryStopNoProgress     = "no_progress"
 	RetryStopBudgetExceeded = "budget_exceeded"
 	RetryStopCtxCancelled   = "ctx_cancelled"
+	// RetryStopBgWorkLive fires when the turn ended with uncancelled
+	// background work the agent deliberately parked on. Re-Asking the
+	// session would interrupt the park and, on ephemeral sessions, the
+	// defer Stop() would orphan the bg work. No retry is attempted.
+	RetryStopBgWorkLive = "bg_work_live"
 )
 
 // FormatUnresolvedToolErrorMarker returns the marker string used to surface
@@ -83,6 +88,13 @@ func emitRetryAbort(h EventHandler, reason, toolName, excerpt string) {
 	}
 }
 
+// retrySession is the minimal slice of *claude.Session that the retry
+// loop depends on. Exists so tests can drive runRetryLoop with a fake
+// that scripts a sequence of TurnResults without spawning a real CLI.
+type retrySession interface {
+	Ask(ctx context.Context, content string) (*claude.TurnResult, error)
+}
+
 // ClaudeProvider wraps the Claude SDK behind the Provider interface.
 type ClaudeProvider struct {
 	events      chan AgentEvent
@@ -99,6 +111,64 @@ func NewClaudeProvider(sessionOpts ...claude.SessionOption) *ClaudeProvider {
 }
 
 func (p *ClaudeProvider) Name() string { return "claude" }
+
+// runRetryLoop drives the provider-layer retry-on-tool-error loop. Takes
+// the result of the initial Ask and may issue follow-up Asks up to
+// cfg.MaxToolErrorRetries times. Exits early when the turn is parked on
+// bg work (G2), no tool_use_error is present (G1), the retry budget is
+// exhausted, or the ctx is cancelled. Returns the final TurnResult, the
+// number of retry Asks issued, and the stop reason recorded on the last
+// decision. The caller appends the unresolved marker and fires
+// OnRetryAbort on the returned stop reason when applicable.
+func runRetryLoop(ctx context.Context, session retrySession, initial *claude.TurnResult, cfg ExecuteConfig) (*claude.TurnResult, int, string, error) {
+	result := initial
+	start := time.Now()
+	budget := computeRetryTimeBudget(cfg)
+	stopReason := RetryStopExhausted
+	var (
+		prevExcerpt string
+		havePrev    bool
+		attempts    int
+	)
+	for attempts < cfg.MaxToolErrorRetries {
+		// G2: never retry when the turn ended with live background work.
+		// Re-Ask would interrupt the park and defer session.Stop() would
+		// orphan the bg tasks. Check before the content walk so the signal
+		// dominates even on turns that also carry a tool_use_error.
+		if result.HasLiveBackgroundWork {
+			stopReason = RetryStopBgWorkLive
+			break
+		}
+		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
+		if !ok {
+			break
+		}
+		if ctx.Err() != nil {
+			stopReason = RetryStopCtxCancelled
+			break
+		}
+		if time.Since(start) >= budget {
+			stopReason = RetryStopBudgetExceeded
+			break
+		}
+		if havePrev && excerpt == prevExcerpt {
+			stopReason = RetryStopNoProgress
+			break
+		}
+		prevExcerpt = excerpt
+		havePrev = true
+		attempts++
+
+		emitRetry(cfg.EventHandler, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)
+
+		next, askErr := session.Ask(ctx, buildRetryPrompt())
+		if askErr != nil {
+			return nil, attempts, stopReason, askErr
+		}
+		result = next
+	}
+	return result, attempts, stopReason, nil
+}
 
 func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.WorktreeContext, opts ...ExecuteOption) (*AgentResult, error) {
 	cfg := applyOptions(opts)
@@ -165,48 +235,14 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		}
 	}()
 
-	start := time.Now()
-	budget := computeRetryTimeBudget(cfg)
-
 	result, err := session.Ask(ctx, fullPrompt)
 	if err != nil {
 		return nil, err
 	}
 
-	var (
-		prevExcerpt string
-		havePrev    bool
-		attempts    int
-		stopReason  = RetryStopExhausted
-	)
-	for attempts < cfg.MaxToolErrorRetries {
-		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
-		if !ok {
-			break
-		}
-		if ctx.Err() != nil {
-			stopReason = RetryStopCtxCancelled
-			break
-		}
-		if time.Since(start) >= budget {
-			stopReason = RetryStopBudgetExceeded
-			break
-		}
-		if havePrev && excerpt == prevExcerpt {
-			stopReason = RetryStopNoProgress
-			break
-		}
-		prevExcerpt = excerpt
-		havePrev = true
-		attempts++
-
-		emitRetry(cfg.EventHandler, attempts, cfg.MaxToolErrorRetries, toolName, excerpt)
-
-		next, askErr := session.Ask(ctx, buildRetryPrompt())
-		if askErr != nil {
-			return nil, askErr
-		}
-		result = next
+	result, attempts, stopReason, err := runRetryLoop(ctx, session, result, cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	agentResult := ClaudeResultToAgentResult(result)

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -261,8 +261,8 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			agentResult.UnresolvedToolError = unresolved
 			agentResult.Text = AppendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
 			// Fire the abort callback once per loop execution that stopped
-			// with a tool error still present. Unifies the four stop reasons
-			// (exhausted, no_progress, budget_exceeded, ctx_cancelled).
+			// with a tool error still present. Covers all five stop reasons:
+			// exhausted, no_progress, budget_exceeded, ctx_cancelled, bg_work_live.
 			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 		}
 	}

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -249,7 +249,12 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	if info := session.Info(); info != nil {
 		agentResult.SessionID = info.SessionID
 	}
-	if cfg.MaxToolErrorRetries > 0 {
+	// When bg work is live the retry loop deliberately skips retrying — the
+	// session parked normally and the bg tasks are still running. The result
+	// may still contain a tool_use_error block (e.g. a Skill error that
+	// triggered the park), but surfacing it as an unresolved-tool-error
+	// marker would be misleading: no retry was ever attempted or warranted.
+	if cfg.MaxToolErrorRetries > 0 && stopReason != RetryStopBgWorkLive {
 		if toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks); ok {
 			unresolved := &UnresolvedToolError{
 				Tool:     toolName,
@@ -261,8 +266,9 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			agentResult.UnresolvedToolError = unresolved
 			agentResult.Text = AppendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
 			// Fire the abort callback once per loop execution that stopped
-			// with a tool error still present. Covers all five stop reasons:
-			// exhausted, no_progress, budget_exceeded, ctx_cancelled, bg_work_live.
+			// with a tool error still present. Covers all four stop reasons:
+			// exhausted, no_progress, budget_exceeded, ctx_cancelled.
+			// bg_work_live is excluded above — no retry was attempted.
 			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
 		}
 	}

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -303,6 +303,8 @@ func (p *ClaudeLongRunningProvider) Start(ctx context.Context) error {
 	return nil
 }
 
+// SendMessage issues one Ask on the persistent session. Unlike Execute, it
+// does not run the retry loop — tool-error retries are not applied here.
 func (p *ClaudeLongRunningProvider) SendMessage(ctx context.Context, message string) (*AgentResult, error) {
 	result, err := p.session.Ask(ctx, message)
 	if err != nil {

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -303,6 +303,42 @@ func TestRunRetryLoop_SkipsWhenBgWorkLiveAndParallelCancel(t *testing.T) {
 	}
 }
 
+// TestRunRetryLoop_BgWorkLiveNoUnresolvedError verifies the contract that
+// Execute relies on: when HasLiveBackgroundWork=true and a tool_use_error
+// is present, runRetryLoop returns stopReason=RetryStopBgWorkLive with
+// attempts=0, which causes Execute to SKIP the post-loop UnresolvedToolError
+// block (guarded by stopReason != RetryStopBgWorkLive). This ensures the
+// parked-session case never pollutes agentResult.Text with a spurious
+// "[unresolved tool error (bg_work_live) after 0/N retries]" marker.
+func TestRunRetryLoop_BgWorkLiveNoUnresolvedError(t *testing.T) {
+	t.Parallel()
+	initial := turnResult(
+		"parked",
+		realToolUseErrorBlocks("Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation"),
+		true, // HasLiveBackgroundWork — G2 gate fires
+	)
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	result, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries when bg work is live, got %d", attempts)
+	}
+	if reason != RetryStopBgWorkLive {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopBgWorkLive, reason)
+	}
+	// Confirm: FinalTurnToolError WOULD return ok=true on this result,
+	// so the Execute guard (stopReason != RetryStopBgWorkLive) is what
+	// prevents the UnresolvedToolError marker from being appended.
+	_, _, ok := claude.FinalTurnToolError(result.ContentBlocks)
+	if !ok {
+		t.Error("FinalTurnToolError must return ok=true on this result — the Execute guard is what suppresses the marker, not the absence of an error block")
+	}
+}
+
 // TestRunRetryLoop_PropagatesAskError ensures an Ask transport error
 // aborts the loop cleanly without masking.
 func TestRunRetryLoop_PropagatesAskError(t *testing.T) {

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -1,0 +1,319 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
+)
+
+// scriptedSession drives runRetryLoop with a pre-scripted sequence of
+// TurnResults. The first result is returned by the caller of Execute
+// before runRetryLoop is invoked, so the slice held here represents
+// the responses to each follow-up "retry" Ask.
+type scriptedSession struct {
+	responses []*claude.TurnResult
+	asks      []string
+	askErrs   []error
+	cursor    int
+}
+
+func (s *scriptedSession) Ask(ctx context.Context, content string) (*claude.TurnResult, error) {
+	s.asks = append(s.asks, content)
+	if s.cursor < len(s.askErrs) {
+		if err := s.askErrs[s.cursor]; err != nil {
+			s.cursor++
+			return nil, err
+		}
+	}
+	if s.cursor >= len(s.responses) {
+		return nil, errors.New("scriptedSession: no more responses queued")
+	}
+	r := s.responses[s.cursor]
+	s.cursor++
+	return r, nil
+}
+
+// realToolUseErrorBlocks is the minimal set of ContentBlocks that
+// FinalTurnToolError will flag as retry-worthy: IsError true and the
+// <tool_use_error> wrapper present.
+func realToolUseErrorBlocks(excerpt string) []claude.ContentBlock {
+	return []claude.ContentBlock{
+		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{
+			Type:       claude.ContentBlockTypeToolResult,
+			ToolUseID:  "t1",
+			ToolResult: "<tool_use_error>" + excerpt + "</tool_use_error>",
+			IsError:    true,
+		},
+	}
+}
+
+// nonzeroExitBashBlocks mimics a `gh pr checks` exit-8 shape: IsError
+// true but no <tool_use_error> wrapper. Must not trigger retry.
+func nonzeroExitBashBlocks() []claude.ContentBlock {
+	return []claude.ContentBlock{
+		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{
+			Type:       claude.ContentBlockTypeToolResult,
+			ToolUseID:  "t1",
+			ToolResult: "Exit code 8\nForge Visual Tests\tpending",
+			IsError:    true,
+		},
+	}
+}
+
+func cleanBlocks() []claude.ContentBlock {
+	return []claude.ContentBlock{{Type: claude.ContentBlockTypeText, Text: "done"}}
+}
+
+func turnResult(text string, blocks []claude.ContentBlock, bgLive bool) *claude.TurnResult {
+	return &claude.TurnResult{
+		Text:                  text,
+		ContentBlocks:         blocks,
+		HasLiveBackgroundWork: bgLive,
+		Success:               true,
+	}
+}
+
+func TestRunRetryLoop_RetriesUntilClean(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("first"), false)
+	fake := &scriptedSession{
+		responses: []*claude.TurnResult{
+			turnResult("err2", realToolUseErrorBlocks("second"), false),
+			turnResult("clean", cleanBlocks(), false),
+		},
+	}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	result, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("expected 2 retry Asks, got %d", attempts)
+	}
+	if len(fake.asks) != 2 {
+		t.Errorf("expected 2 Ask calls, got %d", len(fake.asks))
+	}
+	if result.Text != "clean" {
+		t.Errorf("expected final text=clean, got %q", result.Text)
+	}
+	// stopReason is the last assigned value — default "exhausted" when
+	// the loop exited via the "no more error" break.
+	if reason != RetryStopExhausted {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopExhausted, reason)
+	}
+}
+
+func TestRunRetryLoop_RespectsCountLimit(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("same"), false)
+	fake := &scriptedSession{
+		responses: []*claude.TurnResult{
+			// second excerpt must differ or no_progress would short-circuit
+			turnResult("err2", realToolUseErrorBlocks("different"), false),
+		},
+	}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 1}
+
+	result, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected exactly 1 retry Ask, got %d", attempts)
+	}
+	if reason != RetryStopExhausted {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopExhausted, reason)
+	}
+	if result.Text != "err2" {
+		t.Errorf("expected final text=err2, got %q", result.Text)
+	}
+}
+
+func TestRunRetryLoop_NoProgressAborts(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("identical"), false)
+	fake := &scriptedSession{
+		responses: []*claude.TurnResult{
+			turnResult("err2", realToolUseErrorBlocks("identical"), false),
+		},
+	}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 5}
+
+	_, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 retry before no_progress abort, got %d", attempts)
+	}
+	if reason != RetryStopNoProgress {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopNoProgress, reason)
+	}
+}
+
+func TestRunRetryLoop_CtxCancelled(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("first"), false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the loop runs
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	_, attempts, reason, err := runRetryLoop(ctx, fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no Asks before ctx check, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if reason != RetryStopCtxCancelled {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopCtxCancelled, reason)
+	}
+}
+
+func TestRunRetryLoop_DisabledByDefault(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("first"), false)
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 0}
+
+	result, attempts, _, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected 0 retries, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if result != initial {
+		t.Error("expected the initial result returned unchanged")
+	}
+}
+
+// TestRunRetryLoop_SkipsWhenBgWorkLive is the G2 regression for
+// evidence log 1: a Skill disable-model-invocation tool_use_error fired
+// while bg Bash work was parked. Retry would orphan the parked work;
+// the gate must block before the content walk.
+func TestRunRetryLoop_SkipsWhenBgWorkLive(t *testing.T) {
+	t.Parallel()
+	initial := turnResult(
+		"parked",
+		realToolUseErrorBlocks("Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation"),
+		true, // HasLiveBackgroundWork
+	)
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	_, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries when bg work is live, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if reason != RetryStopBgWorkLive {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopBgWorkLive, reason)
+	}
+}
+
+// TestRunRetryLoop_SkipsOnNonzeroExitBash is the G1 regression for
+// evidence log 2: `gh pr checks` exit 8 sets IsError but no wrapper.
+// FinalTurnToolError returns ok=false, retry does not fire.
+func TestRunRetryLoop_SkipsOnNonzeroExitBash(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("polling", nonzeroExitBashBlocks(), false)
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	result, attempts, _, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries on nonzero-exit Bash, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if result != initial {
+		t.Error("expected the initial result returned unchanged")
+	}
+}
+
+// TestRunRetryLoop_RetriesCleanlyOnRealToolUseError ensures G1+G2
+// tightening did not break the PLA-212 recover-on-retry path.
+func TestRunRetryLoop_RetriesCleanlyOnRealToolUseError(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("parallel-cancelled", realToolUseErrorBlocks("Cancelled: parallel tool call"), false)
+	fake := &scriptedSession{
+		responses: []*claude.TurnResult{
+			turnResult("fixed", cleanBlocks(), false),
+		},
+	}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 2}
+
+	result, attempts, _, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 retry Ask, got %d", attempts)
+	}
+	if result.Text != "fixed" {
+		t.Errorf("expected recovered result, got %q", result.Text)
+	}
+}
+
+// TestRunRetryLoop_SkipsWhenBgWorkLiveAndParallelCancel checks that G2
+// dominates G1 — even a real tool_use_error with the marker does not
+// retry when bg work is live.
+func TestRunRetryLoop_SkipsWhenBgWorkLiveAndParallelCancel(t *testing.T) {
+	t.Parallel()
+	initial := turnResult(
+		"parked+error",
+		realToolUseErrorBlocks("Cancelled: parallel tool call Bash(ruff check) errored"),
+		true,
+	)
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	_, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries, got %d", attempts)
+	}
+	if reason != RetryStopBgWorkLive {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopBgWorkLive, reason)
+	}
+}
+
+// TestRunRetryLoop_PropagatesAskError ensures an Ask transport error
+// aborts the loop cleanly without masking.
+func TestRunRetryLoop_PropagatesAskError(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("first"), false)
+	askErr := errors.New("transport boom")
+	fake := &scriptedSession{askErrs: []error{askErr}}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	_, _, _, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err == nil || !strings.Contains(err.Error(), "transport boom") {
+		t.Errorf("expected transport error to propagate, got %v", err)
+	}
+}

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -106,10 +106,11 @@ func (e ToolCompleteAgentEvent) AgentEventType() AgentEventType { return AgentEv
 
 // TurnCompleteAgentEvent is emitted when a turn finishes.
 type TurnCompleteAgentEvent struct {
-	TurnNumber int
-	Success    bool
-	DurationMs int64
-	CostUSD    float64
+	DurationMs            int64
+	CostUSD               float64
+	TurnNumber            int
+	HasLiveBackgroundWork bool
+	Success               bool
 }
 
 func (e TurnCompleteAgentEvent) AgentEventType() AgentEventType { return AgentEventTurnComplete }

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -25,7 +25,8 @@ type AgentResult struct {
 // AgentResult.Text, which may be replaced downstream (e.g. when a plan file
 // is read instead of the agent's text). Reason distinguishes why the loop
 // stopped — "exhausted" (count budget reached), "budget_exceeded",
-// "no_progress", or "ctx_cancelled".
+// "no_progress", "ctx_cancelled", or "bg_work_live" (live background work
+// present; retry was intentionally skipped to avoid orphaning bg tasks).
 type UnresolvedToolError struct {
 	Tool     string
 	Excerpt  string
@@ -147,9 +148,11 @@ type RetryHandler interface {
 	// OnRetryAbort fires once per retry-loop execution when the loop
 	// stops while a tool error is still present. reason is one of
 	// "exhausted" (count budget reached), "no_progress",
-	// "budget_exceeded", or "ctx_cancelled". The same reason is
-	// carried on UnresolvedToolError.Reason and in the appended
-	// marker, so handlers can correlate logs with downstream output.
+	// "budget_exceeded", "ctx_cancelled", or "bg_work_live" (live
+	// background work present; retry intentionally skipped). The same
+	// reason is carried on UnresolvedToolError.Reason and in the
+	// appended marker, so handlers can correlate logs with downstream
+	// output.
 	OnRetryAbort(reason, tool, excerpt string)
 }
 

--- a/yoloswe/reviewer/bridge_test.go
+++ b/yoloswe/reviewer/bridge_test.go
@@ -48,10 +48,10 @@ type testTurnCompleteEvent struct {
 func (e testTurnCompleteEvent) StreamEventKind() agentstream.EventKind {
 	return agentstream.KindTurnComplete
 }
-func (e testTurnCompleteEvent) StreamTurnNum() int    { return 1 }
-func (e testTurnCompleteEvent) StreamIsSuccess() bool { return e.success }
-func (e testTurnCompleteEvent) StreamDuration() int64 { return e.durationMs }
-func (e testTurnCompleteEvent) StreamCost() float64 { return 0 }
+func (e testTurnCompleteEvent) StreamTurnNum() int                { return 1 }
+func (e testTurnCompleteEvent) StreamIsSuccess() bool             { return e.success }
+func (e testTurnCompleteEvent) StreamDuration() int64             { return e.durationMs }
+func (e testTurnCompleteEvent) StreamCost() float64               { return 0 }
 func (e testTurnCompleteEvent) StreamHasLiveBackgroundWork() bool { return false }
 
 type testErrorEvent struct {

--- a/yoloswe/reviewer/bridge_test.go
+++ b/yoloswe/reviewer/bridge_test.go
@@ -51,7 +51,8 @@ func (e testTurnCompleteEvent) StreamEventKind() agentstream.EventKind {
 func (e testTurnCompleteEvent) StreamTurnNum() int    { return 1 }
 func (e testTurnCompleteEvent) StreamIsSuccess() bool { return e.success }
 func (e testTurnCompleteEvent) StreamDuration() int64 { return e.durationMs }
-func (e testTurnCompleteEvent) StreamCost() float64   { return 0 }
+func (e testTurnCompleteEvent) StreamCost() float64 { return 0 }
+func (e testTurnCompleteEvent) StreamHasLiveBackgroundWork() bool { return false }
 
 type testErrorEvent struct {
 	err error


### PR DESCRIPTION
## Summary

- **G1**: `FinalTurnToolError` now requires `IsError` AND the `<tool_use_error>` marker, so nonzero-exit Bash (`gh pr checks` exit 8, `grep -q` exit 1) no longer triggers retry.
- **G2**: New `TurnResult.HasLiveBackgroundWork` gate — `runRetryLoop` checks it before the content walk, so `defer session.Stop()` on the ephemeral session cannot orphan parked bg tasks. New stop reason `bg_work_live`.
- Retry loop extracted into `runRetryLoop` behind a minimal `retrySession` interface so it is unit-testable without spawning a real CLI.

Context: two real jiradozer runs showed #152's retry firing on turns it should never have touched — a Skill `disable-model-invocation` permanent error while bg Bash was parked (Execute returned, `defer Stop()` orphaned the bg work), and a `gh pr checks` exit-8 informational nonzero exit (three turns wasted fighting the agent's intentional park-and-wait). Wire-level evidence from Claude session JSONL confirmed `<tool_use_error>` is the stable CLI sentinel for refused/blocked/cancelled tool invocations — nonzero-exit Bash never carries it. Full design doc in `docs/design/jiradozer-tool-error-retry-v2.md`.

G3 (permanent-error deny list) tracked separately in #153 pending post-merge log evidence.

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `bazel build //...` — clean
- [x] `bazel test //...` — all 55 targets pass
- [x] 13 detection-level tests in `turn_retry_test.go`, including 3 fixture-driven cases loaded from real session JSONL extracts in `testdata/retry/`
- [x] 10 new provider-level tests in `multiagent/agent/claude_provider_retry_test.go` covering every stop reason plus G1/G2 core regressions and the G2-dominates-G1 case
- [ ] Watch jiradozer runs post-merge for residual permanent-error retries (feeds #153 decision)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider retry control-flow and event interfaces (`agentstream.TurnComplete`), so regressions could alter retry behavior or event bridging across providers, though changes are well-covered by new unit and fixture tests.
> 
> **Overview**
> Tightens the Claude tool-error retry loop so it only triggers on **real CLI-reported** tool failures and never interrupts turns that are parked on background work.
> 
> This changes `FinalTurnToolError` to require both `is_error=true` *and* the `<tool_use_error>` marker (avoiding retries on nonzero-exit Bash like `gh pr checks`), propagates a new `HasLiveBackgroundWork` flag through `TurnResult`/`TurnComplete` events, and gates retries on that flag with a new stop reason `bg_work_live`. The retry logic is extracted into `runRetryLoop` with new unit tests and fixture-based regression coverage, and the event bridge/UI logging is updated to surface the new background-work signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5281ebdc6bb69d38576422a6b2e16c7fa39ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->