### PR TITLE
jiradozer: track workflow progress via issue labels

### DIFF
--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "orchestrator.go",
         "poller.go",
         "state.go",
+        "steplabels.go",
         "workflow.go",
     ],
     importpath = "github.com/bazelment/yoloswe/jiradozer",

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -3,7 +3,9 @@ package jiradozer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -567,6 +569,21 @@ func NewPromptData(issue *tracker.Issue, baseBranch string) PromptData {
 // reuse across separate process invocations (e.g. plan step then build step).
 func PlanFilePath(workDir string) string {
 	return filepath.Join(workDir, ".jiradozer", "plan.md")
+}
+
+// LoadPersistedPlan reads plan.md from workDir. Returns "" and no error when
+// the file does not exist (a missing plan is normal, not a failure). The
+// returned content is trimmed.
+func LoadPersistedPlan(workDir string) (string, error) {
+	planPath := PlanFilePath(workDir)
+	content, err := os.ReadFile(planPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read persisted plan %s: %w", planPath, err)
+	}
+	return strings.TrimSpace(string(content)), nil
 }
 
 // PersistPlan writes plan output to PlanFilePath so --run-step=build can load it.

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -550,9 +550,10 @@ func JoinRoundOutputs(outputs []string) string {
 }
 
 func NewPromptData(issue *tracker.Issue, baseBranch string) PromptData {
-	// Strip jiradozer-* bookkeeping labels so agent prompts see only
-	// user-facing labels. Callers that need the full set (e.g. phase skip
-	// logic in Workflow) work off a separately-tracked copy.
+	// Strip jiradozer's phase bookkeeping labels (exact-match allowlist, see
+	// isJiradozerLabel) so agent prompts see only user-facing labels.
+	// Callers that need the full set (e.g. phase skip logic in Workflow)
+	// work off a separately-tracked copy.
 	userLabels := make([]string, 0, len(issue.Labels))
 	for _, l := range issue.Labels {
 		if !isJiradozerLabel(l) {

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -550,10 +550,19 @@ func JoinRoundOutputs(outputs []string) string {
 }
 
 func NewPromptData(issue *tracker.Issue, baseBranch string) PromptData {
+	// Strip jiradozer-* bookkeeping labels so agent prompts see only
+	// user-facing labels. Callers that need the full set (e.g. phase skip
+	// logic in Workflow) work off a separately-tracked copy.
+	userLabels := make([]string, 0, len(issue.Labels))
+	for _, l := range issue.Labels {
+		if !isJiradozerLabel(l) {
+			userLabels = append(userLabels, l)
+		}
+	}
 	d := PromptData{
 		Identifier: issue.Identifier,
 		Title:      issue.Title,
-		Labels:     strings.Join(issue.Labels, ", "),
+		Labels:     strings.Join(userLabels, ", "),
 		BaseBranch: baseBranch,
 	}
 	if issue.Description != nil {

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -36,6 +36,19 @@ func TestNewPromptData(t *testing.T) {
 	assert.Empty(t, data.BuildOutput)
 }
 
+func TestNewPromptData_StripsJiradozerLabels(t *testing.T) {
+	issue := &tracker.Issue{
+		ID:         "id",
+		Identifier: "ENG-1",
+		Title:      "Test",
+		Labels:     []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"},
+	}
+
+	data := NewPromptData(issue, "main")
+
+	assert.Equal(t, "bug, feature", data.Labels)
+}
+
 func TestNewPromptData_NilOptionalFields(t *testing.T) {
 	issue := &tracker.Issue{
 		ID:         "id",

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -647,15 +647,18 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	// Inject plan into prompt data for the build step.
 	// Priority: --plan-file flag > persisted plan.md > no plan.
 	if stepName == "build" {
-		planPath := jiradozer.PlanFilePath(cfg.WorkDir)
 		if planContent != "" {
 			data.Plan = planContent
 			logger.Info("using plan from --plan-file")
-		} else if content, err := os.ReadFile(planPath); err == nil {
-			data.Plan = strings.TrimSpace(string(content))
-			logger.Info("loaded persisted plan", "path", planPath)
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("read persisted plan %s: %w", planPath, err)
+		} else {
+			content, err := jiradozer.LoadPersistedPlan(cfg.WorkDir)
+			if err != nil {
+				return err
+			}
+			if content != "" {
+				data.Plan = content
+				logger.Info("loaded persisted plan", "path", jiradozer.PlanFilePath(cfg.WorkDir))
+			}
 		}
 		if data.Plan == "" {
 			logger.Warn("NO PLAN AVAILABLE — build step is running without a plan; use --plan-file to provide one, or run the plan step first")

--- a/jiradozer/discovery_test.go
+++ b/jiradozer/discovery_test.go
@@ -54,6 +54,9 @@ func (m *mockDiscoveryTracker) UpdateIssueState(_ context.Context, _ string, _ s
 func (m *mockDiscoveryTracker) AddLabel(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *mockDiscoveryTracker) RemoveLabel(_ context.Context, _ string, _ string) error {
+	return nil
+}
 
 func TestDiscovery_DeduplicatesIssues(t *testing.T) {
 	issueA := &tracker.Issue{ID: "a", Identifier: "ENG-1", Title: "Issue A"}

--- a/jiradozer/integration/fake_tracker.go
+++ b/jiradozer/integration/fake_tracker.go
@@ -217,3 +217,21 @@ func (f *FakeTracker) AddLabel(_ context.Context, issueID string, label string) 
 	fi.issue.Labels = append(fi.issue.Labels, label)
 	return nil
 }
+
+func (f *FakeTracker) RemoveLabel(_ context.Context, issueID string, label string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.record("RemoveLabel", issueID, label)
+	fi, ok := f.issues[issueID]
+	if !ok {
+		return fmt.Errorf("issue %q not found", issueID)
+	}
+	filtered := fi.issue.Labels[:0]
+	for _, l := range fi.issue.Labels {
+		if l != label {
+			filtered = append(filtered, l)
+		}
+	}
+	fi.issue.Labels = filtered
+	return nil
+}

--- a/jiradozer/integration/fake_tracker.go
+++ b/jiradozer/integration/fake_tracker.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -226,12 +227,10 @@ func (f *FakeTracker) RemoveLabel(_ context.Context, issueID string, label strin
 	if !ok {
 		return fmt.Errorf("issue %q not found", issueID)
 	}
-	filtered := fi.issue.Labels[:0]
-	for _, l := range fi.issue.Labels {
-		if l != label {
-			filtered = append(filtered, l)
-		}
-	}
-	fi.issue.Labels = filtered
+	// Allocate a fresh slice — FetchIssue hands out shallow Issue copies that
+	// alias the same Labels backing array, so an in-place filter would
+	// corrupt previously returned copies.
+	next := slices.DeleteFunc(slices.Clone(fi.issue.Labels), func(l string) bool { return l == label })
+	fi.issue.Labels = next
 	return nil
 }

--- a/jiradozer/integration/orchestrator_test.go
+++ b/jiradozer/integration/orchestrator_test.go
@@ -63,6 +63,9 @@ func (m *mockOrchestratorTracker) UpdateIssueState(_ context.Context, _ string, 
 func (m *mockOrchestratorTracker) AddLabel(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *mockOrchestratorTracker) RemoveLabel(_ context.Context, _ string, _ string) error {
+	return nil
+}
 
 // mockWTManager tracks worktree operations without real git.
 type mockWTManager struct {

--- a/jiradozer/poller_test.go
+++ b/jiradozer/poller_test.go
@@ -122,6 +122,9 @@ func (m *mockPollerTracker) UpdateIssueState(_ context.Context, _ string, _ stri
 func (m *mockPollerTracker) AddLabel(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *mockPollerTracker) RemoveLabel(_ context.Context, _ string, _ string) error {
+	return nil
+}
 
 func TestPollForFeedback_FiltersBotComments(t *testing.T) {
 	now := time.Now()

--- a/jiradozer/steplabels.go
+++ b/jiradozer/steplabels.go
@@ -1,7 +1,5 @@
 package jiradozer
 
-import "strings"
-
 // Phase names used as label segments for step tracking. Four high-level
 // phases are surfaced to users as labels; review gates and create_pr fold
 // into the adjacent agent phase.
@@ -66,7 +64,14 @@ func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done
 
 // isJiradozerLabel reports whether label is one of jiradozer's bookkeeping
 // phase labels. Callers strip these from user-facing prompts so agents see
-// only substantive labels.
+// only substantive labels. The check is an exact-match allowlist against
+// the eight phase × state labels so unrelated jiradozer-prefixed labels
+// (e.g. a team-owned jiradozer-backlog) are left visible to agents.
 func isJiradozerLabel(label string) bool {
-	return strings.HasPrefix(label, "jiradozer-")
+	for _, p := range phaseTable {
+		if label == inProgressLabel(p.name) || label == doneLabel(p.name) {
+			return true
+		}
+	}
+	return false
 }

--- a/jiradozer/steplabels.go
+++ b/jiradozer/steplabels.go
@@ -10,8 +10,19 @@ const (
 	PhaseShip     = "ship"
 )
 
-// allPhases lists phases in workflow order. Used for skip-done detection.
-var allPhases = []string{PhasePlan, PhaseBuild, PhaseValidate, PhaseShip}
+// phaseTable is the single source of truth for phase ordering and the
+// starting WorkflowStep of each phase. Review gates and StepCreatingPR are
+// not primary starts; they are folded into the preceding phase by
+// phaseForStep.
+var phaseTable = []struct {
+	name      string
+	startStep WorkflowStep
+}{
+	{PhasePlan, StepPlanning},
+	{PhaseBuild, StepBuilding},
+	{PhaseValidate, StepValidating},
+	{PhaseShip, StepShipping},
+}
 
 // phaseForStep maps a WorkflowStep to its phase name, or "" if the step
 // does not belong to a labelled phase (review gates, terminal states).
@@ -30,32 +41,23 @@ func phaseForStep(s WorkflowStep) string {
 	return ""
 }
 
-// startStepForPhase returns the first WorkflowStep of the given phase.
-// Used when forcing the workflow to start at a mid-phase step after
-// skipping completed phases.
 func startStepForPhase(phase string) WorkflowStep {
-	switch phase {
-	case PhasePlan:
-		return StepPlanning
-	case PhaseBuild:
-		return StepBuilding
-	case PhaseValidate:
-		return StepValidating
-	case PhaseShip:
-		return StepShipping
+	for _, p := range phaseTable {
+		if p.name == phase {
+			return p.startStep
+		}
 	}
 	return StepInit
 }
 
-func inProgressLabel(phase string) string { return "jiradozer-" + phase + "-inprogress" }
-func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done" }
-
-// hasLabel reports whether the label set contains name.
-func hasLabel(labels []string, name string) bool {
-	for _, l := range labels {
-		if l == name {
-			return true
+func phaseAfter(phase string) string {
+	for i, p := range phaseTable {
+		if p.name == phase && i+1 < len(phaseTable) {
+			return phaseTable[i+1].name
 		}
 	}
-	return false
+	return ""
 }
+
+func inProgressLabel(phase string) string { return "jiradozer-" + phase + "-inprogress" }
+func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done" }

--- a/jiradozer/steplabels.go
+++ b/jiradozer/steplabels.go
@@ -1,0 +1,61 @@
+package jiradozer
+
+// Phase names used as label segments for step tracking. Four high-level
+// phases are surfaced to users as labels; review gates and create_pr fold
+// into the adjacent agent phase.
+const (
+	PhasePlan     = "plan"
+	PhaseBuild    = "build"
+	PhaseValidate = "validate"
+	PhaseShip     = "ship"
+)
+
+// allPhases lists phases in workflow order. Used for skip-done detection.
+var allPhases = []string{PhasePlan, PhaseBuild, PhaseValidate, PhaseShip}
+
+// phaseForStep maps a WorkflowStep to its phase name, or "" if the step
+// does not belong to a labelled phase (review gates, terminal states).
+// StepCreatingPR folds into PhaseBuild.
+func phaseForStep(s WorkflowStep) string {
+	switch s {
+	case StepPlanning:
+		return PhasePlan
+	case StepBuilding, StepCreatingPR:
+		return PhaseBuild
+	case StepValidating:
+		return PhaseValidate
+	case StepShipping:
+		return PhaseShip
+	}
+	return ""
+}
+
+// startStepForPhase returns the first WorkflowStep of the given phase.
+// Used when forcing the workflow to start at a mid-phase step after
+// skipping completed phases.
+func startStepForPhase(phase string) WorkflowStep {
+	switch phase {
+	case PhasePlan:
+		return StepPlanning
+	case PhaseBuild:
+		return StepBuilding
+	case PhaseValidate:
+		return StepValidating
+	case PhaseShip:
+		return StepShipping
+	}
+	return StepInit
+}
+
+func inProgressLabel(phase string) string { return "jiradozer-" + phase + "-inprogress" }
+func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done" }
+
+// hasLabel reports whether the label set contains name.
+func hasLabel(labels []string, name string) bool {
+	for _, l := range labels {
+		if l == name {
+			return true
+		}
+	}
+	return false
+}

--- a/jiradozer/steplabels.go
+++ b/jiradozer/steplabels.go
@@ -1,5 +1,7 @@
 package jiradozer
 
+import "strings"
+
 // Phase names used as label segments for step tracking. Four high-level
 // phases are surfaced to users as labels; review gates and create_pr fold
 // into the adjacent agent phase.
@@ -61,3 +63,10 @@ func phaseAfter(phase string) string {
 
 func inProgressLabel(phase string) string { return "jiradozer-" + phase + "-inprogress" }
 func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done" }
+
+// isJiradozerLabel reports whether label is one of jiradozer's bookkeeping
+// phase labels. Callers strip these from user-facing prompts so agents see
+// only substantive labels.
+func isJiradozerLabel(label string) bool {
+	return strings.HasPrefix(label, "jiradozer-")
+}

--- a/jiradozer/steplabels_test.go
+++ b/jiradozer/steplabels_test.go
@@ -1,0 +1,70 @@
+package jiradozer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPhaseForStep(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		want string
+		step WorkflowStep
+	}{
+		{"", StepInit},
+		{PhasePlan, StepPlanning},
+		{"", StepPlanReview},
+		{PhaseBuild, StepBuilding},
+		{PhaseBuild, StepCreatingPR},
+		{"", StepBuildReview},
+		{PhaseValidate, StepValidating},
+		{"", StepValidateReview},
+		{PhaseShip, StepShipping},
+		{"", StepShipReview},
+		{"", StepDone},
+		{"", StepFailed},
+		{"", StepCancelled},
+	}
+	for _, c := range cases {
+		t.Run(c.step.String(), func(t *testing.T) {
+			assert.Equal(t, c.want, phaseForStep(c.step))
+		})
+	}
+}
+
+func TestStartStepForPhase(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, StepPlanning, startStepForPhase(PhasePlan))
+	assert.Equal(t, StepBuilding, startStepForPhase(PhaseBuild))
+	assert.Equal(t, StepValidating, startStepForPhase(PhaseValidate))
+	assert.Equal(t, StepShipping, startStepForPhase(PhaseShip))
+	assert.Equal(t, StepInit, startStepForPhase("unknown"))
+}
+
+func TestPhaseAfter(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, PhaseBuild, phaseAfter(PhasePlan))
+	assert.Equal(t, PhaseValidate, phaseAfter(PhaseBuild))
+	assert.Equal(t, PhaseShip, phaseAfter(PhaseValidate))
+	assert.Empty(t, phaseAfter(PhaseShip), "ship is the last phase")
+	assert.Empty(t, phaseAfter("bogus"))
+}
+
+func TestLabelFormat(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "jiradozer-plan-inprogress", inProgressLabel(PhasePlan))
+	assert.Equal(t, "jiradozer-plan-done", doneLabel(PhasePlan))
+	assert.Equal(t, "jiradozer-build-inprogress", inProgressLabel(PhaseBuild))
+	assert.Equal(t, "jiradozer-validate-done", doneLabel(PhaseValidate))
+	assert.Equal(t, "jiradozer-ship-inprogress", inProgressLabel(PhaseShip))
+}
+
+func TestHasLabel(t *testing.T) {
+	t.Parallel()
+	labels := []string{"bug", "jiradozer-plan-done"}
+	assert.True(t, hasLabel(labels, "bug"))
+	assert.True(t, hasLabel(labels, "jiradozer-plan-done"))
+	assert.False(t, hasLabel(labels, "other"))
+	assert.False(t, hasLabel(nil, "anything"))
+}

--- a/jiradozer/steplabels_test.go
+++ b/jiradozer/steplabels_test.go
@@ -59,12 +59,3 @@ func TestLabelFormat(t *testing.T) {
 	assert.Equal(t, "jiradozer-validate-done", doneLabel(PhaseValidate))
 	assert.Equal(t, "jiradozer-ship-inprogress", inProgressLabel(PhaseShip))
 }
-
-func TestHasLabel(t *testing.T) {
-	t.Parallel()
-	labels := []string{"bug", "jiradozer-plan-done"}
-	assert.True(t, hasLabel(labels, "bug"))
-	assert.True(t, hasLabel(labels, "jiradozer-plan-done"))
-	assert.False(t, hasLabel(labels, "other"))
-	assert.False(t, hasLabel(nil, "anything"))
-}

--- a/jiradozer/steplabels_test.go
+++ b/jiradozer/steplabels_test.go
@@ -59,3 +59,19 @@ func TestLabelFormat(t *testing.T) {
 	assert.Equal(t, "jiradozer-validate-done", doneLabel(PhaseValidate))
 	assert.Equal(t, "jiradozer-ship-inprogress", inProgressLabel(PhaseShip))
 }
+
+func TestIsJiradozerLabel_AllowlistOnly(t *testing.T) {
+	t.Parallel()
+	// All eight phase × state labels should be recognized.
+	for _, p := range phaseTable {
+		assert.True(t, isJiradozerLabel(inProgressLabel(p.name)), "%s in-progress", p.name)
+		assert.True(t, isJiradozerLabel(doneLabel(p.name)), "%s done", p.name)
+	}
+	// Unrelated jiradozer-prefixed labels must NOT be filtered, so teams
+	// can use the namespace without their labels being hidden from agents.
+	assert.False(t, isJiradozerLabel("jiradozer-backlog"))
+	assert.False(t, isJiradozerLabel("jiradozer-plan-unknown"))
+	assert.False(t, isJiradozerLabel("jiradozer-"))
+	assert.False(t, isJiradozerLabel(""))
+	assert.False(t, isJiradozerLabel("bug"))
+}

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -313,14 +313,49 @@ func (c *Client) UpdateIssueState(ctx context.Context, issueID string, stateID s
 // AddLabel adds a label to a GitHub issue. The operation is idempotent —
 // GitHub returns 200 OK even if the label is already present.
 func (c *Client) AddLabel(ctx context.Context, issueID string, label string) error {
+	result, err := c.gh.Run(ctx, []string{
+		"api", "-X", "POST",
+		fmt.Sprintf("repos/%s/%s/issues/%s/labels", c.owner, c.repo, issueID),
+		"-f", fmt.Sprintf("labels[]=%s", label),
+	}, "")
+	if err == nil {
+		return nil
+	}
+	// GitHub returns 422 "Validation Failed" when the label does not yet
+	// exist on the repo. Create it on demand (matching Linear's ensureLabel
+	// behaviour) and retry once.
+	if result == nil || !strings.Contains(result.Stderr, "422") {
+		return fmt.Errorf("add label %q to issue %s: %w", label, issueID, err)
+	}
+	if cErr := c.ensureRepoLabel(ctx, label); cErr != nil {
+		return fmt.Errorf("add label %q to issue %s: ensure repo label: %w", label, issueID, cErr)
+	}
 	if _, err := c.gh.Run(ctx, []string{
 		"api", "-X", "POST",
 		fmt.Sprintf("repos/%s/%s/issues/%s/labels", c.owner, c.repo, issueID),
 		"-f", fmt.Sprintf("labels[]=%s", label),
 	}, ""); err != nil {
-		return fmt.Errorf("add label %q to issue %s: %w", label, issueID, err)
+		return fmt.Errorf("add label %q to issue %s (after creating repo label): %w", label, issueID, err)
 	}
 	return nil
+}
+
+// ensureRepoLabel creates a label on the repository if it does not already
+// exist. A 422 (label already exists) is treated as success so the operation
+// is idempotent under concurrent creators.
+func (c *Client) ensureRepoLabel(ctx context.Context, label string) error {
+	result, err := c.gh.Run(ctx, []string{
+		"api", "-X", "POST",
+		fmt.Sprintf("repos/%s/%s/labels", c.owner, c.repo),
+		"-f", "name=" + label,
+	}, "")
+	if err == nil {
+		return nil
+	}
+	if result != nil && strings.Contains(result.Stderr, "422") {
+		return nil
+	}
+	return err
 }
 
 // RemoveLabel removes a label from a GitHub issue. The operation is

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -299,7 +299,7 @@ func (c *Client) UpdateIssueState(ctx context.Context, issueID string, stateID s
 		}, ""); err != nil {
 			return fmt.Errorf("update issue state to %s: %w", ghState, err)
 		}
-		c.removeLabel(ctx, issueID, reviewLabel) //nolint:errcheck // best-effort
+		c.RemoveLabel(ctx, issueID, reviewLabel) //nolint:errcheck // best-effort
 		return nil
 
 	case stateReview:
@@ -330,12 +330,21 @@ func (c *Client) AddLabel(ctx context.Context, issueID string, label string) err
 	return nil
 }
 
-func (c *Client) removeLabel(ctx context.Context, issueID, label string) error {
-	_, err := c.gh.Run(ctx, []string{
+// RemoveLabel removes a label from a GitHub issue. The operation is
+// idempotent: a 404 response (label not present on issue) is treated as
+// success.
+func (c *Client) RemoveLabel(ctx context.Context, issueID, label string) error {
+	result, err := c.gh.Run(ctx, []string{
 		"api", "-X", "DELETE",
 		fmt.Sprintf("repos/%s/%s/issues/%s/labels/%s", c.owner, c.repo, issueID, url.PathEscape(label)),
 	}, "")
-	return err
+	if err != nil {
+		if result != nil && strings.Contains(result.Stderr, "HTTP 404") {
+			return nil
+		}
+		return fmt.Errorf("remove label %q from issue %s: %w", label, issueID, err)
+	}
+	return nil
 }
 
 func (c *Client) ghIssueToTracker(gi ghIssue, owner, repo string) *tracker.Issue {

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -343,11 +343,16 @@ func (c *Client) attachLabelToIssue(ctx context.Context, issueID, label string) 
 // ensureRepoLabel creates a label on the repository if it does not already
 // exist. A 422 (label already exists) is treated as success so the operation
 // is idempotent under concurrent creators.
+//
+// GitHub's Create-a-label endpoint requires both "name" and "color" (6-char
+// hex, no leading #). We pass a neutral grey ("ededed") so the label renders
+// but doesn't carry semantic colour. Users can recolour afterwards.
 func (c *Client) ensureRepoLabel(ctx context.Context, label string) error {
 	result, err := c.gh.Run(ctx, []string{
 		"api", "-X", "POST",
 		fmt.Sprintf("repos/%s/%s/labels", c.owner, c.repo),
 		"-f", "name=" + label,
+		"-f", "color=ededed",
 	}, "")
 	if err == nil {
 		return nil

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -303,14 +303,7 @@ func (c *Client) UpdateIssueState(ctx context.Context, issueID string, stateID s
 		return nil
 
 	case stateReview:
-		if _, err := c.gh.Run(ctx, []string{
-			"api", "-X", "POST",
-			fmt.Sprintf("repos/%s/%s/issues/%s/labels", c.owner, c.repo, issueID),
-			"-f", fmt.Sprintf("labels[]=%s", reviewLabel),
-		}, ""); err != nil {
-			return fmt.Errorf("add review label: %w", err)
-		}
-		return nil
+		return c.AddLabel(ctx, issueID, reviewLabel)
 
 	default:
 		return fmt.Errorf("unknown state ID: %q", stateID)

--- a/jiradozer/tracker/github/client.go
+++ b/jiradozer/tracker/github/client.go
@@ -313,11 +313,7 @@ func (c *Client) UpdateIssueState(ctx context.Context, issueID string, stateID s
 // AddLabel adds a label to a GitHub issue. The operation is idempotent —
 // GitHub returns 200 OK even if the label is already present.
 func (c *Client) AddLabel(ctx context.Context, issueID string, label string) error {
-	result, err := c.gh.Run(ctx, []string{
-		"api", "-X", "POST",
-		fmt.Sprintf("repos/%s/%s/issues/%s/labels", c.owner, c.repo, issueID),
-		"-f", fmt.Sprintf("labels[]=%s", label),
-	}, "")
+	result, err := c.attachLabelToIssue(ctx, issueID, label)
 	if err == nil {
 		return nil
 	}
@@ -330,14 +326,18 @@ func (c *Client) AddLabel(ctx context.Context, issueID string, label string) err
 	if cErr := c.ensureRepoLabel(ctx, label); cErr != nil {
 		return fmt.Errorf("add label %q to issue %s: ensure repo label: %w", label, issueID, cErr)
 	}
-	if _, err := c.gh.Run(ctx, []string{
-		"api", "-X", "POST",
-		fmt.Sprintf("repos/%s/%s/issues/%s/labels", c.owner, c.repo, issueID),
-		"-f", fmt.Sprintf("labels[]=%s", label),
-	}, ""); err != nil {
+	if _, err := c.attachLabelToIssue(ctx, issueID, label); err != nil {
 		return fmt.Errorf("add label %q to issue %s (after creating repo label): %w", label, issueID, err)
 	}
 	return nil
+}
+
+func (c *Client) attachLabelToIssue(ctx context.Context, issueID, label string) (*wt.CmdResult, error) {
+	return c.gh.Run(ctx, []string{
+		"api", "-X", "POST",
+		fmt.Sprintf("repos/%s/%s/issues/%s/labels", c.owner, c.repo, issueID),
+		"-f", fmt.Sprintf("labels[]=%s", label),
+	}, "")
 }
 
 // ensureRepoLabel creates a label on the repository if it does not already

--- a/jiradozer/tracker/linear/client.go
+++ b/jiradozer/tracker/linear/client.go
@@ -232,6 +232,8 @@ func (c *Client) RemoveLabel(ctx context.Context, issueID string, label string) 
 	}
 
 	// Find the label ID on the issue by name. If not present, idempotent no-op.
+	// Labels and LabelIDs are populated in parallel by nodeToIssue from a
+	// single Labels.Nodes iteration, so index i is safe across both slices.
 	var targetID string
 	for i, name := range issueResp.Labels {
 		if name == label {

--- a/jiradozer/tracker/linear/client.go
+++ b/jiradozer/tracker/linear/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -244,12 +245,7 @@ func (c *Client) RemoveLabel(ctx context.Context, issueID string, label string) 
 		return nil
 	}
 
-	remaining := make([]string, 0, len(issueResp.LabelIDs))
-	for _, id := range issueResp.LabelIDs {
-		if id != targetID {
-			remaining = append(remaining, id)
-		}
-	}
+	remaining := slices.DeleteFunc(slices.Clone(issueResp.LabelIDs), func(id string) bool { return id == targetID })
 
 	req := addLabelToIssueMutation(issueID, remaining)
 	resp, err := c.execute(ctx, req)

--- a/jiradozer/tracker/linear/client.go
+++ b/jiradozer/tracker/linear/client.go
@@ -221,6 +221,47 @@ func (c *Client) AddLabel(ctx context.Context, issueID string, label string) err
 	return nil
 }
 
+// RemoveLabel detaches a label (by name) from an issue. If the label is not
+// present on the issue (or does not exist in the workspace), returns nil.
+// The operation is idempotent.
+func (c *Client) RemoveLabel(ctx context.Context, issueID string, label string) error {
+	issueResp, err := c.fetchIssueByID(ctx, issueID)
+	if err != nil {
+		return fmt.Errorf("remove label: fetch issue: %w", err)
+	}
+
+	// Find the label ID on the issue by name. If not present, idempotent no-op.
+	var targetID string
+	for i, name := range issueResp.Labels {
+		if name == label {
+			if i < len(issueResp.LabelIDs) {
+				targetID = issueResp.LabelIDs[i]
+			}
+			break
+		}
+	}
+	if targetID == "" {
+		return nil
+	}
+
+	remaining := make([]string, 0, len(issueResp.LabelIDs))
+	for _, id := range issueResp.LabelIDs {
+		if id != targetID {
+			remaining = append(remaining, id)
+		}
+	}
+
+	req := addLabelToIssueMutation(issueID, remaining)
+	resp, err := c.execute(ctx, req)
+	if err != nil {
+		return fmt.Errorf("remove label from issue: %w", err)
+	}
+	if resp.Data == nil || !resp.Data.IssueUpdate.Success {
+		return fmt.Errorf("remove label from issue: mutation returned success=false")
+	}
+	return nil
+}
+
 // fetchIssueByID returns a minimal issue record (team ID + label IDs) needed
 // for AddLabel. Uses the issueID (Linear UUID), not the human identifier.
 func (c *Client) fetchIssueByID(ctx context.Context, issueID string) (*tracker.Issue, error) {

--- a/jiradozer/tracker/local/local.go
+++ b/jiradozer/tracker/local/local.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -290,19 +291,11 @@ func (t *Tracker) RemoveLabel(_ context.Context, issueID string, label string) e
 		return err
 	}
 
-	filtered := f.Issue.Labels[:0]
-	removed := false
-	for _, l := range f.Issue.Labels {
-		if l == label {
-			removed = true
-			continue
-		}
-		filtered = append(filtered, l)
+	original := len(f.Issue.Labels)
+	f.Issue.Labels = slices.DeleteFunc(f.Issue.Labels, func(l string) bool { return l == label })
+	if len(f.Issue.Labels) == original {
+		return nil
 	}
-	if !removed {
-		return nil // not present — idempotent
-	}
-	f.Issue.Labels = filtered
 	return t.writeFile(issueID, f)
 }
 

--- a/jiradozer/tracker/local/local.go
+++ b/jiradozer/tracker/local/local.go
@@ -280,6 +280,32 @@ func (t *Tracker) AddLabel(_ context.Context, issueID string, label string) erro
 	return t.writeFile(issueID, f)
 }
 
+// RemoveLabel removes a label from a local issue. It is idempotent.
+func (t *Tracker) RemoveLabel(_ context.Context, issueID string, label string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	f, err := t.readFile(issueID)
+	if err != nil {
+		return err
+	}
+
+	filtered := f.Issue.Labels[:0]
+	removed := false
+	for _, l := range f.Issue.Labels {
+		if l == label {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, l)
+	}
+	if !removed {
+		return nil // not present — idempotent
+	}
+	f.Issue.Labels = filtered
+	return t.writeFile(issueID, f)
+}
+
 // --- internal helpers ---
 
 func (t *Tracker) filePath(issueID string) (string, error) {

--- a/jiradozer/tracker/local/local_test.go
+++ b/jiradozer/tracker/local/local_test.go
@@ -209,3 +209,45 @@ func TestUpdateStateNotFound(t *testing.T) {
 	err := tr.UpdateIssueState(ctx, "nonexistent", "local-done")
 	assert.Error(t, err)
 }
+
+func TestAddAndRemoveLabel(t *testing.T) {
+	tr := newTestTracker(t)
+	ctx := context.Background()
+
+	issue, err := tr.CreateIssue("Task", "desc")
+	require.NoError(t, err)
+
+	require.NoError(t, tr.AddLabel(ctx, issue.ID, "bug"))
+	require.NoError(t, tr.AddLabel(ctx, issue.ID, "priority"))
+
+	fetched, err := tr.FetchIssue(ctx, issue.Identifier)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bug", "priority"}, fetched.Labels)
+
+	// AddLabel is idempotent.
+	require.NoError(t, tr.AddLabel(ctx, issue.ID, "bug"))
+	fetched, err = tr.FetchIssue(ctx, issue.Identifier)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bug", "priority"}, fetched.Labels)
+
+	// RemoveLabel drops the label.
+	require.NoError(t, tr.RemoveLabel(ctx, issue.ID, "bug"))
+	fetched, err = tr.FetchIssue(ctx, issue.Identifier)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"priority"}, fetched.Labels)
+
+	// RemoveLabel is idempotent: removing an absent label is a no-op.
+	require.NoError(t, tr.RemoveLabel(ctx, issue.ID, "bug"))
+	require.NoError(t, tr.RemoveLabel(ctx, issue.ID, "never-existed"))
+	fetched, err = tr.FetchIssue(ctx, issue.Identifier)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"priority"}, fetched.Labels)
+}
+
+func TestRemoveLabelNotFound(t *testing.T) {
+	tr := newTestTracker(t)
+	ctx := context.Background()
+
+	err := tr.RemoveLabel(ctx, "nonexistent", "bug")
+	assert.Error(t, err)
+}

--- a/jiradozer/tracker/tracker.go
+++ b/jiradozer/tracker/tracker.go
@@ -33,4 +33,8 @@ type IssueTracker interface {
 	// AddLabel attaches a label to an issue. It is idempotent: adding a label
 	// that already exists must not return an error.
 	AddLabel(ctx context.Context, issueID string, label string) error
+
+	// RemoveLabel detaches a label from an issue. It is idempotent: removing
+	// a label that is not present must not return an error.
+	RemoveLabel(ctx context.Context, issueID string, label string) error
 }

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -453,6 +453,12 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 		if w.phases[PhaseShip] != phaseDone {
 			w.completePhase(ctx, PhaseShip)
 		}
+		// Final sweep: completePhase's -inprogress removal is best-effort, so
+		// a transient RemoveLabel failure can leave the issue with both
+		// -inprogress and -done for a completed phase. At StepDone there's no
+		// subsequent handlePhaseBoundary to reconcile via skipDonePhases, so
+		// do the cleanup here.
+		w.cleanupStalePhaseLabels(ctx)
 		return
 	}
 
@@ -464,6 +470,26 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 
 	if phase := phaseForStep(w.state.Current()); phase != "" {
 		w.enterPhase(ctx, phase)
+	}
+}
+
+// cleanupStalePhaseLabels removes any -inprogress label still present on
+// the issue for a phase that bookkeeping considers phaseDone. This is the
+// terminal counterpart to skipDonePhases' stale-label reconciliation —
+// without it, a transient RemoveLabel failure during completePhase would
+// leave the issue permanently tagged with both -inprogress and -done.
+func (w *Workflow) cleanupStalePhaseLabels(ctx context.Context) {
+	labels := w.refreshLabels(ctx)
+	for _, p := range phaseTable {
+		if w.phases[p.name] != phaseDone {
+			continue
+		}
+		if !slices.Contains(labels, inProgressLabel(p.name)) {
+			continue
+		}
+		if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(p.name)); err != nil {
+			w.logger.Warn("failed to clear stale in-progress label at terminal sweep", "phase", p.name, "error", err)
+		}
 	}
 }
 
@@ -534,8 +560,11 @@ func (w *Workflow) skipDonePhases(ctx context.Context) {
 // refreshLabels fetches the latest label set from the tracker and returns it
 // for phase decisions (including jiradozer-* bookkeeping labels). The
 // user-facing subset is mirrored onto w.issue.Labels so agent prompts don't
-// see bookkeeping noise via promptData. On fetch failure, returns the last
-// known full set from w.lastLabels.
+// see bookkeeping noise via promptData. Labels and LabelIDs are filtered in
+// lockstep so they continue to describe the same attachment set — Linear's
+// nodeToIssue populates them in parallel, and any future caller using them
+// together would otherwise get a mismatch. On fetch failure, returns the
+// last known full set from w.lastLabels.
 func (w *Workflow) refreshLabels(ctx context.Context) []string {
 	fresh, err := w.tracker.FetchIssue(ctx, w.issue.Identifier)
 	if err != nil || fresh == nil {
@@ -547,8 +576,19 @@ func (w *Workflow) refreshLabels(ctx context.Context) []string {
 		return w.lastLabels
 	}
 	w.lastLabels = fresh.Labels
-	w.issue.Labels = slices.DeleteFunc(slices.Clone(fresh.Labels), isJiradozerLabel)
-	w.issue.LabelIDs = fresh.LabelIDs
+	filteredLabels := make([]string, 0, len(fresh.Labels))
+	filteredIDs := make([]string, 0, len(fresh.LabelIDs))
+	for i, name := range fresh.Labels {
+		if isJiradozerLabel(name) {
+			continue
+		}
+		filteredLabels = append(filteredLabels, name)
+		if i < len(fresh.LabelIDs) {
+			filteredIDs = append(filteredIDs, fresh.LabelIDs[i])
+		}
+	}
+	w.issue.Labels = filteredLabels
+	w.issue.LabelIDs = filteredIDs
 	return fresh.Labels
 }
 
@@ -605,7 +645,76 @@ func (w *Workflow) tryRedo(ctx context.Context, redoTarget WorkflowStep) error {
 		return fmt.Errorf("step %s has been re-run %d times (max %d), giving up", redoTarget, count-1, w.maxRedos)
 	}
 	w.logger.Info("redo attempt", "target", redoTarget, "attempt", count, "max", w.maxRedos)
-	return w.transition(redoTarget, "redo")
+	if err := w.transition(redoTarget, "redo"); err != nil {
+		return err
+	}
+	w.reopenPhaseOnRedo(ctx, redoTarget)
+	return nil
+}
+
+// reopenPhaseOnRedo keeps phase labels honest across backward (redo)
+// transitions. The state machine allows transitions like
+// ValidateReview → Building, which rewinds the agent into an already-
+// completed phase. Without this reconciliation, the issue would keep
+// jiradozer-build-done while the build agent is actively re-running, and
+// observers would see stale labels until the next forward phase boundary.
+//
+// Semantics: when redoing into a phase earlier than (or the same as) the
+// current in-progress phase, mark the target phase and every later phase
+// as not-started again, replace any -done labels with -inprogress, and
+// clear stray -inprogress labels on phases we're rewinding past.
+func (w *Workflow) reopenPhaseOnRedo(ctx context.Context, redoTarget WorkflowStep) {
+	targetPhase := phaseForStep(redoTarget)
+	if targetPhase == "" {
+		// Redoing into a review gate or terminal step has no phase of its
+		// own; nothing to reconcile here.
+		return
+	}
+	// Find targetPhase's index in phaseTable; every phase at or after that
+	// index needs to be rewound.
+	targetIdx := -1
+	for i, p := range phaseTable {
+		if p.name == targetPhase {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx < 0 {
+		return
+	}
+	for i := targetIdx; i < len(phaseTable); i++ {
+		phase := phaseTable[i].name
+		prior := w.phases[phase]
+		// Target phase: re-enter as in-progress. Later phases: reset to
+		// not-started (they haven't happened in this rewound run).
+		if i == targetIdx {
+			if prior == phaseDone {
+				if err := w.tracker.RemoveLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
+					w.logger.Warn("failed to remove -done label on redo", "phase", phase, "error", err)
+				}
+			}
+			// Force a fresh -inprogress write even if prior was phaseInProgress,
+			// in case the previous -inprogress was removed by skipDonePhases or
+			// a prior boundary.
+			w.phases[phase] = phaseNotStarted
+			w.enterPhase(ctx, phase)
+		} else {
+			// Phases "ahead" of the redo target shouldn't carry state from
+			// the forward run we're rewinding. Clear any labels and reset
+			// bookkeeping so the next forward pass starts clean.
+			if prior == phaseInProgress {
+				if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
+					w.logger.Warn("failed to remove -inprogress on redo", "phase", phase, "error", err)
+				}
+			}
+			if prior == phaseDone {
+				if err := w.tracker.RemoveLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
+					w.logger.Warn("failed to remove -done on redo", "phase", phase, "error", err)
+				}
+			}
+			w.phases[phase] = phaseNotStarted
+		}
+	}
 }
 
 func (w *Workflow) transitionToReview(ctx context.Context, reviewStep WorkflowStep, trigger string) {

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -442,7 +442,10 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 	cur := w.state.Current()
 
 	if cur == StepDone {
-		if w.phases[PhaseShip] == phaseInProgress {
+		// Reconcile the ship phase even when enterPhase(ship) failed: the
+		// state machine reaching StepDone is authoritative evidence that
+		// shipping ran, so retry the -done write unless it's already there.
+		if w.phases[PhaseShip] != phaseDone {
 			w.completePhase(ctx, PhaseShip)
 		}
 		return
@@ -542,10 +545,6 @@ func (w *Workflow) refreshLabels(ctx context.Context) []string {
 	w.issue.Labels = slices.DeleteFunc(slices.Clone(fresh.Labels), isJiradozerLabel)
 	w.issue.LabelIDs = fresh.LabelIDs
 	return fresh.Labels
-}
-
-func isJiradozerLabel(label string) bool {
-	return strings.HasPrefix(label, "jiradozer-")
 }
 
 // enterPhase flips internal bookkeeping to inProgress only after the

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -527,6 +527,8 @@ func (w *Workflow) refreshLabels(ctx context.Context) []string {
 	if err != nil || fresh == nil {
 		if err != nil {
 			w.logger.Warn("failed to refresh issue labels", "error", err)
+		} else {
+			w.logger.Warn("refresh issue returned nil without error; falling back to cached labels")
 		}
 		return w.lastLabels
 	}
@@ -540,27 +542,40 @@ func isJiradozerLabel(label string) bool {
 	return strings.HasPrefix(label, "jiradozer-")
 }
 
+// enterPhase flips internal bookkeeping to inProgress only after the
+// tracker confirms the -inprogress label write. On tracker failure the
+// phase stays in phaseNotStarted so a retry (or the next event) will
+// attempt the write again — keeping the in-memory state and the tracker
+// from silently diverging.
 func (w *Workflow) enterPhase(ctx context.Context, phase string) {
 	if w.phases[phase] != phaseNotStarted {
 		return
 	}
-	w.phases[phase] = phaseInProgress
 	if err := w.tracker.AddLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 		w.logger.Warn("failed to add phase in-progress label", "phase", phase, "error", err)
+		return
 	}
+	w.phases[phase] = phaseInProgress
 }
 
+// completePhase flips internal bookkeeping to phaseDone only after the
+// tracker confirms the -done label write. The -inprogress removal is
+// best-effort (a stale -inprogress will be reconciled on the next
+// skipDonePhases), but the -done write is authoritative: without it the
+// phase stays "in progress" in memory and the workflow will retry the
+// transition rather than advance past a phase the tracker didn't record.
 func (w *Workflow) completePhase(ctx context.Context, phase string) {
 	if w.phases[phase] == phaseDone {
 		return
 	}
-	w.phases[phase] = phaseDone
 	if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 		w.logger.Warn("failed to remove phase in-progress label", "phase", phase, "error", err)
 	}
 	if err := w.tracker.AddLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
 		w.logger.Warn("failed to add phase done label", "phase", phase, "error", err)
+		return
 	}
+	w.phases[phase] = phaseDone
 }
 
 // tryRedo transitions to the redo target if the circuit breaker hasn't tripped.

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -34,6 +35,8 @@ type Workflow struct {
 	sessionIDs      map[WorkflowStep]string
 	stateIDs        map[string]string
 	redoCounts      map[WorkflowStep]int
+	phaseEntered    map[string]bool
+	phaseCompleted  map[string]bool
 	OnTransition    func(step WorkflowStep)
 	OnRoundProgress func(roundIndex, roundTotal int)
 	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error)
@@ -49,16 +52,18 @@ type Workflow struct {
 // NewWorkflow creates a new workflow for the given issue.
 func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logger *slog.Logger) *Workflow {
 	return &Workflow{
-		tracker:      t,
-		issue:        issue,
-		state:        NewStateMachine(),
-		config:       cfg,
-		logger:       logger,
-		stateIDs:     make(map[string]string),
-		sessionIDs:   make(map[WorkflowStep]string),
-		redoCounts:   make(map[WorkflowStep]int),
-		maxRedos:     DefaultMaxRedos,
-		runStepAgent: RunStepAgent,
+		tracker:        t,
+		issue:          issue,
+		state:          NewStateMachine(),
+		config:         cfg,
+		logger:         logger,
+		stateIDs:       make(map[string]string),
+		sessionIDs:     make(map[WorkflowStep]string),
+		redoCounts:     make(map[WorkflowStep]int),
+		phaseEntered:   make(map[string]bool),
+		phaseCompleted: make(map[string]bool),
+		maxRedos:       DefaultMaxRedos,
+		runStepAgent:   RunStepAgent,
 	}
 }
 
@@ -118,6 +123,15 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		if err := w.tracker.UpdateIssueState(ctx, w.issue.ID, id); err != nil {
 			w.logger.Warn("failed to update issue state to in_progress", "error", err)
 		}
+	}
+
+	// Honor pre-existing -done labels by skipping completed phases. A fresh
+	// workflow run never re-does plan/build/validate/ship that the user has
+	// already marked done. Users clear the label manually to re-run a phase.
+	w.skipDonePhases(ctx, "workflow_start")
+	// Enter the phase we actually start in (after skip).
+	if phase := phaseForStep(w.state.Current()); phase != "" {
+		w.enterPhase(ctx, phase)
 	}
 
 	for {
@@ -347,7 +361,7 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 		w.logger.Info("auto-approving", "step", w.state.Current())
 		w.status(fmt.Sprintf("Auto-approved %s", w.state.Current()))
 		w.feedback = ""
-		if err := w.transition(approveTarget, "auto_approved"); err != nil {
+		if err := w.approveTransition(ctx, approveTarget, "auto_approved"); err != nil {
 			w.fail(ctx, err)
 		}
 		return
@@ -369,7 +383,7 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 		w.logger.Info("feedback: approved", "step", w.state.Current())
 		w.status("Approved")
 		w.feedback = ""
-		if err := w.transition(approveTarget, "approved"); err != nil {
+		if err := w.approveTransition(ctx, approveTarget, "approved"); err != nil {
 			w.fail(ctx, err)
 		}
 	case FeedbackRedo:
@@ -387,7 +401,7 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 		// incorporated — they don't restart the planning step. For other review
 		// steps, redo is the right behavior (the user wants changes applied).
 		if w.state.Current() == StepPlanReview {
-			if err := w.transition(approveTarget, "approved_with_feedback"); err != nil {
+			if err := w.approveTransition(ctx, approveTarget, "approved_with_feedback"); err != nil {
 				w.fail(ctx, err)
 			}
 		} else {
@@ -396,6 +410,179 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 			}
 		}
 	}
+}
+
+// approveTransition advances to approveTarget via the normal state machine,
+// then checks for mid-run label edits that skip the upcoming phase. If the
+// upcoming phase is already -done, completes the prior phase label and jumps
+// forward to the next not-done phase using ForceState. Also marks entry into
+// whichever phase the workflow actually lands on.
+func (w *Workflow) approveTransition(ctx context.Context, approveTarget WorkflowStep, trigger string) error {
+	if err := w.transition(approveTarget, trigger); err != nil {
+		return err
+	}
+	// Phase-boundary crossings: complete the prior phase and possibly skip ahead.
+	w.handlePhaseBoundary(ctx)
+	return nil
+}
+
+// handlePhaseBoundary is called after a transition lands on a phase-start
+// step (StepBuilding/StepValidating/StepShipping/StepDone) or the build-phase
+// create_pr step. It completes the prior phase, then refreshes labels and may
+// skip forward over additional phases whose -done label is already present.
+func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
+	cur := w.state.Current()
+	curPhase := phaseForStep(cur)
+
+	// Terminal StepDone closes out the ship phase.
+	if cur == StepDone {
+		if !w.phaseCompleted[PhaseShip] && w.phaseEntered[PhaseShip] {
+			w.completePhase(ctx, PhaseShip)
+		}
+		return
+	}
+
+	// If we just entered a new phase, complete any prior phases that were in
+	// flight but not yet completed.
+	if curPhase != "" {
+		w.completePriorPhases(ctx, curPhase)
+	}
+
+	// Check whether the current phase is already marked -done by a user edit.
+	// If so, skip forward.
+	w.skipDonePhases(ctx, "phase_boundary")
+
+	// Mark entry into whichever phase we actually landed on.
+	if phase := phaseForStep(w.state.Current()); phase != "" {
+		w.enterPhase(ctx, phase)
+	}
+}
+
+// completePriorPhases marks any earlier phases as completed (remove -inprogress,
+// add -done) up to — but not including — the current phase.
+func (w *Workflow) completePriorPhases(ctx context.Context, currentPhase string) {
+	for _, p := range allPhases {
+		if p == currentPhase {
+			return
+		}
+		if w.phaseEntered[p] && !w.phaseCompleted[p] {
+			w.completePhase(ctx, p)
+		}
+	}
+}
+
+// skipDonePhases refreshes labels from the tracker, then walks phases forward
+// from the current step. For each phase already marked -done it uses
+// ForceState to jump to the next phase's starting step. If all remaining
+// phases are -done, jumps to StepDone.
+func (w *Workflow) skipDonePhases(ctx context.Context, trigger string) {
+	labels := w.refreshLabels(ctx)
+
+	for {
+		cur := w.state.Current()
+		phase := phaseForStep(cur)
+		if phase == "" {
+			return
+		}
+		if !hasLabel(labels, doneLabel(phase)) {
+			return
+		}
+		// Phase is already done — record completion (no label writes; label is
+		// already there), and skip to the next phase's start step.
+		w.phaseEntered[phase] = true
+		w.phaseCompleted[phase] = true
+		nextPhase := phaseAfter(phase)
+		if nextPhase == "" {
+			w.logger.Info("all phases already marked done; skipping to StepDone", "trigger", trigger)
+			w.state.ForceState(StepDone)
+			if w.OnTransition != nil {
+				w.OnTransition(StepDone)
+			}
+			return
+		}
+		next := startStepForPhase(nextPhase)
+		w.logger.Info("skipping phase (label present)", "phase", phase, "next", next, "trigger", trigger)
+		w.state.ForceState(next)
+		if w.OnTransition != nil {
+			w.OnTransition(next)
+		}
+		// If we skipped past plan, load the persisted plan from disk so the
+		// build step isn't run blind.
+		if phase == PhasePlan && w.plan == "" {
+			w.loadPersistedPlan()
+		}
+	}
+}
+
+// phaseAfter returns the phase immediately following p in allPhases, or ""
+// if p is the last phase or unknown.
+func phaseAfter(p string) string {
+	for i, name := range allPhases {
+		if name == p && i+1 < len(allPhases) {
+			return allPhases[i+1]
+		}
+	}
+	return ""
+}
+
+// refreshLabels fetches the latest label set from the tracker. On failure,
+// falls back to the cached labels from the initial issue snapshot and logs
+// a warning. Also updates w.issue.Labels with the fresh set on success.
+func (w *Workflow) refreshLabels(ctx context.Context) []string {
+	fresh, err := w.tracker.FetchIssue(ctx, w.issue.Identifier)
+	if err != nil || fresh == nil {
+		if err != nil {
+			w.logger.Warn("failed to refresh issue labels", "error", err)
+		}
+		return w.issue.Labels
+	}
+	w.issue.Labels = fresh.Labels
+	w.issue.LabelIDs = fresh.LabelIDs
+	return fresh.Labels
+}
+
+// enterPhase adds the -inprogress label for phase. No-op if already entered
+// in this workflow run.
+func (w *Workflow) enterPhase(ctx context.Context, phase string) {
+	if w.phaseEntered[phase] {
+		return
+	}
+	w.phaseEntered[phase] = true
+	if err := w.tracker.AddLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
+		w.logger.Warn("failed to add phase in-progress label", "phase", phase, "error", err)
+	}
+}
+
+// completePhase removes the -inprogress label and adds the -done label for
+// phase. Both operations are best-effort. No-op if already completed.
+func (w *Workflow) completePhase(ctx context.Context, phase string) {
+	if w.phaseCompleted[phase] {
+		return
+	}
+	w.phaseCompleted[phase] = true
+	if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
+		w.logger.Warn("failed to remove phase in-progress label", "phase", phase, "error", err)
+	}
+	if err := w.tracker.AddLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
+		w.logger.Warn("failed to add phase done label", "phase", phase, "error", err)
+	}
+}
+
+// loadPersistedPlan reads the persisted plan.md from disk into w.plan so the
+// build step can run without re-planning. Logs a warning if no plan is found.
+func (w *Workflow) loadPersistedPlan() {
+	planPath := PlanFilePath(w.config.WorkDir)
+	content, err := os.ReadFile(planPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			w.logger.Warn("skipping plan but no persisted plan found; build will run blind", "path", planPath)
+		} else {
+			w.logger.Warn("failed to load persisted plan", "path", planPath, "error", err)
+		}
+		return
+	}
+	w.plan = strings.TrimSpace(string(content))
+	w.logger.Info("loaded persisted plan from disk after skipping plan phase", "path", planPath)
 }
 
 // tryRedo transitions to the redo target if the circuit breaker hasn't tripped.

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -24,6 +24,15 @@ const (
 // comments are repeatedly parsed as redo requests.
 const DefaultMaxRedos = 3
 
+// phaseState tracks per-phase bookkeeping: notStarted → inProgress → done.
+type phaseState int
+
+const (
+	phaseNotStarted phaseState = iota
+	phaseInProgress
+	phaseDone
+)
+
 // Workflow drives the issue through plan → build → create_pr → validate → ship.
 type Workflow struct {
 	lastCommentAt   time.Time
@@ -35,8 +44,7 @@ type Workflow struct {
 	sessionIDs      map[WorkflowStep]string
 	stateIDs        map[string]string
 	redoCounts      map[WorkflowStep]int
-	phaseEntered    map[string]bool
-	phaseCompleted  map[string]bool
+	phases          map[string]phaseState
 	OnTransition    func(step WorkflowStep)
 	OnRoundProgress func(roundIndex, roundTotal int)
 	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error)
@@ -46,25 +54,31 @@ type Workflow struct {
 	buildOutput     string
 	feedback        string
 	botCommentIDs   []string
+	lastLabels      []string
 	maxRedos        int
 }
 
 // NewWorkflow creates a new workflow for the given issue.
 func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logger *slog.Logger) *Workflow {
-	return &Workflow{
-		tracker:        t,
-		issue:          issue,
-		state:          NewStateMachine(),
-		config:         cfg,
-		logger:         logger,
-		stateIDs:       make(map[string]string),
-		sessionIDs:     make(map[WorkflowStep]string),
-		redoCounts:     make(map[WorkflowStep]int),
-		phaseEntered:   make(map[string]bool),
-		phaseCompleted: make(map[string]bool),
-		maxRedos:       DefaultMaxRedos,
-		runStepAgent:   RunStepAgent,
+	w := &Workflow{
+		tracker:      t,
+		issue:        issue,
+		state:        NewStateMachine(),
+		config:       cfg,
+		logger:       logger,
+		stateIDs:     make(map[string]string),
+		sessionIDs:   make(map[WorkflowStep]string),
+		redoCounts:   make(map[WorkflowStep]int),
+		phases:       make(map[string]phaseState),
+		maxRedos:     DefaultMaxRedos,
+		runStepAgent: RunStepAgent,
 	}
+	if issue != nil {
+		// Seed the label cache from the initial issue so refreshLabels has a
+		// sensible fallback before the first successful fetch.
+		w.lastLabels = slices.Clone(issue.Labels)
+	}
+	return w
 }
 
 // SetRenderer sets the terminal renderer for streaming output.
@@ -128,8 +142,7 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 	// Honor pre-existing -done labels by skipping completed phases. A fresh
 	// workflow run never re-does plan/build/validate/ship that the user has
 	// already marked done. Users clear the label manually to re-run a phase.
-	w.skipDonePhases(ctx, "workflow_start")
-	// Enter the phase we actually start in (after skip).
+	w.skipDonePhases(ctx)
 	if phase := phaseForStep(w.state.Current()); phase != "" {
 		w.enterPhase(ctx, phase)
 	}
@@ -412,70 +425,52 @@ func (w *Workflow) runReview(ctx context.Context, approveTarget, redoTarget Work
 	}
 }
 
-// approveTransition advances to approveTarget via the normal state machine,
-// then checks for mid-run label edits that skip the upcoming phase. If the
-// upcoming phase is already -done, completes the prior phase label and jumps
-// forward to the next not-done phase using ForceState. Also marks entry into
-// whichever phase the workflow actually lands on.
+// approveTransition advances to approveTarget, then closes out the prior
+// phase and skips ahead over any phases whose -done label was added mid-run.
 func (w *Workflow) approveTransition(ctx context.Context, approveTarget WorkflowStep, trigger string) error {
 	if err := w.transition(approveTarget, trigger); err != nil {
 		return err
 	}
-	// Phase-boundary crossings: complete the prior phase and possibly skip ahead.
 	w.handlePhaseBoundary(ctx)
 	return nil
 }
 
-// handlePhaseBoundary is called after a transition lands on a phase-start
-// step (StepBuilding/StepValidating/StepShipping/StepDone) or the build-phase
-// create_pr step. It completes the prior phase, then refreshes labels and may
-// skip forward over additional phases whose -done label is already present.
 func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 	cur := w.state.Current()
-	curPhase := phaseForStep(cur)
 
-	// Terminal StepDone closes out the ship phase.
 	if cur == StepDone {
-		if !w.phaseCompleted[PhaseShip] && w.phaseEntered[PhaseShip] {
+		if w.phases[PhaseShip] == phaseInProgress {
 			w.completePhase(ctx, PhaseShip)
 		}
 		return
 	}
 
-	// If we just entered a new phase, complete any prior phases that were in
-	// flight but not yet completed.
-	if curPhase != "" {
+	if curPhase := phaseForStep(cur); curPhase != "" {
 		w.completePriorPhases(ctx, curPhase)
 	}
 
-	// Check whether the current phase is already marked -done by a user edit.
-	// If so, skip forward.
-	w.skipDonePhases(ctx, "phase_boundary")
+	w.skipDonePhases(ctx)
 
-	// Mark entry into whichever phase we actually landed on.
 	if phase := phaseForStep(w.state.Current()); phase != "" {
 		w.enterPhase(ctx, phase)
 	}
 }
 
-// completePriorPhases marks any earlier phases as completed (remove -inprogress,
-// add -done) up to — but not including — the current phase.
 func (w *Workflow) completePriorPhases(ctx context.Context, currentPhase string) {
-	for _, p := range allPhases {
-		if p == currentPhase {
+	for _, p := range phaseTable {
+		if p.name == currentPhase {
 			return
 		}
-		if w.phaseEntered[p] && !w.phaseCompleted[p] {
-			w.completePhase(ctx, p)
+		if w.phases[p.name] == phaseInProgress {
+			w.completePhase(ctx, p.name)
 		}
 	}
 }
 
 // skipDonePhases refreshes labels from the tracker, then walks phases forward
-// from the current step. For each phase already marked -done it uses
-// ForceState to jump to the next phase's starting step. If all remaining
-// phases are -done, jumps to StepDone.
-func (w *Workflow) skipDonePhases(ctx context.Context, trigger string) {
+// from the current step, jumping past any phase already marked -done via
+// forceTransition. If all remaining phases are -done, jumps to StepDone.
+func (w *Workflow) skipDonePhases(ctx context.Context) {
 	labels := w.refreshLabels(ctx)
 
 	for {
@@ -484,105 +479,78 @@ func (w *Workflow) skipDonePhases(ctx context.Context, trigger string) {
 		if phase == "" {
 			return
 		}
-		if !hasLabel(labels, doneLabel(phase)) {
+		if !slices.Contains(labels, doneLabel(phase)) {
 			return
 		}
-		// Phase is already done — record completion (no label writes; label is
-		// already there), and skip to the next phase's start step.
-		w.phaseEntered[phase] = true
-		w.phaseCompleted[phase] = true
+		// Mark bookkeeping only — labels are already on the tracker (that's why
+		// we're skipping), so no AddLabel/RemoveLabel writes are needed.
+		w.phases[phase] = phaseDone
 		nextPhase := phaseAfter(phase)
 		if nextPhase == "" {
-			w.logger.Info("all phases already marked done; skipping to StepDone", "trigger", trigger)
-			w.state.ForceState(StepDone)
-			if w.OnTransition != nil {
-				w.OnTransition(StepDone)
-			}
+			w.logger.Info("all phases already marked done; skipping to StepDone")
+			w.forceTransition(StepDone)
 			return
 		}
 		next := startStepForPhase(nextPhase)
-		w.logger.Info("skipping phase (label present)", "phase", phase, "next", next, "trigger", trigger)
-		w.state.ForceState(next)
-		if w.OnTransition != nil {
-			w.OnTransition(next)
-		}
-		// If we skipped past plan, load the persisted plan from disk so the
-		// build step isn't run blind.
+		w.logger.Info("skipping phase (label present)", "phase", phase, "next", next)
+		w.forceTransition(next)
 		if phase == PhasePlan && w.plan == "" {
-			w.loadPersistedPlan()
+			if content, err := LoadPersistedPlan(w.config.WorkDir); err != nil {
+				w.logger.Warn("failed to load persisted plan after skipping plan phase", "error", err)
+			} else if content == "" {
+				w.logger.Warn("skipping plan but no persisted plan found; build will run blind", "path", PlanFilePath(w.config.WorkDir))
+			} else {
+				w.plan = content
+				w.logger.Info("loaded persisted plan from disk after skipping plan phase", "path", PlanFilePath(w.config.WorkDir))
+			}
 		}
 	}
 }
 
-// phaseAfter returns the phase immediately following p in allPhases, or ""
-// if p is the last phase or unknown.
-func phaseAfter(p string) string {
-	for i, name := range allPhases {
-		if name == p && i+1 < len(allPhases) {
-			return allPhases[i+1]
-		}
-	}
-	return ""
-}
-
-// refreshLabels fetches the latest label set from the tracker. On failure,
-// falls back to the cached labels from the initial issue snapshot and logs
-// a warning. Also updates w.issue.Labels with the fresh set on success.
+// refreshLabels fetches the latest label set from the tracker and returns it
+// for phase decisions (including jiradozer-* bookkeeping labels). The
+// user-facing subset is mirrored onto w.issue.Labels so agent prompts don't
+// see bookkeeping noise via promptData. On fetch failure, returns the last
+// known full set from w.lastLabels.
 func (w *Workflow) refreshLabels(ctx context.Context) []string {
 	fresh, err := w.tracker.FetchIssue(ctx, w.issue.Identifier)
 	if err != nil || fresh == nil {
 		if err != nil {
 			w.logger.Warn("failed to refresh issue labels", "error", err)
 		}
-		return w.issue.Labels
+		return w.lastLabels
 	}
-	w.issue.Labels = fresh.Labels
+	w.lastLabels = fresh.Labels
+	w.issue.Labels = slices.DeleteFunc(slices.Clone(fresh.Labels), isJiradozerLabel)
 	w.issue.LabelIDs = fresh.LabelIDs
 	return fresh.Labels
 }
 
-// enterPhase adds the -inprogress label for phase. No-op if already entered
-// in this workflow run.
+func isJiradozerLabel(label string) bool {
+	return strings.HasPrefix(label, "jiradozer-")
+}
+
 func (w *Workflow) enterPhase(ctx context.Context, phase string) {
-	if w.phaseEntered[phase] {
+	if w.phases[phase] != phaseNotStarted {
 		return
 	}
-	w.phaseEntered[phase] = true
+	w.phases[phase] = phaseInProgress
 	if err := w.tracker.AddLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 		w.logger.Warn("failed to add phase in-progress label", "phase", phase, "error", err)
 	}
 }
 
-// completePhase removes the -inprogress label and adds the -done label for
-// phase. Both operations are best-effort. No-op if already completed.
 func (w *Workflow) completePhase(ctx context.Context, phase string) {
-	if w.phaseCompleted[phase] {
+	if w.phases[phase] == phaseDone {
 		return
 	}
-	w.phaseCompleted[phase] = true
+	w.phases[phase] = phaseDone
 	if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 		w.logger.Warn("failed to remove phase in-progress label", "phase", phase, "error", err)
 	}
 	if err := w.tracker.AddLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
 		w.logger.Warn("failed to add phase done label", "phase", phase, "error", err)
 	}
-}
-
-// loadPersistedPlan reads the persisted plan.md from disk into w.plan so the
-// build step can run without re-planning. Logs a warning if no plan is found.
-func (w *Workflow) loadPersistedPlan() {
-	planPath := PlanFilePath(w.config.WorkDir)
-	content, err := os.ReadFile(planPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			w.logger.Warn("skipping plan but no persisted plan found; build will run blind", "path", planPath)
-		} else {
-			w.logger.Warn("failed to load persisted plan", "path", planPath, "error", err)
-		}
-		return
-	}
-	w.plan = strings.TrimSpace(string(content))
-	w.logger.Info("loaded persisted plan from disk after skipping plan phase", "path", planPath)
 }
 
 // tryRedo transitions to the redo target if the circuit breaker hasn't tripped.
@@ -665,6 +633,16 @@ func (w *Workflow) transition(target WorkflowStep, trigger string) error {
 		w.OnTransition(target)
 	}
 	return nil
+}
+
+// forceTransition bypasses state machine validation (used when jumping over
+// already-done phases) but still fires OnTransition so subscribers see the
+// jump.
+func (w *Workflow) forceTransition(target WorkflowStep) {
+	w.state.ForceState(target)
+	if w.OnTransition != nil {
+		w.OnTransition(target)
+	}
 }
 
 func (w *Workflow) fail(ctx context.Context, err error) {

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -58,11 +58,13 @@ type Workflow struct {
 	maxRedos        int
 }
 
-// NewWorkflow creates a new workflow for the given issue.
+// NewWorkflow creates a new workflow for the given issue. The caller's
+// Issue is not mutated: the workflow takes a shallow copy and filters its
+// own copy's Labels so the first agent prompt (before any successful
+// refreshLabels) doesn't leak bookkeeping labels.
 func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logger *slog.Logger) *Workflow {
 	w := &Workflow{
 		tracker:      t,
-		issue:        issue,
 		state:        NewStateMachine(),
 		config:       cfg,
 		logger:       logger,
@@ -74,12 +76,13 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		runStepAgent: RunStepAgent,
 	}
 	if issue != nil {
-		// Seed the label cache from the initial issue so refreshLabels has a
-		// sensible fallback before the first successful fetch. Also filter
-		// jiradozer-* out of issue.Labels so the first agent prompt (before
-		// any successful refresh) doesn't leak bookkeeping labels.
+		// Shallow-copy so Labels mutations on w.issue don't bleed back into
+		// the caller's struct. lastLabels keeps the full (unfiltered) set for
+		// phase-skip decisions before the first tracker fetch.
+		issueCopy := *issue
 		w.lastLabels = slices.Clone(issue.Labels)
-		issue.Labels = slices.DeleteFunc(slices.Clone(issue.Labels), isJiradozerLabel)
+		issueCopy.Labels = slices.DeleteFunc(slices.Clone(issue.Labels), isJiradozerLabel)
+		w.issue = &issueCopy
 	}
 	return w
 }
@@ -442,9 +445,11 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 	cur := w.state.Current()
 
 	if cur == StepDone {
-		// Reconcile the ship phase even when enterPhase(ship) failed: the
-		// state machine reaching StepDone is authoritative evidence that
-		// shipping ran, so retry the -done write unless it's already there.
+		// Reaching StepDone is authoritative evidence that every prior phase
+		// ran to completion. Retry any -done writes that were left unfinished
+		// by transient tracker failures at earlier boundaries (including ship
+		// itself), so the final issue reflects the real workflow state.
+		w.completePriorPhases(ctx, PhaseShip)
 		if w.phases[PhaseShip] != phaseDone {
 			w.completePhase(ctx, PhaseShip)
 		}
@@ -564,21 +569,28 @@ func (w *Workflow) enterPhase(ctx context.Context, phase string) {
 }
 
 // completePhase flips internal bookkeeping to phaseDone only after the
-// tracker confirms the -done label write. The -inprogress removal is
-// best-effort (a stale -inprogress will be reconciled on the next
-// skipDonePhases), but the -done write is authoritative: without it the
-// phase stays "in progress" in memory and the workflow will retry the
-// transition rather than advance past a phase the tracker didn't record.
+// tracker confirms the -done label write. Order matters: add -done first,
+// then remove -inprogress. A crash between these two calls leaves the
+// issue with both labels, which skipDonePhases reconciles on the next run.
+// The reverse order would leave the issue with NEITHER label on crash,
+// losing durable evidence that the phase completed and causing a resumed
+// run to redo an already-finished phase.
+//
+// The -inprogress removal is best-effort (a stale -inprogress will be
+// cleared on the next skipDonePhases), but the -done write is
+// authoritative: without it the phase stays "in progress" in memory and
+// the workflow will retry the transition rather than advance past a phase
+// the tracker didn't record.
 func (w *Workflow) completePhase(ctx context.Context, phase string) {
 	if w.phases[phase] == phaseDone {
 		return
 	}
-	if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
-		w.logger.Warn("failed to remove phase in-progress label", "phase", phase, "error", err)
-	}
 	if err := w.tracker.AddLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
 		w.logger.Warn("failed to add phase done label", "phase", phase, "error", err)
 		return
+	}
+	if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
+		w.logger.Warn("failed to remove phase in-progress label", "phase", phase, "error", err)
 	}
 	w.phases[phase] = phaseDone
 }

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -459,12 +459,18 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 	}
 }
 
+// completePriorPhases walks phaseTable up to currentPhase and attempts to
+// mark each earlier phase as done. Phases already phaseDone are skipped by
+// completePhase itself. Phases still phaseNotStarted can happen when the
+// initial enterPhase AddLabel failed transiently; since the state machine
+// has since advanced past them, retry the -done write here so the issue
+// reflects the workflow's actual progress.
 func (w *Workflow) completePriorPhases(ctx context.Context, currentPhase string) {
 	for _, p := range phaseTable {
 		if p.name == currentPhase {
 			return
 		}
-		if w.phases[p.name] == phaseInProgress {
+		if w.phases[p.name] != phaseDone {
 			w.completePhase(ctx, p.name)
 		}
 	}

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -75,8 +75,11 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 	}
 	if issue != nil {
 		// Seed the label cache from the initial issue so refreshLabels has a
-		// sensible fallback before the first successful fetch.
+		// sensible fallback before the first successful fetch. Also filter
+		// jiradozer-* out of issue.Labels so the first agent prompt (before
+		// any successful refresh) doesn't leak bookkeeping labels.
 		w.lastLabels = slices.Clone(issue.Labels)
+		issue.Labels = slices.DeleteFunc(slices.Clone(issue.Labels), isJiradozerLabel)
 	}
 	return w
 }
@@ -482,8 +485,15 @@ func (w *Workflow) skipDonePhases(ctx context.Context) {
 		if !slices.Contains(labels, doneLabel(phase)) {
 			return
 		}
-		// Mark bookkeeping only — labels are already on the tracker (that's why
-		// we're skipping), so no AddLabel/RemoveLabel writes are needed.
+		// The -done label is authoritative, so clear any stale -inprogress
+		// label left over from a prior interrupted run or a user toggling
+		// phase state manually. Without this, the issue can end up tagged
+		// both -inprogress and -done for the same phase.
+		if slices.Contains(labels, inProgressLabel(phase)) {
+			if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
+				w.logger.Warn("failed to clear stale in-progress label while skipping phase", "phase", phase, "error", err)
+			}
+		}
 		w.phases[phase] = phaseDone
 		nextPhase := phaseAfter(phase)
 		if nextPhase == "" {

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1113,6 +1113,25 @@ func labelSequence(mt *mockWorkflowTracker) []string {
 	return out
 }
 
+// TestNewWorkflow_FiltersJiradozerLabelsFromIssue verifies that NewWorkflow
+// strips jiradozer-* labels from issue.Labels at construction time so agent
+// prompts (which read issue.Labels directly) don't see bookkeeping labels
+// before the first successful refreshLabels call.
+func TestNewWorkflow_FiltersJiradozerLabelsFromIssue(t *testing.T) {
+	t.Parallel()
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"}
+
+	wf := NewWorkflow(&mockWorkflowTracker{}, issue, testConfig(), discardLogger())
+
+	// issue.Labels should have jiradozer-* filtered out.
+	assert.Equal(t, []string{"bug", "feature"}, wf.issue.Labels)
+	// lastLabels should retain the full set for skip decisions.
+	assert.Equal(t,
+		[]string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"},
+		wf.lastLabels)
+}
+
 // TestWorkflow_EnterPhase_Idempotent verifies enterPhase adds the inprogress
 // label on first call and is a no-op on repeat.
 func TestWorkflow_EnterPhase_Idempotent(t *testing.T) {
@@ -1223,6 +1242,36 @@ func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
 	assert.Equal(t, phaseDone, wf.phases[PhaseBuild])
 	// No label writes should happen for skipped phases (label already present).
 	assert.Empty(t, labelSequence(mt))
+}
+
+// TestWorkflow_SkipDonePhases_ClearsStaleInProgress verifies that when a phase
+// has both -inprogress and -done labels (e.g. from a prior interrupted run),
+// skipDonePhases removes the stale -inprogress label so the issue doesn't end
+// up with contradictory phase labels.
+func TestWorkflow_SkipDonePhases_ClearsStaleInProgress(t *testing.T) {
+	workDir := t.TempDir()
+	PersistPlan(workDir, "persisted plan", discardLogger())
+
+	issue := testIssue()
+	issue.Labels = []string{"jiradozer-plan-inprogress", "jiradozer-plan-done"}
+
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: issue.Labels},
+	}
+
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+	wf := NewWorkflow(mt, issue, cfg, discardLogger())
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.skipDonePhases(context.Background())
+
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+	// The stale -inprogress should have been cleared.
+	assert.Equal(t,
+		[]string{"RemoveLabel:jiradozer-plan-inprogress"},
+		labelSequence(mt))
 }
 
 // TestWorkflow_SkipDonePhases_AllDone verifies that if every phase is already

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -31,15 +31,32 @@ type mockWorkflowTracker struct {
 	comments           []tracker.Comment  // returned by FetchComments
 	postCommentReply   *tracker.Comment   // if set, PostComment always returns this
 	postCommentReplies []*tracker.Comment // if set, PostComment returns these in order (last repeated)
+	fetchIssueReply    *tracker.Issue     // if set, FetchIssue returns this (used to feed labels into refreshLabels)
+	fetchIssueReplies  []*tracker.Issue   // if set, FetchIssue returns these in order (last repeated)
 	calls              []trackerCall
 	mu                 sync.Mutex
 	commentIdx         int // tracks which comment set to return (for polling)
 	postCommentIdx     int // tracks index into postCommentReplies
+	fetchIssueIdx      int // tracks index into fetchIssueReplies
 }
 
 func (m *mockWorkflowTracker) FetchIssue(_ context.Context, id string) (*tracker.Issue, error) {
-	m.recordCall("FetchIssue", id)
-	return nil, nil
+	m.mu.Lock()
+	m.calls = append(m.calls, trackerCall{method: "FetchIssue", args: []string{id}})
+	var reply *tracker.Issue
+	if m.fetchIssueReply != nil {
+		reply = m.fetchIssueReply
+	} else if len(m.fetchIssueReplies) > 0 {
+		idx := m.fetchIssueIdx
+		if idx >= len(m.fetchIssueReplies) {
+			idx = len(m.fetchIssueReplies) - 1
+		} else {
+			m.fetchIssueIdx++
+		}
+		reply = m.fetchIssueReplies[idx]
+	}
+	m.mu.Unlock()
+	return reply, nil
 }
 
 func (m *mockWorkflowTracker) ListIssues(_ context.Context, _ tracker.IssueFilter) ([]*tracker.Issue, error) {
@@ -93,6 +110,11 @@ func (m *mockWorkflowTracker) UpdateIssueState(_ context.Context, issueID string
 
 func (m *mockWorkflowTracker) AddLabel(_ context.Context, issueID string, label string) error {
 	m.recordCall("AddLabel", issueID, label)
+	return nil
+}
+
+func (m *mockWorkflowTracker) RemoveLabel(_ context.Context, issueID string, label string) error {
+	m.recordCall("RemoveLabel", issueID, label)
 	return nil
 }
 
@@ -1071,4 +1093,224 @@ func TestWorkflow_CircuitBreaker_TripsInRunReview(t *testing.T) {
 	wf.runReview(context.Background(), StepBuilding, StepPlanning)
 	assert.Equal(t, StepFailed, wf.state.Current(), "second redo should trip circuit breaker")
 	assert.Contains(t, wf.lastError.Error(), "re-run")
+}
+
+// --- Phase Label Tests ---
+
+// labelSequence returns the ordered list of label-mutating calls
+// (AddLabel/RemoveLabel) with their label args.
+func labelSequence(mt *mockWorkflowTracker) []string {
+	mt.mu.Lock()
+	defer mt.mu.Unlock()
+	var out []string
+	for _, c := range mt.calls {
+		if c.method == "AddLabel" || c.method == "RemoveLabel" {
+			out = append(out, c.method+":"+c.args[1])
+		}
+	}
+	return out
+}
+
+// TestWorkflow_EnterPhase_Idempotent verifies enterPhase adds the inprogress
+// label on first call and is a no-op on repeat.
+func TestWorkflow_EnterPhase_Idempotent(t *testing.T) {
+	mt := &mockWorkflowTracker{}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	wf.enterPhase(context.Background(), PhasePlan)
+	wf.enterPhase(context.Background(), PhasePlan) // repeat
+
+	assert.Equal(t, []string{"AddLabel:jiradozer-plan-inprogress"}, labelSequence(mt))
+	assert.True(t, wf.phaseEntered[PhasePlan])
+}
+
+// TestWorkflow_CompletePhase_Idempotent verifies completePhase removes the
+// inprogress label and adds the done label, and is a no-op on repeat.
+func TestWorkflow_CompletePhase_Idempotent(t *testing.T) {
+	mt := &mockWorkflowTracker{}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	wf.completePhase(context.Background(), PhasePlan)
+	wf.completePhase(context.Background(), PhasePlan) // repeat
+
+	assert.Equal(t,
+		[]string{"RemoveLabel:jiradozer-plan-inprogress", "AddLabel:jiradozer-plan-done"},
+		labelSequence(mt))
+	assert.True(t, wf.phaseCompleted[PhasePlan])
+}
+
+// TestWorkflow_ApproveTransition_CrossesPhaseBoundary verifies that a
+// plan_review → building transition completes the plan phase and enters the
+// build phase in the correct order.
+func TestWorkflow_ApproveTransition_CrossesPhaseBoundary(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{"bug"}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	// Simulate plan phase already entered (as if by workflow start).
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	wf.phaseEntered[PhasePlan] = true
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	require.NoError(t, wf.approveTransition(context.Background(), StepBuilding, "approved"))
+
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t,
+		[]string{
+			"RemoveLabel:jiradozer-plan-inprogress",
+			"AddLabel:jiradozer-plan-done",
+			"AddLabel:jiradozer-build-inprogress",
+		},
+		labelSequence(mt))
+}
+
+// TestWorkflow_ApproveTransition_StaysWithinPhase verifies that a
+// build_review → validating transition completes the build phase (started as
+// "building" through creating_pr). When re-entering building via redo, the
+// phase is not re-entered.
+func TestWorkflow_ApproveTransition_BuildToValidate(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepBuildReview)
+	wf.phaseEntered[PhaseBuild] = true // simulate build phase already in-flight
+
+	require.NoError(t, wf.approveTransition(context.Background(), StepValidating, "approved"))
+
+	assert.Equal(t, StepValidating, wf.state.Current())
+	assert.Equal(t,
+		[]string{
+			"RemoveLabel:jiradozer-build-inprogress",
+			"AddLabel:jiradozer-build-done",
+			"AddLabel:jiradozer-validate-inprogress",
+		},
+		labelSequence(mt))
+}
+
+// TestWorkflow_SkipDonePhases_FromInit verifies that skipDonePhases at workflow
+// start jumps over phases whose -done label is already present.
+func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
+	workDir := t.TempDir()
+	// Seed a persisted plan so the build step has something to work with.
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, ".jiradozer"), 0o755))
+	require.NoError(t, os.WriteFile(PlanFilePath(workDir), []byte("persisted plan"), 0o644))
+
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-plan-done", "jiradozer-build-done"}
+
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: issue.Labels},
+	}
+
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+	wf := NewWorkflow(mt, issue, cfg, discardLogger())
+
+	// Workflow starts at StepPlanning (the first step after init transition).
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	wf.skipDonePhases(context.Background(), "test")
+
+	// Should have jumped forward past plan and build to validating.
+	assert.Equal(t, StepValidating, wf.state.Current())
+	// Plan should have been loaded from disk since plan phase was skipped.
+	assert.Equal(t, "persisted plan", wf.plan)
+	// Phases skipped should be marked entered + completed (internal bookkeeping).
+	assert.True(t, wf.phaseCompleted[PhasePlan])
+	assert.True(t, wf.phaseCompleted[PhaseBuild])
+	// No label writes should happen for skipped phases (label already present).
+	assert.Empty(t, labelSequence(mt))
+}
+
+// TestWorkflow_SkipDonePhases_AllDone verifies that if every phase is already
+// done, the workflow jumps straight to StepDone.
+func TestWorkflow_SkipDonePhases_AllDone(t *testing.T) {
+	issue := testIssue()
+	issue.Labels = []string{
+		"jiradozer-plan-done",
+		"jiradozer-build-done",
+		"jiradozer-validate-done",
+		"jiradozer-ship-done",
+	}
+
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: issue.Labels},
+	}
+	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.skipDonePhases(context.Background(), "test")
+
+	assert.Equal(t, StepDone, wf.state.Current())
+}
+
+// TestWorkflow_HandlePhaseBoundary_MidRunSkip simulates a user adding
+// `jiradozer-validate-done` mid-run: after build review approves, the
+// workflow should complete the build phase and then skip validate, landing on
+// StepShipping with the validate-done bookkeeping recorded.
+func TestWorkflow_HandlePhaseBoundary_MidRunSkip(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		// On refresh, the issue now has validate-done.
+		fetchIssueReply: &tracker.Issue{Labels: []string{
+			"bug",
+			"jiradozer-validate-done",
+		}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepBuildReview)
+	wf.phaseEntered[PhaseBuild] = true
+
+	require.NoError(t, wf.approveTransition(context.Background(), StepValidating, "approved"))
+
+	// Should have skipped validate and landed on shipping.
+	assert.Equal(t, StepShipping, wf.state.Current())
+	assert.True(t, wf.phaseCompleted[PhaseValidate])
+	// Build is completed (label writes) and ship is entered (label write).
+	// Validate phase labels are NOT written — the -done label was user-added.
+	assert.Equal(t,
+		[]string{
+			"RemoveLabel:jiradozer-build-inprogress",
+			"AddLabel:jiradozer-build-done",
+			"AddLabel:jiradozer-ship-inprogress",
+		},
+		labelSequence(mt))
+}
+
+// TestWorkflow_HandlePhaseBoundary_StepDone verifies that reaching StepDone
+// completes the ship phase when ship was entered.
+func TestWorkflow_HandlePhaseBoundary_StepDone(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepShipReview)
+	wf.phaseEntered[PhaseShip] = true
+
+	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
+
+	assert.Equal(t, StepDone, wf.state.Current())
+	assert.Equal(t,
+		[]string{
+			"RemoveLabel:jiradozer-ship-inprogress",
+			"AddLabel:jiradozer-ship-done",
+		},
+		labelSequence(mt))
+}
+
+// TestWorkflow_RefreshLabels_FallbackOnError verifies that when FetchIssue
+// returns nil (or error), refreshLabels falls back to the cached labels.
+func TestWorkflow_RefreshLabels_FallbackOnError(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		// No fetchIssueReply set — FetchIssue returns (nil, nil).
+	}
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-plan-done"}
+	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
+
+	labels := wf.refreshLabels(context.Background())
+	assert.Equal(t, []string{"bug", "jiradozer-plan-done"}, labels)
 }

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -35,6 +35,8 @@ type mockWorkflowTracker struct {
 	postCommentReplies []*tracker.Comment // if set, PostComment returns these in order (last repeated)
 	fetchIssueReply    *tracker.Issue     // if set, FetchIssue returns this (used to feed labels into refreshLabels)
 	fetchIssueReplies  []*tracker.Issue   // if set, FetchIssue returns these in order (last repeated)
+	addLabelErr        map[string]error   // if label name is in map, AddLabel returns the mapped error
+	removeLabelErr     map[string]error   // if label name is in map, RemoveLabel returns the mapped error
 	calls              []trackerCall
 	mu                 sync.Mutex
 	commentIdx         int // tracks which comment set to return (for polling)
@@ -112,11 +114,17 @@ func (m *mockWorkflowTracker) UpdateIssueState(_ context.Context, issueID string
 
 func (m *mockWorkflowTracker) AddLabel(_ context.Context, issueID string, label string) error {
 	m.recordCall("AddLabel", issueID, label)
+	if err, ok := m.addLabelErr[label]; ok {
+		return err
+	}
 	return nil
 }
 
 func (m *mockWorkflowTracker) RemoveLabel(_ context.Context, issueID string, label string) error {
 	m.recordCall("RemoveLabel", issueID, label)
+	if err, ok := m.removeLabelErr[label]; ok {
+		return err
+	}
 	return nil
 }
 
@@ -1157,6 +1165,44 @@ func TestWorkflow_CompletePhase_Idempotent(t *testing.T) {
 	assert.Equal(t,
 		[]string{"RemoveLabel:jiradozer-plan-inprogress", "AddLabel:jiradozer-plan-done"},
 		labelSequence(mt))
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+}
+
+// TestWorkflow_EnterPhase_TrackerFailureDoesNotAdvanceState verifies that
+// enterPhase leaves phaseState at phaseNotStarted when AddLabel fails, so
+// subsequent events can retry the write rather than silently believing the
+// phase is in progress.
+func TestWorkflow_EnterPhase_TrackerFailureDoesNotAdvanceState(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		addLabelErr: map[string]error{"jiradozer-plan-inprogress": errors.New("boom")},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	wf.enterPhase(context.Background(), PhasePlan)
+
+	assert.Equal(t, phaseNotStarted, wf.phases[PhasePlan])
+	// On retry (tracker now healthy), the state should advance.
+	mt.addLabelErr = nil
+	wf.enterPhase(context.Background(), PhasePlan)
+	assert.Equal(t, phaseInProgress, wf.phases[PhasePlan])
+}
+
+// TestWorkflow_CompletePhase_DoneLabelFailureDoesNotAdvanceState verifies
+// completePhase leaves phaseState intact when the -done AddLabel fails, so
+// the workflow doesn't record a phase as done that the tracker never saw.
+func TestWorkflow_CompletePhase_DoneLabelFailureDoesNotAdvanceState(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		addLabelErr: map[string]error{"jiradozer-plan-done": errors.New("boom")},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	wf.phases[PhasePlan] = phaseInProgress
+
+	wf.completePhase(context.Background(), PhasePlan)
+
+	assert.NotEqual(t, phaseDone, wf.phases[PhasePlan])
+	// Retry succeeds.
+	mt.addLabelErr = nil
+	wf.completePhase(context.Background(), PhasePlan)
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
 }
 

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1122,22 +1122,45 @@ func labelSequence(mt *mockWorkflowTracker) []string {
 }
 
 // TestNewWorkflow_FiltersJiradozerLabelsFromIssue verifies that NewWorkflow
-// strips jiradozer-* labels from issue.Labels at construction time so agent
-// prompts (which read issue.Labels directly) don't see bookkeeping labels
-// before the first successful refreshLabels call.
+// strips jiradozer-* labels from the workflow's internal issue copy at
+// construction time so agent prompts (which read issue.Labels directly)
+// don't see bookkeeping labels before the first successful refreshLabels
+// call, while leaving the caller's struct untouched.
 func TestNewWorkflow_FiltersJiradozerLabelsFromIssue(t *testing.T) {
 	t.Parallel()
-	issue := testIssue()
-	issue.Labels = []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"}
+	callerIssue := testIssue()
+	callerLabels := []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"}
+	callerIssue.Labels = callerLabels
 
-	wf := NewWorkflow(&mockWorkflowTracker{}, issue, testConfig(), discardLogger())
+	wf := NewWorkflow(&mockWorkflowTracker{}, callerIssue, testConfig(), discardLogger())
 
-	// issue.Labels should have jiradozer-* filtered out.
+	// The workflow's internal issue view has jiradozer-* filtered out.
 	assert.Equal(t, []string{"bug", "feature"}, wf.issue.Labels)
 	// lastLabels should retain the full set for skip decisions.
 	assert.Equal(t,
 		[]string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"},
 		wf.lastLabels)
+	// The caller's Issue struct must not be mutated — NewWorkflow takes a
+	// shallow copy so external references remain stable.
+	assert.Equal(t, callerLabels, callerIssue.Labels,
+		"NewWorkflow must not mutate the caller's issue.Labels")
+	assert.NotSame(t, callerIssue, wf.issue,
+		"NewWorkflow must hold its own Issue copy, not the caller's pointer")
+}
+
+// TestNewWorkflow_PreservesUnrelatedJiradozerLabels verifies the narrowed
+// allowlist: labels that happen to share the jiradozer- prefix but aren't
+// one of the eight phase × state labels (e.g. a team's jiradozer-backlog)
+// stay visible to agents.
+func TestNewWorkflow_PreservesUnrelatedJiradozerLabels(t *testing.T) {
+	t.Parallel()
+	issue := testIssue()
+	issue.Labels = []string{"jiradozer-backlog", "jiradozer-plan-done", "bug"}
+
+	wf := NewWorkflow(&mockWorkflowTracker{}, issue, testConfig(), discardLogger())
+
+	// Only the recognized phase label is stripped.
+	assert.Equal(t, []string{"jiradozer-backlog", "bug"}, wf.issue.Labels)
 }
 
 // TestWorkflow_EnterPhase_Idempotent verifies enterPhase adds the inprogress
@@ -1162,9 +1185,47 @@ func TestWorkflow_CompletePhase_Idempotent(t *testing.T) {
 	wf.completePhase(context.Background(), PhasePlan)
 	wf.completePhase(context.Background(), PhasePlan) // repeat
 
+	// -done is written first so a crash between the two calls leaves durable
+	// evidence of completion. -inprogress removal is best-effort cleanup.
 	assert.Equal(t,
-		[]string{"RemoveLabel:jiradozer-plan-inprogress", "AddLabel:jiradozer-plan-done"},
+		[]string{"AddLabel:jiradozer-plan-done", "RemoveLabel:jiradozer-plan-inprogress"},
 		labelSequence(mt))
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+}
+
+// TestWorkflow_CompletePhase_WritesDoneBeforeRemovingInProgress verifies the
+// crash-safe ordering inside completePhase: a crash (or RemoveLabel failure)
+// after the -done write must still leave durable evidence of completion on
+// the tracker, so a resumed run reads -done and skips the finished phase.
+// Reversing the order would leave the issue with NEITHER label on crash.
+func TestWorkflow_CompletePhase_WritesDoneBeforeRemovingInProgress(t *testing.T) {
+	mt := &mockWorkflowTracker{}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	wf.completePhase(context.Background(), PhasePlan)
+
+	seq := labelSequence(mt)
+	require.GreaterOrEqual(t, len(seq), 2, "expected at least AddLabel + RemoveLabel")
+	assert.Equal(t, "AddLabel:jiradozer-plan-done", seq[0],
+		"done label must be written first so it is durable if the process crashes next")
+	assert.Equal(t, "RemoveLabel:jiradozer-plan-inprogress", seq[1],
+		"in-progress removal is best-effort cleanup that runs after -done is safe")
+}
+
+// TestWorkflow_CompletePhase_RemoveInProgressFailureStillAdvances verifies
+// that when -done succeeds but the subsequent -inprogress removal fails,
+// completePhase still advances the in-memory phase to phaseDone. The
+// tracker has the authoritative -done label; the stale -inprogress is a
+// cosmetic issue that skipDonePhases will reconcile on the next run.
+func TestWorkflow_CompletePhase_RemoveInProgressFailureStillAdvances(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		removeLabelErr: map[string]error{"jiradozer-plan-inprogress": errors.New("transient")},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	wf.phases[PhasePlan] = phaseInProgress
+
+	wf.completePhase(context.Background(), PhasePlan)
+
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
 }
 
@@ -1253,8 +1314,8 @@ func TestWorkflow_ApproveTransition_CrossesPhaseBoundary(t *testing.T) {
 	assert.Equal(t, StepBuilding, wf.state.Current())
 	assert.Equal(t,
 		[]string{
-			"RemoveLabel:jiradozer-plan-inprogress",
 			"AddLabel:jiradozer-plan-done",
+			"RemoveLabel:jiradozer-plan-inprogress",
 			"AddLabel:jiradozer-build-inprogress",
 		},
 		labelSequence(mt))
@@ -1280,8 +1341,8 @@ func TestWorkflow_ApproveTransition_BuildToValidate(t *testing.T) {
 	assert.Equal(t, StepValidating, wf.state.Current())
 	assert.Equal(t,
 		[]string{
-			"RemoveLabel:jiradozer-build-inprogress",
 			"AddLabel:jiradozer-build-done",
+			"RemoveLabel:jiradozer-build-inprogress",
 			"AddLabel:jiradozer-validate-inprogress",
 		},
 		labelSequence(mt))
@@ -1400,15 +1461,16 @@ func TestWorkflow_HandlePhaseBoundary_MidRunSkip(t *testing.T) {
 	// Validate phase labels are NOT written — the -done label was user-added.
 	assert.Equal(t,
 		[]string{
-			"RemoveLabel:jiradozer-build-inprogress",
 			"AddLabel:jiradozer-build-done",
+			"RemoveLabel:jiradozer-build-inprogress",
 			"AddLabel:jiradozer-ship-inprogress",
 		},
 		labelSequence(mt))
 }
 
 // TestWorkflow_HandlePhaseBoundary_StepDone verifies that reaching StepDone
-// completes the ship phase when ship was entered.
+// completes the ship phase when ship was entered and all prior phases were
+// already done (the normal clean-run path).
 func TestWorkflow_HandlePhaseBoundary_StepDone(t *testing.T) {
 	mt := &mockWorkflowTracker{
 		fetchIssueReply: &tracker.Issue{Labels: []string{}},
@@ -1416,6 +1478,10 @@ func TestWorkflow_HandlePhaseBoundary_StepDone(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepShipReview)
+	// Normal clean-run state: every prior phase is already phaseDone.
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseDone
+	wf.phases[PhaseValidate] = phaseDone
 	wf.phases[PhaseShip] = phaseInProgress
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
@@ -1423,8 +1489,8 @@ func TestWorkflow_HandlePhaseBoundary_StepDone(t *testing.T) {
 	assert.Equal(t, StepDone, wf.state.Current())
 	assert.Equal(t,
 		[]string{
-			"RemoveLabel:jiradozer-ship-inprogress",
 			"AddLabel:jiradozer-ship-done",
+			"RemoveLabel:jiradozer-ship-inprogress",
 		},
 		labelSequence(mt))
 }
@@ -1441,8 +1507,12 @@ func TestWorkflow_HandlePhaseBoundary_StepDone_RecoversFromFailedShipEnter(t *te
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepShipReview)
-	// Simulate a failed ship enter: phases[PhaseShip] never advanced past
-	// phaseNotStarted because the -inprogress write failed at entry.
+	// Prior phases completed cleanly; ship entry failed transiently so
+	// phases[PhaseShip] is still phaseNotStarted even though the state
+	// machine reached StepShipReview.
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseDone
+	wf.phases[PhaseValidate] = phaseDone
 	assert.Equal(t, phaseNotStarted, wf.phases[PhaseShip])
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
@@ -1450,6 +1520,37 @@ func TestWorkflow_HandlePhaseBoundary_StepDone_RecoversFromFailedShipEnter(t *te
 	assert.Equal(t, StepDone, wf.state.Current())
 	assert.Equal(t, phaseDone, wf.phases[PhaseShip])
 	seq := labelSequence(mt)
+	assert.Contains(t, seq, "AddLabel:jiradozer-ship-done")
+}
+
+// TestWorkflow_HandlePhaseBoundary_StepDone_ReconcilesPriorPhases verifies
+// that reaching StepDone retries -done writes for any prior phase whose
+// earlier completePhase call failed transiently. Reaching StepDone is
+// authoritative evidence the workflow ran every phase, so a missing
+// validate-done must not be left on the issue.
+func TestWorkflow_HandlePhaseBoundary_StepDone_ReconcilesPriorPhases(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepShipReview)
+	// Simulate a workflow where plan and build completed cleanly, but
+	// completePhase(PhaseValidate) failed transiently at the validate→ship
+	// boundary so PhaseValidate is still phaseInProgress. Ship entered
+	// successfully.
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseDone
+	wf.phases[PhaseValidate] = phaseInProgress
+	wf.phases[PhaseShip] = phaseInProgress
+
+	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
+
+	assert.Equal(t, StepDone, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhaseValidate])
+	assert.Equal(t, phaseDone, wf.phases[PhaseShip])
+	seq := labelSequence(mt)
+	assert.Contains(t, seq, "AddLabel:jiradozer-validate-done")
 	assert.Contains(t, seq, "AddLabel:jiradozer-ship-done")
 }
 

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1206,6 +1206,34 @@ func TestWorkflow_CompletePhase_DoneLabelFailureDoesNotAdvanceState(t *testing.T
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
 }
 
+// TestWorkflow_CompletePriorPhases_RecoversFromFailedEnter verifies that
+// approving a phase boundary still writes -done for a prior phase whose
+// initial enterPhase AddLabel failed. Without this, a transient tracker
+// failure at workflow start would leave the issue missing plan-done even
+// though the workflow ran planning and has moved on.
+func TestWorkflow_CompletePriorPhases_RecoversFromFailedEnter(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		addLabelErr: map[string]error{"jiradozer-plan-inprogress": errors.New("transient")},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	// Simulate initial enterPhase call that failed at workflow start.
+	wf.enterPhase(context.Background(), PhasePlan)
+	assert.Equal(t, phaseNotStarted, wf.phases[PhasePlan])
+
+	// Workflow has advanced through planning and is now crossing the
+	// plan → build boundary. Clear the AddLabel error so completion can
+	// write -done successfully.
+	mt.addLabelErr = nil
+	wf.completePriorPhases(context.Background(), PhaseBuild)
+
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+	seq := labelSequence(mt)
+	// Expect the -done write, even though the initial -inprogress never
+	// made it onto the issue.
+	assert.Contains(t, seq, "AddLabel:jiradozer-plan-done")
+}
+
 // TestWorkflow_ApproveTransition_CrossesPhaseBoundary verifies that a
 // plan_review → building transition completes the plan phase and enters the
 // build phase in the correct order.
@@ -1243,7 +1271,9 @@ func TestWorkflow_ApproveTransition_BuildToValidate(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepBuildReview)
-	wf.phases[PhaseBuild] = phaseInProgress // simulate build phase already in-flight
+	// Simulate plan already completed (normal mid-run state) and build in-flight.
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseInProgress
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepValidating, "approved"))
 
@@ -1357,6 +1387,8 @@ func TestWorkflow_HandlePhaseBoundary_MidRunSkip(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepBuildReview)
+	// Normal mid-run state: plan done, build in-flight.
+	wf.phases[PhasePlan] = phaseDone
 	wf.phases[PhaseBuild] = phaseInProgress
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepValidating, "approved"))

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -2,8 +2,10 @@ package jiradozer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -890,7 +892,7 @@ func TestCaptureOutput_BuildDoesNotPersist(t *testing.T) {
 
 	// No plan file should be created for build output.
 	_, err := os.Stat(PlanFilePath(workDir))
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func TestCaptureOutput_EmptyPlanDoesNotOverwrite(t *testing.T) {
@@ -1121,7 +1123,7 @@ func TestWorkflow_EnterPhase_Idempotent(t *testing.T) {
 	wf.enterPhase(context.Background(), PhasePlan) // repeat
 
 	assert.Equal(t, []string{"AddLabel:jiradozer-plan-inprogress"}, labelSequence(mt))
-	assert.True(t, wf.phaseEntered[PhasePlan])
+	assert.Equal(t, phaseInProgress, wf.phases[PhasePlan])
 }
 
 // TestWorkflow_CompletePhase_Idempotent verifies completePhase removes the
@@ -1136,7 +1138,7 @@ func TestWorkflow_CompletePhase_Idempotent(t *testing.T) {
 	assert.Equal(t,
 		[]string{"RemoveLabel:jiradozer-plan-inprogress", "AddLabel:jiradozer-plan-done"},
 		labelSequence(mt))
-	assert.True(t, wf.phaseCompleted[PhasePlan])
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
 }
 
 // TestWorkflow_ApproveTransition_CrossesPhaseBoundary verifies that a
@@ -1150,7 +1152,7 @@ func TestWorkflow_ApproveTransition_CrossesPhaseBoundary(t *testing.T) {
 
 	// Simulate plan phase already entered (as if by workflow start).
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
-	wf.phaseEntered[PhasePlan] = true
+	wf.phases[PhasePlan] = phaseInProgress
 	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepBuilding, "approved"))
@@ -1176,7 +1178,7 @@ func TestWorkflow_ApproveTransition_BuildToValidate(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepBuildReview)
-	wf.phaseEntered[PhaseBuild] = true // simulate build phase already in-flight
+	wf.phases[PhaseBuild] = phaseInProgress // simulate build phase already in-flight
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepValidating, "approved"))
 
@@ -1195,8 +1197,7 @@ func TestWorkflow_ApproveTransition_BuildToValidate(t *testing.T) {
 func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
 	workDir := t.TempDir()
 	// Seed a persisted plan so the build step has something to work with.
-	require.NoError(t, os.MkdirAll(filepath.Join(workDir, ".jiradozer"), 0o755))
-	require.NoError(t, os.WriteFile(PlanFilePath(workDir), []byte("persisted plan"), 0o644))
+	PersistPlan(workDir, "persisted plan", discardLogger())
 
 	issue := testIssue()
 	issue.Labels = []string{"bug", "jiradozer-plan-done", "jiradozer-build-done"}
@@ -1211,15 +1212,15 @@ func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
 
 	// Workflow starts at StepPlanning (the first step after init transition).
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
-	wf.skipDonePhases(context.Background(), "test")
+	wf.skipDonePhases(context.Background())
 
 	// Should have jumped forward past plan and build to validating.
 	assert.Equal(t, StepValidating, wf.state.Current())
 	// Plan should have been loaded from disk since plan phase was skipped.
 	assert.Equal(t, "persisted plan", wf.plan)
 	// Phases skipped should be marked entered + completed (internal bookkeeping).
-	assert.True(t, wf.phaseCompleted[PhasePlan])
-	assert.True(t, wf.phaseCompleted[PhaseBuild])
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+	assert.Equal(t, phaseDone, wf.phases[PhaseBuild])
 	// No label writes should happen for skipped phases (label already present).
 	assert.Empty(t, labelSequence(mt))
 }
@@ -1241,7 +1242,7 @@ func TestWorkflow_SkipDonePhases_AllDone(t *testing.T) {
 	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
-	wf.skipDonePhases(context.Background(), "test")
+	wf.skipDonePhases(context.Background())
 
 	assert.Equal(t, StepDone, wf.state.Current())
 }
@@ -1261,13 +1262,13 @@ func TestWorkflow_HandlePhaseBoundary_MidRunSkip(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepBuildReview)
-	wf.phaseEntered[PhaseBuild] = true
+	wf.phases[PhaseBuild] = phaseInProgress
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepValidating, "approved"))
 
 	// Should have skipped validate and landed on shipping.
 	assert.Equal(t, StepShipping, wf.state.Current())
