### PR TITLE
fix: flag mixed bg+sync turns as live background work

### DIFF
--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1555,6 +1555,15 @@ func (s *Session) completeWakeupSuppressedTurn(result TurnResult) {
 		result.Text = turn.FullText
 		result.Thinking = turn.FullThinking
 		result.ContentBlocks = turn.ContentBlocks
+		// Mirror handleResult: the wakeup safety timer firing does not tell
+		// us anything about bg work state. If the logical turn still has
+		// uncancelled bg Bash/Monitor tools, surface HasLiveBackgroundWork so
+		// retry loops do not interrupt them. Parallel to completeSuppressedTurn
+		// (which sets this unconditionally because bg-task suppression only
+		// activates when bg work exists) and handleResult's mixed-turn check.
+		if !result.HasLiveBackgroundWork && turn.hasLiveBackgroundWork() {
+			result.HasLiveBackgroundWork = true
+		}
 	}
 	s.mu.Unlock()
 

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1460,13 +1460,9 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		result.Success = false
 	}
 
-	// Mixed-turn guard: the turn has live bg work (run_in_background:true Bash,
-	// Monitor, etc.) but also sync tools, so shouldSuppress was false and the
-	// ResultMessage is real sync completion. We still must flag the live bg
-	// work so orchestrators (jiradozer rounds, retry loops, session cleanup)
-	// do not advance past the turn or Stop() the session and orphan the bg
-	// tasks. wasSuppressed indicates a prior suppressed ResultMessage already
-	// set the flag; do not overwrite.
+	// Mixed bg+sync turns fell through suppression (sync completion is real),
+	// so flag live bg work here. The suppressed-bg-error and budget-exceeded
+	// branches above already set the flag, hence the wasSuppressed/already-set guards.
 	if !wasSuppressed && !result.HasLiveBackgroundWork && turn.hasLiveBackgroundWork() {
 		result.HasLiveBackgroundWork = true
 	}

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1460,6 +1460,17 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		result.Success = false
 	}
 
+	// Mixed-turn guard: the turn has live bg work (run_in_background:true Bash,
+	// Monitor, etc.) but also sync tools, so shouldSuppress was false and the
+	// ResultMessage is real sync completion. We still must flag the live bg
+	// work so orchestrators (jiradozer rounds, retry loops, session cleanup)
+	// do not advance past the turn or Stop() the session and orphan the bg
+	// tasks. wasSuppressed indicates a prior suppressed ResultMessage already
+	// set the flag; do not overwrite.
+	if !wasSuppressed && !result.HasLiveBackgroundWork && turn.hasLiveBackgroundWork() {
+		result.HasLiveBackgroundWork = true
+	}
+
 	s.finalizeTurn(result)
 }
 

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1456,7 +1456,8 @@ func TestHasLiveBackgroundWork_PureSyncTurnDoesNotFlag(t *testing.T) {
 
 // TestHasLiveBackgroundWork_CancelledBgToolDoesNotFlag asserts that a
 // cancelled bg tool_use (its tool_result is an error) does not count as live
-// bg work — the CLI never launched it.
+// bg work — the CLI never launched it. Covers both the turn predicate and
+// the end-to-end handleResult → TurnCompleteEvent path.
 func TestHasLiveBackgroundWork_CancelledBgToolDoesNotFlag(t *testing.T) {
 	s := newTestSession(t)
 
@@ -1475,6 +1476,14 @@ func TestHasLiveBackgroundWork_CancelledBgToolDoesNotFlag(t *testing.T) {
 	turn := s.turnManager.CurrentTurn()
 	if turn.hasLiveBackgroundWork() {
 		t.Fatal("cancelled bg tool must not register as live background work")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	tce := drainUntilTurnComplete(t, s.events, time.Second)
+	if tce.HasLiveBackgroundWork {
+		t.Error("TurnCompleteEvent.HasLiveBackgroundWork must be false when the only bg tool was cancelled")
 	}
 }
 

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1525,3 +1525,64 @@ func TestHasLiveBackgroundWork_PureBgTurnUsesSuppressionPath(t *testing.T) {
 	}
 	s.mu.Unlock()
 }
+
+// TestScheduleWakeup_SafetyTimerSurfacesLiveBgWork verifies that when the
+// wakeup safety timer fires on a turn that ALSO has an uncancelled bg Bash
+// tool use, the emitted TurnCompleteEvent carries HasLiveBackgroundWork=true.
+// Mirrors handleResult's mixed-turn check at session.go:1466 and closes a
+// parallel-path drift gap: without this, a wakeup-suppressed turn could
+// swallow the bg-work signal, letting an orchestrator advance or stop the
+// session while a bg tool was still running in the CLI.
+func TestScheduleWakeup_SafetyTimerSurfacesLiveBgWork(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "wake-1", Name: "ScheduleWakeup", Input: map[string]interface{}{
+			"delaySeconds": float64(60),
+			"prompt":       "check",
+			"reason":       "waiting",
+		}},
+		{ID: "bg-1", Name: "Bash", Input: map[string]interface{}{
+			"command":           "sleep 60",
+			"run_in_background": true,
+		}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErrFalse := false
+	results := []protocol.ToolResultBlock{
+		{ToolUseID: "wake-1", Content: "scheduled", IsError: &isErrFalse},
+		{ToolUseID: "bg-1", Content: "queued bg", IsError: &isErrFalse},
+	}
+	simulateUserToolResults(t, s, results)
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{
+		Type: "result", IsError: false,
+		Usage: protocol.UsageDetails{InputTokens: 10, OutputTokens: 5},
+	})
+
+	// Replace the real safety timer with a short one so the test does
+	// not block for the full ScheduleWakeup delay + 60s buffer.
+	s.mu.Lock()
+	if s.wakeupState.timer != nil {
+		s.wakeupState.timer.Stop()
+	}
+	safetyResult := TurnResult{TurnNumber: 1, Success: true}
+	s.wakeupState.timer = time.AfterFunc(20*time.Millisecond, func() {
+		s.completeWakeupSuppressedTurn(safetyResult)
+	})
+	s.mu.Unlock()
+
+	tc := drainUntilTurnComplete(t, s.events, time.Second)
+	if !tc.HasLiveBackgroundWork {
+		t.Error("wakeup safety-timer completion with a live bg Bash must surface HasLiveBackgroundWork=true")
+	}
+
+	// Clean up bg safety timer to avoid leaking a goroutine.
+	s.mu.Lock()
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
+	}
+	s.mu.Unlock()
+}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1379,3 +1379,140 @@ func TestScheduleWakeup_SafetyTimerPreventsLateResultDoubleCompletion(t *testing
 		}
 	}
 }
