### PR TITLE
fix(retry-detector): don't retry when agent self-recovered from tool error (G4)

### DIFF
--- a/agent-cli-wrapper/claude/testdata/retry/edit_error_then_recovered.json
+++ b/agent-cli-wrapper/claude/testdata/retry/edit_error_then_recovered.json
@@ -1,0 +1,48 @@
+[
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_edit_1",
+    "tool_name": "Edit",
+    "tool_input": {
+      "file_path": "/repo/foo.go",
+      "old_string": "old",
+      "new_string": "new"
+    }
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_edit_1",
+    "tool_result": "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+    "is_error": true
+  },
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_read_1",
+    "tool_name": "Read",
+    "tool_input": {
+      "file_path": "/repo/foo.go"
+    }
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_read_1",
+    "tool_result": "package foo\n\nfunc Old() {}\n",
+    "is_error": false
+  },
+  {
+    "type": "tool_use",
+    "tool_use_id": "toolu_edit_2",
+    "tool_name": "Edit",
+    "tool_input": {
+      "file_path": "/repo/foo.go",
+      "old_string": "old",
+      "new_string": "new"
+    }
+  },
+  {
+    "type": "tool_result",
+    "tool_use_id": "toolu_edit_2",
+    "tool_result": "Successfully edited /repo/foo.go",
+    "is_error": false
+  }
+]

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -109,7 +109,7 @@ func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok boo
 		// Build tool name map only on the error path (uncommon case).
 		toolNames := make(map[string]string)
 		for _, b := range blocks {
-			if b.Type == ContentBlockTypeToolUse {
+			if b.Type == ContentBlockTypeToolUse && b.ToolUseID != "" {
 				toolNames[b.ToolUseID] = b.ToolName
 			}
 		}

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -94,25 +94,24 @@ func excerptRunes(s string, max int) string {
 // cancelled sibling (carrying the marker) is still the last tool_result
 // in forward order, so it remains detectable.
 func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
-	toolNames := make(map[string]string)
-	for _, block := range blocks {
-		if block.Type == ContentBlockTypeToolUse && block.ToolUseID != "" {
-			toolNames[block.ToolUseID] = block.ToolName
-		}
-	}
-	// Walk in reverse to find the last tool_result block.
 	for i := len(blocks) - 1; i >= 0; i-- {
 		block := blocks[i]
 		if block.Type != ContentBlockTypeToolResult {
 			continue
 		}
-		// Found the last tool_result. It must have IsError AND the marker.
 		if !block.IsError {
 			return "", "", false
 		}
 		content := stringifyToolResult(block.ToolResult)
 		if !strings.Contains(content, toolUseErrorMarker) {
 			return "", "", false
+		}
+		// Build tool name map only on the error path (uncommon case).
+		toolNames := make(map[string]string)
+		for _, b := range blocks {
+			if b.Type == ContentBlockTypeToolUse {
+				toolNames[b.ToolUseID] = b.ToolName
+			}
 		}
 		name := toolNames[block.ToolUseID]
 		if name == "" {

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -78,16 +78,21 @@ func excerptRunes(s string, max int) string {
 	return s
 }
 
-// FinalTurnToolError reports the first CLI-reported tool_use_error in
-// blocks, returning the failing tool's name and a bounded excerpt. A
-// block qualifies iff IsError is set AND the content carries the
-// toolUseErrorMarker wrapper — the marker is the stable signal the CLI
-// uses for tool invocations it refused, blocked, or cancelled. Nonzero-
-// exit Bash (e.g. `gh pr checks` exit 8) sets IsError but lacks the
-// wrapper and must not trigger retry.
+// FinalTurnToolError reports a CLI-reported tool_use_error only when it
+// is the LAST tool_result in the turn. A block qualifies iff IsError is
+// set AND the content carries the toolUseErrorMarker wrapper — the marker
+// is the stable signal the CLI uses for tool invocations it refused,
+// blocked, or cancelled. Nonzero-exit Bash (e.g. `gh pr checks` exit 8)
+// sets IsError but lacks the wrapper and must not trigger retry.
 //
-// On parallel batches, first qualifying block wins (first with both
-// IsError and the marker).
+// Walking in reverse catches the last tool_result first. If the agent
+// recovered from a transient error (e.g. "File has not been read yet"
+// followed by a successful Read + Edit), the last tool_result is a
+// success, so ok=false — the turn is not retried.
+//
+// On parallel batches where the errored group is the final group, the
+// cancelled sibling (carrying the marker) is still the last tool_result
+// in forward order, so it remains detectable.
 func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
 	toolNames := make(map[string]string)
 	for _, block := range blocks {
@@ -95,13 +100,19 @@ func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok boo
 			toolNames[block.ToolUseID] = block.ToolName
 		}
 	}
-	for _, block := range blocks {
-		if block.Type != ContentBlockTypeToolResult || !block.IsError {
+	// Walk in reverse to find the last tool_result block.
+	for i := len(blocks) - 1; i >= 0; i-- {
+		block := blocks[i]
+		if block.Type != ContentBlockTypeToolResult {
 			continue
+		}
+		// Found the last tool_result. It must have IsError AND the marker.
+		if !block.IsError {
+			return "", "", false
 		}
 		content := stringifyToolResult(block.ToolResult)
 		if !strings.Contains(content, toolUseErrorMarker) {
-			continue
+			return "", "", false
 		}
 		name := toolNames[block.ToolUseID]
 		if name == "" {

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -253,6 +253,46 @@ func TestFinalTurnToolError_Fixture_RealToolUseError(t *testing.T) {
 	}
 }
 
+// TestFinalTurnToolError_Fixture_EditErrorThenRecovered is the G4
+// regression for the 2026-04-18 production failure: a single turn with
+// one early Edit tool_use_error followed by a successful Read + Edit.
+// The agent self-recovered; FinalTurnToolError must return ok=false.
+func TestFinalTurnToolError_Fixture_EditErrorThenRecovered(t *testing.T) {
+	t.Parallel()
+	blocks := loadRetryFixture(t, "edit_error_then_recovered.json")
+	if _, _, ok := FinalTurnToolError(blocks); ok {
+		t.Error("recovered-error fixture must not trigger retry (G4: error is not the last tool_result)")
+	}
+}
+
+// TestFinalTurnToolError_ErrorIsLastToolResult verifies the positive G4
+// case: when the last tool_result in the turn IS the errored one, retry
+// must still fire.
+func TestFinalTurnToolError_ErrorIsLastToolResult(t *testing.T) {
+	t.Parallel()
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Read"},
+		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "file contents", IsError: false},
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t2", ToolName: "Edit"},
+		{
+			Type:       ContentBlockTypeToolResult,
+			ToolUseID:  "t2",
+			ToolResult: "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+			IsError:    true,
+		},
+	}
+	name, excerpt, ok := FinalTurnToolError(blocks)
+	if !ok {
+		t.Fatal("expected ok=true when error is the last tool_result")
+	}
+	if name != "Edit" {
+		t.Errorf("expected tool=Edit, got %q", name)
+	}
+	if !strings.Contains(excerpt, "File has not been read yet") {
+		t.Errorf("expected excerpt to contain error text, got %q", excerpt)
+	}
+}
+
 // loadRetryFixture reads a JSON snapshot of []ContentBlock from
 // testdata/retry/. Fixtures are hand-extracted from real Claude CLI
 // session JSONL files to guard the detector against regressions.

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -454,6 +454,49 @@ is the load-bearing regression coverage.
   INFO, not WARN, when `reason == bg_work_live` since it's the
   expected case.
 
+## G4 — Error must be the final tool_result in the turn
+
+Added after a production failure on 2026-04-18 (commit on
+`fix/retry-detector-recovered-errors`).
+
+**Symptom.** Jiradozer validate ran a 16-Edit turn. One early Edit returned
+`<tool_use_error>File has not been read yet</tool_use_error>`. The agent
+recovered: Read the file, re-issued the Edit, completed 20+ more tool calls,
+and ended with `stop_reason=end_turn` and a 1426-char summary text.
+Jiradozer's retry loop still fired ("Retry 1/3: tool error in Edit") and
+re-ran "simplify review from scratch," wasting ~5 min and clobbering the
+successful output.
+
+**Evidence.**
+- Session JSONL:
+  `~/.claude/projects/-home-ubuntu-worktrees-yoloswe-faeture-step-tracking/fc29ffb6-7b4d-40f6-80bc-4be1b0a2df33.jsonl`
+  line 132 (errored tool_result), line 156 (clean `end_turn` with text summary).
+- Jiradozer log:
+  `~/.jiradozer/logs/jiradozer-20260418-042630-3768733.log`
+  lines 203–208: `turn complete step=validate success=true` immediately
+  followed by `retry on tool error ... tool=Edit`.
+
+**Root cause.** The pre-G4 `FinalTurnToolError` walked `ContentBlocks` in
+forward order and returned the *first* qualifying error block. It never
+checked whether the error was the *last* tool_result. A turn with a transient
+early error and later recovery looked identical to a terminal error.
+
+**Fix.** Walk `ContentBlocks` in reverse. Take the first `tool_result`
+encountered (i.e. the last one in forward order). Return `ok=true` only if
+that last tool_result has both `IsError==true` and the `toolUseErrorMarker`.
+If the agent recovered (last tool_result is a success), `ok=false`.
+
+**Compatibility.** Existing G1/G2/G3 gates in `claude_provider.go` are
+unchanged. The PLA-212 fixture (`real_tool_use_error.json`) still passes
+because in that fixture the cancelled parallel sibling IS the last
+tool_result. The `parked_with_skill_error.json` fixture still returns
+`ok=true` at the detector level (Skill error is the last tool_result);
+G2 (`HasLiveBackgroundWork`) continues to suppress the retry.
+
+**Test regression.** `TestFinalTurnToolError_Fixture_EditErrorThenRecovered`
+in `turn_retry_test.go` + `TestRunRetryLoop_SkipsWhenAgentRecovered` in
+`claude_provider_retry_test.go`.
+
 ## Open questions for human review
 
 1. **Do we need G3 at all?** If G1+G2 land and no log shows a

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -115,7 +115,7 @@ func (p *ClaudeProvider) Name() string { return "claude" }
 // runRetryLoop drives the provider-layer retry-on-tool-error loop. Takes
 // the result of the initial Ask and may issue follow-up Asks up to
 // cfg.MaxToolErrorRetries times. Exits early when the turn is parked on
-// bg work (G2), no tool_use_error is present (G1), the retry budget is
+// bg work (G2), no tool_use_error is present or agent self-recovered (G1/G4), the retry budget is
 // exhausted, or the ctx is cancelled. Returns the final TurnResult, the
 // number of retry Asks issued, and the stop reason recorded on the last
 // decision. The caller appends the unresolved marker and fires

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -339,6 +339,53 @@ func TestRunRetryLoop_BgWorkLiveNoUnresolvedError(t *testing.T) {
 	}
 }
 
+// recoveredErrorBlocks returns a block sequence where an early Edit
+// tool_use_error is followed by a successful Read + Edit, mirroring the
+// 2026-04-18 production failure (fc29ffb6 session, line 132 → 156).
+func recoveredErrorBlocks() []claude.ContentBlock {
+	return []claude.ContentBlock{
+		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "edit1", ToolName: "Edit"},
+		{
+			Type:       claude.ContentBlockTypeToolResult,
+			ToolUseID:  "edit1",
+			ToolResult: "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+			IsError:    true,
+		},
+		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "read1", ToolName: "Read"},
+		{Type: claude.ContentBlockTypeToolResult, ToolUseID: "read1", ToolResult: "file contents", IsError: false},
+		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "edit2", ToolName: "Edit"},
+		{Type: claude.ContentBlockTypeToolResult, ToolUseID: "edit2", ToolResult: "edit applied", IsError: false},
+	}
+}
+
+// TestRunRetryLoop_SkipsWhenAgentRecovered is the G4 regression for the
+// 2026-04-18 production failure: a turn that had an early Edit error
+// followed by a successful recovery must not trigger retry.
+func TestRunRetryLoop_SkipsWhenAgentRecovered(t *testing.T) {
+	t.Parallel()
+	initial := &claude.TurnResult{
+		Text:          "Validated successfully.",
+		ContentBlocks: recoveredErrorBlocks(),
+		Success:       true,
+	}
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	result, attempts, _, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries when agent self-recovered, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if result != initial {
+		t.Error("expected the original result returned unchanged")
+	}
+}
+
 // TestRunRetryLoop_PropagatesAskError ensures an Ask transport error
 // aborts the loop cleanly without masking.
 func TestRunRetryLoop_PropagatesAskError(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Production failure**: jiradozer validate ran a 16-Edit turn. One early Edit returned `<tool_use_error>File has not been read yet</tool_use_error>`. The agent recovered: Read the file, re-issued the Edit, completed 20+ more tool calls, ended with `stop_reason=end_turn` and a 1426-char review summary. Jiradozer's retry loop still fired ("Retry 1/3: tool error in Edit") and re-ran "simplify review from scratch," wasting ~5 min and clobbering the successful output.
- **Root cause**: `FinalTurnToolError` walked `ContentBlocks` in forward order and returned the *first* qualifying error block, never checking whether it was the *last* tool_result. A turn with a transient early error and successful recovery looked identical to a terminal error.
- **Fix**: Walk `ContentBlocks` in reverse. Take the first `tool_result` found (i.e. the last in forward order). Return `ok=true` only if that last tool_result has both `IsError==true` and the `<tool_use_error>` marker. If the last tool_result is a success, `ok=false` — no retry.
- **Existing behavior preserved**: PLA-212 (`real_tool_use_error.json`) and `parked_with_skill_error.json` fixtures are unaffected — in both, the errored/cancelled block IS the last tool_result. G1/G2/G3 gates in `claude_provider.go` are unchanged.

Evidence:
- Session JSONL: `~/.claude/projects/-home-ubuntu-worktrees-yoloswe-faeture-step-tracking/fc29ffb6-7b4d-40f6-80bc-4be1b0a2df33.jsonl` — line 132 (errored tool_result), line 156 (clean `end_turn`)
- Jiradozer log: `~/.jiradozer/logs/jiradozer-20260418-042630-3768733.log` — lines 203–208

## Test plan

- [x] `TestFinalTurnToolError_Fixture_EditErrorThenRecovered` — new fixture `edit_error_then_recovered.json` (errored Edit + successful Read + successful Edit); asserts `ok=false`
- [x] `TestFinalTurnToolError_ErrorIsLastToolResult` — positive G4 case: when the last tool_result IS errored, retry still fires
- [x] `TestRunRetryLoop_SkipsWhenAgentRecovered` — provider-level: recovered-error blocks → 0 retries, 0 Ask calls
- [x] All existing fixtures (`real_tool_use_error.json`, `parked_with_skill_error.json`, `nonzero_exit_bash.json`) still pass
- [x] `scripts/lint.sh` clean
- [x] `bazel test //agent-cli-wrapper/... //multiagent/... //jiradozer/...` — 23/23 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the retry gate behavior in a production execution loop, which could reduce retries in some edge cases if the last `tool_result` heuristic is wrong. Covered by new fixture-driven and provider-level unit tests for both recovered and terminal error scenarios.
> 
> **Overview**
> Prevents the provider retry loop from firing when a turn had an early `tool_use_error` but later succeeded in the same turn (agent self-recovered).
> 
> `FinalTurnToolError` now scans `ContentBlocks` in reverse and only returns `ok=true` if the *last* `tool_result` is an error **and** contains the `<tool_use_error>` marker; otherwise it suppresses retry.
> 
> Adds regression coverage with a new `edit_error_then_recovered.json` fixture plus unit tests (including a positive case where the final `tool_result` is still errored), and updates the design doc to document the new G4 gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b3b774c4c24f45475d9d1a674257ec743b1a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->