-	assert.True(t, wf.phaseCompleted[PhaseValidate])
+	assert.Equal(t, phaseDone, wf.phases[PhaseValidate])
 	// Build is completed (label writes) and ship is entered (label write).
 	// Validate phase labels are NOT written — the -done label was user-added.
 	assert.Equal(t,
@@ -1288,7 +1289,7 @@ func TestWorkflow_HandlePhaseBoundary_StepDone(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
 
 	walkTo(t, wf.state, StepShipReview)
-	wf.phaseEntered[PhaseShip] = true
+	wf.phases[PhaseShip] = phaseInProgress
 
 	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
 

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1429,6 +1429,30 @@ func TestWorkflow_HandlePhaseBoundary_StepDone(t *testing.T) {
 		labelSequence(mt))
 }
 
+// TestWorkflow_HandlePhaseBoundary_StepDone_RecoversFromFailedShipEnter
+// verifies that reaching StepDone writes ship-done even when the initial
+// enterPhase(PhaseShip) AddLabel failed. Without this recovery, a transient
+// tracker failure at ship phase start would silently leave the terminal
+// ship-done label missing from the issue.
+func TestWorkflow_HandlePhaseBoundary_StepDone_RecoversFromFailedShipEnter(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepShipReview)
+	// Simulate a failed ship enter: phases[PhaseShip] never advanced past
+	// phaseNotStarted because the -inprogress write failed at entry.
+	assert.Equal(t, phaseNotStarted, wf.phases[PhaseShip])
+
+	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
+
+	assert.Equal(t, StepDone, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhaseShip])
+	seq := labelSequence(mt)
+	assert.Contains(t, seq, "AddLabel:jiradozer-ship-done")
+}
+
 // TestWorkflow_RefreshLabels_FallbackOnError verifies that when FetchIssue
 // returns nil (or error), refreshLabels falls back to the cached labels.
 func TestWorkflow_RefreshLabels_FallbackOnError(t *testing.T) {

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1567,3 +1567,125 @@ func TestWorkflow_RefreshLabels_FallbackOnError(t *testing.T) {
 	labels := wf.refreshLabels(context.Background())
 	assert.Equal(t, []string{"bug", "jiradozer-plan-done"}, labels)
 }
+
+// TestWorkflow_RefreshLabels_FiltersLabelsAndIDsInLockstep verifies that
+// filtering bookkeeping labels from w.issue.Labels also drops the matching
+// entries from w.issue.LabelIDs, so the two slices continue to describe
+// the same attachment set (Linear's nodeToIssue relies on this invariant).
+func TestWorkflow_RefreshLabels_FiltersLabelsAndIDsInLockstep(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{
+			Labels:   []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"},
+			LabelIDs: []string{"id-bug", "id-plan-inprogress", "id-feature", "id-build-done"},
+		},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	wf.refreshLabels(context.Background())
+
+	assert.Equal(t, []string{"bug", "feature"}, wf.issue.Labels)
+	assert.Equal(t, []string{"id-bug", "id-feature"}, wf.issue.LabelIDs,
+		"LabelIDs must drop the same indices as Labels so callers using them together stay consistent")
+}
+
+// TestWorkflow_TerminalCleanupSweep_RemovesStaleInProgress verifies that
+// reaching StepDone removes any -inprogress label still on the tracker for
+// a phase whose completePhase left it behind (e.g. via a transient
+// RemoveLabel failure). Without this sweep the issue would end up with
+// both -inprogress and -done for a completed phase, violating the
+// glanceable-progress goal.
+func TestWorkflow_TerminalCleanupSweep_RemovesStaleInProgress(t *testing.T) {
+	// First call (handlePhaseBoundary start): issue still carries
+	// ship-inprogress because completePhase's -inprogress removal failed.
+	// Second call (cleanupStalePhaseLabels): same labels — the sweep
+	// should issue another RemoveLabel since phases[ship] == phaseDone.
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{
+			"jiradozer-ship-inprogress",
+		}},
+		removeLabelErr: map[string]error{
+			// Make the first RemoveLabel fail (triggering the leftover
+			// state), then allow the sweep's RemoveLabel to succeed.
+			// Since our mock matches on label name, we can't easily toggle
+			// by call index, so we simulate by pre-setting phases[ship]
+			// to phaseDone and letting the terminal sweep run.
+		},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepShipReview)
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseDone
+	wf.phases[PhaseValidate] = phaseDone
+	wf.phases[PhaseShip] = phaseDone // Pretend completePhase bumped state but left the label behind.
+
+	// Drive through the boundary.
+	require.NoError(t, wf.approveTransition(context.Background(), StepDone, "approved"))
+
+	seq := labelSequence(mt)
+	assert.Contains(t, seq, "RemoveLabel:jiradozer-ship-inprogress",
+		"terminal sweep must clear a stale -inprogress label for a phaseDone phase")
+}
+
+// TestWorkflow_Redo_ReopensCompletedPhase verifies that a backward transition
+// (redo) from a review gate to an earlier agent step reopens the targeted
+// phase: the -done label is removed, -inprogress is re-added, and the
+// phase's in-memory state returns to phaseInProgress. Without this, a
+// validate review → building redo would run the build agent under stale
+// jiradozer-build-done labels, misrepresenting the workflow's active phase.
+func TestWorkflow_Redo_ReopensCompletedPhase(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	// Walk to ValidateReview with plan and build completed, validate in-flight.
+	walkTo(t, wf.state, StepValidateReview)
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseDone
+	wf.phases[PhaseValidate] = phaseInProgress
+
+	require.NoError(t, wf.tryRedo(context.Background(), StepBuilding))
+
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, phaseInProgress, wf.phases[PhaseBuild],
+		"redoing into build must put the phase back in-progress")
+	assert.Equal(t, phaseNotStarted, wf.phases[PhaseValidate],
+		"phases ahead of the redo target are rewound to not-started")
+	seq := labelSequence(mt)
+	// Expected: remove build-done, remove validate-inprogress, add build-inprogress.
+	assert.Contains(t, seq, "RemoveLabel:jiradozer-build-done",
+		"the -done label of the reopened phase must be cleared")
+	assert.Contains(t, seq, "RemoveLabel:jiradozer-validate-inprogress",
+		"the aborted later phase's -inprogress must be cleared")
+	assert.Contains(t, seq, "AddLabel:jiradozer-build-inprogress",
+		"the reopened phase gets a fresh -inprogress label")
+}
+
+// TestWorkflow_Redo_SamePhase verifies that a redo inside the same phase
+// (e.g. PlanReview → Planning) is a no-op for phase bookkeeping — the
+// phase is already in-progress and no label churn is needed.
+func TestWorkflow_Redo_SamePhase(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+
+	walkTo(t, wf.state, StepPlanReview)
+	wf.phases[PhasePlan] = phaseInProgress
+
+	require.NoError(t, wf.tryRedo(context.Background(), StepPlanning))
+
+	assert.Equal(t, StepPlanning, wf.state.Current())
+	// Should still be in-progress (no -done was written); enterPhase is a
+	// no-op because phases[PhasePlan] != phaseNotStarted after reset-and-
+	// re-enter, but we accept that a fresh -inprogress write may occur.
+	assert.Equal(t, phaseInProgress, wf.phases[PhasePlan])
+	seq := labelSequence(mt)
+	// No -done exists for plan (phase never completed), so no RemoveLabel
+	// of -done should fire. At most a redundant -inprogress add.
+	for _, call := range seq {
+		assert.NotEqual(t, "RemoveLabel:jiradozer-plan-done", call,
+			"plan was never done; no -done removal should fire")
+	}
+}


