### PR TITLE
fix(bramble): hide gone worktrees from dropdown, keep with warning if live sessions

### DIFF
--- a/bramble/app/BUILD.bazel
+++ b/bramble/app/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "update_scroll_test.go",
         "welcome_test.go",
         "width_test.go",
+        "worktree_gone_test.go",
         "worktree_warning_test.go",
     ],
     embed = [":app"],

--- a/bramble/app/dropdown.go
+++ b/bramble/app/dropdown.go
@@ -43,9 +43,12 @@ func NewDropdown(items []DropdownItem) *Dropdown {
 // If the previously selected item is no longer present, the selection falls
 // back to the nearest valid index.
 func (d *Dropdown) SetItems(items []DropdownItem) {
+	// Capture the selected ID before ClearFilter resets filteredIndices.
+	// Use the same indirection as SelectedItem() so filtered dropdowns
+	// resolve the ID from d.items (not the filtered position).
 	var prevID string
-	if d.selectedIdx >= 0 && d.selectedIdx < len(d.items) {
-		prevID = d.items[d.selectedIdx].ID
+	if selected := d.SelectedItem(); selected != nil {
+		prevID = selected.ID
 	}
 	d.items = items
 	d.ClearFilter()

--- a/bramble/app/dropdown.go
+++ b/bramble/app/dropdown.go
@@ -39,10 +39,24 @@ func NewDropdown(items []DropdownItem) *Dropdown {
 	}
 }
 
-// SetItems replaces the dropdown items.
+// SetItems replaces the dropdown items, preserving the selected item by ID.
+// If the previously selected item is no longer present, the selection falls
+// back to the nearest valid index.
 func (d *Dropdown) SetItems(items []DropdownItem) {
+	var prevID string
+	if d.selectedIdx >= 0 && d.selectedIdx < len(d.items) {
+		prevID = d.items[d.selectedIdx].ID
+	}
 	d.items = items
 	d.ClearFilter()
+	if prevID != "" {
+		for i, item := range items {
+			if item.ID == prevID {
+				d.selectedIdx = i
+				return
+			}
+		}
+	}
 	if d.selectedIdx >= len(items) {
 		d.selectedIdx = max(0, len(items)-1)
 	}

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -388,13 +388,21 @@ func (m *Model) updateWorktreeDropdown() {
 		}
 
 		var subtitle string
-		if m.worktreeStatuses != nil {
-			if st, ok := m.worktreeStatuses[w.Branch]; ok {
-				subtitle = formatWorktreeStatus(st, sessionCount, m.styles)
+		// Gone worktrees skip git status (directory is gone; git would silently
+		// fail and produce a misleading "clean" status). Show only session count.
+		if w.IsGone {
+			if sessionCount > 0 {
+				subtitle = m.styles.Dim.Render(fmt.Sprintf("%d sessions", sessionCount))
 			}
-		}
-		if subtitle == "" && sessionCount > 0 {
-			subtitle = m.styles.Dim.Render(fmt.Sprintf("%d sessions", sessionCount))
+		} else {
+			if m.worktreeStatuses != nil {
+				if st, ok := m.worktreeStatuses[w.Branch]; ok {
+					subtitle = formatWorktreeStatus(st, sessionCount, m.styles)
+				}
+			}
+			if subtitle == "" && sessionCount > 0 {
+				subtitle = m.styles.Dim.Render(fmt.Sprintf("%d sessions", sessionCount))
+			}
 		}
 
 		var badge string
@@ -571,7 +579,10 @@ func (m Model) fetchGitStatuses() tea.Cmd {
 	cmds := make([]tea.Cmd, 0, len(m.worktrees))
 	for _, w := range m.worktrees {
 		w := w // capture loop variable
-		if w.IsGone && len(m.sessionManager.GetSessionsForWorktree(w.Path)) == 0 {
+		// Skip gone worktrees entirely: the directory no longer exists, so git
+		// commands silently fail and produce a zero-valued status that renders
+		// as a misleading green "clean" subtitle next to the "(gone)" badge.
+		if w.IsGone {
 			continue
 		}
 		cmds = append(cmds, func() tea.Msg {

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -571,6 +571,9 @@ func (m Model) fetchGitStatuses() tea.Cmd {
 	cmds := make([]tea.Cmd, 0, len(m.worktrees))
 	for _, w := range m.worktrees {
 		w := w // capture loop variable
+		if w.IsGone && len(m.sessionManager.GetSessionsForWorktree(w.Path)) == 0 {
+			continue
+		}
 		cmds = append(cmds, func() tea.Msg {
 			manager := wt.NewManager(wtRoot, repoName)
 			status, err := manager.GetGitStatus(ctx, w)

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -379,17 +379,14 @@ func (m *Model) visibleSessions() []session.SessionInfo {
 func (m *Model) updateWorktreeDropdown() {
 	items := make([]DropdownItem, 0, len(m.worktrees))
 	for _, w := range m.worktrees {
-		// Count live in-memory sessions for this worktree.
 		sessionCount := len(m.sessionManager.GetSessionsForWorktree(w.Path))
 
-		// Gone worktrees with no live sessions are hidden from the dropdown.
+		// Gone worktrees with no live sessions are hidden — surfacing them
+		// would only invite the user to try to open a dead directory.
 		if w.IsGone && sessionCount == 0 {
 			continue
 		}
 
-		label := w.Branch
-
-		// Build subtitle with status details
 		var subtitle string
 		if m.worktreeStatuses != nil {
 			if st, ok := m.worktreeStatuses[w.Branch]; ok {
@@ -400,19 +397,16 @@ func (m *Model) updateWorktreeDropdown() {
 			subtitle = m.styles.Dim.Render(fmt.Sprintf("%d sessions", sessionCount))
 		}
 
+		var badge string
 		if w.IsGone {
-			label = w.Branch + " (gone)"
-			if subtitle == "" {
-				subtitle = m.styles.Failed.Render("directory missing")
-			} else {
-				subtitle = m.styles.Failed.Render("(gone)") + " " + subtitle
-			}
+			badge = m.styles.Failed.Render("(gone)")
 		}
 
 		items = append(items, DropdownItem{
 			ID:       w.Branch,
-			Label:    label,
+			Label:    w.Branch,
 			Subtitle: subtitle,
+			Badge:    badge,
 		})
 	}
 	m.worktreeDropdown.SetItems(items)

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -377,10 +377,15 @@ func (m *Model) visibleSessions() []session.SessionInfo {
 
 // updateWorktreeDropdown updates the worktree dropdown items.
 func (m *Model) updateWorktreeDropdown() {
-	items := make([]DropdownItem, len(m.worktrees))
-	for i, w := range m.worktrees {
-		// Count sessions for badge
+	items := make([]DropdownItem, 0, len(m.worktrees))
+	for _, w := range m.worktrees {
+		// Count live in-memory sessions for this worktree.
 		sessionCount := len(m.sessionManager.GetSessionsForWorktree(w.Path))
+
+		// Gone worktrees with no live sessions are hidden from the dropdown.
+		if w.IsGone && sessionCount == 0 {
+			continue
+		}
 
 		label := w.Branch
 
@@ -395,11 +400,20 @@ func (m *Model) updateWorktreeDropdown() {
 			subtitle = m.styles.Dim.Render(fmt.Sprintf("%d sessions", sessionCount))
 		}
 
-		items[i] = DropdownItem{
+		if w.IsGone {
+			label = w.Branch + " (gone)"
+			if subtitle == "" {
+				subtitle = m.styles.Failed.Render("directory missing")
+			} else {
+				subtitle = m.styles.Failed.Render("(gone)") + " " + subtitle
+			}
+		}
+
+		items = append(items, DropdownItem{
 			ID:       w.Branch,
 			Label:    label,
 			Subtitle: subtitle,
-		}
+		})
 	}
 	m.worktreeDropdown.SetItems(items)
 }

--- a/bramble/app/worktree_gone_test.go
+++ b/bramble/app/worktree_gone_test.go
@@ -41,13 +41,13 @@ func TestUpdateWorktreeDropdown_GoneFiltering(t *testing.T) {
 		}
 	}
 
-	// "main" must be visible with no "(gone)" decoration.
+	// "main" must be visible with no "(gone)" badge.
 	foundMain := false
 	for _, item := range items {
 		if item.ID == "main" {
 			foundMain = true
-			if strings.Contains(item.Label, "gone") {
-				t.Errorf("healthy worktree label should not contain 'gone', got %q", item.Label)
+			if strings.Contains(item.Badge, "gone") {
+				t.Errorf("healthy worktree badge should not contain 'gone', got %q", item.Badge)
 			}
 		}
 	}
@@ -55,13 +55,13 @@ func TestUpdateWorktreeDropdown_GoneFiltering(t *testing.T) {
 		t.Errorf("healthy worktree 'main' missing from dropdown")
 	}
 
-	// "gone-with-sessions" must be visible and labeled with "(gone)".
+	// "gone-with-sessions" must be visible and carry a "(gone)" badge.
 	foundGoneWithSessions := false
 	for _, item := range items {
 		if item.ID == "gone-with-sessions" {
 			foundGoneWithSessions = true
-			if !strings.Contains(item.Label, "gone") {
-				t.Errorf("gone worktree with sessions should have 'gone' in label, got %q", item.Label)
+			if !strings.Contains(item.Badge, "gone") {
+				t.Errorf("gone worktree with sessions should have 'gone' in badge, got %q", item.Badge)
 			}
 		}
 	}

--- a/bramble/app/worktree_gone_test.go
+++ b/bramble/app/worktree_gone_test.go
@@ -70,6 +70,49 @@ func TestUpdateWorktreeDropdown_GoneFiltering(t *testing.T) {
 	}
 }
 
+// TestUpdateWorktreeDropdown_GoneWorktreeSkipsGitStatus verifies that a gone
+// worktree does not render a git-status-derived subtitle (e.g. "clean").
+// GetGitStatus silently ignores errors on missing directories and returns a
+// zero WorktreeStatus, which would otherwise render as a misleading green
+// "clean" badge next to "(gone)". fetchGitStatuses is expected to skip gone
+// worktrees, and updateWorktreeDropdown should not render cached status for
+// them either — we simulate a stale cached status here and assert it's ignored.
+func TestUpdateWorktreeDropdown_GoneWorktreeSkipsGitStatus(t *testing.T) {
+	t.Parallel()
+
+	mgr := session.NewManagerWithConfig(session.ManagerConfig{SessionMode: session.SessionModeTmux})
+	defer mgr.Close()
+
+	m := NewModel(context.Background(), "/tmp/wt", "test-repo", "", mgr, nil, nil, 80, 24, nil, nil, session.ManagerConfig{}, nil)
+
+	m.worktrees = []wt.Worktree{
+		{Path: "/tmp/wt/gone-with-sessions", Branch: "gone-with-sessions", IsGone: true},
+	}
+
+	// Simulate a stale cached status from before the worktree went away.
+	m.worktreeStatuses = map[string]*wt.WorktreeStatus{
+		"gone-with-sessions": {IsDirty: false},
+	}
+
+	if _, err := mgr.TrackTmuxWindow("/tmp/wt/gone-with-sessions", "some-task", "@42"); err != nil {
+		t.Fatalf("TrackTmuxWindow: %v", err)
+	}
+
+	m.updateWorktreeDropdown()
+
+	for _, item := range m.worktreeDropdown.items {
+		if item.ID != "gone-with-sessions" {
+			continue
+		}
+		if strings.Contains(item.Subtitle, "clean") {
+			t.Errorf("gone worktree subtitle must not contain 'clean' (stale git status), got %q", item.Subtitle)
+		}
+		if !strings.Contains(item.Subtitle, "sessions") {
+			t.Errorf("gone worktree subtitle should surface session count, got %q", item.Subtitle)
+		}
+	}
+}
+
 func TestUpdateWorktreeDropdown_PreservesSelection(t *testing.T) {
 	t.Parallel()
 

--- a/bramble/app/worktree_gone_test.go
+++ b/bramble/app/worktree_gone_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bazelment/yoloswe/bramble/session"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+func TestUpdateWorktreeDropdown_GoneFiltering(t *testing.T) {
+	t.Parallel()
+
+	// Use Tmux mode so we can inject a live session via TrackTmuxWindow.
+	mgr := session.NewManagerWithConfig(session.ManagerConfig{SessionMode: session.SessionModeTmux})
+	defer mgr.Close()
+
+	m := NewModel(context.Background(), "/tmp/wt", "test-repo", "", mgr, nil, nil, 80, 24, nil, nil, session.ManagerConfig{}, nil)
+
+	m.worktrees = []wt.Worktree{
+		{Path: "/tmp/wt/main", Branch: "main", IsGone: false},
+		{Path: "/tmp/wt/gone-no-sessions", Branch: "gone-no-sessions", IsGone: true},
+		{Path: "/tmp/wt/gone-with-sessions", Branch: "gone-with-sessions", IsGone: true},
+	}
+
+	// Inject a live session for the gone-with-sessions worktree.
+	_, err := mgr.TrackTmuxWindow("/tmp/wt/gone-with-sessions", "some-task", "@42")
+	if err != nil {
+		t.Fatalf("TrackTmuxWindow: %v", err)
+	}
+
+	m.updateWorktreeDropdown()
+
+	items := m.worktreeDropdown.items
+
+	// "gone-no-sessions" must be hidden.
+	for _, item := range items {
+		if item.ID == "gone-no-sessions" {
+			t.Errorf("gone worktree with no sessions should be hidden from dropdown")
+		}
+	}
+
+	// "main" must be visible with no "(gone)" decoration.
+	foundMain := false
+	for _, item := range items {
+		if item.ID == "main" {
+			foundMain = true
+			if strings.Contains(item.Label, "gone") {
+				t.Errorf("healthy worktree label should not contain 'gone', got %q", item.Label)
+			}
+		}
+	}
+	if !foundMain {
+		t.Errorf("healthy worktree 'main' missing from dropdown")
+	}
+
+	// "gone-with-sessions" must be visible and labeled with "(gone)".
+	foundGoneWithSessions := false
+	for _, item := range items {
+		if item.ID == "gone-with-sessions" {
+			foundGoneWithSessions = true
+			if !strings.Contains(item.Label, "gone") {
+				t.Errorf("gone worktree with sessions should have 'gone' in label, got %q", item.Label)
+			}
+		}
+	}
+	if !foundGoneWithSessions {
+		t.Errorf("gone worktree with live sessions should remain in dropdown")
+	}
+}

--- a/bramble/app/worktree_gone_test.go
+++ b/bramble/app/worktree_gone_test.go
@@ -69,3 +69,36 @@ func TestUpdateWorktreeDropdown_GoneFiltering(t *testing.T) {
 		t.Errorf("gone worktree with live sessions should remain in dropdown")
 	}
 }
+
+func TestUpdateWorktreeDropdown_PreservesSelection(t *testing.T) {
+	t.Parallel()
+
+	mgr := session.NewManagerWithConfig(session.ManagerConfig{SessionMode: session.SessionModeTmux})
+	defer mgr.Close()
+
+	m := NewModel(context.Background(), "/tmp/wt", "test-repo", "", mgr, nil, nil, 80, 24, nil, nil, session.ManagerConfig{}, nil)
+
+	m.worktrees = []wt.Worktree{
+		{Path: "/tmp/wt/main", Branch: "main", IsGone: false},
+		{Path: "/tmp/wt/feature", Branch: "feature", IsGone: false},
+		{Path: "/tmp/wt/gone-no-sessions", Branch: "gone-no-sessions", IsGone: true},
+	}
+
+	m.updateWorktreeDropdown()
+	// Select "feature" (index 1 in the two-item list after filtering)
+	m.worktreeDropdown.SelectByID("feature")
+	if m.worktreeDropdown.SelectedItem() == nil || m.worktreeDropdown.SelectedItem().ID != "feature" {
+		t.Fatal("pre-condition: expected 'feature' to be selected")
+	}
+
+	// Refresh with a new list where "gone-no-sessions" is still filtered.
+	// Item count is unchanged, but SetItems must not drift the index.
+	m.updateWorktreeDropdown()
+	if got := m.worktreeDropdown.SelectedItem(); got == nil || got.ID != "feature" {
+		gotID := "<nil>"
+		if got != nil {
+			gotID = got.ID
+		}
+		t.Errorf("selection after refresh = %q, want %q", gotID, "feature")
+	}
+}

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -30,10 +30,8 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":jiradozer_lib"],
     deps = [
-        "//agent-cli-wrapper/claude/render",
         "//jiradozer",
         "//jiradozer/tracker",
         "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -156,7 +156,6 @@ func (w *Worktree) Name() string {
 	return filepath.Base(w.Path)
 }
 
-// WorktreeStatus contains extended status information.
 // WorktreeStatus holds extended status for a worktree.
 type WorktreeStatus struct {
 	LastCommitTime time.Time

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -146,6 +146,9 @@ type Worktree struct {
 	Branch     string
 	Commit     string
 	IsDetached bool
+	// IsGone is true when git knows about the worktree but its directory no
+	// longer exists on disk (e.g. removed via `rm -rf` or `git worktree remove`).
+	IsGone bool
 }
 
 // Name returns the worktree name (directory name).
@@ -577,7 +580,16 @@ func (m *Manager) List(ctx context.Context) ([]Worktree, error) {
 		return nil, err
 	}
 
-	return parseWorktreeList(result.Stdout), nil
+	worktrees := parseWorktreeList(result.Stdout)
+	for i := range worktrees {
+		if worktrees[i].IsGone {
+			continue
+		}
+		if _, statErr := os.Stat(worktrees[i].Path); os.IsNotExist(statErr) {
+			worktrees[i].IsGone = true
+		}
+	}
+	return worktrees, nil
 }
 
 // parseWorktreeList parses git worktree list --porcelain output.
@@ -601,6 +613,7 @@ func parseWorktreeList(output string) []Worktree {
 					Branch:     branch,
 					Commit:     commit,
 					IsDetached: current["detached"] == "true",
+					IsGone:     current["prunable"] == "true",
 				})
 			}
 			current = make(map[string]string)
@@ -614,6 +627,8 @@ func parseWorktreeList(output string) []Worktree {
 			current["bare"] = "true"
 		} else if line == "detached" {
 			current["detached"] = "true"
+		} else if line == "prunable gitdir file points to non-existent location" || strings.HasPrefix(line, "prunable") {
+			current["prunable"] = "true"
 		}
 	}
 
@@ -632,6 +647,7 @@ func parseWorktreeList(output string) []Worktree {
 			Branch:     branch,
 			Commit:     commit,
 			IsDetached: current["detached"] == "true",
+			IsGone:     current["prunable"] == "true",
 		})
 	}
 

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -597,26 +597,16 @@ func parseWorktreeList(output string) []Worktree {
 	var worktrees []Worktree
 	current := make(map[string]string)
 
+	flush := func() {
+		if w, ok := worktreeFromFields(current); ok {
+			worktrees = append(worktrees, w)
+		}
+		current = make(map[string]string)
+	}
+
 	for _, line := range strings.Split(output, "\n") {
 		if line == "" {
-			if _, isBare := current["bare"]; !isBare && current["worktree"] != "" {
-				branch := strings.TrimPrefix(current["branch"], "refs/heads/")
-				if branch == "" {
-					branch = "(detached)"
-				}
-				commit := current["HEAD"]
-				if len(commit) > 8 {
-					commit = commit[:8]
-				}
-				worktrees = append(worktrees, Worktree{
-					Path:       current["worktree"],
-					Branch:     branch,
-					Commit:     commit,
-					IsDetached: current["detached"] == "true",
-					IsGone:     current["prunable"] == "true",
-				})
-			}
-			current = make(map[string]string)
+			flush()
 		} else if strings.HasPrefix(line, "worktree ") {
 			current["worktree"] = line[9:]
 		} else if strings.HasPrefix(line, "HEAD ") {
@@ -627,31 +617,39 @@ func parseWorktreeList(output string) []Worktree {
 			current["bare"] = "true"
 		} else if line == "detached" {
 			current["detached"] = "true"
-		} else if line == "prunable gitdir file points to non-existent location" || strings.HasPrefix(line, "prunable") {
+		} else if line == "prunable" || strings.HasPrefix(line, "prunable ") {
 			current["prunable"] = "true"
 		}
 	}
-
-	// Handle last entry
-	if _, isBare := current["bare"]; !isBare && current["worktree"] != "" {
-		branch := strings.TrimPrefix(current["branch"], "refs/heads/")
-		if branch == "" {
-			branch = "(detached)"
-		}
-		commit := current["HEAD"]
-		if len(commit) > 8 {
-			commit = commit[:8]
-		}
-		worktrees = append(worktrees, Worktree{
-			Path:       current["worktree"],
-			Branch:     branch,
-			Commit:     commit,
-			IsDetached: current["detached"] == "true",
-			IsGone:     current["prunable"] == "true",
-		})
-	}
+	flush()
 
 	return worktrees
+}
+
+// worktreeFromFields builds a Worktree from a parsed porcelain record.
+// The second return is false for bare repos or empty records, which should be skipped.
+func worktreeFromFields(fields map[string]string) (Worktree, bool) {
+	if _, isBare := fields["bare"]; isBare {
+		return Worktree{}, false
+	}
+	if fields["worktree"] == "" {
+		return Worktree{}, false
+	}
+	branch := strings.TrimPrefix(fields["branch"], "refs/heads/")
+	if branch == "" {
+		branch = "(detached)"
+	}
+	commit := fields["HEAD"]
+	if len(commit) > 8 {
+		commit = commit[:8]
+	}
+	return Worktree{
+		Path:       fields["worktree"],
+		Branch:     branch,
+		Commit:     commit,
+		IsDetached: fields["detached"] == "true",
+		IsGone:     fields["prunable"] == "true",
+	}, true
 }
 
 // GetGitStatus returns local git status for a worktree (no network calls).

--- a/wt/worktree_test.go
+++ b/wt/worktree_test.go
@@ -96,6 +96,79 @@ detached
 	}
 }
 
+func TestParseWorktreeListPrunable(t *testing.T) {
+	output := `worktree /path/to/.bare
+bare
+
+worktree /path/to/main
+HEAD abc1234567890
+branch refs/heads/main
+
+worktree /path/to/gone-branch
+HEAD def5678901234
+branch refs/heads/gone-branch
+prunable gitdir file points to non-existent location
+
+`
+	got := parseWorktreeList(output)
+	if len(got) != 2 {
+		t.Fatalf("len(parseWorktreeList()) = %d, want 2", len(got))
+	}
+	if got[0].IsGone {
+		t.Errorf("worktrees[0].IsGone = true, want false")
+	}
+	if !got[1].IsGone {
+		t.Errorf("worktrees[1].IsGone = false, want true")
+	}
+	if got[1].Branch != "gone-branch" {
+		t.Errorf("worktrees[1].Branch = %q, want %q", got[1].Branch, "gone-branch")
+	}
+}
+
+func TestManagerListIsGoneForMissingDir(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "test-repo")
+	bareDir := filepath.Join(repoDir, ".bare")
+
+	if err := os.MkdirAll(bareDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a real directory for "main" and a non-existent path for "gone".
+	mainDir := filepath.Join(repoDir, "main")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gonePath := filepath.Join(repoDir, "gone-branch")
+	// gonePath is intentionally not created.
+
+	mockGit := NewMockGitRunner()
+	mockGit.Results["worktree list --porcelain"] = &CmdResult{
+		Stdout: "worktree " + bareDir + "\nbare\n\n" +
+			"worktree " + mainDir + "\nHEAD abc1234567890\nbranch refs/heads/main\n\n" +
+			"worktree " + gonePath + "\nHEAD def5678901234\nbranch refs/heads/gone-branch\n\n",
+	}
+
+	output := NewOutput(&bytes.Buffer{}, false)
+	m := NewManager(tmpDir, "test-repo", WithGitRunner(mockGit), WithOutput(output))
+
+	ctx := context.Background()
+	worktrees, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(worktrees) != 2 {
+		t.Fatalf("List() returned %d worktrees, want 2", len(worktrees))
+	}
+	if worktrees[0].IsGone {
+		t.Errorf("worktrees[0] (%q) IsGone = true, want false", worktrees[0].Branch)
+	}
+	if !worktrees[1].IsGone {
+		t.Errorf("worktrees[1] (%q) IsGone = false, want true", worktrees[1].Branch)
+	}
+}
+
 func TestWorktreeName(t *testing.T) {
 	wt := Worktree{Path: "/home/user/worktrees/repo/feature-branch"}
 	if wt.Name() != "feature-branch" {

--- a/wt/worktree_test.go
+++ b/wt/worktree_test.go
@@ -65,6 +65,21 @@ detached
 			},
 		},
 		{
+			name: "prunable gone worktree",
+			output: `worktree /path/to/.bare
+bare
+
+worktree /path/to/gone-branch
+HEAD abc1234567890
+branch refs/heads/gone-branch
+prunable gitdir file points to non-existent location
+
+`,
+			expected: []Worktree{
+				{Path: "/path/to/gone-branch", Branch: "gone-branch", Commit: "abc12345", IsDetached: false, IsGone: true},
+			},
+		},
+		{
 			name:     "empty output",
 			output:   "",
 			expected: nil,
@@ -90,6 +105,9 @@ detached
 				}
 				if w.IsDetached != exp.IsDetached {
 					t.Errorf("worktrees[%d].IsDetached = %v, want %v", i, w.IsDetached, exp.IsDetached)
+				}
+				if w.IsGone != exp.IsGone {
+					t.Errorf("worktrees[%d].IsGone = %v, want %v", i, w.IsGone, exp.IsGone)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- Gone worktrees (directory deleted externally via `wt` or `git worktree remove`) are now hidden from the dropdown by default
- Exception: if a gone worktree still has live in-memory sessions attached, it stays visible with a `(gone)` label suffix and red `(gone)` subtitle prefix so the user knows the directory is missing

## Implementation

**`wt/worktree.go`**
- Added `IsGone bool` to the `Worktree` struct
- `parseWorktreeList()` now detects the `prunable` line from `git worktree list --porcelain` output
- `Manager.List()` additionally runs `os.Stat` on each path after parsing — catches the common case where git hasn't yet run its prune cycle

**`bramble/app/model.go`** — `updateWorktreeDropdown()`
- Gone + no live sessions → skipped (hidden)
- Gone + live sessions → included with `" (gone)"` label suffix and red subtitle decoration

## Tests

- `TestParseWorktreeListPrunable` — `prunable` marker in porcelain output sets `IsGone`
- `TestManagerListIsGoneForMissingDir` — `os.Stat` check marks a deleted directory as gone
- `TestUpdateWorktreeDropdown_GoneFiltering` — verifies all three cases: healthy shown normally, gone+no sessions hidden, gone+sessions shown with marker

## Test plan

- [ ] `bazel build //...` passes
- [ ] `scripts/lint.sh` passes
- [ ] `bazel test //wt:wt_test //bramble/app:app_test` passes
- [ ] Manual: delete a worktree dir externally, confirm it disappears from dropdown on next refresh
- [ ] Manual: delete a worktree dir with an active session, confirm it stays with "(gone)" label

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes worktree discovery/parsing (`git worktree list --porcelain`) and UI dropdown population/selection logic, which could affect navigation and status rendering across repos/worktrees.
> 
> **Overview**
> Improves handling of deleted/missing git worktrees by adding `Worktree.IsGone` in `wt` (parsed from `prunable` porcelain records and via an `os.Stat` check during `Manager.List()`).
> 
> Updates Bramble’s worktree dropdown to **hide gone worktrees with no live sessions**, keep gone worktrees with live sessions visible with a `"(gone)"` badge, and **skip git status fetching/rendering** for gone worktrees to avoid misleading “clean” subtitles. Dropdown `SetItems` now preserves the selected item by ID across refreshes.
> 
> Adds targeted tests for gone worktree filtering, skipping stale git-status subtitles, selection preservation, and porcelain parsing/stat-based gone detection; also trims an unused test dependency in `jiradozer`’s Bazel target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f8111cee094ed2af0878700948f101738348ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->