+
+// TestHasLiveBackgroundWork_MixedTurnFlagsFinalResult reproduces the jiradozer
+// round 2 scenario: the agent launches run_in_background:true Bash tasks and
+// then continues calling synchronous tools in the same turn. shouldSuppress
+// must be false (sync completion is real), but the final TurnResult must
+// carry HasLiveBackgroundWork=true so orchestrators know bg work is still
+// running.
+func TestHasLiveBackgroundWork_MixedTurnFlagsFinalResult(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "bramble code-review", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "git push"}},
+		{ID: "tool-3", Name: "Bash", Input: map[string]interface{}{"command": "until [ -s /tmp/x ]; do sleep 5; done", "run_in_background": true}},
+		{ID: "tool-4", Name: "Bash", Input: map[string]interface{}{"command": "jq .status /tmp/x"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Command running in background with ID: b1", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "pushed", IsError: &notErr},
+		{ToolUseID: "tool-3", Content: "Command running in background with ID: b2", IsError: &notErr},
+		{ToolUseID: "tool-4", Content: "not-ready", IsError: &notErr},
+	})
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.shouldSuppressForBgTasks() {
+		t.Fatal("mixed bg+sync turn must not be suppressed")
+	}
+	if !turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must return true when uncancelled bg tools are present")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	tce := drainUntilTurnComplete(t, s.events, time.Second)
+	if !tce.HasLiveBackgroundWork {
+		t.Error("TurnCompleteEvent.HasLiveBackgroundWork must be true for mixed turn with live bg work")
+	}
+	if !tce.Success {
+		t.Error("TurnCompleteEvent.Success must be true — sync work completed without error")
+	}
+}
+
+// TestHasLiveBackgroundWork_PureSyncTurnDoesNotFlag asserts that a turn
+// with no bg tool_use blocks completes with HasLiveBackgroundWork=false.
+func TestHasLiveBackgroundWork_PureSyncTurnDoesNotFlag(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Read", Input: map[string]interface{}{"file_path": "/tmp/x"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "echo hi"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "file contents", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "hi", IsError: &notErr},
+	})
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must return false when no bg tools are present")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	tce := drainUntilTurnComplete(t, s.events, time.Second)
+	if tce.HasLiveBackgroundWork {
+		t.Error("TurnCompleteEvent.HasLiveBackgroundWork must be false for pure-sync turn")
+	}
+}
+
+// TestHasLiveBackgroundWork_CancelledBgToolDoesNotFlag asserts that a
+// cancelled bg tool_use (its tool_result is an error) does not count as live
+// bg work — the CLI never launched it.
+func TestHasLiveBackgroundWork_CancelledBgToolDoesNotFlag(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "exit 1"}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "bramble review", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	isErr := true
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "exit code 1", IsError: &isErr},
+		{ToolUseID: "tool-2", Content: "Cancelled: parallel tool call errored", IsError: &isErr},
+	})
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("cancelled bg tool must not register as live background work")
+	}
+}
+
+// TestHasLiveBackgroundWork_PureBgTurnUsesSuppressionPath confirms the fix
+// does not disturb the pure-bg path: a turn with only bg tools still
+// suppresses (no immediate TurnCompleteEvent) via the existing branch.
+func TestHasLiveBackgroundWork_PureBgTurnUsesSuppressionPath(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "bramble review", "run_in_background": true}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Command running in background with ID: b1", IsError: &notErr},
+	})
+
+	turn := s.turnManager.CurrentTurn()
+	if !turn.shouldSuppressForBgTasks() {
+		t.Fatal("pure-bg turn must still suppress")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	select {
+	case event := <-s.events:
+		if _, ok := event.(TurnCompleteEvent); ok {
+			t.Error("pure-bg turn must not emit TurnCompleteEvent immediately — suppression path changed")
+		}
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Clean up safety timer so the test does not leak a goroutine.
+	s.mu.Lock()
+	if s.bgState.timer != nil {
+		s.bgState.timer.Stop()
+	}
+	s.mu.Unlock()
+}

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -295,28 +295,18 @@ func (turn *turnState) shouldSuppressForBgTasks() bool {
 	if turn == nil {
 		return false
 	}
-
-	cancelled := turn.cancelledToolIDs()
-
 	// Non-bg tools always prevent suppression (even if they errored), because
 	// their presence means the ResultMessage represents completion of synchronous
-	// work. Cancelled bg tools are skipped — they never launched a background task.
-	hasBgTool := false
+	// work.
 	for _, block := range turn.ContentBlocks {
 		if block.Type != ContentBlockTypeToolUse {
 			continue
 		}
 		if !isBackgroundToolUse(block) {
-			return false // non-bg tool → ResultMessage is real completion, never suppress
-		}
-		if !cancelled[block.ToolUseID] {
-			hasBgTool = true
+			return false
 		}
 	}
-	// Either an uncancelled bg tool is present, or task_started has already
-	// registered a live task for this turn (e.g. task_started arrived before
-	// the bg tool's tool_use_id reached ContentBlocks). Both signal live work.
-	return hasBgTool || len(turn.liveTasks) > 0
+	return turn.hasLiveBackgroundWork()
 }
 
 // hasLiveBackgroundWork returns true when the turn has any uncancelled bg

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -319,6 +319,38 @@ func (turn *turnState) shouldSuppressForBgTasks() bool {
 	return hasBgTool || len(turn.liveTasks) > 0
 }
 
+// hasLiveBackgroundWork returns true when the turn has any uncancelled bg
+// tool_use (run_in_background:true Bash, Monitor, etc.) or live registered
+// tasks — regardless of whether sync tools are also present.
+//
+// Unlike shouldSuppressForBgTasks (which gates ResultMessage suppression and
+// thus short-circuits on any non-bg tool), this is used to annotate the final
+// TurnResult so callers can detect "turn ended with sync completion, but bg
+// work is still running in the background". The orchestrator or retry loop
+// can then avoid advancing past the turn or stopping the session and
+// orphaning those bg tasks.
+func (turn *turnState) hasLiveBackgroundWork() bool {
+	if turn == nil {
+		return false
+	}
+	if len(turn.liveTasks) > 0 {
+		return true
+	}
+	cancelled := turn.cancelledToolIDs()
+	for _, block := range turn.ContentBlocks {
+		if block.Type != ContentBlockTypeToolUse {
+			continue
+		}
+		if !isBackgroundToolUse(block) {
+			continue
+		}
+		if !cancelled[block.ToolUseID] {
+			return true
+		}
+	}
+	return false
+}
+
 // longestBackgroundToolTimeoutMs returns the largest timeout_ms value across
 // all non-cancelled background tool_use blocks in the turn. Returns 0 when
 // no bg tool carries an explicit timeout. Used to size the suppression

--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "orchestrator_test.go",
         "poller_test.go",
         "state_test.go",
+        "steplabels_test.go",
         "workflow_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -120,6 +120,13 @@ type StepAgentResult struct {
 	HasLiveBackgroundWork bool
 }
 
+// LiveBackgroundWorkError formats the shared refusal message for a session
+// that ended with live background work. Callers wrap it with their own
+// step/round context prefix.
+func LiveBackgroundWorkError(sessionID string) error {
+	return fmt.Errorf("session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", sessionID)
+}
+
 // RunStepAgent runs an agent session for the given workflow step.
 // On first execution (resumeSessionID == ""), the prompt template is rendered with issue data.
 // On follow-up (resumeSessionID != ""), feedback is sent directly to the resumed session.

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -114,11 +114,6 @@ func truncate(s string, maxLen int) string {
 	return s
 }
 