### PR DESCRIPTION
## Summary

- Add per-phase labels (`jiradozer-<phase>-inprogress` / `-done` for plan/build/validate/ship) that the workflow writes as it moves between phases, giving users a glanceable progress indicator on the issue itself.
- On workflow start, silently skip phases whose `-done` label is already present (re-runs pick up where a prior run left off); if the plan phase is skipped, the persisted plan.md is loaded from disk so the build step isn't run blind.
- Refresh labels from the tracker before each phase boundary, so a user watching a run can add `jiradozer-validate-done` mid-flight to have the workflow skip validate when it gets there.

## Implementation notes

- `tracker.IssueTracker` gains `RemoveLabel`; Linear, GitHub, and local trackers implement it idempotently (404 / absent label → nil).
- New `jiradozer/steplabels.go` owns the phase ↔ label mapping. Four phases only — review gates and `creating_pr` fold into `build`.
- `workflow.go` centralizes label writes in `enterPhase` / `completePhase`. After each review approval, `handlePhaseBoundary` completes the prior phase, refreshes labels, and uses `ForceState` to skip any upcoming `-done` phases. Failed runs leave `-inprogress` on the issue (matches the existing `jiradozer-active` convention).

## Test plan

- [x] `scripts/lint.sh` passes.
- [x] `bazel build //jiradozer/...` passes.
- [x] `bazel test //jiradozer/...` — all 6 targets pass, including:
  - `steplabels_test.go` covering `phaseForStep` / `inProgressLabel` / `doneLabel` / `hasLabel`.
  - 9 new workflow-level tests for enter/complete idempotence, phase-boundary transitions, startup-skip with pre-existing `-done` labels, all-phases-done → `StepDone`, mid-run skip via refreshed labels, and fetch-fallback.
  - `local_test.go` exercising `AddLabel` / `RemoveLabel` idempotence and not-found errors.
