### PR TITLE
feat(reviewer): add Gemini backend + code-review-eval skill extension

### DIFF
--- a/.claude/skills/code-review-eval/SKILL.md
+++ b/.claude/skills/code-review-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-eval
-description: "Compare bramble code-review output across reviewer configs (cursor with composer-2, codex with gpt-5.4-mini, gemini with gemini-2.5-pro). Runs bramble code-review for each config, compares findings side-by-side, and logs results."
+description: "Compare bramble code-review output across reviewer configs (cursor with composer-2, codex with gpt-5.4-mini, gemini with gemini-3.1-flash-lite-preview). Runs bramble code-review for each config, compares findings side-by-side, and logs results."
 argument-hint: "[branch]"
 ---
 
@@ -15,7 +15,7 @@ then compare their findings side-by-side.
 |------|---------|-------|-------|
 | codex-5.4-mini | codex | gpt-5.4-mini | `--backend codex --model gpt-5.4-mini` |
 | cursor-composer2 | cursor | composer-2 | `--backend cursor --model composer-2` |
-| gemini-2.5-pro | gemini | gemini-2.5-pro | `--backend gemini --model gemini-2.5-pro` |
+| gemini-3.1-flash-lite-preview | gemini | gemini-3.1-flash-lite-preview | `--backend gemini --model gemini-3.1-flash-lite-preview` |
 
 ## Step 1: Build and identify target
 
@@ -63,7 +63,7 @@ After all configs complete, read each output and extract the findings. For each 
 
 Then produce a comparison:
 
-| Finding | cursor-composer2 | codex-5.4-mini | gemini-2.5-pro |
+| Finding | cursor-composer2 | codex-5.4-mini | gemini-3.1-flash-lite-preview |
 |---------|-----------------|----------------|----------------|
 | Issue X | found (medium) | missed | found (high) |
 | Issue Y | missed | found (low) | missed |
@@ -92,13 +92,13 @@ Diff: {N} files, {+/-} lines
 |--------|----------|-----|---------|------------|------|-----------------|
 | cursor-composer2 | N | N | ... | ... | ...s | — |
 | codex-5.4-mini | N | N | ... | ... | ...s | N/N |
-| gemini-2.5-pro | N | N | ... | ... | ...s | — |
+| gemini-3.1-flash-lite-preview | N | N | ... | ... | ...s | — |
 
 Consensus (all 3): ...
 Majority (2 of 3): ...
 Unique to cursor: ...
 Unique to codex-5.4-mini: ...
-Unique to gemini-2.5-pro: ...
+Unique to gemini-3.1-flash-lite-preview: ...
 Disagreements: ...
 ```
 
@@ -114,7 +114,7 @@ Schema note: the `Tokens (in/out)` column was added when Gemini support was intr
 |--------|----------|-----|---------|------|
 | cursor-composer2 | | | | |
 | codex-5.4-mini | | | | |
-| gemini-2.5-pro | | | | |
+| gemini-3.1-flash-lite-preview | | | | |
 
 Best config: ...
 Recommendation: ...

--- a/.claude/skills/code-review-eval/SKILL.md
+++ b/.claude/skills/code-review-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-eval
-description: "Compare bramble code-review output across reviewer configs (cursor with composer-2, codex with gpt-5.4/gpt-5.4-mini). Runs bramble code-review for each config, compares findings side-by-side, and logs results."
+description: "Compare bramble code-review output across reviewer configs (cursor with composer-2, codex with gpt-5.4-mini, gemini with gemini-2.5-pro). Runs bramble code-review for each config, compares findings side-by-side, and logs results."
 argument-hint: "[branch]"
 ---
 
@@ -15,6 +15,7 @@ then compare their findings side-by-side.
 |------|---------|-------|-------|
 | codex-5.4-mini | codex | gpt-5.4-mini | `--backend codex --model gpt-5.4-mini` |
 | cursor-composer2 | cursor | composer-2 | `--backend cursor --model composer-2` |
+| gemini-2.5-pro | gemini | gemini-2.5-pro | `--backend gemini --model gemini-2.5-pro` |
 
 ## Step 1: Build and identify target
 
@@ -33,7 +34,8 @@ git diff $(git merge-base origin/main HEAD)..HEAD --stat
 
 Use the **Monitor tool** for each config. `--envelope-file` writes the final
 ResultEnvelope to a file; stdout carries plain-text progress lines for Monitor to
-stream. Codex defaults to `--read-only`. Cursor has no read-only mode, so run it last.
+stream. Codex defaults to `--read-only`. Cursor and Gemini have no read-only mode,
+so they run with default permissions.
 
 Create a fresh `$LOG_DIR` under `/tmp/code-review-eval-{timestamp}/`. For each config:
 
@@ -44,10 +46,11 @@ WORK_DIR=$(pwd) bazel-bin/bramble/bramble_/bramble code-review \
   2>"$LOG_DIR/{NAME}-stderr.txt"
 ```
 
-Arm all Monitors in the same turn so configs run in parallel. Set Monitor
+Arm all three Monitors in the same turn so configs run in parallel. Set Monitor
 `timeout_ms=600000`. After all Monitors complete, read each `$ENVELOPE_FILE` for the
 ResultEnvelope (`verdict`, `issues[]`, `summary`). Note: codex only reports shell
 command tool calls on stdout; file reads are internal to the codex SDK and not surfaced.
+Gemini reports tool calls via ACP.
 
 ## Step 3: Compare findings
 
@@ -60,14 +63,15 @@ After all configs complete, read each output and extract the findings. For each 
 
 Then produce a comparison:
 
-| Finding | cursor-composer2 | codex-5.4-mini |
-|---------|-----------------|----------------|
-| Issue X | found (medium) | missed |
-| Issue Y | missed | found (low) |
-| FP: ... | flagged | — |
+| Finding | cursor-composer2 | codex-5.4-mini | gemini-2.5-pro |
+|---------|-----------------|----------------|----------------|
+| Issue X | found (medium) | missed | found (high) |
+| Issue Y | missed | found (low) | missed |
+| FP: ... | flagged | — | flagged |
 
 Identify:
-- **Consensus findings**: flagged by both configs (high confidence these are real)
+- **Consensus findings**: flagged by all three configs (high confidence these are real)
+- **Majority findings**: flagged by two of three configs (likely real)
 - **Unique findings**: only one config caught it (investigate — real issue or FP?)
 - **False positives**: findings that are clearly not issues
 - **Disagreements**: findings where configs differ on severity or applicability
@@ -84,16 +88,22 @@ Append to `.claude/skills/code-review-eval/data/eval-runs.log`:
 
 Diff: {N} files, {+/-} lines
 
-| Config | Findings | FPs | Verdict | Confidence | Time |
-|--------|----------|-----|---------|------------|------|
-| cursor-composer2 | N | N | ... | ... | ... |
-| codex-5.4-mini | N | N | ... | ... | ... |
+| Config | Findings | FPs | Verdict | Confidence | Time | Tokens (in/out) |
+|--------|----------|-----|---------|------------|------|-----------------|
+| cursor-composer2 | N | N | ... | ... | ...s | — |
+| codex-5.4-mini | N | N | ... | ... | ...s | N/N |
+| gemini-2.5-pro | N | N | ... | ... | ...s | — |
 
-Consensus: ...
+Consensus (all 3): ...
+Majority (2 of 3): ...
 Unique to cursor: ...
 Unique to codex-5.4-mini: ...
+Unique to gemini-2.5-pro: ...
 Disagreements: ...
 ```
+
+Schema note: the `Tokens (in/out)` column was added when Gemini support was introduced
+(2026-04-21). Historical rows without this column remain valid — treat missing as `—`.
 
 ## Final Summary
 
@@ -102,7 +112,9 @@ Disagreements: ...
 
 | Config | Findings | FPs | Verdict | Time |
 |--------|----------|-----|---------|------|
-| ... | | | | |
+| cursor-composer2 | | | | |
+| codex-5.4-mini | | | | |
+| gemini-2.5-pro | | | | |
 
 Best config: ...
 Recommendation: ...
@@ -116,4 +128,5 @@ Recommendation: ...
 | Reviewer impl | `yoloswe/reviewer/reviewer.go` |
 | Cursor backend | `yoloswe/reviewer/backend_cursor.go` |
 | Codex backend | `yoloswe/reviewer/backend_codex.go` |
+| Gemini backend | `yoloswe/reviewer/backend_gemini.go` |
 | Run history | `.claude/skills/code-review-eval/data/eval-runs.log` |

--- a/.claude/skills/code-review-eval/data/eval-runs.log
+++ b/.claude/skills/code-review-eval/data/eval-runs.log
@@ -514,3 +514,47 @@ Notes:
 - cursor's double-envelope concern (rounds 8+) remains open. A single atomic write would fix it, but the root cause is that `envelopeWritten` isn't set on partial-write failure.
 - Both configs ran in ~175s — unusually tight timing (within 4s of each other). No envelope guard activations.
 - The dual-entrypoint `yoloswe/cmd/code-review/main.go` was NOT raised this round by either reviewer. May have been addressed or deprioritized.
+
+## 2026-04-21 — feature/code-review-gemini (Gemini-only model comparison)
+
+Diff: 10 files, +617/-21 lines (Gemini backend via ACP, integration test, tests)
+
+**Purpose:** Compare three Gemini models for quality and speed — not a multi-backend round.
+
+| Config | Findings | FPs | Verdict | Time | Tokens (in/out) |
+|--------|----------|-----|---------|------|-----------------|
+| gemini-3.1-flash-lite-preview | 0 | 0 | accepted | 31s | — |
+| gemini-3-flash-preview | 2 | 0 | rejected | 145s | — |
+| gemini-3.1-pro-preview | 2 | 0 | accepted | 364s | — |
+
+Envelope guard fired: No — all three received proper envelopes.
+
+gemini-3.1-flash-lite-preview findings: none. Summary: "Implementation appears correct and consistent across the codebase."
+
+gemini-3-flash-preview findings (verdict: rejected):
+1. **high** (`backend_gemini.go:115`): Turn-level errors from `TurnCompleteEvent` not extracted or reported in `ReviewResult.ErrorMessage` — similar to how `backend_cursor.go` handles it. Silent failure risk.
+2. **low** (`backend_cursor.go:202`): `shortPath` helper is private to `backend_cursor.go` but used conceptually by `backend_gemini.go` — suggests moving to a shared location.
+
+gemini-3.1-pro-preview findings (verdict: accepted):
+1. **medium** (`backend_gemini.go:147`): Event adapter normalizes tool names in `ToolCallStartEvent` but not in `ToolCallUpdateEvent` — end events receive unformatted names, mismatching start events in logs.
+2. **low** (`backend_gemini.go:61`): Stderr handler force-appends newline to every non-newline-terminated chunk — progress bars or continuous output emit on separate lines with `[gemini stderr]` prefix.
+
+Consensus (gemini-3-flash + gemini-3.1-pro): none — each model found distinct issues.
+
+Unique to gemini-3-flash-preview: TurnCompleteEvent error not propagated (high — real correctness gap).
+Unique to gemini-3.1-pro-preview: ToolCallUpdateEvent tool name not normalized (medium — logging inconsistency).
+
+**Model comparison:**
+| Model | Speed | Depth | Verdict | Notes |
+|-------|-------|-------|---------|-------|
+| gemini-3.1-flash-lite-preview | 31s (fastest) | shallow | accepted | Found nothing — likely insufficient diff comprehension |
+| gemini-3-flash-preview | 145s | medium | rejected | Found a real correctness bug; showed reasoning trace in stderr |
+| gemini-3.1-pro-preview | 364s (slowest, hit 429 rate-limit retry) | deep | accepted | Found two real issues but graded leniently; most thorough logging analysis |
+
+Notes:
+- gemini-3.1-flash-lite-preview was 4.5× faster than flash but found nothing — likely too shallow for Go code review with substantial diffs.
+- gemini-3-flash-preview found the most actionable issue (TurnComplete error extraction) and was 2.5× faster than pro — best quality/time tradeoff.
+- gemini-3.1-pro-preview hit a 429 rate-limit retry (visible in stderr), contributing to 364s total time. Despite two real findings, it issued "accepted" — lenient verdict calibration.
+- Token counts unavailable for all Gemini runs (not reported by Gemini backend).
+- Gemini backends show reasoning traces on stdout (flash) — useful for understanding why findings were made.
+- The TurnComplete error extraction finding (flash) is the most actionable: real missing defensive code, directly comparable to `backend_cursor.go` pattern.

--- a/bramble/cmd/codereview/codereview.go
+++ b/bramble/cmd/codereview/codereview.go
@@ -37,7 +37,7 @@ var Cmd = &cobra.Command{
 	Short: "Run a one-shot code review using an agent backend",
 	Long: `Run a one-shot code review using an agent backend.
 