-// StepAgentResult carries the extended outcome of an agent step. Callers who
-// only care about text + session id should use RunStepAgent; callers that
-// need to detect live background work after the turn (e.g. to refuse to
-// advance rounds while bg tasks are still running) should use
-// RunStepAgentDetailed.
 type StepAgentResult struct {
 	Output                string
 	SessionID             string
@@ -134,10 +129,8 @@ func RunStepAgent(ctx context.Context, stepName string, data PromptData, cfg Ste
 	return res.Output, res.SessionID, err
 }
 
-// RunStepAgentDetailed runs an agent step and returns the full StepAgentResult.
-// Prefer this over RunStepAgent when the caller needs to check
-// HasLiveBackgroundWork to avoid advancing past a round that parked
-// background tasks.
+// RunStepAgentDetailed is RunStepAgent but returns the full StepAgentResult
+// (including HasLiveBackgroundWork).
 func RunStepAgentDetailed(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error) {
 	prompt, err := resolvePromptForExecution(cfg.Prompt, DefaultPromptForStep(stepName), data, feedback, resumeSessionID)
 	if err != nil {

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -502,10 +502,14 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	}
 	if !result.Success {
 		logHandler.flushText()
-		if result.Error != nil {
-			return StepAgentResult{}, result.Error
+		failed := StepAgentResult{
+			SessionID:             result.SessionID,
+			HasLiveBackgroundWork: result.HasLiveBackgroundWork,
 		}
-		return StepAgentResult{}, fmt.Errorf("agent failed")
+		if result.Error != nil {
+			return failed, result.Error
+		}
+		return failed, fmt.Errorf("agent failed")
 	}
 
 	logger.Info("agent completed",

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -127,18 +127,40 @@ func LiveBackgroundWorkError(sessionID string) error {
 	return fmt.Errorf("session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", sessionID)
 }
 
-// RunStepAgent runs an agent session for the given workflow step.
+// LogLiveBackgroundWorkRefusal emits a uniform slog.Error for every call site
+// that surfaces LiveBackgroundWorkError, so field names and wording cannot drift
+// between the workflow paths and the CLI single-shot paths. Pass total > 0 (and
+// the corresponding round) on the rounds path; pass (0, 0) from single-step
+// call sites. err is the original agent error that coincided with the bg-work
+// refusal — logged so it survives even though the returned error surfaces the
+// bg-work message instead.
+func LogLiveBackgroundWorkRefusal(logger *slog.Logger, stepName, sessionID string, round, total int, err error) {
+	if logger == nil {
+		return
+	}
+	if total > 0 {
+		logger.Error("round ended with live background work — refusing to advance",
+			"step", stepName,
+			"round", round,
+			"total", total,
+			"session_id", sessionID,
+			"agent_error", err,
+		)
+		return
+	}
+	logger.Error("step ended with live background work — refusing to advance",
+		"step", stepName,
+		"session_id", sessionID,
+		"agent_error", err,
+	)
+}
+
+// RunStepAgent runs an agent session for the given workflow step and returns
+// the full StepAgentResult (including HasLiveBackgroundWork).
 // On first execution (resumeSessionID == ""), the prompt template is rendered with issue data.
 // On follow-up (resumeSessionID != ""), feedback is sent directly to the resumed session.
 // If renderer is non-nil, agent events are streamed to the terminal.
-func RunStepAgent(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error) {
-	res, err := RunStepAgentDetailed(ctx, stepName, data, cfg, workDir, feedback, resumeSessionID, renderer, logger)
-	return res.Output, res.SessionID, err
-}
-
-// RunStepAgentDetailed is RunStepAgent but returns the full StepAgentResult
-// (including HasLiveBackgroundWork).
-func RunStepAgentDetailed(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error) {
+func RunStepAgent(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error) {
 	prompt, err := resolvePromptForExecution(cfg.Prompt, DefaultPromptForStep(stepName), data, feedback, resumeSessionID)
 	if err != nil {
 		return StepAgentResult{}, fmt.Errorf("render %s prompt: %w", stepName, err)

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -114,14 +114,34 @@ func truncate(s string, maxLen int) string {
 	return s
 }
 
+// StepAgentResult carries the extended outcome of an agent step. Callers who
+// only care about text + session id should use RunStepAgent; callers that
+// need to detect live background work after the turn (e.g. to refuse to
+// advance rounds while bg tasks are still running) should use
+// RunStepAgentDetailed.
+type StepAgentResult struct {
+	Output                string
+	SessionID             string
+	HasLiveBackgroundWork bool
+}
+
 // RunStepAgent runs an agent session for the given workflow step.
 // On first execution (resumeSessionID == ""), the prompt template is rendered with issue data.
 // On follow-up (resumeSessionID != ""), feedback is sent directly to the resumed session.
 // If renderer is non-nil, agent events are streamed to the terminal.
 func RunStepAgent(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error) {
+	res, err := RunStepAgentDetailed(ctx, stepName, data, cfg, workDir, feedback, resumeSessionID, renderer, logger)
+	return res.Output, res.SessionID, err
+}
+
+// RunStepAgentDetailed runs an agent step and returns the full StepAgentResult.
+// Prefer this over RunStepAgent when the caller needs to check
+// HasLiveBackgroundWork to avoid advancing past a round that parked
+// background tasks.
+func RunStepAgentDetailed(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error) {
 	prompt, err := resolvePromptForExecution(cfg.Prompt, DefaultPromptForStep(stepName), data, feedback, resumeSessionID)
 	if err != nil {
-		return "", "", fmt.Errorf("render %s prompt: %w", stepName, err)
+		return StepAgentResult{}, fmt.Errorf("render %s prompt: %w", stepName, err)
 	}
 	return runAgent(ctx, stepName, prompt, cfg, workDir, resumeSessionID, renderer, logger)
 }
@@ -429,14 +449,14 @@ func (c *compositeEventHandler) OnRetryAbort(reason, tool, excerpt string) {
 // runAgent runs an agent with the given prompt and step configuration.
 // If renderer is non-nil, agent events are rendered to the terminal in addition
 // to being logged to the log file.
-func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error) {
+func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error) {
 	model, ok := agent.ModelByID(cfg.Model)
 	if !ok {
-		return "", "", fmt.Errorf("unknown model: %q", cfg.Model)
+		return StepAgentResult{}, fmt.Errorf("unknown model: %q", cfg.Model)
 	}
 	provider, err := agent.NewProviderForModel(model)
 	if err != nil {
-		return "", "", fmt.Errorf("create provider: %w", err)
+		return StepAgentResult{}, fmt.Errorf("create provider: %w", err)
 	}
 	defer provider.Close()
 
@@ -485,14 +505,14 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	result, err := provider.Execute(ctx, prompt, nil, opts...)
 	if err != nil {
 		logHandler.flushText()
-		return "", "", fmt.Errorf("agent execution: %w", err)
+		return StepAgentResult{}, fmt.Errorf("agent execution: %w", err)
 	}
 	if !result.Success {
 		logHandler.flushText()
 		if result.Error != nil {
-			return "", "", result.Error
+			return StepAgentResult{}, result.Error
 		}
-		return "", "", fmt.Errorf("agent failed")
+		return StepAgentResult{}, fmt.Errorf("agent failed")
 	}
 
 	logger.Info("agent completed",
@@ -516,7 +536,11 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	if e := result.UnresolvedToolError; e != nil && output != result.Text {
 		output = agent.AppendUnresolvedToolErrorMarker(output, *e)
 	}
-	return output, result.SessionID, nil
+	return StepAgentResult{
+		Output:                output,
+		SessionID:             result.SessionID,
+		HasLiveBackgroundWork: result.HasLiveBackgroundWork,
+	}, nil
 }
 
 // resolveOutput returns the plan file content if one was detected, otherwise the agent's text output.

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -1,7 +1,9 @@
 package jiradozer
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -476,4 +478,43 @@ func TestReplay_PlanContentPostedToTracker(t *testing.T) {
 	assert.Contains(t, buildPrompt, "# Plan")
 	assert.Contains(t, buildPrompt, "1. Fix widget")
 	assert.Contains(t, buildPrompt, "Approved Plan")
+}
+
+func TestLogLiveBackgroundWorkRefusal_StepShape(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	LogLiveBackgroundWorkRefusal(logger, "plan", "sess-step", 0, 0, errors.New("boom"))
+
+	out := buf.String()
+	assert.Contains(t, out, "step ended with live background work")
+	assert.Contains(t, out, "step=plan")
+	assert.Contains(t, out, "session_id=sess-step")
+	assert.Contains(t, out, "agent_error=boom")
+	assert.NotContains(t, out, "round=", "single-step path must not emit round fields")
+	assert.NotContains(t, out, "total=", "single-step path must not emit total fields")
+}
+
+func TestLogLiveBackgroundWorkRefusal_RoundShape(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	LogLiveBackgroundWorkRefusal(logger, "build", "sess-round", 2, 5, errors.New("kaboom"))
+
+	out := buf.String()
+	assert.Contains(t, out, "round ended with live background work")
+	assert.Contains(t, out, "step=build")
+	assert.Contains(t, out, "round=2")
+	assert.Contains(t, out, "total=5")
+	assert.Contains(t, out, "session_id=sess-round")
+	assert.Contains(t, out, "agent_error=kaboom")
+}
+
+func TestLogLiveBackgroundWorkRefusal_NilLoggerNoPanic(t *testing.T) {
+	// A nil logger is not a supported call-site shape, but the helper must
+	// refuse to panic if a defensive caller ever hands one in, since its
+	// purpose is observability and crashing the process would defeat that.
+	assert.NotPanics(t, func() {
+		LogLiveBackgroundWorkRefusal(nil, "plan", "sess", 0, 0, errors.New("x"))
+	})
 }

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -30,8 +30,10 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":jiradozer_lib"],
     deps = [
+        "//agent-cli-wrapper/claude/render",
         "//jiradozer",
         "//jiradozer/tracker",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -679,7 +679,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 			"session_id", res.SessionID,
 			"agent_error", err,
 		)
-		return fmt.Errorf("run-step %s: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun the step after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", stepName, res.SessionID)
+		return fmt.Errorf("run-step %s: %w", stepName, jiradozer.LiveBackgroundWorkError(res.SessionID))
 	}
 	if err != nil {
 		return fmt.Errorf("run-step %s: %w", stepName, err)
@@ -731,7 +731,7 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 					"session_id", res.SessionID,
 					"agent_error", err,
 				)
-				return fmt.Errorf("run-step %s round %d/%d: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun the round after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", stepName, i+1, totalRounds, res.SessionID)
+				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, jiradozer.LiveBackgroundWorkError(res.SessionID))
 			}
 			if err != nil {
 				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -637,7 +637,7 @@ func runFromDescription(ctx context.Context, description, runStep, planContent s
 }
 
 // runStepAgentDetailed is overridable so unit tests can stub the agent call.
-var runStepAgentDetailed = jiradozer.RunStepAgentDetailed
+var runStepAgentDetailed = jiradozer.RunStepAgent
 
 func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, renderer *render.Renderer, logger *slog.Logger) error {
 	stepCfg, ok := cfg.StepByName(stepName)
@@ -674,11 +674,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 
 	res, err := runStepAgentDetailed(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
 	if res.HasLiveBackgroundWork {
-		logger.Error("step ended with live background work — refusing to advance",
-			"step", stepName,
-			"session_id", res.SessionID,
-			"agent_error", err,
-		)
+		jiradozer.LogLiveBackgroundWorkRefusal(logger, stepName, res.SessionID, 0, 0, err)
 		return fmt.Errorf("run-step %s: %w", stepName, jiradozer.LiveBackgroundWorkError(res.SessionID))
 	}
 	if err != nil {
@@ -724,13 +720,7 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 				sessionIDs = append(sessionIDs, res.SessionID)
 			}
 			if res.HasLiveBackgroundWork {
-				logger.Error("round ended with live background work — refusing to advance",
-					"step", stepName,
-					"round", i+1,
-					"total", totalRounds,
-					"session_id", res.SessionID,
-					"agent_error", err,
-				)
+				jiradozer.LogLiveBackgroundWorkRefusal(logger, stepName, res.SessionID, i+1, totalRounds, err)
 				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, jiradozer.LiveBackgroundWorkError(res.SessionID))
 			}
 			if err != nil {

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -673,15 +673,16 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	}
 
 	res, err := runStepAgentDetailed(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
-	if err != nil {
-		return fmt.Errorf("run-step %s: %w", stepName, err)
-	}
 	if res.HasLiveBackgroundWork {
 		logger.Error("step ended with live background work — refusing to advance",
 			"step", stepName,
 			"session_id", res.SessionID,
+			"agent_error", err,
 		)
 		return fmt.Errorf("run-step %s: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun the step after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", stepName, res.SessionID)
+	}
+	if err != nil {
+		return fmt.Errorf("run-step %s: %w", stepName, err)
 	}
 	output := res.Output
 	if output == "" {
@@ -719,20 +720,23 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 		} else {
 			roundCfg := jiradozer.ResolveRound(round, resolved)
 			res, err := runStepAgentDetailed(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
-			if err != nil {
-				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
+			if res.SessionID != "" {
+				sessionIDs = append(sessionIDs, res.SessionID)
 			}
-			output = res.Output
-			sessionIDs = append(sessionIDs, res.SessionID)
 			if res.HasLiveBackgroundWork {
 				logger.Error("round ended with live background work — refusing to advance",
 					"step", stepName,
 					"round", i+1,
 					"total", totalRounds,
 					"session_id", res.SessionID,
+					"agent_error", err,
 				)
 				return fmt.Errorf("run-step %s round %d/%d: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun the round after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", stepName, i+1, totalRounds, res.SessionID)
 			}
+			if err != nil {
+				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
+			}
+			output = res.Output
 		}
 		allOutputs = append(allOutputs, output)
 	}

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -707,13 +707,21 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 			}
 		} else {
 			roundCfg := jiradozer.ResolveRound(round, resolved)
-			var sessionID string
-			var err error
-			output, sessionID, err = jiradozer.RunStepAgent(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
+			res, err := jiradozer.RunStepAgentDetailed(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
 			if err != nil {
 				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
 			}
-			sessionIDs = append(sessionIDs, sessionID)
+			output = res.Output
+			sessionIDs = append(sessionIDs, res.SessionID)
+			if res.HasLiveBackgroundWork {
+				logger.Error("round ended with live background work — refusing to advance",
+					"step", stepName,
+					"round", i+1,
+					"total", totalRounds,
+					"session_id", res.SessionID,
+				)
+				return fmt.Errorf("run-step %s round %d/%d: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun the round after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", stepName, i+1, totalRounds, res.SessionID)
+			}
 		}
 		allOutputs = append(allOutputs, output)
 	}

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -636,6 +636,9 @@ func runFromDescription(ctx context.Context, description, runStep, planContent s
 	return wf.Run(ctx)
 }
 
+// runStepAgentDetailed is overridable so unit tests can stub the agent call.
+var runStepAgentDetailed = jiradozer.RunStepAgentDetailed
+
 func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, renderer *render.Renderer, logger *slog.Logger) error {
 	stepCfg, ok := cfg.StepByName(stepName)
 	if !ok {
@@ -669,12 +672,20 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 		return runSingleStepRounds(ctx, stepName, data, resolved, cfg.WorkDir, renderer, logger)
 	}
 
-	output, sessionID, err := jiradozer.RunStepAgent(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
+	res, err := runStepAgentDetailed(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
 	if err != nil {
 		return fmt.Errorf("run-step %s: %w", stepName, err)
 	}
+	if res.HasLiveBackgroundWork {
+		logger.Error("step ended with live background work — refusing to advance",
+			"step", stepName,
+			"session_id", res.SessionID,
+		)
+		return fmt.Errorf("run-step %s: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — rerun the step after the bg work completes, or have the agent use ScheduleWakeup/Monitor to wait", stepName, res.SessionID)
+	}
+	output := res.Output
 	if output == "" {
-		logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", sessionID)
+		logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", res.SessionID)
 	} else {
 		fmt.Printf("=== %s output ===\n%s\n", stepName, output)
 	}
@@ -707,7 +718,7 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 			}
 		} else {
 			roundCfg := jiradozer.ResolveRound(round, resolved)
-			res, err := jiradozer.RunStepAgentDetailed(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
+			res, err := runStepAgentDetailed(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
 			if err != nil {
 				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
 			}

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -222,6 +223,56 @@ func TestRunSingleStep_RejectsLiveBackgroundWork(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "live background work")
 	assert.Contains(t, err.Error(), "sess-oneshot")
+}
+
+// TestRunSingleStep_PrefersLiveBgWorkOverAgentError asserts that when the
+// agent returns BOTH an error AND HasLiveBackgroundWork, the bg-work refusal
+// path fires — the bg-work message is the actionable one, and swallowing it
+// because the turn also errored would re-open the premature-exit gap.
+func TestRunSingleStep_PrefersLiveBgWorkOverAgentError(t *testing.T) {
+	prev := runStepAgentDetailed
+	t.Cleanup(func() { runStepAgentDetailed = prev })
+
+	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _, _, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		return jiradozer.StepAgentResult{
+			SessionID:             "sess-err-live",
+			HasLiveBackgroundWork: true,
+		}, errors.New("agent execution: boom")
+	}
+
+	cfg := &jiradozer.Config{Plan: jiradozer.StepConfig{Prompt: "inline"}}
+	issue := &tracker.Issue{Identifier: "ENG-1", Title: "t"}
+
+	err := runSingleStep(context.Background(), "plan", issue, cfg, "", nil, slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "live background work")
+	assert.Contains(t, err.Error(), "sess-err-live")
+	assert.NotContains(t, err.Error(), "boom", "bg-work message wins over the raw agent error")
+}
+
+// TestRunSingleStepRounds_PrefersLiveBgWorkOverAgentError is the round-based
+// analogue: the bg-work refusal must fire on the first round that reports
+// HasLiveBackgroundWork, regardless of whether the round also returned an
+// error.
+func TestRunSingleStepRounds_PrefersLiveBgWorkOverAgentError(t *testing.T) {
+	prev := runStepAgentDetailed
+	t.Cleanup(func() { runStepAgentDetailed = prev })
+
+	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _, _, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		return jiradozer.StepAgentResult{
+			SessionID:             "sess-err-live-rounds",
+			HasLiveBackgroundWork: true,
+		}, errors.New("agent execution: boom")
+	}
+
+	resolved := jiradozer.StepConfig{
+		Rounds: []jiradozer.RoundConfig{{Prompt: "r1"}, {Prompt: "r2"}},
+	}
+
+	err := runSingleStepRounds(context.Background(), "plan", jiradozer.PromptData{}, resolved, t.TempDir(), nil, slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "live background work")
+	assert.Contains(t, err.Error(), "sess-err-live-rounds")
 }
 
 type discardWriter struct{}

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/jiradozer"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
@@ -163,3 +167,63 @@ func TestRedactArgs(t *testing.T) {
 		})
 	}
 }
+
+// TestRunSingleStepRounds_RejectsLiveBackgroundWork asserts the multi-round
+// single-step CLI path refuses to advance past a round whose agent result
+// reports HasLiveBackgroundWork.
+func TestRunSingleStepRounds_RejectsLiveBackgroundWork(t *testing.T) {
+	prev := runStepAgentDetailed
+	t.Cleanup(func() { runStepAgentDetailed = prev })
+
+	var calls int
+	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _, _, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		calls++
+		return jiradozer.StepAgentResult{
+			Output:                "round output",
+			SessionID:             "sess-live",
+			HasLiveBackgroundWork: true,
+		}, nil
+	}
+
+	resolved := jiradozer.StepConfig{
+		Rounds: []jiradozer.RoundConfig{
+			{Prompt: "first round"},
+			{Prompt: "second round"}, // must NOT run — first round's guard must short-circuit.
+		},
+	}
+
+	err := runSingleStepRounds(context.Background(), "plan", jiradozer.PromptData{}, resolved, t.TempDir(), nil, slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "live background work")
+	assert.Contains(t, err.Error(), "sess-live")
+	assert.Equal(t, 1, calls, "guard must short-circuit before round 2")
+}
+
+// TestRunSingleStep_RejectsLiveBackgroundWork asserts the non-round single-step
+// CLI path (runSingleStep → RunStepAgentDetailed) also refuses to advance.
+func TestRunSingleStep_RejectsLiveBackgroundWork(t *testing.T) {
+	prev := runStepAgentDetailed
+	t.Cleanup(func() { runStepAgentDetailed = prev })
+
+	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _, _, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		return jiradozer.StepAgentResult{
+			Output:                "oneshot output",
+			SessionID:             "sess-oneshot",
+			HasLiveBackgroundWork: true,
+		}, nil
+	}
+
+	cfg := &jiradozer.Config{
+		Plan: jiradozer.StepConfig{Prompt: "inline"},
+	}
+	issue := &tracker.Issue{Identifier: "ENG-1", Title: "t"}
+
+	err := runSingleStep(context.Background(), "plan", issue, cfg, "", nil, slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "live background work")
+	assert.Contains(t, err.Error(), "sess-oneshot")
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/jiradozer/docs/design.md
+++ b/jiradozer/docs/design.md
@@ -148,9 +148,11 @@ type PromptData struct {
 
 // RunStepAgent is the single entry point for all steps.
 // First call: renders prompt template. Follow-up: resumes session with feedback.
-func RunStepAgent(ctx context.Context, stepName string, issue *tracker.Issue, data PromptData,
+// Returns StepAgentResult (Output, SessionID, HasLiveBackgroundWork) so callers
+// can refuse to advance past a turn that still has live bg Bash/Monitor tasks.
+func RunStepAgent(ctx context.Context, stepName string, data PromptData,
     cfg StepConfig, workDir string, feedback string, resumeSessionID string,
-    logger *slog.Logger) (string, string, error)
+    renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error)
 ```
 
 Each step has a built-in default prompt template:
@@ -233,10 +235,12 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
     data.Plan = w.plan
     data.BuildOutput = w.buildOutput
 
-    output, sessionID, err := RunStepAgent(ctx, stepName, w.issue, data, cfg,
-        w.config.WorkDir, w.feedback, w.sessionIDs[w.state.Current()], w.logger)
-    // ...
-    w.sessionIDs[w.state.Current()] = sessionID
+    res, err := RunStepAgent(ctx, stepName, data, cfg,
+        w.config.WorkDir, w.feedback, w.sessionIDs[w.state.Current()], nil, w.logger)
+    if res.HasLiveBackgroundWork {
+        // Refuse to advance past a mixed bg+sync turn; see jiradozer/agent.go.
+    }
+    w.sessionIDs[w.state.Current()] = res.SessionID
 }
 ```
 

--- a/jiradozer/integration/e2e_workflow_test.go
+++ b/jiradozer/integration/e2e_workflow_test.go
@@ -205,11 +205,11 @@ func TestE2E_PlanStep_Smoke(t *testing.T) {
 		MaxBudgetUSD:   1.0,
 	}
 
-	output, sessionID, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", nil, logger)
+	res, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err, "plan step should succeed")
-	assert.NotEmpty(t, output, "plan output should not be empty")
-	assert.NotEmpty(t, sessionID, "should return a session ID")
-	t.Logf("Plan output (first 300 chars): %.300s", output)
+	assert.NotEmpty(t, res.Output, "plan output should not be empty")
+	assert.NotEmpty(t, res.SessionID, "should return a session ID")
+	t.Logf("Plan output (first 300 chars): %.300s", res.Output)
 }
 
 // TestE2E_HumanFeedback runs the full workflow with human feedback injected

--- a/jiradozer/integration/session_resumption_test.go
+++ b/jiradozer/integration/session_resumption_test.go
@@ -55,30 +55,30 @@ func TestSessionResumption_PlanFeedbackLoop(t *testing.T) {
 
 	// --- Step 1: First execution (no session ID, no feedback) ---
 	t.Log("Step 1: First planning execution")
-	output1, sessionID1, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", nil, logger)
+	res1, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err, "first plan execution should succeed")
-	require.NotEmpty(t, output1, "first plan output should not be empty")
-	require.NotEmpty(t, sessionID1, "first execution should return a session ID")
-	t.Logf("Session ID from step 1: %s", sessionID1)
-	t.Logf("Plan output (first 200 chars): %.200s", output1)
+	require.NotEmpty(t, res1.Output, "first plan output should not be empty")
+	require.NotEmpty(t, res1.SessionID, "first execution should return a session ID")
+	t.Logf("Session ID from step 1: %s", res1.SessionID)
+	t.Logf("Plan output (first 200 chars): %.200s", res1.Output)
 
 	// --- Step 2: Resume with feedback (same session ID) ---
 	t.Log("Step 2: Resume with feedback (redo)")
 	feedback := "Please also add validation for required fields and return typed errors instead of generic errors"
-	output2, sessionID2, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, feedback, sessionID1, nil, logger)
+	res2, err := jiradozer.RunStepAgent(ctx, "plan", data, stepCfg, workDir, feedback, res1.SessionID, nil, logger)
 	require.NoError(t, err, "resumed plan execution should succeed")
