### PR TITLE
fix(agent-cli-wrapper): re-suppress chained ScheduleWakeup calls

### DIFF
--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -55,19 +55,12 @@ func (b *bgSuppressionState) reset() {
 // continuation turn. If the continuation also calls ScheduleWakeup, it is
 // suppressed again, chaining until a turn completes without ScheduleWakeup.
 type wakeupSuppressionState struct {
-	timer *time.Timer // safety timer; fires if no continuation arrives
-	// suppressedWakeupToolID is the tool_use_id of the ScheduleWakeup block
-	// that triggered the current suppression. Used to detect when a
-	// continuation appends a NEW ScheduleWakeup (different ID) vs the stale
-	// original block that persists in ContentBlocks across continuations.
-	suppressedWakeupToolID string
-	accumulatedUsage       TurnUsage // token/cost totals from suppressed turns
-	// suppressedTurnNumber is the original turn number that waiters are
-	// blocked on. The continuation turn has a higher number, but we
-	// complete it under the original number so WaitForTurn callers unblock.
-	suppressedTurnNumber int
-	active               bool // true while waiting for the continuation turn
-	timerFired           bool // set by the safety timer
+	timer                  *time.Timer // safety timer; fires if no continuation arrives
+	suppressedWakeupToolID string      // tool_use_id that triggered suppression; detects stale vs new blocks
+	accumulatedUsage       TurnUsage   // token/cost totals from suppressed turns
+	suppressedTurnNumber   int         // original turn number; continuations complete under this number
+	active                 bool        // true while waiting for the continuation turn
+	timerFired             bool        // set by the safety timer
 }
 
 // reset clears wakeup suppression state and stops any pending timer.
@@ -1376,11 +1369,11 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	//     re-suppress, chaining the wakeup sequence.
 	maxTurnsReached := s.config.MaxTurns > 0 && turnNumber >= s.config.MaxTurns
 	latestWakeupID := turn.latestScheduleWakeupToolID()
-	// alreadySuppressedThisWakeup: we previously suppressed on this exact
-	// tool_use_id, meaning no new ScheduleWakeup was appended by the
-	// continuation. priorSuppressedWakeupToolID was snapshotted under mu above.
-	alreadySuppressedThisWakeup := wakeupSuppressed && latestWakeupID == priorSuppressedWakeupToolID
-	shouldSuppressWakeup := !msg.IsError && !maxTurnsReached && latestWakeupID != "" && !alreadySuppressedThisWakeup
+	// priorSuppressedWakeupToolID was snapshotted under mu above. If it matches
+	// latestWakeupID, the continuation appended no new ScheduleWakeup — the stale
+	// original block is the only one present, so we release rather than re-suppress.
+	shouldSuppressWakeup := !msg.IsError && !maxTurnsReached && latestWakeupID != "" &&
+		!(wakeupSuppressed && latestWakeupID == priorSuppressedWakeupToolID)
 	if shouldSuppressWakeup {
 		s.mu.Lock()
 		s.cumulativeCostUSD += msg.TotalCostUSD

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -55,14 +55,19 @@ func (b *bgSuppressionState) reset() {
 // continuation turn. If the continuation also calls ScheduleWakeup, it is
 // suppressed again, chaining until a turn completes without ScheduleWakeup.
 type wakeupSuppressionState struct {
-	timer            *time.Timer // safety timer; fires if no continuation arrives
-	accumulatedUsage TurnUsage   // token/cost totals from suppressed turns
-	active           bool        // true while waiting for the continuation turn
-	timerFired       bool        // set by the safety timer
+	timer *time.Timer // safety timer; fires if no continuation arrives
+	// suppressedWakeupToolID is the tool_use_id of the ScheduleWakeup block
+	// that triggered the current suppression. Used to detect when a
+	// continuation appends a NEW ScheduleWakeup (different ID) vs the stale
+	// original block that persists in ContentBlocks across continuations.
+	suppressedWakeupToolID string
+	accumulatedUsage       TurnUsage // token/cost totals from suppressed turns
 	// suppressedTurnNumber is the original turn number that waiters are
 	// blocked on. The continuation turn has a higher number, but we
 	// complete it under the original number so WaitForTurn callers unblock.
 	suppressedTurnNumber int
+	active               bool // true while waiting for the continuation turn
+	timerFired           bool // set by the safety timer
 }
 
 // reset clears wakeup suppression state and stops any pending timer.
@@ -70,6 +75,7 @@ func (w *wakeupSuppressionState) reset() {
 	w.active = false
 	w.timerFired = false
 	w.suppressedTurnNumber = 0
+	w.suppressedWakeupToolID = ""
 	if w.timer != nil {
 		w.timer.Stop()
 		w.timer = nil
@@ -1126,12 +1132,13 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	wakeupTimerFired := s.wakeupState.timerFired
 	s.wakeupState.timerFired = false
 	wakeupSuppressed := s.wakeupState.active
-	// Snapshot suppressedTurnNumber under the initial lock. A later read
-	// after mu.Unlock would race with SendMessage/SendToolResult, which
-	// resets wakeupState to zero — that would emit the completion under
-	// turn 0 and strand WaitForTurn/CollectResponse callers waiting on
-	// the real original turn number.
+	// Snapshot suppressedTurnNumber and suppressedWakeupToolID under the
+	// initial lock. A later read after mu.Unlock would race with
+	// SendMessage/SendToolResult, which resets wakeupState to zero — that
+	// would emit the completion under turn 0 and strand WaitForTurn/
+	// CollectResponse callers waiting on the real original turn number.
 	wakeupSuppressedTurnNumber := s.wakeupState.suppressedTurnNumber
+	priorSuppressedWakeupToolID := s.wakeupState.suppressedWakeupToolID
 	// Clear wakeupState.active under the same lock where timerFired is read.
 	// Leaving it true while mu is released would race with the safety-timer
 	// callback (completeWakeupSuppressedTurn), which would see active=true
@@ -1351,7 +1358,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		}
 	}
 
-	// Check if the turn ends with a ScheduleWakeup tool call. When present,
+	// Check if the turn ends with a NEW ScheduleWakeup tool call. When present,
 	// the CLI will auto-inject a continuation user message after the specified
 	// delay, and the continuation's assistant response is appended to the
 	// same turn (the CLI does NOT start a new turn in turnManager — that only
@@ -1361,15 +1368,19 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// Skip suppression when:
 	//   - the result carries an error (propagate immediately)
 	//   - MaxTurns has been reached (let the normal path surface it)
-	//   - the turn does not contain a ScheduleWakeup tool_use
-	//   - wakeupSuppressed is true: this ResultMessage is the continuation
-	//     that releases the prior suppression. The original ScheduleWakeup
-	//     tool_use block persists in ContentBlocks (no StartTurn was called),
-	//     so hasScheduleWakeup() still returns true; without this guard we
-	//     would spuriously re-arm the safety timer for up to ~61 minutes.
-	//     This mirrors the bgState !wasSuppressed guard above.
+	//   - the latest ScheduleWakeup tool_use_id matches the one we already
+	//     suppressed on: this means no new ScheduleWakeup was appended by the
+	//     continuation, so the stale original block is the only one present
+	//     and we should NOT re-suppress. If the continuation DID call
+	//     ScheduleWakeup, its block has a different tool_use_id and we
+	//     re-suppress, chaining the wakeup sequence.
 	maxTurnsReached := s.config.MaxTurns > 0 && turnNumber >= s.config.MaxTurns
-	shouldSuppressWakeup := !msg.IsError && !maxTurnsReached && !wakeupSuppressed && turn.hasScheduleWakeup()
+	latestWakeupID := turn.latestScheduleWakeupToolID()
+	// alreadySuppressedThisWakeup: we previously suppressed on this exact
+	// tool_use_id, meaning no new ScheduleWakeup was appended by the
+	// continuation. priorSuppressedWakeupToolID was snapshotted under mu above.
+	alreadySuppressedThisWakeup := wakeupSuppressed && latestWakeupID == priorSuppressedWakeupToolID
+	shouldSuppressWakeup := !msg.IsError && !maxTurnsReached && latestWakeupID != "" && !alreadySuppressedThisWakeup
 	if shouldSuppressWakeup {
 		s.mu.Lock()
 		s.cumulativeCostUSD += msg.TotalCostUSD
@@ -1387,14 +1398,19 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 
 		// On first suppression, capture the original turn number so chained
 		// continuation turns can be completed under the same number.
-		if !wakeupSuppressed {
+		if s.wakeupState.suppressedTurnNumber == 0 {
 			s.wakeupState.suppressedTurnNumber = turnNumber
 		}
+		// Record which ScheduleWakeup triggered this suppression. The next
+		// handleResult will compare latestScheduleWakeupToolID() against this
+		// to distinguish a new chained call from the stale original block.
+		s.wakeupState.suppressedWakeupToolID = latestWakeupID
 
 		totalCostSoFar := s.cumulativeCostUSD
 		if s.config.MaxBudgetUSD > 0 && totalCostSoFar >= s.config.MaxBudgetUSD {
 			s.wakeupState.accumulatedUsage = TurnUsage{}
 			s.wakeupState.active = false
+			s.wakeupState.suppressedWakeupToolID = ""
 			s.mu.Unlock()
 			// Fall through to normal completion with budget error.
 		} else {
@@ -1402,7 +1418,9 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 
 			// Safety timer: delay + 60s buffer. ScheduleWakeup delays are
 			// clamped to [60, 3600] by the runtime, so worst case is ~61 min.
-			delaySec := turn.scheduleWakeupDelaySeconds()
+			// Use the latest block's delay — for chained wakeups the
+			// continuation appends a new ScheduleWakeup with its own delay.
+			delaySec := turn.latestScheduleWakeupDelaySeconds()
 			if delaySec < 60 {
 				delaySec = 60
 			}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -982,6 +982,179 @@ func TestScheduleWakeup_ContinuationDoesNotReSuppress(t *testing.T) {
 	}
 }
 
+// TestScheduleWakeup_ChainedWakeupReSuppress verifies the documented chaining
+// behavior: when a continuation turn itself calls ScheduleWakeup (with a NEW
+// tool_use_id), suppression is re-armed rather than released. The session only
+// completes when a continuation arrives without a new ScheduleWakeup.
+// This is the production scenario where jiradozer exited prematurely because
+// the second ScheduleWakeup was not re-suppressed.
+func TestScheduleWakeup_ChainedWakeupReSuppress(t *testing.T) {
+	s := newTestSession(t)
+	isErrFalse := false
+
+	// --- Turn 1: agent calls ScheduleWakeup (tool-1) ---
+	simulateAssistantToolUse(s, []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "ScheduleWakeup", Input: map[string]interface{}{
+			"delaySeconds": float64(60), "prompt": "check again", "reason": "polling",
+		}},
+	})
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "scheduled", IsError: &isErrFalse},
+	})
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{
+		Type: "result", IsError: false,
+		Usage:        protocol.UsageDetails{InputTokens: 100, OutputTokens: 50},
+		TotalCostUSD: 0.01,
+	})
+
+	// Assert first suppression is armed.
+	s.mu.RLock()
+	active1 := s.wakeupState.active
+	origTurn := s.wakeupState.suppressedTurnNumber
+	suppID1 := s.wakeupState.suppressedWakeupToolID
+	timer1 := s.wakeupState.timer
+	s.mu.RUnlock()
+	if !active1 {
+		t.Fatal("wakeup suppression should be active after first ScheduleWakeup")
+	}
+	if origTurn != 1 {
+		t.Errorf("expected suppressedTurnNumber=1, got %d", origTurn)
+	}
+	if suppID1 != "tool-1" {
+		t.Errorf("expected suppressedWakeupToolID=tool-1, got %q", suppID1)
+	}
+	if timer1 == nil {
+		t.Error("safety timer should be active after first ScheduleWakeup")
+	}
+	// Stop the first safety timer; we'll assert re-arming after the second.
+	s.mu.Lock()
+	if s.wakeupState.timer != nil {
+		s.wakeupState.timer.Stop()
+		s.wakeupState.timer = nil
+	}
+	s.mu.Unlock()
+
+	// --- Continuation 1: agent calls a second ScheduleWakeup (tool-2) ---
+	// The CLI appends the new content to the same turn (no StartTurn call),
+	// so tool-1 still persists in ContentBlocks alongside the new tool-2.
+	s.turnManager.AppendContentBlock(ContentBlock{
+		Type:      ContentBlockTypeToolUse,
+		ToolUseID: "tool-2",
+		ToolName:  "ScheduleWakeup",
+		ToolInput: map[string]interface{}{
+			"delaySeconds": float64(120), "prompt": "still polling", "reason": "waiting on codex",
+		},
+	})
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{
+		Type: "result", IsError: false,
+		Usage:        protocol.UsageDetails{InputTokens: 200, OutputTokens: 75},
+		TotalCostUSD: 0.02,
+	})
+
+	// The second ScheduleWakeup must re-suppress — no TurnCompleteEvent yet.
+	select {
+	case event := <-s.events:
+		if _, ok := event.(TurnCompleteEvent); ok {
+			t.Fatal("got unexpected TurnCompleteEvent after chained ScheduleWakeup — suppression was not re-armed")
+		}
+	default:
+		// Good — no TurnCompleteEvent.
+	}
+
+	// Verify suppression is still active and re-armed with the new tool ID.
+	s.mu.RLock()
+	active2 := s.wakeupState.active
+	suppID2 := s.wakeupState.suppressedWakeupToolID
+	origTurn2 := s.wakeupState.suppressedTurnNumber
+	timer2 := s.wakeupState.timer
+	s.mu.RUnlock()
+	if !active2 {
+		t.Error("wakeup suppression should still be active after chained ScheduleWakeup")
+	}
+	if suppID2 != "tool-2" {
+		t.Errorf("expected suppressedWakeupToolID=tool-2 after re-arm, got %q", suppID2)
+	}
+	if origTurn2 != 1 {
+		t.Errorf("expected suppressedTurnNumber still=1, got %d", origTurn2)
+	}
+	if timer2 == nil {
+		t.Error("safety timer should be re-armed after chained ScheduleWakeup")
+	}
+	// Stop the second safety timer to avoid interference.
+	s.mu.Lock()
+	if s.wakeupState.timer != nil {
+		s.wakeupState.timer.Stop()
+		s.wakeupState.timer = nil
+	}
+	s.mu.Unlock()
+
+	// --- Continuation 2: no new ScheduleWakeup (Bash + text) ---
+	// Now the continuation resolves without calling ScheduleWakeup, so
+	// suppression should release and TurnCompleteEvent should fire.
+	s.turnManager.AppendContentBlock(ContentBlock{
+		Type:      ContentBlockTypeToolUse,
+		ToolUseID: "tool-3",
+		ToolName:  "Bash",
+		ToolInput: map[string]interface{}{"command": "echo done"},
+	})
+	s.turnManager.AppendText("All checks passed. Codex review complete.")
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{
+		Type: "result", IsError: false,
+		Usage:        protocol.UsageDetails{InputTokens: 300, OutputTokens: 100},
+		TotalCostUSD: 0.03,
+	})
+
+	// Now we MUST get a TurnCompleteEvent with the original turn number.
+	var tc TurnCompleteEvent
+	deadline := time.After(time.Second)
+	for {
+		var found bool
+		select {
+		case event := <-s.events:
+			if tce, ok := event.(TurnCompleteEvent); ok {
+				tc = tce
+				found = true
+			}
+		case <-deadline:
+			t.Fatal("expected TurnCompleteEvent after final continuation (no ScheduleWakeup)")
+		}
+		if found {
+			break
+		}
+	}
+
+	// Turn number must be the original (1), not the continuation's number.
+	if tc.TurnNumber != 1 {
+		t.Errorf("expected TurnNumber=1 (original suppressed), got %d", tc.TurnNumber)
+	}
+	if !tc.Success {
+		t.Error("expected success=true")
+	}
+
+	// Usage must accumulate across all three handleResult calls.
+	if got, want := tc.Usage.InputTokens, 100+200+300; got != want {
+		t.Errorf("expected accumulated InputTokens=%d, got %d", want, got)
+	}
+	if got, want := tc.Usage.OutputTokens, 50+75+100; got != want {
+		t.Errorf("expected accumulated OutputTokens=%d, got %d", want, got)
+	}
+	const wantCost = 0.01 + 0.02 + 0.03
+	if tc.Usage.CostUSD < wantCost-1e-9 || tc.Usage.CostUSD > wantCost+1e-9 {
+		t.Errorf("expected accumulated CostUSD=%v, got %v", wantCost, tc.Usage.CostUSD)
+	}
+
+	// Suppression must be cleared.
+	s.mu.RLock()
+	stillActive := s.wakeupState.active
+	s.mu.RUnlock()
+	if stillActive {
+		t.Error("wakeup suppression must be cleared after final continuation")
+	}
+}
+
 // TestScheduleWakeup_WakeupStateClearedOnNewTurn verifies that a pending
 // wakeup suppression does not leak into a subsequent user-initiated turn.
 // SendMessage/SendToolResult must reset wakeupState so handleResult for

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -30,9 +30,9 @@ func drainUntilTurnComplete(t *testing.T, events <-chan Event, timeout time.Dura
 			}
 		case <-deadline:
 			t.Fatal("TurnCompleteEvent not emitted within timeout")