-Supported backends: cursor, codex.
+Supported backends: cursor, codex, gemini.
 
 Output:
   Default:         NDJSON progress events on stdout, final envelope also on stdout
@@ -57,7 +57,7 @@ analysis. Set $BRAMBLE_RUN_TAG to tag the log with an external run id.`,
 }
 
 func init() {
-	Cmd.Flags().StringVar(&backend, "backend", "cursor", "Backend: cursor or codex")
+	Cmd.Flags().StringVar(&backend, "backend", "cursor", "Backend: cursor, codex, or gemini")
 	Cmd.Flags().StringVar(&model, "model", "", "Model override (default: backend-specific)")
 	Cmd.Flags().StringVar(&effort, "effort", "", "Reasoning effort level for codex (low, medium, high)")
 	Cmd.Flags().StringVar(&sandbox, "sandbox", "", "Codex sandbox mode: read-only, workspace-write, danger-full-access (default: danger-full-access)")

--- a/yoloswe/reviewer/BUILD.bazel
+++ b/yoloswe/reviewer/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "json_output.go",
         "reviewer.go",
         "runlog.go",
+        "tool_display.go",
     ],
     importpath = "github.com/bazelment/yoloswe/yoloswe/reviewer",
     visibility = ["//visibility:public"],

--- a/yoloswe/reviewer/BUILD.bazel
+++ b/yoloswe/reviewer/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     ],
     embed = [":reviewer"],
     deps = [
+        "//agent-cli-wrapper/acp",
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/codex",
     ],

--- a/yoloswe/reviewer/BUILD.bazel
+++ b/yoloswe/reviewer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "backend.go",
         "backend_codex.go",
         "backend_cursor.go",
+        "backend_gemini.go",
         "json_output.go",
         "reviewer.go",
         "runlog.go",
@@ -13,6 +14,7 @@ go_library(
     importpath = "github.com/bazelment/yoloswe/yoloswe/reviewer",
     visibility = ["//visibility:public"],
     deps = [
+        "//agent-cli-wrapper/acp",
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/claude/render",
         "//agent-cli-wrapper/codex",
@@ -25,6 +27,7 @@ go_test(
     name = "reviewer_test",
     srcs = [
         "backend_cursor_test.go",
+        "backend_gemini_test.go",
         "backend_test.go",
         "bridge_test.go",
         "json_output_test.go",

--- a/yoloswe/reviewer/backend.go
+++ b/yoloswe/reviewer/backend.go
@@ -242,9 +242,11 @@ var sensitiveToolInputKeys = map[string]bool{
 	"path":             true,
 	"file_path":        true,
 	"pattern":          true,
+	"query":            true,
 	"simpleCommands":   true,
 	"parsingResult":    true,
 	"args":             true,
+	"url":              true,
 	"workingDirectory": true,
 }
 

--- a/yoloswe/reviewer/backend.go
+++ b/yoloswe/reviewer/backend.go
@@ -4,11 +4,25 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/agentstream"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 )
+
+// stderrPrefixHandler returns a stderr chunk handler that writes each chunk to
+// os.Stderr tagged with "[prefix stderr] ", ensuring a trailing newline.
+func stderrPrefixHandler(prefix string) func([]byte) {
+	tag := "[" + prefix + " stderr] "
+	return func(data []byte) {
+		os.Stderr.WriteString(tag)
+		os.Stderr.Write(data)
+		if len(data) == 0 || data[len(data)-1] != '\n' {
+			os.Stderr.WriteString("\n")
+		}
+	}
+}
 
 // Backend abstracts the agent lifecycle for different providers.
 type Backend interface {

--- a/yoloswe/reviewer/backend_codex.go
+++ b/yoloswe/reviewer/backend_codex.go
@@ -3,7 +3,6 @@ package reviewer
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/codex"
 )
@@ -23,13 +22,7 @@ func (b *codexBackend) Start(ctx context.Context) error {
 	opts := []codex.ClientOption{
 		codex.WithClientName("codex-review"),
 		codex.WithClientVersion("1.0.0"),
-		codex.WithStderrHandler(func(data []byte) {
-			s := string(data)
-			if s != "" && s[len(s)-1] != '\n' {
-				s += "\n"
-			}
-			fmt.Fprintf(os.Stderr, "[codex stderr] %s", s)
-		}),
+		codex.WithStderrHandler(stderrPrefixHandler("codex")),
 	}
 	// Wire the read-only approval handler at the client level. This is
 	// paired with ApprovalPolicyOnFailure on the thread (set in

--- a/yoloswe/reviewer/backend_cursor.go
+++ b/yoloswe/reviewer/backend_cursor.go
@@ -3,8 +3,6 @@ package reviewer
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/cursor"
@@ -46,13 +44,7 @@ func (b *cursorBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 	// with AppArmor unprivileged userns restrictions (same bwrap issue as
 	// Codex—see Config doc in reviewer.go). With or without --force, the
 	// session ends without result when --sandbox is enabled.
-	opts = append(opts, cursor.WithTrust(), cursor.WithForce(), cursor.WithStderrHandler(func(data []byte) {
-		s := string(data)
-		if s != "" && s[len(s)-1] != '\n' {
-			s += "\n"
-		}
-		fmt.Fprintf(os.Stderr, "[cursor stderr] %s", s)
-	}))
+	opts = append(opts, cursor.WithTrust(), cursor.WithForce(), cursor.WithStderrHandler(stderrPrefixHandler("cursor")))
 
 	events, err := cursor.QueryStream(ctx, prompt, opts...)
 	if err != nil {
@@ -130,80 +122,33 @@ func (a *cursorEventAdapter) filtered(ctx context.Context) <-chan cursor.Event {
 	return out
 }
 
-// cursorToolNames maps Cursor tool call names to short display names.
-var cursorToolNames = map[string]string{
-	"readToolCall":        "read",
-	"shellToolCall":       "shell",
-	"globToolCall":        "glob",
-	"grepToolCall":        "grep",
-	"editToolCall":        "edit",
-	"writeToolCall":       "write",
-	"updateTodosToolCall": "updateTodos",
+// cursorToolDisplay renders Cursor's ToolCall events for terminal output.
+var cursorToolDisplay = toolDisplay{
+	tools: map[string]toolInfo{
+		"readToolCall":        {Display: "read", ArgKey: "path", ArgFormat: argFormatPath},
+		"shellToolCall":       {Display: "shell", ArgKey: "command", ArgFormat: argFormatCommand},
+		"globToolCall":        {Display: "glob", ArgKey: "globPattern", ArgFormat: argFormatPlain},
+		"grepToolCall":        {Display: "grep", ArgKey: "pattern", ArgFormat: argFormatPlain},
+		"editToolCall":        {Display: "edit", ArgKey: "path", ArgFormat: argFormatPath},
+		"writeToolCall":       {Display: "write", ArgKey: "path", ArgFormat: argFormatPath},
+		"updateTodosToolCall": {Display: "updateTodos"},
+	},
+	fallback: cursorFallbackName,
 }
 
-// cursorToolArgKeys maps Cursor tool call names to the most informative arg key.
-var cursorToolArgKeys = map[string]string{
-	"readToolCall":  "path",
-	"shellToolCall": "command",
-	"globToolCall":  "globPattern",
-	"grepToolCall":  "pattern",
-	"editToolCall":  "path",
-	"writeToolCall": "path",
+// cursorFallbackName strips the "ToolCall" suffix and lowercases the first
+// letter; e.g. "listFilesToolCall" → "listFiles".
+func cursorFallbackName(name string) string {
+	if !strings.HasSuffix(name, "ToolCall") {
+		return name
+	}
+	s := strings.TrimSuffix(name, "ToolCall")
+	if s == "" {
+		return name
+	}
+	return strings.ToLower(s[:1]) + s[1:]
 }
 
-// formatCursorToolDisplay formats a cursor tool call into a human-readable display string.
-// e.g. "readToolCall" + {path: "/foo/bar/baz.go"} → "read .../bar/baz.go"
 func formatCursorToolDisplay(name string, input map[string]interface{}) string {
-	displayName, ok := cursorToolNames[name]
-	if !ok {
-		// Strip "ToolCall" suffix and lowercase for unknown tools
-		displayName = name
-		if strings.HasSuffix(displayName, "ToolCall") {
-			displayName = strings.TrimSuffix(displayName, "ToolCall")
-			if displayName != "" {
-				displayName = strings.ToLower(displayName[:1]) + displayName[1:]
-			}
-		}
-	}
-
-	argKey := cursorToolArgKeys[name]
-	if argKey == "" || input == nil {
-		return displayName
-	}
-
-	argVal, ok := input[argKey]
-	if !ok {
-		return displayName
-	}
-
-	argStr, ok := argVal.(string)
-	if !ok || argStr == "" {
-		return displayName
-	}
-
-	// Format the argument value
-	switch argKey {
-	case "path":
-		argStr = shortPath(argStr)
-	case "command":
-		if len(argStr) > 50 {
-			argStr = argStr[:47] + "..."
-		}
-	}
-
-	if name == "shellToolCall" {
-		return displayName + ": " + argStr
-	}
-	return displayName + " " + argStr
-}
-
-// shortPath returns the last 2 path components prefixed with ".../"
-// e.g. "/home/user/project/pkg/file.go" → ".../pkg/file.go"
-func shortPath(p string) string {
-	dir, file := filepath.Split(p)
-	if dir == "" {
-		return file
-	}
-	parent := filepath.Base(filepath.Clean(dir))
-	return ".../" + parent + "/" + file
+	return cursorToolDisplay.format(name, input)
 }

--- a/yoloswe/reviewer/backend_gemini.go
+++ b/yoloswe/reviewer/backend_gemini.go
@@ -9,8 +9,10 @@ import (
 )
 
 // geminiBackend wraps the Gemini ACP client as a Backend.
-// The ACP client is started once in Start() and reused across RunPrompt calls
-// to support multi-turn review via FollowUp.
+// The ACP client process is started once in Start() and kept alive across
+// RunPrompt calls to amortize startup cost. Each RunPrompt creates a new ACP
+// session, so there is no shared conversation context between turns — FollowUp
+// calls start fresh conversations, unlike the codex backend which reuses a thread.
 //
 // # Verified model IDs (tested against live Gemini CLI, 2026-04-21)
 //

--- a/yoloswe/reviewer/backend_gemini.go
+++ b/yoloswe/reviewer/backend_gemini.go
@@ -87,17 +87,32 @@ func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 		}
 	}()
 
-	if _, promptErr := session.Prompt(ctx, prompt); promptErr != nil {
-		return nil, fmt.Errorf("gemini: prompt failed: %w", promptErr)
-	}
+	_, promptErr := session.Prompt(ctx, prompt)
+
+	// Cancel the adapter context to unblock the bridge goroutine regardless
+	// of whether Prompt succeeded or failed, then drain whatever it produced.
+	// This preserves any text or metadata already streamed before the error.
+	adapterCancel()
 
 	var r *bridgeResult
 	select {
 	case r = <-bridged:
 	case err := <-bridgeErr:
+		if promptErr != nil {
+			return nil, fmt.Errorf("gemini: prompt failed: %w (bridge: %v)", promptErr, err)
+		}
 		return nil, fmt.Errorf("gemini: %w", err)
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	}
+
+	if promptErr != nil {
+		return &ReviewResult{
+			ResponseText: r.responseText,
+			Success:      false,
+			DurationMs:   r.durationMs,
+			ErrorMessage: promptErr.Error(),
+		}, fmt.Errorf("gemini: prompt failed: %w", promptErr)
 	}
 
 	if tc, ok := r.turnEvent.(acp.TurnCompleteEvent); ok && tc.Error != nil {

--- a/yoloswe/reviewer/backend_gemini.go
+++ b/yoloswe/reviewer/backend_gemini.go
@@ -9,7 +9,8 @@ import (
 )
 
 // geminiBackend wraps the Gemini ACP client as a Backend.
-// Each RunPrompt call is a one-shot execution (no persistent session).
+// The ACP client is started once in Start() and reused across RunPrompt calls
+// to support multi-turn review via FollowUp.
 //
 // # Verified model IDs (tested against live Gemini CLI, 2026-04-21)
 //
@@ -23,6 +24,7 @@ import (
 //	Loaded cached credentials.
 //	[STARTUP] Phase 'cli_startup' was started but never ended. Skipping metrics.
 type geminiBackend struct {
+	client *acp.Client
 	config Config
 }
 
@@ -30,20 +32,11 @@ func newGeminiBackend(config Config) *geminiBackend {
 	return &geminiBackend{config: config}
 }
 
-func (b *geminiBackend) Start(_ context.Context) error {
-	return nil
-}
-
-func (b *geminiBackend) Stop() error {
-	return nil
-}
-
-func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler EventHandler) (*ReviewResult, error) {
+func (b *geminiBackend) Start(ctx context.Context) error {
 	binaryArgs := []string{"--experimental-acp"}
 	if b.config.Model != "" {
 		binaryArgs = append(binaryArgs, "--model", b.config.Model)
 	}
-
 	client := acp.NewClient(
 		acp.WithClientName("gemini-review"),
 		acp.WithClientVersion("1.0.0"),
@@ -51,16 +44,30 @@ func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 		acp.WithStderrHandler(stderrPrefixHandler("gemini")),
 	)
 	if err := client.Start(ctx); err != nil {
-		return nil, fmt.Errorf("gemini: failed to start ACP client: %w", err)
+		return fmt.Errorf("gemini: failed to start ACP client: %w", err)
 	}
-	defer client.Stop()
+	b.client = client
+	return nil
+}
+
+func (b *geminiBackend) Stop() error {
+	if b.client != nil {
+		return b.client.Stop()
+	}
+	return nil
+}
+
+func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler EventHandler) (*ReviewResult, error) {
+	if b.client == nil {
+		return nil, fmt.Errorf("gemini: backend not started")
+	}
 
 	var sessionOpts []acp.SessionOption
 	if b.config.WorkDir != "" {
 		sessionOpts = append(sessionOpts, acp.WithSessionCWD(b.config.WorkDir))
 	}
 
-	session, err := client.NewSession(ctx, sessionOpts...)
+	session, err := b.client.NewSession(ctx, sessionOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("gemini: failed to create session: %w", err)
 	}
@@ -79,7 +86,7 @@ func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 	bridged := make(chan *bridgeResult, 1)
 	bridgeErr := make(chan error, 1)
 	go func() {
-		r, err := bridgeStreamEvents(adapterCtx, filterGeminiEvents(adapterCtx, client.Events()), handler, "")
+		r, err := bridgeStreamEvents(adapterCtx, filterGeminiEvents(adapterCtx, b.client.Events()), handler, "")
 		if err != nil {
 			bridgeErr <- err
 		} else {
@@ -89,10 +96,11 @@ func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 
 	_, promptErr := session.Prompt(ctx, prompt)
 
-	// Cancel the adapter context to unblock the bridge goroutine regardless
-	// of whether Prompt succeeded or failed, then drain whatever it produced.
-	// This preserves any text or metadata already streamed before the error.
-	adapterCancel()
+	if promptErr != nil {
+		// Cancel the adapter context to unblock the bridge goroutine on the
+		// error path so we can drain any partial output already streamed.
+		adapterCancel()
+	}
 
 	var r *bridgeResult
 	select {

--- a/yoloswe/reviewer/backend_gemini.go
+++ b/yoloswe/reviewer/backend_gemini.go
@@ -11,6 +11,18 @@ import (
 
 // geminiBackend wraps the Gemini ACP client as a Backend.
 // Each RunPrompt call is a one-shot execution (no persistent session).
+//
+// # Verified model IDs (tested against live Gemini CLI, 2026-04-21)
+//
+//   - gemini-3.1-flash-lite-preview: ~670ms turn, working
+//   - gemini-2.5-flash: ~1700ms turn, working
+//
+// # Known stderr noise
+//
+// The Gemini CLI emits these lines on every startup; they are harmless:
+//
+//	Loaded cached credentials.
+//	[STARTUP] Phase 'cli_startup' was started but never ended. Skipping metrics.
 type geminiBackend struct {
 	config Config
 }

--- a/yoloswe/reviewer/backend_gemini.go
+++ b/yoloswe/reviewer/backend_gemini.go
@@ -3,7 +3,6 @@ package reviewer
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
@@ -31,38 +30,26 @@ func newGeminiBackend(config Config) *geminiBackend {
 	return &geminiBackend{config: config}
 }
 
-// Start is a no-op for Gemini (one-shot per prompt via ACP).
 func (b *geminiBackend) Start(_ context.Context) error {
 	return nil
 }
 
-// Stop is a no-op for Gemini (one-shot per prompt via ACP).
 func (b *geminiBackend) Stop() error {
 	return nil
 }
 
 func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler EventHandler) (*ReviewResult, error) {
-	// Build ACP client options. The default binary is "gemini" with
-	// "--experimental-acp"; we override args to also set --model if specified.
 	binaryArgs := []string{"--experimental-acp"}
 	if b.config.Model != "" {
 		binaryArgs = append(binaryArgs, "--model", b.config.Model)
 	}
 
-	opts := []acp.ClientOption{
+	client := acp.NewClient(
 		acp.WithClientName("gemini-review"),
 		acp.WithClientVersion("1.0.0"),
 		acp.WithBinaryArgs(binaryArgs...),
-		acp.WithStderrHandler(func(data []byte) {
-			s := string(data)
-			if s != "" && s[len(s)-1] != '\n' {
-				s += "\n"
-			}
-			fmt.Fprintf(os.Stderr, "[gemini stderr] %s", s)
-		}),
-	}
-
-	client := acp.NewClient(opts...)
+		acp.WithStderrHandler(stderrPrefixHandler("gemini")),
+	)
 	if err := client.Start(ctx); err != nil {
 		return nil, fmt.Errorf("gemini: failed to start ACP client: %w", err)
 	}
@@ -77,26 +64,22 @@ func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 	if err != nil {
 		return nil, fmt.Errorf("gemini: failed to create session: %w", err)
 	}
-
-	// Extract agent info from ClientReadyEvent for OnSessionInfo.
-	// The session ID comes from SessionCreatedEvent; we capture it from
-	// the events channel before prompting, since Prompt blocks until done.
-	sessionID := session.ID()
-
-	// Notify the handler with session info (model may be empty when Gemini picks its own default).
 	if handler != nil {
-		handler.OnSessionInfo(sessionID, b.config.Model)
+		// ACP does not emit a ReadyEvent equivalent with model info; report
+		// what we configured so callers see a stable session start.
+		handler.OnSessionInfo(session.ID(), b.config.Model)
 	}
 
-	// Use a derived context so the adapter goroutine is unblocked on early return.
+	// Derived context unblocks the filter goroutine's sends on early return.
 	adapterCtx, adapterCancel := context.WithCancel(ctx)
 	defer adapterCancel()
 
-	// Start the event adapter goroutine before Prompt (which blocks until turn complete).
-	adapter := &geminiEventAdapter{handler: handler, events: client.Events()}
-	bridged, bridgeErr := make(chan *bridgeResult, 1), make(chan error, 1)
+	// Prompt blocks until turn complete while events are delivered through
+	// the event channel, so the bridge must drain concurrently.
+	bridged := make(chan *bridgeResult, 1)
+	bridgeErr := make(chan error, 1)
 	go func() {
-		r, err := bridgeStreamEvents(adapterCtx, adapter.filtered(adapterCtx), handler, "")
+		r, err := bridgeStreamEvents(adapterCtx, filterGeminiEvents(adapterCtx, client.Events()), handler, "")
 		if err != nil {
 			bridgeErr <- err
 		} else {
@@ -104,55 +87,59 @@ func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler Ev
 		}
 	}()
 
-	result, promptErr := session.Prompt(ctx, prompt)
-	if promptErr != nil {
+	if _, promptErr := session.Prompt(ctx, prompt); promptErr != nil {
 		return nil, fmt.Errorf("gemini: prompt failed: %w", promptErr)
 	}
-	_ = result // bridgeStreamEvents handles TurnComplete
 
-	// Wait for the bridge goroutine to finish processing events.
+	var r *bridgeResult
 	select {
-	case r := <-bridged:
-		return &ReviewResult{
-			ResponseText: r.responseText,
-			Success:      r.success,
-			DurationMs:   r.durationMs,
-		}, nil
+	case r = <-bridged:
 	case err := <-bridgeErr:
 		return nil, fmt.Errorf("gemini: %w", err)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+
+	if tc, ok := r.turnEvent.(acp.TurnCompleteEvent); ok && tc.Error != nil {
+		if handler != nil {
+			handler.OnError(tc.Error, "turn_complete")
+		}
+		return nil, fmt.Errorf("gemini turn failed: %w", tc.Error)
+	}
+
+	return &ReviewResult{
+		ResponseText: r.responseText,
+		Success:      r.success,
+		DurationMs:   r.durationMs,
+	}, nil
 }
 
-// geminiEventAdapter filters ACP events before they reach bridgeStreamEvents.
-// It handles ClientReadyEvent and SessionCreatedEvent out-of-band and
-// normalizes Gemini tool names for display.
-type geminiEventAdapter struct {
-	handler EventHandler
-	events  <-chan acp.Event
-}
-
-// filtered returns a channel that re-emits ACP events as acp.Event,
-// handling infrastructure events separately and normalizing tool names.
-func (a *geminiEventAdapter) filtered(ctx context.Context) <-chan acp.Event {
+// filterGeminiEvents re-emits ACP events, dropping infrastructure events
+// (ClientReady/SessionCreated) and normalizing tool names on start/update
+// events so the bridge and downstream renderer see the display name.
+func filterGeminiEvents(ctx context.Context, events <-chan acp.Event) <-chan acp.Event {
 	out := make(chan acp.Event)
 	go func() {
 		defer close(out)
-		for ev := range a.events {
-			switch e := ev.(type) {
-			case acp.ClientReadyEvent, acp.SessionCreatedEvent:
-				// Infrastructure events: not part of agentstream; drop silently.
-				_ = e
-			case acp.ToolCallStartEvent:
-				// Normalize Gemini tool names before bridge sees them.
-				e.ToolName = formatGeminiToolDisplay(e.ToolName, e.Input)
-				select {
-				case out <- e:
-				case <-ctx.Done():
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-events:
+				if !ok {
 					return
 				}
-			default:
+				switch e := ev.(type) {
+				case acp.ClientReadyEvent, acp.SessionCreatedEvent:
+					// agentstream.KindUnknown; bridge would drop anyway.
+					continue
+				case acp.ToolCallStartEvent:
+					e.ToolName = formatGeminiToolDisplay(e.ToolName, e.Input)
+					ev = e
+				case acp.ToolCallUpdateEvent:
+					e.ToolName = formatGeminiToolDisplay(e.ToolName, e.Input)
+					ev = e
+				}
 				select {
 				case out <- ev:
 				case <-ctx.Done():
@@ -164,98 +151,35 @@ func (a *geminiEventAdapter) filtered(ctx context.Context) <-chan acp.Event {
 	return out
 }
 
-// geminiToolNames maps Gemini CLI tool names to short display names.
-var geminiToolNames = map[string]string{
-	"read_file":   "read",
-	"write_file":  "write",
-	"run_shell":   "shell",
-	"list_dir":    "ls",
-	"glob":        "glob",
-	"grep":        "grep",
-	"edit":        "edit",
-	"search":      "search",
-	"web_fetch":   "fetch",
-	"web_search":  "search",
-	"view_file":   "read",
-	"create_file": "write",
-	"delete_file": "delete",
-	"rename_file": "rename",
-	"list_files":  "ls",
-	"bash":        "shell",
-	"python":      "python",
+// geminiToolDisplay renders Gemini's ACP tool calls for terminal output.
+// Entries here reflect tools observed in live Gemini CLI runs; unknown names
+// fall through to geminiFallbackName (strip _file/_text/_dir).
+var geminiToolDisplay = toolDisplay{
+	tools: map[string]toolInfo{
+		"read_file":  {Display: "read", ArgKey: "path", ArgFormat: argFormatPath},
+		"write_file": {Display: "write", ArgKey: "path", ArgFormat: argFormatPath},
+		"edit":       {Display: "edit", ArgKey: "path", ArgFormat: argFormatPath},
+		"list_dir":   {Display: "ls", ArgKey: "path", ArgFormat: argFormatPath},
+		"run_shell":  {Display: "shell", ArgKey: "command", ArgFormat: argFormatCommand},
+		"bash":       {Display: "shell", ArgKey: "command", ArgFormat: argFormatCommand},
+		"glob":       {Display: "glob", ArgKey: "pattern", ArgFormat: argFormatPlain},
+		"grep":       {Display: "grep", ArgKey: "pattern", ArgFormat: argFormatPlain},
+		"web_fetch":  {Display: "fetch", ArgKey: "url", ArgFormat: argFormatLongIdentifier},
+		"web_search": {Display: "search", ArgKey: "query", ArgFormat: argFormatQuery},
+	},
+	fallback: geminiFallbackName,
 }
 
-// geminiToolArgKeys maps Gemini tool names to the most informative input key.
-var geminiToolArgKeys = map[string]string{
-	"read_file":   "path",
-	"write_file":  "path",
-	"view_file":   "path",
-	"create_file": "path",
-	"delete_file": "path",
-	"rename_file": "old_path",
-	"run_shell":   "command",
-	"bash":        "command",
-	"python":      "code",
-	"glob":        "pattern",
-	"grep":        "pattern",
-	"search":      "query",
-	"web_fetch":   "url",
-	"web_search":  "query",
-	"list_dir":    "path",
-	"list_files":  "path",
-	"edit":        "path",
-}
-
-// formatGeminiToolDisplay formats a Gemini tool call into a human-readable string.
-// e.g. "read_file" + {path: "/foo/bar/baz.go"} → "read .../bar/baz.go"
-func formatGeminiToolDisplay(name string, input map[string]interface{}) string {
-	displayName, ok := geminiToolNames[name]
-	if !ok {
-		// Convert snake_case to camelCase-ish short form for unknown tools.
-		displayName = geminiShortName(name)
-	}
-
-	argKey := geminiToolArgKeys[name]
-	if argKey == "" || input == nil {
-		return displayName
-	}
-
-	argVal, ok := input[argKey]
-	if !ok {
-		return displayName
-	}
-
-	argStr, ok := argVal.(string)
-	if !ok || argStr == "" {
-		return displayName
-	}
-
-	switch argKey {
-	case "path", "old_path":
-		argStr = shortPath(argStr)
-	case "command", "code":
-		if len(argStr) > 50 {
-			argStr = argStr[:47] + "..."
-		}
-	case "url", "query":
-		if len(argStr) > 60 {
-			argStr = argStr[:57] + "..."
-		}
-	}
-
-	if argKey == "command" || argKey == "code" {
-		return displayName + ": " + argStr
-	}
-	return displayName + " " + argStr
-}
-
-// geminiShortName converts a snake_case tool name to a compact display name.
-func geminiShortName(name string) string {
-	// Strip trailing _file, _text, _dir suffixes for brevity
+// geminiFallbackName trims common suffixes from snake_case tool names.
+func geminiFallbackName(name string) string {
 	for _, suffix := range []string{"_file", "_text", "_dir"} {
 		if strings.HasSuffix(name, suffix) {
 			return strings.TrimSuffix(name, suffix)
 		}
 	}
 	return name
+}
+
+func formatGeminiToolDisplay(name string, input map[string]interface{}) string {
+	return geminiToolDisplay.format(name, input)
 }

--- a/yoloswe/reviewer/backend_gemini.go
+++ b/yoloswe/reviewer/backend_gemini.go
@@ -1,0 +1,249 @@
+package reviewer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
+)
+
+// geminiBackend wraps the Gemini ACP client as a Backend.
+// Each RunPrompt call is a one-shot execution (no persistent session).
+type geminiBackend struct {
+	config Config
+}
+
+func newGeminiBackend(config Config) *geminiBackend {
+	return &geminiBackend{config: config}
+}
+
+// Start is a no-op for Gemini (one-shot per prompt via ACP).
+func (b *geminiBackend) Start(_ context.Context) error {
+	return nil
+}
+
+// Stop is a no-op for Gemini (one-shot per prompt via ACP).
+func (b *geminiBackend) Stop() error {
+	return nil
+}
+
+func (b *geminiBackend) RunPrompt(ctx context.Context, prompt string, handler EventHandler) (*ReviewResult, error) {
+	// Build ACP client options. The default binary is "gemini" with
+	// "--experimental-acp"; we override args to also set --model if specified.
+	binaryArgs := []string{"--experimental-acp"}
+	if b.config.Model != "" {
+		binaryArgs = append(binaryArgs, "--model", b.config.Model)
+	}
+
+	opts := []acp.ClientOption{
+		acp.WithClientName("gemini-review"),
+		acp.WithClientVersion("1.0.0"),
+		acp.WithBinaryArgs(binaryArgs...),
+		acp.WithStderrHandler(func(data []byte) {
+			s := string(data)
+			if s != "" && s[len(s)-1] != '\n' {
+				s += "\n"
+			}
+			fmt.Fprintf(os.Stderr, "[gemini stderr] %s", s)
+		}),
+	}
+
+	client := acp.NewClient(opts...)
+	if err := client.Start(ctx); err != nil {
+		return nil, fmt.Errorf("gemini: failed to start ACP client: %w", err)
+	}
+	defer client.Stop()
+
+	var sessionOpts []acp.SessionOption
+	if b.config.WorkDir != "" {
+		sessionOpts = append(sessionOpts, acp.WithSessionCWD(b.config.WorkDir))
+	}
+
+	session, err := client.NewSession(ctx, sessionOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: failed to create session: %w", err)
+	}
+
+	// Extract agent info from ClientReadyEvent for OnSessionInfo.
+	// The session ID comes from SessionCreatedEvent; we capture it from
+	// the events channel before prompting, since Prompt blocks until done.
+	sessionID := session.ID()
+
+	// Notify the handler with session info (model may be empty when Gemini picks its own default).
+	if handler != nil {
+		handler.OnSessionInfo(sessionID, b.config.Model)
+	}
+
+	// Use a derived context so the adapter goroutine is unblocked on early return.
+	adapterCtx, adapterCancel := context.WithCancel(ctx)
+	defer adapterCancel()
+
+	// Start the event adapter goroutine before Prompt (which blocks until turn complete).
+	adapter := &geminiEventAdapter{handler: handler, events: client.Events()}
+	bridged, bridgeErr := make(chan *bridgeResult, 1), make(chan error, 1)
+	go func() {
+		r, err := bridgeStreamEvents(adapterCtx, adapter.filtered(adapterCtx), handler, "")
+		if err != nil {
+			bridgeErr <- err
+		} else {
+			bridged <- r
+		}
+	}()
+
+	result, promptErr := session.Prompt(ctx, prompt)
+	if promptErr != nil {
+		return nil, fmt.Errorf("gemini: prompt failed: %w", promptErr)
+	}
+	_ = result // bridgeStreamEvents handles TurnComplete
+
+	// Wait for the bridge goroutine to finish processing events.
+	select {
+	case r := <-bridged:
+		return &ReviewResult{
+			ResponseText: r.responseText,
+			Success:      r.success,
+			DurationMs:   r.durationMs,
+		}, nil
+	case err := <-bridgeErr:
+		return nil, fmt.Errorf("gemini: %w", err)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// geminiEventAdapter filters ACP events before they reach bridgeStreamEvents.
+// It handles ClientReadyEvent and SessionCreatedEvent out-of-band and
+// normalizes Gemini tool names for display.
+type geminiEventAdapter struct {
+	handler EventHandler
+	events  <-chan acp.Event
+}
+
+// filtered returns a channel that re-emits ACP events as acp.Event,
+// handling infrastructure events separately and normalizing tool names.
+func (a *geminiEventAdapter) filtered(ctx context.Context) <-chan acp.Event {
+	out := make(chan acp.Event)
+	go func() {
+		defer close(out)
+		for ev := range a.events {
+			switch e := ev.(type) {
+			case acp.ClientReadyEvent, acp.SessionCreatedEvent:
+				// Infrastructure events: not part of agentstream; drop silently.
+				_ = e
+			case acp.ToolCallStartEvent:
+				// Normalize Gemini tool names before bridge sees them.
+				e.ToolName = formatGeminiToolDisplay(e.ToolName, e.Input)
+				select {
+				case out <- e:
+				case <-ctx.Done():
+					return
+				}
+			default:
+				select {
+				case out <- ev:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out
+}
+
+// geminiToolNames maps Gemini CLI tool names to short display names.
+var geminiToolNames = map[string]string{
+	"read_file":   "read",
+	"write_file":  "write",
+	"run_shell":   "shell",
+	"list_dir":    "ls",
+	"glob":        "glob",
+	"grep":        "grep",
+	"edit":        "edit",
+	"search":      "search",
+	"web_fetch":   "fetch",
+	"web_search":  "search",
+	"view_file":   "read",
+	"create_file": "write",
+	"delete_file": "delete",
+	"rename_file": "rename",
+	"list_files":  "ls",
+	"bash":        "shell",
+	"python":      "python",
+}
+
+// geminiToolArgKeys maps Gemini tool names to the most informative input key.
+var geminiToolArgKeys = map[string]string{
+	"read_file":   "path",
+	"write_file":  "path",
+	"view_file":   "path",
+	"create_file": "path",
+	"delete_file": "path",
+	"rename_file": "old_path",
+	"run_shell":   "command",
+	"bash":        "command",
+	"python":      "code",
+	"glob":        "pattern",
+	"grep":        "pattern",
+	"search":      "query",
+	"web_fetch":   "url",
+	"web_search":  "query",
+	"list_dir":    "path",
+	"list_files":  "path",
+	"edit":        "path",
+}
+
+// formatGeminiToolDisplay formats a Gemini tool call into a human-readable string.
+// e.g. "read_file" + {path: "/foo/bar/baz.go"} → "read .../bar/baz.go"
+func formatGeminiToolDisplay(name string, input map[string]interface{}) string {
+	displayName, ok := geminiToolNames[name]
+	if !ok {
+		// Convert snake_case to camelCase-ish short form for unknown tools.
+		displayName = geminiShortName(name)
+	}
+
+	argKey := geminiToolArgKeys[name]
+	if argKey == "" || input == nil {
+		return displayName
+	}
+
+	argVal, ok := input[argKey]
+	if !ok {
+		return displayName
+	}
+
+	argStr, ok := argVal.(string)
+	if !ok || argStr == "" {
+		return displayName
+	}
+
+	switch argKey {
+	case "path", "old_path":
+		argStr = shortPath(argStr)
+	case "command", "code":
+		if len(argStr) > 50 {
+			argStr = argStr[:47] + "..."
+		}
+	case "url", "query":
+		if len(argStr) > 60 {
+			argStr = argStr[:57] + "..."
+		}
+	}
+
+	if argKey == "command" || argKey == "code" {
+		return displayName + ": " + argStr
+	}
+	return displayName + " " + argStr
+}
+
+// geminiShortName converts a snake_case tool name to a compact display name.
+func geminiShortName(name string) string {
+	// Strip trailing _file, _text, _dir suffixes for brevity
+	for _, suffix := range []string{"_file", "_text", "_dir"} {
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix)
+		}
+	}
+	return name
+}

--- a/yoloswe/reviewer/backend_gemini_test.go
+++ b/yoloswe/reviewer/backend_gemini_test.go
@@ -125,7 +125,7 @@ func TestFormatGeminiToolDisplay(t *testing.T) {
 	}
 }
 
-func TestGeminiShortName(t *testing.T) {
+func TestGeminiFallbackName(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -140,9 +140,9 @@ func TestGeminiShortName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := geminiShortName(tt.input)
+			got := geminiFallbackName(tt.input)
 			if got != tt.want {
-				t.Errorf("geminiShortName(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("geminiFallbackName(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -156,7 +156,6 @@ func TestNewGeminiBackend_StartsAndStopsCleanly(t *testing.T) {
 	if b == nil {
 		t.Fatal("expected non-nil backend")
 	}
-	// Start and Stop are no-ops for Gemini
 	if err := b.Start(nil); err != nil { //nolint:staticcheck
 		t.Errorf("Start should be no-op, got error: %v", err)
 	}

--- a/yoloswe/reviewer/backend_gemini_test.go
+++ b/yoloswe/reviewer/backend_gemini_test.go
@@ -246,7 +246,7 @@ func TestFilterGeminiEvents_ContextCancellation(t *testing.T) {
 	}
 }
 
-func TestNewGeminiBackend_StartsAndStopsCleanly(t *testing.T) {
+func TestNewGeminiBackend_StopBeforeStartIsNoop(t *testing.T) {
 	b := newGeminiBackend(Config{
 		BackendType: BackendGemini,
 		Model:       "gemini-2.5-pro",
@@ -254,10 +254,8 @@ func TestNewGeminiBackend_StartsAndStopsCleanly(t *testing.T) {
 	if b == nil {
 		t.Fatal("expected non-nil backend")
 	}
-	if err := b.Start(nil); err != nil { //nolint:staticcheck
-		t.Errorf("Start should be no-op, got error: %v", err)
-	}
+	// Stop before Start must be safe (client is nil).
 	if err := b.Stop(); err != nil {
-		t.Errorf("Stop should be no-op, got error: %v", err)
+		t.Errorf("Stop before Start should be no-op, got error: %v", err)
 	}
 }

--- a/yoloswe/reviewer/backend_gemini_test.go
+++ b/yoloswe/reviewer/backend_gemini_test.go
@@ -1,0 +1,166 @@
+package reviewer
+
+import (
+	"testing"
+)
+
+func TestFormatGeminiToolDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		input    map[string]interface{}
+		want     string
+	}{
+		{
+			name:     "read_file with path",
+			toolName: "read_file",
+			input:    map[string]interface{}{"path": "/home/user/project/pkg/file.go"},
+			want:     "read .../pkg/file.go",
+		},
+		{
+			name:     "write_file with path",
+			toolName: "write_file",
+			input:    map[string]interface{}{"path": "/home/user/project/main.go"},
+			want:     "write .../project/main.go",
+		},
+		{
+			name:     "run_shell with command",
+			toolName: "run_shell",
+			input:    map[string]interface{}{"command": "git diff HEAD~1"},
+			want:     "shell: git diff HEAD~1",
+		},
+		{
+			name:     "run_shell with long command truncated",
+			toolName: "run_shell",
+			input:    map[string]interface{}{"command": "git diff HEAD~1 --name-only -- some/very/long/path/that/exceeds/limit"},
+			want:     "shell: git diff HEAD~1 --name-only -- some/very/long/p...",
+		},
+		{
+			name:     "bash with command",
+			toolName: "bash",
+			input:    map[string]interface{}{"command": "ls -la"},
+			want:     "shell: ls -la",
+		},
+		{
+			name:     "glob with pattern",
+			toolName: "glob",
+			input:    map[string]interface{}{"pattern": "**/*.go"},
+			want:     "glob **/*.go",
+		},
+		{
+			name:     "grep with pattern",
+			toolName: "grep",
+			input:    map[string]interface{}{"pattern": "ParseMessage"},
+			want:     "grep ParseMessage",
+		},
+		{
+			name:     "list_dir with path",
+			toolName: "list_dir",
+			input:    map[string]interface{}{"path": "/home/user/project"},
+			want:     "ls .../user/project",
+		},
+		{
+			name:     "web_fetch with url",
+			toolName: "web_fetch",
+			input:    map[string]interface{}{"url": "https://example.com/api"},
+			want:     "fetch https://example.com/api",
+		},
+		{
+			name:     "web_search with long query truncated",
+			toolName: "web_search",
+			input:    map[string]interface{}{"query": "this is a very long search query that exceeds the limit set by our formatter implementation"},
+			want:     "search this is a very long search query that exceeds the limit s...",
+		},
+		{
+			name:     "unknown tool with _file suffix",
+			toolName: "custom_file",
+			input:    nil,
+			want:     "custom",
+		},
+		{
+			name:     "unknown tool without suffix",
+			toolName: "custom_thing",
+			input:    nil,
+			want:     "custom_thing",
+		},
+		{
+			name:     "read_file with nil input",
+			toolName: "read_file",
+			input:    nil,
+			want:     "read",
+		},
+		{
+			name:     "read_file with missing path key",
+			toolName: "read_file",
+			input:    map[string]interface{}{"other": "value"},
+			want:     "read",
+		},
+		{
+			name:     "read_file with empty path",
+			toolName: "read_file",
+			input:    map[string]interface{}{"path": ""},
+			want:     "read",
+		},
+		{
+			name:     "read_file with non-string path",
+			toolName: "read_file",
+			input:    map[string]interface{}{"path": 42},
+			want:     "read",
+		},
+		{
+			name:     "edit with path",
+			toolName: "edit",
+			input:    map[string]interface{}{"path": "/home/user/project/session.go"},
+			want:     "edit .../project/session.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatGeminiToolDisplay(tt.toolName, tt.input)
+			if got != tt.want {
+				t.Errorf("formatGeminiToolDisplay(%q, %v) = %q, want %q", tt.toolName, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiShortName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"create_file", "create"},
+		{"delete_file", "delete"},
+		{"read_text", "read"},
+		{"list_dir", "list"},
+		{"custom_thing", "custom_thing"},
+		{"tool", "tool"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := geminiShortName(tt.input)
+			if got != tt.want {
+				t.Errorf("geminiShortName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewGeminiBackend_StartsAndStopsCleanly(t *testing.T) {
+	b := newGeminiBackend(Config{
+		BackendType: BackendGemini,
+		Model:       "gemini-2.5-pro",
+	})
+	if b == nil {
+		t.Fatal("expected non-nil backend")
+	}
+	// Start and Stop are no-ops for Gemini
+	if err := b.Start(nil); err != nil { //nolint:staticcheck
+		t.Errorf("Start should be no-op, got error: %v", err)
+	}
+	if err := b.Stop(); err != nil {
+		t.Errorf("Stop should be no-op, got error: %v", err)
+	}
+}

--- a/yoloswe/reviewer/backend_gemini_test.go
+++ b/yoloswe/reviewer/backend_gemini_test.go
@@ -1,7 +1,10 @@
 package reviewer
 
 import (
+	"context"
 	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
 )
 
 func TestFormatGeminiToolDisplay(t *testing.T) {
@@ -145,6 +148,101 @@ func TestGeminiFallbackName(t *testing.T) {
 				t.Errorf("geminiFallbackName(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func makeGeminiEventChan(events ...acp.Event) <-chan acp.Event {
+	ch := make(chan acp.Event, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch
+}
+
+func collectFilteredGeminiEvents(ctx context.Context, events ...acp.Event) []acp.Event {
+	out := filterGeminiEvents(ctx, makeGeminiEventChan(events...))
+	var result []acp.Event
+	for e := range out {
+		result = append(result, e)
+	}
+	return result
+}
+
+func TestFilterGeminiEvents_DropsInfrastructureEvents(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	got := collectFilteredGeminiEvents(ctx,
+		acp.ClientReadyEvent{AgentName: "gemini"},
+		acp.SessionCreatedEvent{SessionID: "s1"},
+		acp.TextDeltaEvent{Delta: "hello"},
+	)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d: %v", len(got), got)
+	}
+	if _, ok := got[0].(acp.TextDeltaEvent); !ok {
+		t.Errorf("expected TextDeltaEvent, got %T", got[0])
+	}
+}
+
+func TestFilterGeminiEvents_NormalizesToolCallStartName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	got := collectFilteredGeminiEvents(ctx,
+		acp.ToolCallStartEvent{
+			ToolName: "read_file",
+			Input:    map[string]interface{}{"path": "/a/b/c.go"},
+		},
+	)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(got))
+	}
+	e, ok := got[0].(acp.ToolCallStartEvent)
+	if !ok {
+		t.Fatalf("expected ToolCallStartEvent, got %T", got[0])
+	}
+	if e.ToolName != "read .../b/c.go" {
+		t.Errorf("ToolName = %q, want %q", e.ToolName, "read .../b/c.go")
+	}
+}
+
+func TestFilterGeminiEvents_NormalizesToolCallUpdateName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	got := collectFilteredGeminiEvents(ctx,
+		acp.ToolCallUpdateEvent{
+			ToolName: "run_shell",
+			Input:    map[string]interface{}{"command": "ls"},
+			Status:   "completed",
+		},
+	)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(got))
+	}
+	e, ok := got[0].(acp.ToolCallUpdateEvent)
+	if !ok {
+		t.Fatalf("expected ToolCallUpdateEvent, got %T", got[0])
+	}
+	if e.ToolName != "shell: ls" {
+		t.Errorf("ToolName = %q, want %q", e.ToolName, "shell: ls")
+	}
+}
+
+func TestFilterGeminiEvents_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	// A blocked (non-buffered, never written) channel should drain immediately
+	// because the context is already cancelled.
+	in := make(chan acp.Event)
+	out := filterGeminiEvents(ctx, in)
+	var got []acp.Event
+	for e := range out {
+		got = append(got, e)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 events with cancelled context, got %d", len(got))
 	}
 }
 

--- a/yoloswe/reviewer/integration/reviewer_test.go
+++ b/yoloswe/reviewer/integration/reviewer_test.go
@@ -4,11 +4,14 @@ package integration
 
 import (
 	"context"
+	"flag"
 	"testing"
 	"time"
 
 	"github.com/bazelment/yoloswe/yoloswe/reviewer"
 )
+
+var geminiModel = flag.String("gemini-model", reviewer.DefaultGeminiModel, "Gemini model ID to use in integration tests")
 
 // TestReviewWithResult_Codex tests that a simple review round-trip completes
 // within a reasonable time using the codex backend.
@@ -85,7 +88,7 @@ func TestReviewWithResult_Cursor(t *testing.T) {
 func TestReviewWithResult_Gemini(t *testing.T) {
 	config := reviewer.Config{
 		BackendType: reviewer.BackendGemini,
-		Model:       "gemini-2.5-flash",
+		Model:       *geminiModel,
 		WorkDir:     t.TempDir(),
 		Verbose:     true,
 	}

--- a/yoloswe/reviewer/integration/reviewer_test.go
+++ b/yoloswe/reviewer/integration/reviewer_test.go
@@ -78,3 +78,39 @@ func TestReviewWithResult_Cursor(t *testing.T) {
 
 	t.Logf("Review completed in %v (response length: %d chars)", elapsed, len(result.ResponseText))
 }
+
+// TestReviewWithResult_Gemini tests that a simple review round-trip completes
+// within a reasonable time using the gemini backend via ACP.
+// Requires the "gemini" CLI to be installed and authenticated.
+func TestReviewWithResult_Gemini(t *testing.T) {
+	config := reviewer.Config{
+		BackendType: reviewer.BackendGemini,
+		Model:       "gemini-2.5-flash",
+		WorkDir:     t.TempDir(),
+		Verbose:     true,
+	}
+
+	r := reviewer.New(config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if err := r.Start(ctx); err != nil {
+		t.Fatalf("Failed to start reviewer: %v", err)
+	}
+	defer r.Stop()
+
+	start := time.Now()
+	result, err := r.ReviewWithResult(ctx, "Say 'hello' and nothing else.")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ReviewWithResult failed after %v: %v", elapsed, err)
+	}
+
+	if result.ResponseText == "" {
+		t.Fatal("Expected non-empty response text")
+	}
+
+	t.Logf("Review completed in %v (response length: %d chars)", elapsed, len(result.ResponseText))
+}

--- a/yoloswe/reviewer/json_output_test.go
+++ b/yoloswe/reviewer/json_output_test.go
@@ -265,15 +265,15 @@ func TestBuildEnvelope_GeminiBackend(t *testing.T) {
 		Success:      true,
 		DurationMs:   5000,
 	}
-	env := BuildEnvelope(result, BackendGemini, "gemini-2.5-pro", "sess-gemini-1")
+	env := BuildEnvelope(result, BackendGemini, "gemini-3.1-flash-lite-preview", "sess-gemini-1")
 	if env.Status != StatusOK {
 		t.Errorf("status = %s, want ok", env.Status)
 	}
 	if env.Backend != "gemini" {
 		t.Errorf("backend = %q, want gemini", env.Backend)
 	}
-	if env.Model != "gemini-2.5-pro" {
-		t.Errorf("model = %q, want gemini-2.5-pro", env.Model)
+	if env.Model != "gemini-3.1-flash-lite-preview" {
+		t.Errorf("model = %q, want gemini-3.1-flash-lite-preview", env.Model)
 	}
 	if env.SessionID != "sess-gemini-1" {
 		t.Errorf("session_id = %q, want sess-gemini-1", env.SessionID)
@@ -291,7 +291,7 @@ func TestBuildEnvelope_GeminiBackendError(t *testing.T) {
 		ErrorMessage: "gemini: ACP client failed to start",
 		Success:      false,
 	}
-	env := BuildEnvelope(result, BackendGemini, "gemini-2.5-pro", "")
+	env := BuildEnvelope(result, BackendGemini, "gemini-3.1-flash-lite-preview", "")
 	if env.Status != StatusError {
 		t.Errorf("status = %s, want error", env.Status)
 	}

--- a/yoloswe/reviewer/json_output_test.go
+++ b/yoloswe/reviewer/json_output_test.go
@@ -259,6 +259,50 @@ func TestBuildEnvelope_NilResult(t *testing.T) {
 	}
 }
 
+func TestBuildEnvelope_GeminiBackend(t *testing.T) {
+	result := &ReviewResult{
+		ResponseText: `{"verdict":"accepted","summary":"lgtm","issues":[]}`,
+		Success:      true,
+		DurationMs:   5000,
+	}
+	env := BuildEnvelope(result, BackendGemini, "gemini-2.5-pro", "sess-gemini-1")
+	if env.Status != StatusOK {
+		t.Errorf("status = %s, want ok", env.Status)
+	}
+	if env.Backend != "gemini" {
+		t.Errorf("backend = %q, want gemini", env.Backend)
+	}
+	if env.Model != "gemini-2.5-pro" {
+		t.Errorf("model = %q, want gemini-2.5-pro", env.Model)
+	}
+	if env.SessionID != "sess-gemini-1" {
+		t.Errorf("session_id = %q, want sess-gemini-1", env.SessionID)
+	}
+	if env.Review.Verdict != "accepted" {
+		t.Errorf("verdict = %q, want accepted", env.Review.Verdict)
+	}
+	if env.SchemaVersion != JSONSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", env.SchemaVersion, JSONSchemaVersion)
+	}
+}
+
+func TestBuildEnvelope_GeminiBackendError(t *testing.T) {
+	result := &ReviewResult{
+		ErrorMessage: "gemini: ACP client failed to start",
+		Success:      false,
+	}
+	env := BuildEnvelope(result, BackendGemini, "gemini-2.5-pro", "")
+	if env.Status != StatusError {
+		t.Errorf("status = %s, want error", env.Status)
+	}
+	if env.Backend != "gemini" {
+		t.Errorf("backend = %q, want gemini", env.Backend)
+	}
+	if env.Error != "gemini: ACP client failed to start" {
+		t.Errorf("error = %q, want gemini error", env.Error)
+	}
+}
+
 func TestPrintJSONResult_RoundTrip(t *testing.T) {
 	env := ResultEnvelope{
 		SchemaVersion: JSONSchemaVersion,

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -289,7 +289,10 @@ func (r *Reviewer) ReviewWithResult(ctx context.Context, prompt string) (*Review
 	handler := r.newEventHandler()
 	result, err := r.backend.RunPrompt(ctx, prompt, handler)
 	if err != nil {
-		return nil, err
+		if result != nil {
+			r.renderer.TurnCompleteWithTokens(result.Success, result.DurationMs, result.InputTokens, result.OutputTokens)
+		}
+		return result, err
 	}
 	r.renderer.TurnCompleteWithTokens(result.Success, result.DurationMs, result.InputTokens, result.OutputTokens)
 	return result, nil
@@ -300,7 +303,10 @@ func (r *Reviewer) FollowUp(ctx context.Context, prompt string) (*ReviewResult, 
 	handler := r.newEventHandler()
 	result, err := r.backend.RunPrompt(ctx, prompt, handler)
 	if err != nil {
-		return nil, err
+		if result != nil {
+			r.renderer.TurnCompleteWithTokens(result.Success, result.DurationMs, result.InputTokens, result.OutputTokens)
+		}
+		return result, err
 	}
 	r.renderer.TurnCompleteWithTokens(result.Success, result.DurationMs, result.InputTokens, result.OutputTokens)
 	return result, nil

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -21,6 +21,10 @@ const (
 	BackendCodex  BackendType = "codex"
 	BackendCursor BackendType = "cursor"
 	BackendGemini BackendType = "gemini"
+
+	// DefaultGeminiModel is the model used when BackendGemini is selected and
+	// no --model flag is provided.
+	DefaultGeminiModel = "gemini-3.1-flash-lite-preview"
 )
 
 // Config holds reviewer configuration.
@@ -201,7 +205,7 @@ func New(config Config) *Reviewer {
 	// Apply Gemini-specific defaults.
 	if config.BackendType == BackendGemini {
 		if config.Model == "" {
-			config.Model = "gemini-3.1-flash-lite-preview"
+			config.Model = DefaultGeminiModel
 		}
 	}
 

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -20,6 +20,7 @@ type BackendType string
 const (
 	BackendCodex  BackendType = "codex"
 	BackendCursor BackendType = "cursor"
+	BackendGemini BackendType = "gemini"
 )
 
 // Config holds reviewer configuration.
@@ -197,6 +198,13 @@ func New(config Config) *Reviewer {
 	if config.BackendType == "" {
 		config.BackendType = BackendCodex
 	}
+	// Apply Gemini-specific defaults.
+	if config.BackendType == BackendGemini {
+		if config.Model == "" {
+			config.Model = "gemini-2.5-pro"
+		}
+	}
+
 	// Apply codex-specific defaults only for codex backend.
 	// See Config doc for why danger-full-access is the default sandbox.
 	if config.BackendType == BackendCodex {
@@ -224,6 +232,8 @@ func New(config Config) *Reviewer {
 	switch config.BackendType {
 	case BackendCursor:
 		backend = newCursorBackend(config)
+	case BackendGemini:
+		backend = newGeminiBackend(config)
 	default:
 		backend = newCodexBackend(config)
 	}
@@ -306,10 +316,10 @@ func (r *Reviewer) LastSessionID() string { return r.lastSessionID }
 // ValidateBackend returns an error if the given backend string is not supported.
 func ValidateBackend(backend string) error {
 	switch BackendType(backend) {
-	case BackendCursor, BackendCodex:
+	case BackendCursor, BackendCodex, BackendGemini:
 		return nil
 	default:
-		return fmt.Errorf("unknown backend %q (supported: cursor, codex)", backend)
+		return fmt.Errorf("unknown backend %q (supported: cursor, codex, gemini)", backend)
 	}
 }
 

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -201,7 +201,7 @@ func New(config Config) *Reviewer {
 	// Apply Gemini-specific defaults.
 	if config.BackendType == BackendGemini {
 		if config.Model == "" {
-			config.Model = "gemini-2.5-pro"
+			config.Model = "gemini-3.1-flash-lite-preview"
 		}
 	}
 

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -346,7 +346,7 @@ func ResolveWorkDir() (string, error) {
 // collisions between concurrent runs. Returns "" if no log dir is configured.
 //
 // Note: protocol session logging is currently only supported by the Codex
-// backend; the Cursor backend silently ignores SessionLogPath.
+// backend; Cursor and Gemini backends silently ignore SessionLogPath.
 func ResolveProtocolLogPath(flagValue string) (string, error) {
 	dir := flagValue
 	if dir == "" {

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -1,5 +1,5 @@
 // Package reviewer provides a multi-backend wrapper for code review using
-// agent CLIs (Codex, Cursor).
+// agent CLIs (Codex, Cursor, Gemini).
 package reviewer
 
 import (

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -249,6 +249,7 @@ func TestValidateBackend(t *testing.T) {
 	}{
 		{"cursor", false},
 		{"codex", false},
+		{"gemini", false},
 		{"unknown", true},
 		{"", true},
 	}
@@ -259,6 +260,63 @@ func TestValidateBackend(t *testing.T) {
 				t.Errorf("ValidateBackend(%q) error = %v, wantErr %v", tt.backend, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestNew_GeminiBackend(t *testing.T) {
+	r := New(Config{
+		BackendType: BackendGemini,
+	})
+
+	if r.config.BackendType != BackendGemini {
+		t.Errorf("expected gemini backend, got %s", r.config.BackendType)
+	}
+	if r.config.Model != "gemini-2.5-pro" {
+		t.Errorf("expected default model gemini-2.5-pro, got %s", r.config.Model)
+	}
+	if r.backend == nil {
+		t.Error("backend should not be nil for gemini")
+	}
+	// Gemini backend Start and Stop are no-ops.
+	if err := r.backend.Start(nil); err != nil { //nolint:staticcheck
+		t.Errorf("gemini start should be no-op, got error: %v", err)
+	}
+	if err := r.backend.Stop(); err != nil {
+		t.Errorf("gemini stop should be no-op, got error: %v", err)
+	}
+}
+
+func TestNew_GeminiBackend_CustomModel(t *testing.T) {
+	r := New(Config{
+		BackendType: BackendGemini,
+		Model:       "gemini-2.5-flash",
+	})
+	if r.config.Model != "gemini-2.5-flash" {
+		t.Errorf("expected custom model gemini-2.5-flash, got %s", r.config.Model)
+	}
+}
+
+func TestNew_ApprovalPolicyNotOverriddenForGemini(t *testing.T) {
+	r := New(Config{BackendType: BackendGemini})
+	if r.config.ApprovalPolicy != "" {
+		t.Errorf("expected gemini approval policy to remain empty, got %q", r.config.ApprovalPolicy)
+	}
+}
+
+func TestEffectiveModel_GeminiDefault(t *testing.T) {
+	r := New(Config{BackendType: BackendGemini})
+	if got := r.EffectiveModel(); got != "gemini-2.5-pro" {
+		t.Errorf("EffectiveModel() = %q, want gemini-2.5-pro", got)
+	}
+}
+
+func TestValidateBackend_GeminiErrorMessage(t *testing.T) {
+	err := ValidateBackend("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+	if !containsString(err.Error(), "gemini") {
+		t.Errorf("error message should mention gemini: %q", err.Error())
 	}
 }
 

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -39,7 +39,7 @@ func TestBuildPrompt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			prompt := BuildPrompt(tt.goal)
 			for _, s := range tt.contains {
-				if !containsString(prompt, s) {
+				if !strings.Contains(prompt, s) {
 					t.Errorf("BuildPrompt(%q) should contain %q", tt.goal, s)
 				}
 			}
@@ -88,7 +88,7 @@ func TestBuildJSONPrompt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			prompt := BuildJSONPrompt(tt.goal)
 			for _, s := range tt.contains {
-				if !containsString(prompt, s) {
+				if !strings.Contains(prompt, s) {
 					t.Errorf("BuildJSONPrompt(%q) should contain %q", tt.goal, s)
 				}
 			}
@@ -197,19 +197,6 @@ func TestNew_CursorBackend(t *testing.T) {
 	}
 }
 
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStringHelper(s, substr))
-}
-
-func containsStringHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
 func TestNew_SessionLogPath(t *testing.T) {
 	r := New(Config{
 		SessionLogPath: "/tmp/test-session.jsonl",
@@ -315,7 +302,7 @@ func TestValidateBackend_GeminiErrorMessage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown backend")
 	}
-	if !containsString(err.Error(), "gemini") {
+	if !strings.Contains(err.Error(), "gemini") {
 		t.Errorf("error message should mention gemini: %q", err.Error())
 	}
 }

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -271,8 +271,8 @@ func TestNew_GeminiBackend(t *testing.T) {
 	if r.config.BackendType != BackendGemini {
 		t.Errorf("expected gemini backend, got %s", r.config.BackendType)
 	}
-	if r.config.Model != "gemini-2.5-pro" {
-		t.Errorf("expected default model gemini-2.5-pro, got %s", r.config.Model)
+	if r.config.Model != "gemini-3.1-flash-lite-preview" {
+		t.Errorf("expected default model gemini-3.1-flash-lite-preview, got %s", r.config.Model)
 	}
 	if r.backend == nil {
 		t.Error("backend should not be nil for gemini")
@@ -305,8 +305,8 @@ func TestNew_ApprovalPolicyNotOverriddenForGemini(t *testing.T) {
 
 func TestEffectiveModel_GeminiDefault(t *testing.T) {
 	r := New(Config{BackendType: BackendGemini})
-	if got := r.EffectiveModel(); got != "gemini-2.5-pro" {
-		t.Errorf("EffectiveModel() = %q, want gemini-2.5-pro", got)
+	if got := r.EffectiveModel(); got != "gemini-3.1-flash-lite-preview" {
+		t.Errorf("EffectiveModel() = %q, want gemini-3.1-flash-lite-preview", got)
 	}
 }
 

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -264,13 +264,6 @@ func TestNew_GeminiBackend(t *testing.T) {
 	if r.backend == nil {
 		t.Error("backend should not be nil for gemini")
 	}
-	// Gemini backend Start and Stop are no-ops.
-	if err := r.backend.Start(nil); err != nil { //nolint:staticcheck
-		t.Errorf("gemini start should be no-op, got error: %v", err)
-	}
-	if err := r.backend.Stop(); err != nil {
-		t.Errorf("gemini stop should be no-op, got error: %v", err)
-	}
 }
 
 func TestNew_GeminiBackend_CustomModel(t *testing.T) {

--- a/yoloswe/reviewer/tool_display.go
+++ b/yoloswe/reviewer/tool_display.go
@@ -1,0 +1,96 @@
+package reviewer
+
+import (
+	"path/filepath"
+)
+
+// toolDisplay renders a tool call (name + input map) into a human-readable
+// one-line string for terminal output. Each backend declares a toolDisplay
+// describing its tool names, the most informative input key for each tool,
+// and a fallback rule for unknown tool names.
+type toolDisplay struct {
+	// tools maps backend-native tool names to display info. The zero value
+	// (empty Display, empty ArgKey) falls through to fallback + no arg.
+	tools map[string]toolInfo
+	// fallback renames an unknown tool name for display. If nil, the raw
+	// tool name is used.
+	fallback func(string) string
+}
+
+// toolInfo describes how one tool is rendered. ArgKey names the input-map key
+// whose value (if present, non-empty, and a string) is included in the display.
+// ArgFormat selects how that value is formatted.
+type toolInfo struct {
+	Display   string
+	ArgKey    string
+	ArgFormat argFormat
+}
+
+// argFormat enumerates display formats for a tool argument value.
+type argFormat int
+
+const (
+	argFormatPath           argFormat = iota // shorten to .../parent/file
+	argFormatCommand                         // truncate at 50, prefix with ": "
+	argFormatQuery                           // truncate at 60, prefix with " "
+	argFormatPlain                           // include verbatim, prefix with " "
+	argFormatLongIdentifier                  // truncate at 60, prefix with " " (used for URLs)
+)
+
+const (
+	maxCommandDisplay = 50
+	maxQueryDisplay   = 60
+)
+
+// format renders a tool call for display.
+func (d *toolDisplay) format(name string, input map[string]interface{}) string {
+	info, ok := d.tools[name]
+	if !ok {
+		display := name
+		if d.fallback != nil {
+			display = d.fallback(name)
+		}
+		return display
+	}
+	if info.ArgKey == "" || input == nil {
+		return info.Display
+	}
+	raw, ok := input[info.ArgKey]
+	if !ok {
+		return info.Display
+	}
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		return info.Display
+	}
+	switch info.ArgFormat {
+	case argFormatPath:
+		return info.Display + " " + shortPath(s)
+	case argFormatCommand:
+		return info.Display + ": " + truncate(s, maxCommandDisplay)
+	case argFormatQuery, argFormatLongIdentifier:
+		return info.Display + " " + truncate(s, maxQueryDisplay)
+	default:
+		return info.Display + " " + s
+	}
+}
+
+// truncate shortens s to max runes (approximated as bytes — callers pass
+// ASCII-only values) and appends "..." when truncated.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}
+
+// shortPath returns the last 2 path components prefixed with ".../".
+// e.g. "/home/user/project/pkg/file.go" → ".../pkg/file.go"
+func shortPath(p string) string {
+	dir, file := filepath.Split(p)
+	if dir == "" {
+		return file
+	}
+	parent := filepath.Base(filepath.Clean(dir))
+	return ".../" + parent + "/" + file
+}


### PR DESCRIPTION
## Summary

- Adds `BackendGemini` ("gemini") as a third code-review backend alongside `cursor` and `codex`, using the existing ACP client to drive the Gemini CLI in one-shot mode
- Wires the backend through the factory, `ValidateBackend`, and the `--backend` CLI flag
- Extends `/code-review-eval` to run three configs in parallel and produce 3-way consensus comparisons

## Implementation

**`yoloswe/reviewer/backend_gemini.go`**
- `geminiBackend`: one-shot ACP client per `RunPrompt` call (Start/Stop are no-ops, matching the cursor pattern)
- `geminiEventAdapter`: filters infrastructure events (`ClientReadyEvent`, `SessionCreatedEvent`) and normalizes Gemini snake_case tool names to short display names before the bridge sees them
- `formatGeminiToolDisplay` / `geminiShortName`: tool display formatting analogous to `formatCursorToolDisplay`
- Spawns the bridge goroutine before calling `session.Prompt` (which blocks), then waits for the bridge result

**`yoloswe/reviewer/reviewer.go`**
- `BackendGemini = "gemini"` constant
- Default model: `gemini-2.5-pro` (applied in `New()` like codex defaults)
- Factory `case BackendGemini:` branch
- `ValidateBackend` now accepts `cursor`, `codex`, `gemini`

## Tests

| File | What's covered |
|------|---------------|
| `backend_gemini_test.go` | `formatGeminiToolDisplay` (14 cases), `geminiShortName`, Start/Stop no-op |
| `reviewer_test.go` | Factory dispatch → `*geminiBackend`, default model, no approval policy override, `EffectiveModel`, error message mentions "gemini" |
| `json_output_test.go` | `BuildEnvelope` success + error with Gemini backend tag |
| `integration/reviewer_test.go` | `TestReviewWithResult_Gemini` — real Gemini CLI round-trip, 5m timeout |

## Checklist

- [x] `scripts/lint.sh` passes
- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (58/58)
- [x] Integration BUILD.bazel is hand-maintained with `# gazelle:ignore`, `gotags = ["integration"]`, `tags = ["manual"]`
- [x] No existing Cursor/Codex backends modified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `gemini` execution path that starts an external CLI process via ACP and feeds its streaming events through existing review/envelope plumbing, which can affect runtime behavior and error handling across backends. Also refactors tool-call display/stderr handling shared by Cursor/Codex, so regressions would surface as logging/UX issues or misreported turn completion on failures.
> 
> **Overview**
> Adds **Gemini** as a third `bramble code-review` backend (`--backend gemini`) by introducing `BackendGemini` with a default model and wiring it through `reviewer.New`, `ValidateBackend`, and CLI help/flag text.
> 
> Implements a new ACP-based `geminiBackend` that maintains a long-lived client, creates a fresh session per prompt, filters/normalizes streamed events (including tool name formatting), and propagates turn-level errors; `ReviewWithResult`/`FollowUp` now return partial `ReviewResult` on error so the renderer can still print completion metadata.
> 
> Refactors terminal tool-call rendering into a shared `tool_display.go` helper (used by Cursor and Gemini) and centralizes stderr chunk prefixing via `stderrPrefixHandler` (used by Codex/Cursor/Gemini). Updates build/test wiring and adds unit + integration coverage for Gemini plus documentation updates to run 3-way `code-review-eval` comparisons and log token columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c8666e38d01e4ae5c0bb5d26e37474f4a655ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->