-	require.NotEmpty(t, output2, "resumed plan output should not be empty")
-	require.NotEmpty(t, sessionID2, "resumed execution should return a session ID")
-	t.Logf("Session ID from step 2: %s", sessionID2)
-	t.Logf("Plan output (first 200 chars): %.200s", output2)
+	require.NotEmpty(t, res2.Output, "resumed plan output should not be empty")
+	require.NotEmpty(t, res2.SessionID, "resumed execution should return a session ID")
+	t.Logf("Session ID from step 2: %s", res2.SessionID)
+	t.Logf("Plan output (first 200 chars): %.200s", res2.Output)
 
 	// --- Assertions ---
 	// The resumed output should be different from the first (feedback was incorporated).
-	assert.NotEqual(t, output1, output2, "resumed output should differ from first execution")
+	assert.NotEqual(t, res1.Output, res2.Output, "resumed output should differ from first execution")
 
 	// The session IDs should be related (same or evolved).
 	// Claude's session resume keeps the same session ID.
-	t.Logf("Session IDs: first=%s, second=%s", sessionID1, sessionID2)
+	t.Logf("Session IDs: first=%s, second=%s", res1.SessionID, res2.SessionID)
 }
 
 // TestSessionResumption_BuildAfterPlan verifies that the plan output from
