### PR TITLE
fix(jiradozer): stop killing worktrees on bg false-positive + on genuine step failure

### DIFF
--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -868,7 +868,7 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 			if p.ToolUseID != nil {
 				toolUseID = *p.ToolUseID
 			}
-			s.turnManager.TrackTask(p.TaskID, toolUseID)
+			alreadyCompleted := s.turnManager.TrackTask(p.TaskID, toolUseID)
 			s.emit(TaskStartedEvent{
 				ToolUseID:    p.ToolUseID,
 				WorkflowName: p.WorkflowName,
@@ -878,6 +878,14 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 				Prompt:       p.Prompt,
 				TurnNumber:   turnNum,
 			})
+			if alreadyCompleted {
+				// CLI emitted terminal task event before task_started (event
+				// reordering). The earlier UntrackTask could not release
+				// suppression because tasksEverTracked was still 0; now that
+				// TrackTask bumped it, AllTasksCompleted flips true and the
+				// held turn can finalize without waiting for the safety timer.
+				s.maybeReleaseSuppression("task_started:late-after-terminal")
+			}
 		} else {
 			slog.Warn("failed to decode task_started payload")
 		}

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -864,7 +864,11 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 		}
 	case protocol.SystemSubtypeTaskStarted:
 		if p, ok := msg.AsTaskStarted(); ok {
-			s.turnManager.TrackTask(p.TaskID)
+			toolUseID := ""
+			if p.ToolUseID != nil {
+				toolUseID = *p.ToolUseID
+			}
+			s.turnManager.TrackTask(p.TaskID, toolUseID)
 			s.emit(TaskStartedEvent{
 				ToolUseID:    p.ToolUseID,
 				WorkflowName: p.WorkflowName,
@@ -892,7 +896,7 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 			if p.Patch.Status != nil {
 				switch *p.Patch.Status {
 				case "completed", "failed", "killed":
-					s.turnManager.UntrackTask(p.TaskID)
+					s.turnManager.UntrackTask(p.TaskID, "")
 					s.maybeReleaseSuppression("task_updated:" + *p.Patch.Status)
 				}
 			}
@@ -927,7 +931,11 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 			// Belt-and-suspenders: task_notification may fire without a
 			// preceding terminal task_updated (e.g. if the bg process writes
 			// stdout on exit). Drain the live set and attempt release.
-			s.turnManager.UntrackTask(p.TaskID)
+			toolUseID := ""
+			if p.ToolUseID != nil {
+				toolUseID = *p.ToolUseID
+			}
+			s.turnManager.UntrackTask(p.TaskID, toolUseID)
 			s.maybeReleaseSuppression("task_notification")
 		} else {
 			slog.Warn("failed to decode task_notification payload")

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1774,3 +1774,70 @@ func TestTrackTaskAfterTerminalEventDoesNotRevive(t *testing.T) {
 		t.Fatal("hasLiveBackgroundWork must be false after late task_started for an already-completed task")
 	}
 }
+
+// TestReorderedTerminalThenStartedReleasesSuppressedTurn drives the full
+// turn-completion path. When the CLI reorders task_notification (terminal)
+// before task_started, the suppressed turn must finalize immediately on the
+// late task_started — NOT wait for the bg-task safety timer.
+//
+// Uses Monitor (not bg-Bash) because Monitor's release path is terminal
+// task events; bg-Bash releases via continuation ResultMessage and so
+// wouldn't exercise the task-reordering code path.
+func TestReorderedTerminalThenStartedReleasesSuppressedTurn(t *testing.T) {
+	// Use a long safety timeout so the test would hang / fail rather than
+	// silently succeed via timer-fired path.
+	s := newTestSession(t, WithBgTaskSafetyTimeout(30*time.Second))
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Monitor", Input: map[string]interface{}{"command": "tail -f log"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Monitor armed", IsError: &notErr},
+	})
+
+	// handleResult must suppress (Monitor is background-releasing; no sync tool).
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	s.mu.RLock()
+	suppActive := s.bgState.active
+	s.mu.RUnlock()
+	if !suppActive {
+		t.Fatal("expected suppression to be active after pure-bg Monitor turn")
+	}
+
+	// Terminal event arrives FIRST. UntrackTask records completedTaskIDs
+	// but tasksEverTracked is still 0, so maybeReleaseSuppression's
+	// AllTasksCompleted returns false and suppression persists.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1", "tool_use_id": "tool-1", "status": "completed",
+	}))
+
+	s.mu.RLock()
+	suppStillActive := s.bgState.active
+	s.mu.RUnlock()
+	if !suppStillActive {
+		t.Fatal("suppression should still be active — task_started has not fired yet, tasksEverTracked is 0")
+	}
+
+	// Late task_started fires. TrackTask returns alreadyCompleted=true,
+	// session.go calls maybeReleaseSuppression, which finalizes the turn
+	// (AllTasksCompleted now flips true: tasksEverTracked==1, liveTasks empty,
+	// no uncancelled bg-Bash since Monitor is in backgroundTools).
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u2",
+		"task_id": "task-1", "tool_use_id": "tool-1",
+	}))
+
+	// Turn must complete well under the 30s safety timeout.
+	waitForTurnComplete(t, s.events, 2*time.Second)
+
+	s.mu.RLock()
+	afterActive := s.bgState.active
+	s.mu.RUnlock()
+	if afterActive {
+		t.Error("suppression should be released after late task_started via maybeReleaseSuppression")
+	}
+}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1841,3 +1841,57 @@ func TestReorderedTerminalThenStartedReleasesSuppressedTurn(t *testing.T) {
 		t.Error("suppression should be released after late task_started via maybeReleaseSuppression")
 	}
 }