- [ ] Manual: run against a test issue in Linear, confirm labels appear at each phase boundary.
- [ ] Manual: pre-set `jiradozer-plan-done` + `jiradozer-build-done` on an issue and confirm the workflow resumes at validate without re-running plan/build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workflow progression and tracker mutation APIs by adding per-phase label bookkeeping and skip/redo reconciliation, which could affect how runs advance or resume across trackers. Risk is mitigated by extensive new unit/integration tests and idempotent label operations.
> 
> **Overview**
> Adds **phase-based progress labels** to issues (e.g. `jiradozer-plan-inprogress`/`-done` for plan/build/validate/ship) and updates the workflow to write/clear these labels as phases start/complete, including cleanup of stale labels.
> 
> Workflow runs now **resume/skip completed phases** when `*-done` labels already exist (including mid-run label refresh allowing user-driven skipping), and redo transitions reopen prior phases by removing `*-done` and re-adding `*-inprogress`.
> 
> Extends `tracker.IssueTracker` with `RemoveLabel` and implements idempotent label removal across GitHub/Linear/local (GitHub also auto-creates missing repo labels on `AddLabel`); agent prompt rendering now strips only the exact bookkeeping labels, and build step plan loading is centralized via `LoadPersistedPlan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6e62d2e3eb88d98586ee93e787c3d921fe80e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->