@@ -112,11 +112,11 @@ func TestSessionResumption_BuildAfterPlan(t *testing.T) {
 	// Plan step.
 	t.Log("Running plan step")
 	data := jiradozer.NewPromptData(issue, "main")
-	planOutput, planSessionID, err := jiradozer.RunStepAgent(ctx, "plan", data, planCfg, workDir, "", "", nil, logger)
+	planRes, err := jiradozer.RunStepAgent(ctx, "plan", data, planCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err)
-	require.NotEmpty(t, planOutput)
-	require.NotEmpty(t, planSessionID)
-	t.Logf("Plan session ID: %s", planSessionID)
+	require.NotEmpty(t, planRes.Output)
+	require.NotEmpty(t, planRes.SessionID)
+	t.Logf("Plan session ID: %s", planRes.SessionID)
 
 	// Build step — uses the plan output.
 	buildCfg := jiradozer.StepConfig{
@@ -125,15 +125,15 @@ func TestSessionResumption_BuildAfterPlan(t *testing.T) {
 		MaxTurns:       3,
 		MaxBudgetUSD:   1.0,
 	}
-	data.Plan = planOutput
+	data.Plan = planRes.Output
 
 	t.Log("Running build step with plan output")
-	buildOutput, buildSessionID, err := jiradozer.RunStepAgent(ctx, "build", data, buildCfg, workDir, "", "", nil, logger)
+	buildRes, err := jiradozer.RunStepAgent(ctx, "build", data, buildCfg, workDir, "", "", nil, logger)
 	require.NoError(t, err)
-	require.NotEmpty(t, buildOutput)
-	require.NotEmpty(t, buildSessionID)
-	t.Logf("Build session ID: %s", buildSessionID)
+	require.NotEmpty(t, buildRes.Output)
+	require.NotEmpty(t, buildRes.SessionID)
+	t.Logf("Build session ID: %s", buildRes.SessionID)
 
 	// Build and plan should have different session IDs (different steps).
-	assert.NotEqual(t, planSessionID, buildSessionID, "plan and build should have different sessions")
+	assert.NotEqual(t, planRes.SessionID, buildRes.SessionID, "plan and build should have different sessions")
 }

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -421,7 +421,11 @@ func TestOrchestrator_CancelWithForceCleanup(t *testing.T) {
 func TestOrchestrator_CancelWithCleanExit(t *testing.T) {
 	// Verify that a subprocess that traps SIGINT and exits 0 is still
 	// classified as StepCancelled, not StepDone.
-	t.Parallel()
+	//
+	// Intentionally NOT t.Parallel(): fork/exec of the freshly written
+	// test.sh races ETXTBSY against other tests' cmd.Start() calls under
+	// load (observed on GitHub Actions). The other Cancel* tests in this
+	// file are also serial for the same reason.
 	cfg := testOrchestratorConfig()
 
 	// Script traps SIGINT and exits cleanly (exit 0).
@@ -682,8 +686,9 @@ func TestOrchestrator_StartClaimsInProgress(t *testing.T) {
 // triggering a ClearSeen (which would cause an infinite retry storm when slots
 // free up).
 func TestRunWithDiscovery_ConcurrencyLimitKeepsPending(t *testing.T) {
-	t.Parallel()
-
+	// Intentionally NOT t.Parallel(): fork/exec of a freshly written
+	// shell script can race ETXTBSY against other tests' cmd.Start()
+	// calls under load.
 	// Use a script that exits quickly so slots free up.
 	fastScript := writeTestScript(t, "exit 0")
 

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -47,7 +47,7 @@ type Workflow struct {
 	phases          map[string]phaseState
 	OnTransition    func(step WorkflowStep)
 	OnRoundProgress func(roundIndex, roundTotal int)
-	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (string, string, error)
+	runStepAgent    func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error)
 	renderer        *render.Renderer
 	issue           *tracker.Issue
 	plan            string
@@ -73,7 +73,7 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		redoCounts:   make(map[WorkflowStep]int),
 		phases:       make(map[string]phaseState),
 		maxRedos:     DefaultMaxRedos,
-		runStepAgent: RunStepAgent,
+		runStepAgent: RunStepAgentDetailed,
 	}
 	if issue != nil {
 		// Shallow-copy so Labels mutations on w.issue don't bleed back into
@@ -256,15 +256,20 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 				roundFeedback = feedback
 				feedbackInjected = true
 			}
-			var roundSessionID string
-			output, roundSessionID, err = w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.renderer, w.logger)
-			if roundSessionID != "" {
-				roundSessionIDs = append(roundSessionIDs, roundSessionID)
+			var res StepAgentResult
+			res, err = w.runStepAgent(ctx, stepName, data, roundCfg, w.config.WorkDir, roundFeedback, "", w.renderer, w.logger)
+			if res.SessionID != "" {
+				roundSessionIDs = append(roundSessionIDs, res.SessionID)
+			}
+			if res.HasLiveBackgroundWork {
+				w.fail(ctx, fmt.Errorf("%s round %d/%d: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — have the agent use ScheduleWakeup/Monitor to wait", stepName, i+1, totalRounds, res.SessionID))
+				return
 			}
 			if err != nil {
 				w.fail(ctx, fmt.Errorf("%s round %d/%d: %w", stepName, i+1, totalRounds, err))
 				return
 			}
+			output = res.Output
 		}
 		allOutputs = append(allOutputs, output)
 
@@ -316,11 +321,17 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 
 	stepStart := time.Now()
 	cfg := w.config.ResolveStep(stepCfg)
-	output, newSessionID, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.renderer, w.logger)
+	res, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.renderer, w.logger)
+	if res.HasLiveBackgroundWork {
+		w.fail(ctx, fmt.Errorf("%s step: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — have the agent use ScheduleWakeup/Monitor to wait", stepName, res.SessionID))
+		return
+	}
 	if err != nil {
 		w.fail(ctx, fmt.Errorf("%s step: %w", stepName, err))
 		return
 	}
+	output := res.Output
+	newSessionID := res.SessionID
 
 	stepDuration := time.Since(stepStart)
 	w.logger.Info("step completed", "step", stepName, "issue", w.issue.Identifier, "session_id", newSessionID, "duration", stepDuration)

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -262,7 +262,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 				roundSessionIDs = append(roundSessionIDs, res.SessionID)
 			}
 			if res.HasLiveBackgroundWork {
-				w.fail(ctx, fmt.Errorf("%s round %d/%d: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — have the agent use ScheduleWakeup/Monitor to wait", stepName, i+1, totalRounds, res.SessionID))
+				w.fail(ctx, fmt.Errorf("%s round %d/%d: %w", stepName, i+1, totalRounds, LiveBackgroundWorkError(res.SessionID)))
 				return
 			}
 			if err != nil {
@@ -323,7 +323,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	cfg := w.config.ResolveStep(stepCfg)
 	res, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.renderer, w.logger)
 	if res.HasLiveBackgroundWork {
-		w.fail(ctx, fmt.Errorf("%s step: session %s ended with live background work (bg Bash/Monitor tasks still running); advancing would silently discard their output — have the agent use ScheduleWakeup/Monitor to wait", stepName, res.SessionID))
+		w.fail(ctx, fmt.Errorf("%s step: %w", stepName, LiveBackgroundWorkError(res.SessionID)))
 		return
 	}
 	if err != nil {

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -73,7 +73,7 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		redoCounts:   make(map[WorkflowStep]int),
 		phases:       make(map[string]phaseState),
 		maxRedos:     DefaultMaxRedos,
-		runStepAgent: RunStepAgentDetailed,
+		runStepAgent: RunStepAgent,
 	}
 	if issue != nil {
 		// Shallow-copy so Labels mutations on w.issue don't bleed back into
@@ -262,6 +262,7 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 				roundSessionIDs = append(roundSessionIDs, res.SessionID)
 			}
 			if res.HasLiveBackgroundWork {
+				LogLiveBackgroundWorkRefusal(w.logger, stepName, res.SessionID, i+1, totalRounds, err)
 				w.fail(ctx, fmt.Errorf("%s round %d/%d: %w", stepName, i+1, totalRounds, LiveBackgroundWorkError(res.SessionID)))
 				return
 			}