+			return TurnCompleteEvent{}
 		}
 	}
-	panic("unreachable")
 }
 
 // makeFlexibleContent marshals v into a FlexibleContent.

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -14,18 +14,25 @@ import (
 // is found or the timeout expires.
 func waitForTurnComplete(t *testing.T, events <-chan Event, timeout time.Duration) {
 	t.Helper()
+	drainUntilTurnComplete(t, events, timeout)
+}
+
+// drainUntilTurnComplete drains events until a TurnCompleteEvent arrives and
+// returns it. Fatals if the timeout expires first.
+func drainUntilTurnComplete(t *testing.T, events <-chan Event, timeout time.Duration) TurnCompleteEvent {
+	t.Helper()
 	deadline := time.After(timeout)
 	for {
 		select {
 		case event := <-events:
-			if _, ok := event.(TurnCompleteEvent); ok {
-				return
+			if tce, ok := event.(TurnCompleteEvent); ok {
+				return tce
 			}
-			// Keep draining other events (CLIToolResultEvent, etc.).
 		case <-deadline:
-			t.Fatal("turn did not complete — TurnCompleteEvent not emitted within timeout")
+			t.Fatal("TurnCompleteEvent not emitted within timeout")
 		}
 	}
+	panic("unreachable")
 }
 
 // makeFlexibleContent marshals v into a FlexibleContent.
@@ -714,26 +721,7 @@ func TestScheduleWakeup_ContinuationCompletesTurn(t *testing.T) {
 	}
 	s.handleResult(resultMsg2)
 
-	// Now we SHOULD get a TurnCompleteEvent with the original turn number.
-	// Drain non-TurnCompleteEvents (e.g. CLIToolResultEvent) before checking.
-	var tc TurnCompleteEvent
-	deadline := time.After(time.Second)
-	for {
-		var found bool
-		select {
-		case event := <-s.events:
-			if tce, ok := event.(TurnCompleteEvent); ok {
-				tc = tce
-				found = true
-			}
-			// else keep draining
-		case <-deadline:
-			t.Fatal("expected TurnCompleteEvent for continuation turn")
-		}
-		if found {
-			break
-		}
-	}
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
 	// Turn number should be the original suppressed turn (1), not the
 	// continuation turn's number.
 	if tc.TurnNumber != 1 {
@@ -801,24 +789,7 @@ func TestScheduleWakeup_SafetyTimerCompletesTurn(t *testing.T) {
 	})
 	s.mu.Unlock()
 
-	// Wait for the safety timer to fire, draining non-TurnCompleteEvents.
-	var tc TurnCompleteEvent
-	deadline := time.After(time.Second)
-	for {
-		var found bool
-		select {
-		case event := <-s.events:
-			if tce, ok := event.(TurnCompleteEvent); ok {
-				tc = tce
-				found = true
-			}
-		case <-deadline:
-			t.Fatal("safety timer should have fired and completed the turn")
-		}
-		if found {
-			break
-		}
-	}
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
 	if tc.TurnNumber != 1 {
 		t.Errorf("expected TurnNumber=1, got %d", tc.TurnNumber)
 	}
@@ -852,24 +823,8 @@ func TestScheduleWakeup_ErrorTurnNotSuppressed(t *testing.T) {
 	}
 	s.handleResult(resultMsg)
 
-	// Error results should NOT be suppressed. Drain non-TurnCompleteEvents.
-	var tc TurnCompleteEvent
-	deadline := time.After(time.Second)
-	for {
-		var found bool
-		select {
-		case event := <-s.events:
-			if tce, ok := event.(TurnCompleteEvent); ok {
-				tc = tce
-				found = true
-			}
-		case <-deadline:
-			t.Fatal("error result with ScheduleWakeup should complete immediately, not suppress")
-		}
-		if found {
-			break
-		}
-	}
+	// Error results should NOT be suppressed.
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
 	if tc.Success {
 		t.Error("expected success=false for error result")
 	}
@@ -935,23 +890,7 @@ func TestScheduleWakeup_ContinuationDoesNotReSuppress(t *testing.T) {
 	})
 
 	// The continuation must RELEASE suppression, not re-arm it.
-	var tc TurnCompleteEvent
-	deadline := time.After(time.Second)
-	for {
-		var found bool
-		select {
-		case event := <-s.events:
-			if tce, ok := event.(TurnCompleteEvent); ok {
-				tc = tce
-				found = true
-			}
-		case <-deadline:
-			t.Fatal("expected TurnCompleteEvent after continuation; suppression was spuriously re-armed")
-		}
-		if found {
-			break
-		}
-	}
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
 
 	// Usage must include both the wakeup turn and the continuation.
 	if tc.TurnNumber != 1 {
@@ -1108,23 +1047,7 @@ func TestScheduleWakeup_ChainedWakeupReSuppress(t *testing.T) {
 	})
 
 	// Now we MUST get a TurnCompleteEvent with the original turn number.
-	var tc TurnCompleteEvent
-	deadline := time.After(time.Second)
-	for {
-		var found bool
-		select {
-		case event := <-s.events:
-			if tce, ok := event.(TurnCompleteEvent); ok {
-				tc = tce
-				found = true
-			}
-		case <-deadline:
-			t.Fatal("expected TurnCompleteEvent after final continuation (no ScheduleWakeup)")
-		}
-		if found {
-			break
-		}
-	}
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
 
 	// Turn number must be the original (1), not the continuation's number.
 	if tc.TurnNumber != 1 {
@@ -1237,25 +1160,8 @@ func TestScheduleWakeup_MaxBudgetExceededReleasesSuppression(t *testing.T) {
 		TotalCostUSD: 0.10,
 	})
 
-	// Expect ErrBudgetExceeded on a TurnCompleteEvent, not silent
-	// suppression.
-	var tc TurnCompleteEvent
-	deadline := time.After(time.Second)
-	for {
-		var found bool
-		select {
-		case event := <-s.events:
-			if tce, ok := event.(TurnCompleteEvent); ok {
-				tc = tce
-				found = true
-			}
-		case <-deadline:
-			t.Fatal("expected TurnCompleteEvent with ErrBudgetExceeded, got nothing")
-		}
-		if found {
-			break
-		}
-	}
+	// Expect ErrBudgetExceeded on a TurnCompleteEvent, not silent suppression.
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
 	if !errors.Is(tc.Error, ErrBudgetExceeded) {
 		t.Errorf("expected ErrBudgetExceeded, got %v", tc.Error)
 	}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -992,14 +992,19 @@ func TestScheduleWakeup_ChainedWakeupReSuppress(t *testing.T) {
 		TotalCostUSD: 0.02,
 	})
 