+
+// TestHasLiveBackgroundWork_MixedTurnTerminalWithoutToolUseIDDrains exercises
+// the completedBgToolUseIDs fallback path on a mixed sync+bg turn. task_started
+// carries tool_use_id (populating taskToToolUse), then a terminal task event
+// arrives WITHOUT tool_use_id. UntrackTask must resolve the id via the stored
+// mapping and populate completedBgToolUseIDs so hasLiveBackgroundWork's
+// ContentBlocks walk clears the bg block — and the final TurnCompleteEvent
+// reports HasLiveBackgroundWork=false.
+func TestHasLiveBackgroundWork_MixedTurnTerminalWithoutToolUseIDDrains(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-bg", Name: "Monitor", Input: map[string]interface{}{"command": "tail -f log"}},
+		{ID: "tool-sync", Name: "Bash", Input: map[string]interface{}{"command": "echo sync"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-bg", Content: "Monitor armed", IsError: &notErr},
+		{ToolUseID: "tool-sync", Content: "sync", IsError: &notErr},
+	})
+
+	turn := s.turnManager.CurrentTurn()
+	if !turn.hasLiveBackgroundWork() {
+		t.Fatal("bg tool should be live before terminal task event arrives")
+	}
+
+	// task_started carries tool_use_id — populates taskToToolUse mapping.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1", "tool_use_id": "tool-bg",
+	}))
+
+	// Terminal task_notification OMITS tool_use_id. UntrackTask must fall back
+	// to the taskToToolUse mapping to populate completedBgToolUseIDs.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u2",
+		"task_id": "task-1", "status": "completed",
+	}))
+
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must clear after terminal-without-tool_use_id drains both liveTasks and completedBgToolUseIDs via mapping fallback")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	tce := drainUntilTurnComplete(t, s.events, 2*time.Second)
+	if tce.HasLiveBackgroundWork {
+		t.Error("TurnCompleteEvent.HasLiveBackgroundWork must be false — bg tool drained via fallback mapping")
+	}
+	if !tce.Success {
+		t.Error("TurnCompleteEvent.Success must be true")
+	}
+}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1586,3 +1586,113 @@ func TestScheduleWakeup_SafetyTimerSurfacesLiveBgWork(t *testing.T) {
 	}
 	s.mu.Unlock()
 }
+
+// TestHasLiveBackgroundWork_BgBashCompletedViaTaskNotification reproduces
+// the jiradozer validate round 2 false positive. The agent launched bg-Bash
+// (e.g. `bramble_ops.py launch` with run_in_background=true) in a mixed
+// sync+bg turn. The CLI later emits task_notification with a terminal
+// status, meaning the bg process has exited. The turn must NOT finalize
+// with HasLiveBackgroundWork=true — the launch-receipt tool_result
+// ("Command running in background with ID: …", IsError=false) is not
+// completion; task_notification is.
+func TestHasLiveBackgroundWork_BgBashCompletedViaTaskNotification(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "bramble code-review", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "git status"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Command running in background with ID: b1", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "clean", IsError: &notErr},
+	})
+
+	// task_started carries tool_use_id → the manager records the mapping
+	// so a later terminal task event can flag the tool_use as complete.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1", "tool_use_id": "tool-1",
+	}))
+	// task_notification fires when the bg process exits.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u2",
+		"task_id": "task-1", "tool_use_id": "tool-1", "status": "completed",
+	}))
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must be false once task_notification marked the bg tool_use complete")
+	}
+
+	_ = s.state.Transition(TransitionUserMessageSent)
+	s.handleResult(protocol.ResultMessage{Type: "result", IsError: false})
+
+	tce := drainUntilTurnComplete(t, s.events, time.Second)
+	if tce.HasLiveBackgroundWork {
+		t.Error("TurnCompleteEvent.HasLiveBackgroundWork must be false when bg tasks have task_notified")
+	}
+	if !tce.Success {
+		t.Error("TurnCompleteEvent.Success must be true — sync and bg work both completed")
+	}
+}
+
+// TestHasLiveBackgroundWork_BgBashTaskStartedButStillLive asserts that
+// between task_started and task_notification, the bg tool_use is still
+// considered live — only the terminal signal clears it.
+func TestHasLiveBackgroundWork_BgBashTaskStartedButStillLive(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "sleep 60", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "echo sync"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Command running in background with ID: b1", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "sync", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1", "tool_use_id": "tool-1",
+	}))
+
+	turn := s.turnManager.CurrentTurn()
+	if !turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must remain true while task_started has fired but no terminal signal arrived")
+	}
+}
+
+// TestHasLiveBackgroundWork_TerminalTaskUpdatedMarksToolUseComplete covers
+// the task_updated path (no tool_use_id on the wire) — the manager must
+// resolve the tool_use via the taskID→toolUseID map recorded on task_started.
+func TestHasLiveBackgroundWork_TerminalTaskUpdatedMarksToolUseComplete(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "true", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "echo sync"}},
+	}
+	simulateAssistantToolUse(s, tools)
+
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Command running in background with ID: b1", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "sync", IsError: &notErr},
+	})
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1", "tool_use_id": "tool-1",
+	}))
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_updated", "session_id": "s", "uuid": "u2",
+		"task_id": "task-1",
+		"patch":   map[string]interface{}{"status": "completed"},
+	}))
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must be false once task_updated:completed drained the task")
+	}
+}