@@ -323,6 +324,7 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	cfg := w.config.ResolveStep(stepCfg)
 	res, err := w.runStepAgent(ctx, stepName, w.promptData(), cfg, w.config.WorkDir, feedback, sessionID, w.renderer, w.logger)
 	if res.HasLiveBackgroundWork {
+		LogLiveBackgroundWorkRefusal(w.logger, stepName, res.SessionID, 0, 0, err)
 		w.fail(ctx, fmt.Errorf("%s step: %w", stepName, LiveBackgroundWorkError(res.SessionID)))
 		return
 	}

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -670,8 +670,8 @@ func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
 	wf.lastCommentAt = staleTime
 
 	// Stub runStepAgent so runStep executes without invoking a real agent.
-	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (string, string, error) {
-		return "step output", "session-1", nil
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		return StepAgentResult{Output: "step output", SessionID: "session-1"}, nil
 	}
 
 	wf.runStep(context.Background(), "plan", cfg.Plan, StepPlanReview, "plan_complete")
@@ -718,8 +718,8 @@ func TestWorkflow_RunStepRounds_SetsLastCommentAtFromFinalRound(t *testing.T) {
 	wf.lastCommentAt = staleTime
 
 	// Stub runStepAgent so rounds execute without a real agent.
-	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (string, string, error) {
-		return "round output", "", nil
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		return StepAgentResult{Output: "round output"}, nil
 	}
 
 	wf.runStepRounds(context.Background(), "plan", roundsCfg, StepPlanReview, "plan_complete")
@@ -758,14 +758,104 @@ func TestWorkflow_RunStepRounds_CommandFirstFeedbackInjection(t *testing.T) {
 	wf.feedback = "please fix the tests"
 
 	var capturedFeedback string
-	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, feedback string, _ string, _ *render.Renderer, _ *slog.Logger) (string, string, error) {
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, feedback string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
 		capturedFeedback = feedback
-		return "agent output", "", nil
+		return StepAgentResult{Output: "agent output"}, nil
 	}
 
 	wf.runStepRounds(context.Background(), "build", roundsCfg, StepBuildReview, "build_complete")
 
 	assert.Equal(t, "please fix the tests", capturedFeedback, "feedback should be injected into the first agent round")
+}
+
+// TestWorkflow_RunStep_RejectsLiveBackgroundWork verifies that the single-step
+// workflow path fails when the agent result reports HasLiveBackgroundWork,
+// preventing silent advancement past bg work that the CLI harness would
+// otherwise orphan.
+func TestWorkflow_RunStep_RejectsLiveBackgroundWork(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockWorkflowTracker{workflowStates: testWorkflowStates()}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		return StepAgentResult{
+			Output:                "agent output",
+			SessionID:             "sess-live-step",
+			HasLiveBackgroundWork: true,
+		}, nil
+	}
+
+	wf.runStep(context.Background(), "plan", testConfig().Plan, StepPlanReview, "plan_complete")
+
+	require.Error(t, wf.lastError)
+	assert.Contains(t, wf.lastError.Error(), "live background work")
+	assert.Contains(t, wf.lastError.Error(), "sess-live-step")
+}
+
+// TestWorkflow_RunStepRounds_RejectsLiveBackgroundWork verifies that the
+// multi-round workflow path short-circuits when any round reports
+// HasLiveBackgroundWork and does not run subsequent rounds.
+func TestWorkflow_RunStepRounds_RejectsLiveBackgroundWork(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockWorkflowTracker{workflowStates: testWorkflowStates()}
+	roundsCfg := StepConfig{
+		Rounds: []RoundConfig{
+			{Prompt: "round one"},
+			{Prompt: "round two"}, // must NOT run
+		},
+	}
+
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	var calls int
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		calls++
+		return StepAgentResult{
+			Output:                "round one output",
+			SessionID:             "sess-live-round",
+			HasLiveBackgroundWork: true,
+		}, nil
+	}
+
+	wf.runStepRounds(context.Background(), "plan", roundsCfg, StepPlanReview, "plan_complete")
+
+	require.Error(t, wf.lastError)
+	assert.Contains(t, wf.lastError.Error(), "live background work")
+	assert.Contains(t, wf.lastError.Error(), "sess-live-round")
+	assert.Equal(t, 1, calls, "guard must short-circuit before round 2")
+}
+
+// TestWorkflow_RunStep_PrefersLiveBgWorkOverAgentError asserts the
+// workflow single-step path surfaces the bg-work refusal even when the
+// agent also returned an error — otherwise a failing mixed turn would
+// swallow the premature-exit signal.
+func TestWorkflow_RunStep_PrefersLiveBgWorkOverAgentError(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockWorkflowTracker{workflowStates: testWorkflowStates()}
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		return StepAgentResult{
+			SessionID:             "sess-err-live-wf",
+			HasLiveBackgroundWork: true,
+		}, errors.New("agent execution: boom")
+	}
+
+	wf.runStep(context.Background(), "plan", testConfig().Plan, StepPlanReview, "plan_complete")
+
+	require.Error(t, wf.lastError)
+	assert.Contains(t, wf.lastError.Error(), "live background work")
+	assert.Contains(t, wf.lastError.Error(), "sess-err-live-wf")
+	assert.NotContains(t, wf.lastError.Error(), "boom", "bg-work message wins over the raw agent error")
 }
 
 // TestWorkflow_TransitionToReview_PreservesLastCommentAt verifies that

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1,6 +1,7 @@
 package jiradozer
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -150,6 +151,11 @@ func (m *mockWorkflowTracker) getCalls(method string) []trackerCall {
 
 func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+}