-	// The second ScheduleWakeup must re-suppress — no TurnCompleteEvent yet.
-	select {
-	case event := <-s.events:
-		if _, ok := event.(TurnCompleteEvent); ok {
-			t.Fatal("got unexpected TurnCompleteEvent after chained ScheduleWakeup — suppression was not re-armed")
+	// The second ScheduleWakeup must re-suppress — drain all queued events
+	// with a short deadline and assert none are TurnCompleteEvent.
+	drainDeadline := time.After(50 * time.Millisecond)
+drainLoop:
+	for {
+		select {
+		case event := <-s.events:
+			if _, ok := event.(TurnCompleteEvent); ok {
+				t.Fatal("got unexpected TurnCompleteEvent after chained ScheduleWakeup — suppression was not re-armed")
+			}
+		case <-drainDeadline:
+			break drainLoop
 		}
-	default:
-		// Good — no TurnCompleteEvent.
 	}
 
 	// Verify suppression is still active and re-armed with the new tool ID.

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -201,27 +201,50 @@ func (turn *turnState) hasScheduleWakeup() bool {
 	return false
 }
 
-// scheduleWakeupDelaySeconds extracts the delaySeconds value from the first
-// ScheduleWakeup tool_use in the turn. Returns 0 if not found or malformed.
-// Accepts float64 (JSON default), int, and int64 to match the decoder
-// tolerance used for other tool-input numerics in this package.
-func (turn *turnState) scheduleWakeupDelaySeconds() float64 {
+// latestScheduleWakeupToolID returns the tool_use_id of the LAST ScheduleWakeup
+// block in the turn, or "" if none. Used to detect when a continuation appends
+// a new ScheduleWakeup (different ID) vs the stale original block.
+func (turn *turnState) latestScheduleWakeupToolID() string {
+	if turn == nil {
+		return ""
+	}
+	id := ""
+	for _, block := range turn.ContentBlocks {
+		if block.Type == ContentBlockTypeToolUse && block.ToolName == scheduleWakeupToolName {
+			id = block.ToolUseID
+		}
+	}
+	return id
+}
+
+// latestScheduleWakeupDelaySeconds extracts the delaySeconds from the LAST
+// ScheduleWakeup block. For chained wakeups the continuation appends a new
+// block; the safety timer should be set from the newest delay, not the first.
+func (turn *turnState) latestScheduleWakeupDelaySeconds() float64 {
 	if turn == nil {
 		return 0
 	}
+	delay := float64(0)
+	found := false
 	for _, block := range turn.ContentBlocks {
 		if block.Type == ContentBlockTypeToolUse && block.ToolName == scheduleWakeupToolName {
 			switch v := block.ToolInput["delaySeconds"].(type) {
 			case float64:
-				return v
+				delay = v
+				found = true
 			case int:
-				return float64(v)
+				delay = float64(v)
+				found = true
 			case int64:
-				return float64(v)
+				delay = float64(v)
+				found = true
 			}
 		}
 	}
-	return 0
+	if !found {
+		return 0
+	}
+	return delay
 }
 
 // turnState tracks the state of a single turn.

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -225,24 +225,17 @@ func (turn *turnState) latestScheduleWakeupDelaySeconds() float64 {
 		return 0
 	}
 	delay := float64(0)
-	found := false
 	for _, block := range turn.ContentBlocks {
 		if block.Type == ContentBlockTypeToolUse && block.ToolName == scheduleWakeupToolName {
 			switch v := block.ToolInput["delaySeconds"].(type) {
 			case float64:
 				delay = v
-				found = true
 			case int:
 				delay = float64(v)
-				found = true
 			case int64:
 				delay = float64(v)
-				found = true
 			}
 		}
-	}
-	if !found {
-		return 0
 	}
 	return delay
 }


### PR DESCRIPTION
## Summary

- **Production symptom**: Jiradozer validate/round-2 (`/pr-polish --local`) exited prematurely on 2026-04-18 while waiting for a bramble codex review to finish. The agent had called `ScheduleWakeup(120s)` twice across two continuation cycles; the second wakeup was not re-suppressed, `session.Ask` returned, and `defer session.Stop()` tore down the CLI.
- **Root cause**: The `!wakeupSuppressed` guard at `session.go:1372` defeated the documented chaining behavior. Since the CLI does not call `StartTurn` for wakeup continuations, the original `ScheduleWakeup` `tool_use` block persists in `ContentBlocks` — `hasScheduleWakeup()` returns true on the continuation even with no new wakeup. The binary guard could not distinguish "stale original block" from "new chained block".
- **Fix (Option A — track tool_use_id)**: Added `suppressedWakeupToolID string` to `wakeupSuppressionState`. On each `handleResult`, compare `latestScheduleWakeupToolID()` against the stored ID — different ID means a new wakeup was appended (re-suppress); same ID means the stale original block is the only one (release suppression). Also switched the safety timer to use `latestScheduleWakeupDelaySeconds()` so chained wakeups use the newest delay.

## Test plan

- [x] `TestScheduleWakeup_ChainedWakeupReSuppress` — new three-phase test: first wakeup suppresses → second wakeup (different tool_use_id) re-suppresses → non-wakeup continuation releases; asserts usage accumulation across all three turns
- [x] `TestScheduleWakeup_ContinuationDoesNotReSuppress` — existing regression: stale original block (same tool_use_id) does not re-suppress
- [x] `TestScheduleWakeup_ContinuationCompletesTurn`, `TestScheduleWakeup_SafetyTimerCompletesTurn`, `TestScheduleWakeup_ErrorTurnNotSuppressed`, `TestScheduleWakeup_WakeupStateClearedOnNewTurn` — all existing wakeup tests pass
- [x] `bazel test //agent-cli-wrapper/... //multiagent/... //jiradozer/...` — all green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches turn-suppression/unblocking logic in `Session.handleResult`, so regressions could cause hangs or premature `TurnCompleteEvent` emission, but the change is narrowly scoped and covered by new/updated unit tests.
> 
> **Overview**
> Fixes `ScheduleWakeup` turn-suppression so **chained wakeups re-suppress correctly** while continuations that *don’t* add a new wakeup release suppression.
> 
> This tracks the triggering `ScheduleWakeup` via a stored `tool_use_id`, compares it against the turn’s *latest* wakeup block, and arms the safety timer from the latest wakeup delay to match chained behavior. Tests are refactored to share an event-draining helper and add a new regression test covering the multi-wakeup chain scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9478d1768cda26b6feb7a73004c929269e17f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->