--- a/agent-cli-wrapper/claude/session_bg_test.go
+++ b/agent-cli-wrapper/claude/session_bg_test.go
@@ -1696,3 +1696,81 @@ func TestHasLiveBackgroundWork_TerminalTaskUpdatedMarksToolUseComplete(t *testin
 		t.Fatal("hasLiveBackgroundWork must be false once task_updated:completed drained the task")
 	}
 }
+
+// TestHasLiveBackgroundWork_TaskNotificationWithoutToolUseIDDrainsLiveTasks
+// covers the wire edge-case where the CLI omits tool_use_id on BOTH
+// task_started and task_notification. hasLiveBackgroundWork's liveTasks
+// check must still return false, because UntrackTask records completion by
+// task_id independent of tool_use_id. (The per-block bg tool_use may remain
+// marked live until the safety timer fires — that is the structural limit
+// of the protocol — but liveTasks must drain.)
+func TestHasLiveBackgroundWork_TaskNotificationWithoutToolUseIDDrainsLiveTasks(t *testing.T) {
+	s := newTestSession(t)
+
+	// Only sync tools in content (no bg tool_use block) so the ContentBlocks
+	// loop is a no-op and hasLiveBackgroundWork reduces to the liveTasks check.
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-sync", Name: "Bash", Input: map[string]interface{}{"command": "echo sync"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-sync", Content: "sync", IsError: &notErr},
+	})
+
+	// task_started with NO tool_use_id — e.g. a CLI-internal subagent task.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1",
+	}))
+
+	turn := s.turnManager.CurrentTurn()
+	if !turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must be true while the task is live")
+	}
+
+	// task_notification also without tool_use_id.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u2",
+		"task_id": "task-1", "status": "completed",
+	}))
+
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must be false after terminal task_notification drains liveTasks, even without tool_use_id")
+	}
+}
+
+// TestTrackTaskAfterTerminalEventDoesNotRevive asserts that if the CLI ever
+// emits task_notification (terminal) before task_started for the same
+// task_id, a later task_started must not re-insert the task into liveTasks.
+// Otherwise the false-positive class the PR kills could come back via event
+// reordering.
+func TestTrackTaskAfterTerminalEventDoesNotRevive(t *testing.T) {
+	s := newTestSession(t)
+
+	tools := []protocol.ToolUseBlock{
+		{ID: "tool-1", Name: "Bash", Input: map[string]interface{}{"command": "true", "run_in_background": true}},
+		{ID: "tool-2", Name: "Bash", Input: map[string]interface{}{"command": "echo sync"}},
+	}
+	simulateAssistantToolUse(s, tools)
+	simulateUserToolResults(t, s, []protocol.ToolResultBlock{
+		{ToolUseID: "tool-1", Content: "Command running in background with ID: b1", IsError: &notErr},
+		{ToolUseID: "tool-2", Content: "sync", IsError: &notErr},
+	})
+
+	// Terminal event arrives FIRST (event reordering).
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_notification", "session_id": "s", "uuid": "u1",
+		"task_id": "task-1", "tool_use_id": "tool-1", "status": "completed",
+	}))
+
+	// Late task_started for the same task_id.
+	s.handleSystem(makeSystemMessage(t, map[string]interface{}{
+		"type": "system", "subtype": "task_started", "session_id": "s", "uuid": "u2",
+		"task_id": "task-1", "tool_use_id": "tool-1",
+	}))
+
+	turn := s.turnManager.CurrentTurn()
+	if turn.hasLiveBackgroundWork() {
+		t.Fatal("hasLiveBackgroundWork must be false after late task_started for an already-completed task")
+	}
+}

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -631,6 +632,13 @@ func (tm *turnManager) TrackTask(taskID, toolUseID string) {
 // takes precedence over the taskID mapping (task_notification carries
 // tool_use_id directly; task_updated does not).
 // No-op if the task is not tracked or there is no current turn.
+//
+// When both the caller's toolUseID and the task_started mapping are empty
+// — i.e. neither the terminal event nor its preceding task_started carried
+// a tool_use_id — the task cannot be linked back to a bg tool_use block.
+// completedBgToolUseIDs is left untouched; hasLiveBackgroundWork then keeps
+// the launch-receipt bg tool marked live until the suppression safety
+// timeout fires. A warning is logged so this shows up in traces.
 func (tm *turnManager) UntrackTask(taskID, toolUseID string) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
@@ -642,12 +650,15 @@ func (tm *turnManager) UntrackTask(taskID, toolUseID string) {
 	if resolvedToolUseID == "" {
 		resolvedToolUseID = tm.currentTurn.taskToToolUse[taskID]
 	}
-	if resolvedToolUseID != "" {
-		if tm.currentTurn.completedBgToolUseIDs == nil {
-			tm.currentTurn.completedBgToolUseIDs = make(map[string]struct{})
-		}
-		tm.currentTurn.completedBgToolUseIDs[resolvedToolUseID] = struct{}{}
+	if resolvedToolUseID == "" {
+		slog.Warn("UntrackTask: no tool_use_id on terminal event or task_started mapping; bg tool may remain marked live until safety timeout",
+			"task_id", taskID)
+		return
 	}
+	if tm.currentTurn.completedBgToolUseIDs == nil {
+		tm.currentTurn.completedBgToolUseIDs = make(map[string]struct{})
+	}
+	tm.currentTurn.completedBgToolUseIDs[resolvedToolUseID] = struct{}{}
 }
 
 // HasLiveTasks reports whether the current turn has any registered live

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -259,7 +259,17 @@ type turnState struct {
 	// completed/failed/killed). hasLiveBackgroundWork excludes these so a
 	// mixed bg+sync turn is not permanently flagged as live after the bg
 	// process has exited.
-	completedBgToolUseIDs  map[string]struct{}
+	completedBgToolUseIDs map[string]struct{}
+	// completedTaskIDs is the set of task IDs that have reached a terminal
+	// state. Tracked independently of tool_use_id so that:
+	//   1. A late task_started (if the CLI ever reorders terminal-before-started
+	//      for the same task_id) cannot re-insert an already-completed task
+	//      into liveTasks — TrackTask skips such task IDs.
+	//   2. task_notification without a tool_use_id on either the start or the
+	//      terminal event can still record completion by task_id, which is
+	//      enough to keep liveTasks drained even if the per-block
+	//      completedBgToolUseIDs bucket is never populated for that task.
+	completedTaskIDs       map[string]struct{}
 	FullText               string
 	FullThinking           string
 	ContentBlocks          []ContentBlock
@@ -606,11 +616,31 @@ func (tm *turnManager) AppendContentBlock(block ContentBlock) {
 // task_started handling. toolUseID, when non-empty, lets the manager mark the
 // corresponding bg tool_use complete when the task reaches a terminal state
 // — task_updated payloads carry only task_id, so this mapping must be
-// captured at task_started time. No-op if there is no current turn.
+// captured at task_started time.
+//
+// If the task has already been marked completed (via UntrackTask seen earlier
+// due to CLI event reordering), TrackTask does NOT re-insert it into
+// liveTasks. Otherwise a terminal-before-started sequence would revive the
+// live-background-work false-positive this package is trying to kill.
+// No-op if there is no current turn.
 func (tm *turnManager) TrackTask(taskID, toolUseID string) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil || taskID == "" {
+		return
+	}
+	if _, done := tm.currentTurn.completedTaskIDs[taskID]; done {
+		// Terminal event already arrived for this task_id; don't resurrect.
+		if toolUseID != "" {
+			if tm.currentTurn.taskToToolUse == nil {
+				tm.currentTurn.taskToToolUse = make(map[string]string)
+			}
+			tm.currentTurn.taskToToolUse[taskID] = toolUseID
+			if tm.currentTurn.completedBgToolUseIDs == nil {
+				tm.currentTurn.completedBgToolUseIDs = make(map[string]struct{})
+			}
+			tm.currentTurn.completedBgToolUseIDs[toolUseID] = struct{}{}
+		}
 		return
 	}
 	if tm.currentTurn.liveTasks == nil {
@@ -631,14 +661,18 @@ func (tm *turnManager) TrackTask(taskID, toolUseID string) {
 // hasLiveBackgroundWork no longer counts it. toolUseID, when non-empty,
 // takes precedence over the taskID mapping (task_notification carries
 // tool_use_id directly; task_updated does not).
-// No-op if the task is not tracked or there is no current turn.
 //
-// When both the caller's toolUseID and the task_started mapping are empty
-// — i.e. neither the terminal event nor its preceding task_started carried
-// a tool_use_id — the task cannot be linked back to a bg tool_use block.
-// completedBgToolUseIDs is left untouched; hasLiveBackgroundWork then keeps
-// the launch-receipt bg tool marked live until the suppression safety
-// timeout fires. A warning is logged so this shows up in traces.
+// Completion is recorded at two layers: by task_id in completedTaskIDs
+// (always) and by tool_use_id in completedBgToolUseIDs (when resolvable).
+// The task_id layer guards against CLI event reordering — a late
+// task_started for an already-completed task will not revive liveTasks.
+// The tool_use_id layer is what hasLiveBackgroundWork consults when walking
+// ContentBlocks, so it is the critical one for draining the bg signal; when
+// it cannot be populated (both events omitted tool_use_id and no link was
+// ever captured) a warning is logged since the bg block may remain flagged
+// live until the suppression safety timer fires.
+//
+// No-op if taskID is empty or there is no current turn.
 func (tm *turnManager) UntrackTask(taskID, toolUseID string) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
@@ -646,6 +680,10 @@ func (tm *turnManager) UntrackTask(taskID, toolUseID string) {
 		return
 	}
 	delete(tm.currentTurn.liveTasks, taskID)
+	if tm.currentTurn.completedTaskIDs == nil {
+		tm.currentTurn.completedTaskIDs = make(map[string]struct{})
+	}
+	tm.currentTurn.completedTaskIDs[taskID] = struct{}{}
 	resolvedToolUseID := toolUseID
 	if resolvedToolUseID == "" {
 		resolvedToolUseID = tm.currentTurn.taskToToolUse[taskID]
@@ -699,6 +737,14 @@ func (tm *turnManager) AllTasksCompleted() bool {
 	// hasContinuationBgTools is set conservatively on tool_use append. Check
 	// whether any such tool is actually uncancelled (i.e. has a non-error
 	// tool_result) — cancelled bg-Bash tools never produce a continuation.
+	//
+	// Note: completedBgToolUseIDs is NOT consulted here. Unlike
+	// hasLiveBackgroundWork (which answers "are any bg tools still running?"),
+	// AllTasksCompleted gates turn finalization for suppressed turns, and
+	// bg-Bash tools release suppression via the continuation ResultMessage
+	// path — not via terminal task events. Even if a bg-Bash task_notification
+	// arrived (populating completedBgToolUseIDs), the turn must still wait for
+	// its continuation ResultMessage before finalizing.
 	cancelled := tm.currentTurn.cancelledToolIDs()
 	for _, block := range tm.currentTurn.ContentBlocks {
 		if block.Type == ContentBlockTypeToolUse &&

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -618,19 +618,24 @@ func (tm *turnManager) AppendContentBlock(block ContentBlock) {
 // — task_updated payloads carry only task_id, so this mapping must be
 // captured at task_started time.
 //
-// If the task has already been marked completed (via UntrackTask seen earlier
-// due to CLI event reordering), TrackTask does NOT re-insert it into
-// liveTasks. Otherwise a terminal-before-started sequence would revive the
-// live-background-work false-positive this package is trying to kill.
-// No-op if there is no current turn.
-func (tm *turnManager) TrackTask(taskID, toolUseID string) {
+// Returns alreadyCompleted=true when the task has already reached a terminal
+// state (via an earlier UntrackTask — CLI event reordering). In that case
+// liveTasks is NOT re-inserted (preventing revival of the live-background-work
+// false-positive), but tasksEverTracked IS incremented so AllTasksCompleted
+// flips true. The caller is responsible for re-invoking
+// maybeReleaseSuppression so a suppressed turn finalizes immediately rather
+// than waiting for the safety timer. No-op if there is no current turn.
+func (tm *turnManager) TrackTask(taskID, toolUseID string) (alreadyCompleted bool) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil || taskID == "" {
-		return
+		return false
 	}
 	if _, done := tm.currentTurn.completedTaskIDs[taskID]; done {
 		// Terminal event already arrived for this task_id; don't resurrect.
+		// Still count it as tracked so AllTasksCompleted can return true —
+		// terminalBeforeStarted had nothing to increment when it ran.
+		tm.currentTurn.tasksEverTracked++
 		if toolUseID != "" {
 			if tm.currentTurn.taskToToolUse == nil {
 				tm.currentTurn.taskToToolUse = make(map[string]string)
@@ -641,7 +646,7 @@ func (tm *turnManager) TrackTask(taskID, toolUseID string) {
 			}
 			tm.currentTurn.completedBgToolUseIDs[toolUseID] = struct{}{}
 		}
-		return
+		return true
 	}
 	if tm.currentTurn.liveTasks == nil {
 		tm.currentTurn.liveTasks = make(map[string]struct{})
@@ -654,6 +659,7 @@ func (tm *turnManager) TrackTask(taskID, toolUseID string) {
 		}
 		tm.currentTurn.taskToToolUse[taskID] = toolUseID
 	}
+	return false
 }
 
 // UntrackTask removes a task ID from the current turn's live set and marks

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -242,10 +242,23 @@ func (turn *turnState) latestScheduleWakeupDelaySeconds() float64 {
 
 // turnState tracks the state of a single turn.
 type turnState struct {
-	StartTime              time.Time
-	UserMessage            interface{}
-	Tools                  map[string]*toolState
-	liveTasks              map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
+	StartTime   time.Time
+	UserMessage interface{}
+	Tools       map[string]*toolState
+	liveTasks   map[string]struct{} // task IDs registered via task_started that have not reached a terminal state
+	// taskToToolUse maps task_id → tool_use_id for background tasks whose
+	// task_started frame carried a tool_use_id. task_updated payloads do not
+	// carry tool_use_id, so this reverse map lets terminal task_updated
+	// transitions mark the corresponding bg tool_use as complete even though
+	// its launch-receipt tool_result (IsError=false) still lives in
+	// ContentBlocks.
+	taskToToolUse map[string]string
+	// completedBgToolUseIDs is the set of background tool_use IDs whose task
+	// has reached a terminal state (task_notification or task_updated with
+	// completed/failed/killed). hasLiveBackgroundWork excludes these so a
+	// mixed bg+sync turn is not permanently flagged as live after the bg
+	// process has exited.
+	completedBgToolUseIDs  map[string]struct{}
 	FullText               string
 	FullThinking           string
 	ContentBlocks          []ContentBlock
@@ -334,9 +347,17 @@ func (turn *turnState) hasLiveBackgroundWork() bool {
 		if !isBackgroundToolUse(block) {
 			continue
 		}
-		if !cancelled[block.ToolUseID] {
-			return true
+		if cancelled[block.ToolUseID] {
+			continue
 		}
+		// Bg tool_use whose task_notification / terminal task_updated already
+		// arrived: the bg process has exited. Its tool_result still says
+		// "Running in background..." (that's the launch receipt, not
+		// completion), so cancellation alone misses this case.
+		if _, done := turn.completedBgToolUseIDs[block.ToolUseID]; done {
+			continue
+		}
+		return true
 	}
 	return false
 }
@@ -581,8 +602,11 @@ func (tm *turnManager) AppendContentBlock(block ContentBlock) {
 }
 
 // TrackTask records a task ID as live on the current turn. Called from
-// task_started handling. No-op if there is no current turn.
-func (tm *turnManager) TrackTask(taskID string) {
+// task_started handling. toolUseID, when non-empty, lets the manager mark the
+// corresponding bg tool_use complete when the task reaches a terminal state
+// — task_updated payloads carry only task_id, so this mapping must be
+// captured at task_started time. No-op if there is no current turn.
+func (tm *turnManager) TrackTask(taskID, toolUseID string) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil || taskID == "" {
@@ -593,17 +617,37 @@ func (tm *turnManager) TrackTask(taskID string) {
 	}
 	tm.currentTurn.liveTasks[taskID] = struct{}{}
 	tm.currentTurn.tasksEverTracked++
+	if toolUseID != "" {
+		if tm.currentTurn.taskToToolUse == nil {
+			tm.currentTurn.taskToToolUse = make(map[string]string)
+		}
+		tm.currentTurn.taskToToolUse[taskID] = toolUseID
+	}
 }
 
-// UntrackTask removes a task ID from the current turn's live set.
+// UntrackTask removes a task ID from the current turn's live set and marks
+// any bg tool_use associated with that task as complete, so
+// hasLiveBackgroundWork no longer counts it. toolUseID, when non-empty,
+// takes precedence over the taskID mapping (task_notification carries
+// tool_use_id directly; task_updated does not).
 // No-op if the task is not tracked or there is no current turn.
-func (tm *turnManager) UntrackTask(taskID string) {
+func (tm *turnManager) UntrackTask(taskID, toolUseID string) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil || taskID == "" {
 		return
 	}
 	delete(tm.currentTurn.liveTasks, taskID)
+	resolvedToolUseID := toolUseID
+	if resolvedToolUseID == "" {
+		resolvedToolUseID = tm.currentTurn.taskToToolUse[taskID]
+	}
+	if resolvedToolUseID != "" {
+		if tm.currentTurn.completedBgToolUseIDs == nil {
+			tm.currentTurn.completedBgToolUseIDs = make(map[string]struct{})
+		}
+		tm.currentTurn.completedBgToolUseIDs[resolvedToolUseID] = struct{}{}
+	}
 }
 
 // HasLiveTasks reports whether the current turn has any registered live

--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -158,6 +158,8 @@ In team mode (`--filter`), each issue gets its own git worktree under a dedicate
 - **Left intact on failure or cancellation** (`StepFailed`, `StepCancelled`) by default, so the operator can inspect the state and keep any pushed branch / open PR created by earlier steps.
 - **Removed only with `--force-cleanup`** when a run fails or is cancelled. Pass the flag to wipe the worktree and branch so a future retry starts from a clean state.
 
+On shared or untrusted machines (CI runners, shared dev hosts), prefer `--force-cleanup` so a failed run does not leave secrets, tokens, or untracked files from the agent on disk.
+
 After merging the PR, remove the worktree manually:
 
 ```bash

--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -155,7 +155,8 @@ In team mode (`--filter`), each issue gets its own git worktree under a dedicate
 
 - **Created** when the issue is picked up and `Start()` is called.
 - **Left intact** when the workflow completes successfully (`StepDone`). The ship step typically opens a PR but does not merge it — the branch must remain until the PR is reviewed and merged.
-- **Removed** only on workflow failure (`StepFailed`). Failed runs clean up the worktree and branch so a future retry starts from a clean state.
+- **Left intact on failure or cancellation** (`StepFailed`, `StepCancelled`) by default, so the operator can inspect the state and keep any pushed branch / open PR created by earlier steps.
+- **Removed only with `--force-cleanup`** when a run fails or is cancelled. Pass the flag to wipe the worktree and branch so a future retry starts from a clean state.
 
 After merging the PR, remove the worktree manually:
 

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -98,7 +98,7 @@ func main() {
 	rootCmd.Flags().StringVar(&descriptionFile, "description-file", "", "Read task description from file (use - for stdin)")
 	rootCmd.Flags().StringVar(&planFile, "plan-file", "", "Plan file for build step (use - for stdin)")
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Team mode only: for each newly-discovered issue, print the equivalent `bramble new-session` command instead of launching a workflow. TUI remains empty — look at stdout for the printed commands.")
-	rootCmd.Flags().BoolVar(&forceCleanup, "force-cleanup", false, "Team mode only: delete all worktrees on cancellation (Ctrl+C). By default, worktrees with in-progress work are preserved.")
+	rootCmd.Flags().BoolVar(&forceCleanup, "force-cleanup", false, "Team mode only: delete worktrees even for failed or cancelled runs. By default, failed and cancelled worktrees are preserved so in-progress work (including pushed branches / open PRs) is not lost.")
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -508,13 +508,16 @@ func runMultiIssue(ctx context.Context, issueTracker tracker.IssueTracker, cfg *
 		fmt.Fprintf(os.Stderr, "\nPreserved %d worktree(s):\n", len(preserved))
 		for _, pw := range preserved {
 			reason := "cancelled"
-			if pw.Step == jiradozer.StepDone {
+			switch pw.Step {
+			case jiradozer.StepDone:
 				reason = "shipped (PR open, not yet merged)"
+			case jiradozer.StepFailed:
+				reason = "failed (inspect and recover; pushed branch / open PR still intact)"
 			}
 			fmt.Fprintf(os.Stderr, "  %s  %s  (%s)  [%s]\n", pw.Issue, pw.Branch, pw.WorktreePath, reason)
 		}
 		fmt.Fprintf(os.Stderr, "\nTo remove after merging: wt remove <branch>\n")
-		fmt.Fprintf(os.Stderr, "To remove cancelled worktrees on next run: re-run with --force-cleanup\n")
+		fmt.Fprintf(os.Stderr, "To remove failed/cancelled worktrees on next run: re-run with --force-cleanup\n")
 	}
 
 	return err

--- a/jiradozer/integration/orchestrator_test.go
+++ b/jiradozer/integration/orchestrator_test.go
@@ -202,7 +202,7 @@ func TestOrchestrator_WorktreeCreation(t *testing.T) {
 	require.NotContains(t, removed, "jiradozer/ENG-2")
 }
 
-func TestOrchestrator_WorktreeRemovedOnFailure(t *testing.T) {
+func TestOrchestrator_WorktreePreservedOnFailure(t *testing.T) {
 	t.Parallel()
 	issues := []*tracker.Issue{
 		testIssue("1", "ENG-1", "Feature A"),
@@ -221,9 +221,39 @@ func TestOrchestrator_WorktreeRemovedOnFailure(t *testing.T) {
 	// Wait for subprocess to complete.
 	orch.Wait()
 
-	// On failure the worktree must be cleaned up.
+	// Failed workflows preserve the worktree by default so the operator can
+	// inspect the failure and keep any pushed branch / open PR intact.
+	removed := wtm.getRemoved()
+	require.NotContains(t, removed, "jiradozer/ENG-1")
+
+	preserved := orch.PreservedWorktrees()
+	require.Len(t, preserved, 1)
+	require.Equal(t, "jiradozer/ENG-1", preserved[0].Branch)
+	require.Equal(t, "ENG-1", preserved[0].Issue)
+}
+
+func TestOrchestrator_WorktreeRemovedOnFailureWithForceCleanup(t *testing.T) {
+	t.Parallel()
+	issues := []*tracker.Issue{
+		testIssue("1", "ENG-1", "Feature A"),
+	}
+	wtm := newMockWTManager(t)
+	cfg := testOrchestratorConfig()
+	script := writeIntegrationTestScript(t, "exit 1")
+	orch := newOrchWithScript(t, cfg, wtm, script)
+	orch.SetForceCleanup(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := orch.Start(ctx, issues[0])
+	require.NoError(t, err)
+
+	orch.Wait()
+
 	removed := wtm.getRemoved()
 	require.Contains(t, removed, "jiradozer/ENG-1")
+	require.Empty(t, orch.PreservedWorktrees())
 }
 
 func TestOrchestrator_ConcurrencyLimit(t *testing.T) {

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -583,9 +583,11 @@ func shellQuote(s string) string {
 //     merge it, so the branch must remain until the PR is merged.
 //   - StepCancelled: worktree is preserved by default so in-progress work is
 //     not lost; set forceCleanup to remove it unconditionally.
-//   - StepFailed: worktree is removed so a future retry starts clean.
+//   - StepFailed: worktree is preserved by default so the operator can
+//     inspect the failure and keep any pushed branch / open PR created by
+//     earlier steps; set forceCleanup to wipe it.
 func (o *Orchestrator) cleanup(ctx context.Context, mw *managedWorkflow, step WorkflowStep) {
-	preserve := step == StepDone || (step == StepCancelled && !o.forceCleanup)
+	preserve := step == StepDone || ((step == StepCancelled || step == StepFailed) && !o.forceCleanup)
 	if preserve {
 		o.logger.Info("preserving worktree",
 			"step", step,

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -464,7 +464,12 @@ func TestOrchestrator_CancelWithCleanExit(t *testing.T) {
 	require.Empty(t, removed, "cancelled worktree should not be removed")
 }
 
-func TestOrchestrator_FailedStillCleansUp(t *testing.T) {
+// TestOrchestrator_FailedWorktreePreservedByDefault asserts that a StepFailed
+// workflow preserves its worktree and branches by default. Failing steps
+// often fire mid-workflow after real work exists (pushed branch, open PR);
+// silently deleting that work is destructive. Operators can rerun with
+// --force-cleanup to wipe.
+func TestOrchestrator_FailedWorktreePreservedByDefault(t *testing.T) {
 	cfg := testOrchestratorConfig()
 
 	script := writeTestScript(t, "exit 1")
@@ -485,11 +490,42 @@ func TestOrchestrator_FailedStillCleansUp(t *testing.T) {
 
 	orch.Wait()
 
-	// Failed worktrees should still be cleaned up.
 	wtm.mu.Lock()
 	removed := wtm.removed
 	wtm.mu.Unlock()
-	require.Len(t, removed, 1, "failed worktree should be removed")
+	require.Empty(t, removed, "failed worktree must NOT be removed by default")
+
+	preserved := orch.PreservedWorktrees()
+	require.Len(t, preserved, 1)
+	require.Equal(t, "ENG-1", preserved[0].Issue)
+	require.Equal(t, StepFailed, preserved[0].Step)
+}
+
+func TestOrchestrator_FailedWithForceCleanup(t *testing.T) {
+	cfg := testOrchestratorConfig()
+
+	script := writeTestScript(t, "exit 1")
+	orch, wtm := setupSubprocessOrch(t, cfg, script)
+	orch.SetForceCleanup(true)
+
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	err := orch.Start(context.Background(), issue)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-orch.StatusUpdates():
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for status")
+		}
+	}
+
+	orch.Wait()
+
+	wtm.mu.Lock()
+	removed := wtm.removed
+	wtm.mu.Unlock()
+	require.Len(t, removed, 1, "failed worktree must be removed with --force-cleanup")
 	require.Empty(t, orch.PreservedWorktrees())
 }
 


### PR DESCRIPTION
## Summary

Two fixes for `jiradozer --auto-approve all`, both reproduced by
[`INF-394` log](file:///home/ubuntu/.jiradozer/logs/INF-394-20260420-195721.log).

### 1. `fix(agent-cli-wrapper): clear bg-Bash live flag on task_notification`

Follow-up to #160. A mixed sync+bg turn now correctly clears
`HasLiveBackgroundWork` once `task_notification` (or terminal `task_updated`)
arrives. Previously any bg-Bash tool_use permanently flagged the turn as
live — its launch-receipt `tool_result` (`"Command running in background
with ID: …"`, `IsError=false`) never matches the cancellation check, and
nothing else cleared it.

Repro: in validate round 2 of INF-394, the agent kicked off two
`bramble_ops.py launch … run_in_background=true` tasks. Both exited within
milliseconds and both emitted `task_notification`, but jiradozer still
refused to advance, killed the worktree, and force-closed the already-open
PR #2525.

Mechanism:
- `turnManager.TrackTask` now records `task_id → tool_use_id` on
  `task_started` (captured there because `task_updated` payloads carry
  only `task_id`).
- `UntrackTask` marks the tool_use complete on terminal status.
- `hasLiveBackgroundWork` excludes completed bg tool_uses.

Covered by 3 new tests in `session_bg_test.go` (task_notification path,
task_updated path, and the still-live case between start and terminal).

### 2. `jiradozer: preserve worktree on step failure, not just cancellation`

A failed step often fires mid-workflow after real work exists — a
committed diff, a pushed branch, an open PR from the `create_pr` step.
Silently deleting the worktree, local branch, and remote branch (which
also force-closes the PR) is destructive and throws away hours of agent
work.

New policy:

| Step          | Default    | `--force-cleanup`   |
| ------------- | ---------- | ------------------- |
| StepDone      | preserve   | n/a                 |
| StepCancelled | preserve   | wipe                |
| StepFailed    | **preserve (new)** | wipe        |

`--force-cleanup` help text and the end-of-run operator hint updated to
reflect the new scope.

## Test plan

- [x] `scripts/lint.sh` — clean.
- [x] `bazel test //agent-cli-wrapper/... //jiradozer/... --test_timeout=120` — all 13 targets pass.
- [x] New tests:
  - `TestHasLiveBackgroundWork_BgBashCompletedViaTaskNotification`
  - `TestHasLiveBackgroundWork_BgBashTaskStartedButStillLive`
  - `TestHasLiveBackgroundWork_TerminalTaskUpdatedMarksToolUseComplete`
  - `TestOrchestrator_FailedWorktreePreservedByDefault` (flipped from `TestOrchestrator_FailedStillCleansUp`)
  - `TestOrchestrator_FailedWithForceCleanup`
- [ ] Manual smoke: rerun jiradozer on a ticket whose validate step fails;
      confirm the worktree + local/remote branch still exist after exit and
      that `--force-cleanup` wipes them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn/task tracking and suppression-release logic for background CLI tasks and alters worktree cleanup policy on workflow failure, both of which affect orchestration correctness and resource lifecycle.
> 
> **Overview**
> Fixes a mixed sync+background-turn false positive by teaching the Claude wrapper to mark background `tool_use` blocks as completed when terminal `task_notification`/`task_updated` arrives (including event reordering), so `HasLiveBackgroundWork` clears correctly.
> 
> Updates jiradozer’s worktree lifecycle so `StepFailed` now preserves the worktree/branch by default (matching cancellation), with `--force-cleanup` expanded to delete worktrees for *failed or cancelled* runs; help text, end-of-run messaging, and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47641c296c282c0b424c1ea6f4943503a53f4677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->