+
+func capturingLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})), buf
 }
 
 func testIssue() *tracker.Issue {
@@ -1815,4 +1821,71 @@ func TestWorkflow_Redo_SamePhase(t *testing.T) {
 		assert.NotEqual(t, "RemoveLabel:jiradozer-plan-done", call,
 			"plan was never done; no -done removal should fire")
 	}
+}
+
+// TestWorkflow_RunStep_LogsAgentErrorOnLiveBgWork asserts that when the
+// single-step workflow path surfaces the live-bg-work refusal, it also logs
+// the original agent error so production debugging retains the context the
+// error itself drops. Mirrors the behaviour of the CLI runStep path in
+// jiradozer/cmd/jiradozer/main.go.
+func TestWorkflow_RunStep_LogsAgentErrorOnLiveBgWork(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockWorkflowTracker{workflowStates: testWorkflowStates()}
+	logger, buf := capturingLogger()
+	wf := NewWorkflow(mt, testIssue(), testConfig(), logger)
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		return StepAgentResult{
+			SessionID:             "sess-live-log-wf",
+			HasLiveBackgroundWork: true,
+		}, errors.New("agent execution: kaboom")
+	}
+
+	wf.runStep(context.Background(), "plan", testConfig().Plan, StepPlanReview, "plan_complete")
+
+	require.Error(t, wf.lastError)
+	out := buf.String()
+	assert.Contains(t, out, "live background work", "refusal must be logged")
+	assert.Contains(t, out, "sess-live-log-wf", "session id must be logged")
+	assert.Contains(t, out, "agent_error", "agent error key must be logged")
+	assert.Contains(t, out, "kaboom", "original agent error must survive in logs")
+}
+
+// TestWorkflow_RunStepRounds_LogsAgentErrorOnLiveBgWork is the round-based
+// analogue: the refusal path in runStepRounds must log the raw agent error so
+// it is not silently swallowed when the bg-work message is returned instead.
+func TestWorkflow_RunStepRounds_LogsAgentErrorOnLiveBgWork(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockWorkflowTracker{workflowStates: testWorkflowStates()}
+	roundsCfg := StepConfig{
+		Rounds: []RoundConfig{
+			{Prompt: "r1"},
+			{Prompt: "r2"}, // must NOT run
+		},
+	}
+
+	logger, buf := capturingLogger()
+	wf := NewWorkflow(mt, testIssue(), testConfig(), logger)
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		return StepAgentResult{
+			SessionID:             "sess-live-log-rounds",
+			HasLiveBackgroundWork: true,
+		}, errors.New("agent execution: kaboom-rounds")
+	}
+
+	wf.runStepRounds(context.Background(), "plan", roundsCfg, StepPlanReview, "plan_complete")
+
+	require.Error(t, wf.lastError)
+	out := buf.String()
+	assert.Contains(t, out, "live background work", "refusal must be logged")
+	assert.Contains(t, out, "sess-live-log-rounds", "session id must be logged")
+	assert.Contains(t, out, "agent_error", "agent error key must be logged")
+	assert.Contains(t, out, "kaboom-rounds", "original agent error must survive in logs")
 }

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -858,6 +858,43 @@ func TestWorkflow_RunStep_PrefersLiveBgWorkOverAgentError(t *testing.T) {
 	assert.NotContains(t, wf.lastError.Error(), "boom", "bg-work message wins over the raw agent error")
 }
 
+// TestWorkflow_RunStepRounds_PrefersLiveBgWorkOverAgentError is the
+// round-based analogue: the bg-work refusal must fire on the first round
+// that reports HasLiveBackgroundWork, regardless of whether the round also
+// returned an error. Mirrors the single-step test above.
+func TestWorkflow_RunStepRounds_PrefersLiveBgWorkOverAgentError(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockWorkflowTracker{workflowStates: testWorkflowStates()}
+	roundsCfg := StepConfig{
+		Rounds: []RoundConfig{
+			{Prompt: "r1"},
+			{Prompt: "r2"}, // must NOT run
+		},
+	}
+
+	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
+	require.NoError(t, wf.resolveStateIDs(context.Background()))
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	var calls int
+	wf.runStepAgent = func(_ context.Context, _ string, _ PromptData, _ StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (StepAgentResult, error) {
+		calls++
+		return StepAgentResult{
+			SessionID:             "sess-err-live-wf-rounds",
+			HasLiveBackgroundWork: true,
+		}, errors.New("agent execution: boom")
+	}
+
+	wf.runStepRounds(context.Background(), "plan", roundsCfg, StepPlanReview, "plan_complete")
+
+	require.Error(t, wf.lastError)
+	assert.Contains(t, wf.lastError.Error(), "live background work")
+	assert.Contains(t, wf.lastError.Error(), "sess-err-live-wf-rounds")
+	assert.NotContains(t, wf.lastError.Error(), "boom", "bg-work message wins over the raw agent error")
+	assert.Equal(t, 1, calls, "guard must short-circuit before round 2")
+}
+
 // TestWorkflow_TransitionToReview_PreservesLastCommentAt verifies that
 // transitionToReview does not overwrite a lastCommentAt that was already set
 // by the step result comment, preventing a race where user approval posted

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -332,11 +332,12 @@ func ClaudeResultToAgentResult(r *claude.TurnResult) *AgentResult {
 		return nil
 	}
 	return &AgentResult{
-		Text:       r.Text,
-		Thinking:   r.Thinking,
-		Success:    r.Success,
-		Error:      r.Error,
-		DurationMs: r.DurationMs,
+		Text:                  r.Text,
+		Thinking:              r.Thinking,
+		Success:               r.Success,
+		Error:                 r.Error,
+		DurationMs:            r.DurationMs,
+		HasLiveBackgroundWork: r.HasLiveBackgroundWork,
 		Usage: AgentUsage{
 			InputTokens:     r.Usage.InputTokens,
 			OutputTokens:    r.Usage.OutputTokens,

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -18,6 +18,12 @@ type AgentResult struct {
 	Usage               AgentUsage
 	DurationMs          int64
 	Success             bool
+	// HasLiveBackgroundWork is true when the final turn ended with live
+	// background work (run_in_background:true Bash, Monitor tasks, or parked
+	// tools). Orchestrators (jiradozer rounds, retry loops) must check this
+	// before advancing or stopping the session — advancing past the turn can
+	// silently lose the bg work's output, and Stop() would orphan the tasks.
+	HasLiveBackgroundWork bool
 }
 
 // UnresolvedToolError records an unresolved tool error that persisted after

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -18,11 +18,9 @@ type AgentResult struct {
 	Usage               AgentUsage
 	DurationMs          int64
 	Success             bool
-	// HasLiveBackgroundWork is true when the final turn ended with live
-	// background work (run_in_background:true Bash, Monitor tasks, or parked
-	// tools). Orchestrators (jiradozer rounds, retry loops) must check this
-	// before advancing or stopping the session — advancing past the turn can
-	// silently lose the bg work's output, and Stop() would orphan the tasks.
+	// HasLiveBackgroundWork mirrors claude.TurnResult.HasLiveBackgroundWork:
+	// orchestrators must not advance past or Stop() a session when this is set,
+	// or live bg tasks are orphaned.
 	HasLiveBackgroundWork bool
 }
 


### PR DESCRIPTION
## Summary

- Fixes a third premature-exit path in jiradozer rounds not covered by #155 / #158. When an agent launches `run_in_background: true` Bash tools and then does synchronous work in the same turn, `shouldSuppressForBgTasks()` bails on the first non-bg tool, the ResultMessage finalizes as a normal completion with `HasLiveBackgroundWork=false`, and jiradozer advances past the round with bramble reviews (and their waiter loops) still live — silently discarding their output.
- In `agent-cli-wrapper/claude`, split "live bg work" detection from "pure-bg suppression": new `turnState.hasLiveBackgroundWork()` returns true on any uncancelled bg tool_use regardless of sync tools, and `handleResult` now sets `HasLiveBackgroundWork=true` on the non-suppressed branch when the turn has live bg work. Suppression semantics are untouched — sync completion is real; we just propagate the signal.
- In `jiradozer`, add `StepAgentResult` + `RunStepAgentDetailed`; `runSingleStepRounds` fails the round (pointing at `ScheduleWakeup`/`Monitor`) when bg work is still live, rather than advancing silently.

## Repro (round 2 log this fix targets)

Session `0bc3fbd8-9460-46f8-be0e-138f7ab10a11` (log: `jiradozer-20260419-052054-1078509.log`) ended at `success=true, duration=170.4s` while four `run_in_background: true` Bash tool_use blocks were still live:
- `toolu_015xo8ifv287…` (bramble codex)
- `toolu_01N39SgDJSxz4u…` (bramble cursor)
- `toolu_017Z5aj7noYFK…` (until-waiter #1)
- `toolu_01XYpKGQjUp65…` (until-waiter #2)

Each received the synthetic `Command running in background with ID: b…` result, so the CLI registered them as live tasks — but ~15 synchronous Bash calls in the same turn made `shouldSuppressForBgTasks` return `false`, the turn finalized normally, and jiradozer moved on to round 3.

## How the three bug paths differ

| Issue | Trigger | Existing guard |
|---|---|---|
| #155 | `ScheduleWakeup` called once | `shouldSuppressWakeup` |
| #158 | chained `ScheduleWakeup` on continuation | re-suppress in `handleResult` |
| **This** | `run_in_background: true` Bash mixed with sync Bash in one turn | uncovered — `shouldSuppressForBgTasks` returned false, `HasLiveBackgroundWork` stayed false |

## Test plan

- [x] `scripts/lint.sh` — 0 issues across all modules
- [x] `bazel build //...` — 2638 actions, successful
- [x] `bazel test //...` — 56 tests pass
- [x] New unit tests in `agent-cli-wrapper/claude/session_bg_test.go`:
  - `TestHasLiveBackgroundWork_MixedTurnFlagsFinalResult` — reproduces the round 2 scenario: bg-Bash + sync Bash in one turn → `HasLiveBackgroundWork=true`, turn still completes
  - `TestHasLiveBackgroundWork_PureSyncTurnDoesNotFlag` — regression guard
  - `TestHasLiveBackgroundWork_CancelledBgToolDoesNotFlag` — cancelled bg tools don't count
  - `TestHasLiveBackgroundWork_PureBgTurnUsesSuppressionPath` — pure-bg suppression path unchanged
- [ ] Manual verify on next jiradozer run: a round that launches bg bramble reviews and does sync work should now fail the round with a clear error instead of silently moving on.

## Out of scope

- Making the agent use `ScheduleWakeup` / `Monitor` for bg-polling (skill / system-prompt concern).
- Round 3 zero-token exit on unknown slash command — noted in plan as a separate ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn finalization and workflow/CLI control flow to treat mixed sync+background turns as non-advancable, which can alter when runs fail/stop and could impact orchestrator behavior in edge cases (wakeup safety timer, retries). Scope is contained and heavily unit-tested but touches core session/result plumbing.
> 
> **Overview**
> Fixes a premature-advance gap where **mixed turns** (sync tool calls plus `run_in_background` Bash/Monitor work) could complete successfully without signaling that background tasks were still running.
> 
> In `agent-cli-wrapper/claude`, background-work detection is split from suppression via new `turnState.hasLiveBackgroundWork()`, and `handleResult`/`completeWakeupSuppressedTurn` now set `TurnResult.HasLiveBackgroundWork` even when the turn is not suppressed (or completes via wakeup safety timer). Extensive new tests cover mixed/pure-bg/pure-sync/cancelled-bg cases.
> 
> In `jiradozer`, agent execution now returns `StepAgentResult` (including `HasLiveBackgroundWork`), propagates the flag through `multiagent/agent.AgentResult`, and both the workflow runner and `run-step` CLI paths **refuse to advance** when live background work is reported, emitting a standardized error/log shape; tests are updated/added accordingly, plus a couple of flaky fork/exec tests are made serial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477c647d08fb5406be943f96356fb5139c78e8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->