### PR TITLE
sessanalyze stats mode

### DIFF
--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -28,8 +28,11 @@ import (
 type config struct { //nolint:govet // fieldalignment: readability over packing
 	summaryWordLimit int
 	sinceStr         string
+	untilStr         string
+	pricingFile      string
 	modelStr         string
 	limit            int
+	statsMaxRows     int
 	minTurns         int
 	concurrency      int
 	jsonOutput       bool
@@ -37,6 +40,8 @@ type config struct { //nolint:govet // fieldalignment: readability over packing
 	listProjects     bool
 	allProjects      bool
 	summarize        bool
+	stats            bool
+	topLevelOnly     bool
 }
 
 func main() {
@@ -48,6 +53,14 @@ func main() {
 
 	if cfg.listProjects {
 		listProjects()
+		return
+	}
+
+	if cfg.stats {
+		if err := runStats(cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -115,6 +128,7 @@ var flags = flag.NewFlagSet("sessanalyze", flag.ExitOnError)
 func parseFlags(args []string) config {
 	cfg := config{
 		summaryWordLimit: 100,
+		statsMaxRows:     25,
 	}
 	flags.IntVar(&cfg.summaryWordLimit, "summary-limit", 100,
 		"word limit before summarizing agent responses with Haiku (0=no summarization)")
@@ -122,12 +136,17 @@ func parseFlags(args []string) config {
 	flags.BoolVar(&cfg.verbose, "v", false, "show full agent responses (no truncation in display)")
 	flags.BoolVar(&cfg.listProjects, "list", false, "list available projects")
 	flags.StringVar(&cfg.sinceStr, "since", "", "filter sessions after this time (e.g. '2d', '24h', '2026-03-04')")
+	flags.StringVar(&cfg.untilStr, "until", "", "filter sessions before this time (e.g. '2026-04-23T12:00:00Z')")
 	flags.BoolVar(&cfg.allProjects, "all", false, "scan all projects under ~/.claude/projects/")
 	flags.BoolVar(&cfg.summarize, "summarize", false, "use an LLM to generate session summaries")
 	flags.StringVar(&cfg.modelStr, "model", "haiku", "model for summarization: haiku (default) or gemini")
+	flags.StringVar(&cfg.pricingFile, "pricing-file", "", "JSON file with model pricing table for estimated cost")
 	flags.IntVar(&cfg.limit, "n", 0, "limit to the N most recent sessions (0=no limit)")
+	flags.IntVar(&cfg.statsMaxRows, "max-rows", 25, "max rows per stats breakdown table")
 	flags.IntVar(&cfg.minTurns, "min-turns", 0, "exclude sessions with fewer than N turns")
 	flags.IntVar(&cfg.concurrency, "j", 10, "number of concurrent LLM summarization workers")
+	flags.BoolVar(&cfg.stats, "stats", false, "show usage/cost stats instead of per-session transcripts")
+	flags.BoolVar(&cfg.topLevelOnly, "top-level-only", false, "in --stats mode, exclude subagent logs")
 	flags.Parse(args) //nolint:errcheck // ExitOnError mode handles errors
 	return cfg
 }
@@ -139,6 +158,69 @@ func buildQueryFunc(model string) sessionanalysis.QueryFunc {
 	default:
 		return sessionanalysis.HaikuQueryFunc()
 	}
+}
+
+func runStats(cfg config) error {
+	statsCfg := sessionanalysis.DefaultStatsConfig()
+	statsCfg.IncludeSubagents = !cfg.topLevelOnly
+
+	now := time.Now()
+
+	if cfg.sinceStr != "" {
+		since, err := parseTimeBound(cfg.sinceStr, now)
+		if err != nil {
+			return fmt.Errorf("invalid --since value: %w", err)
+		}
+		statsCfg.Since = since
+	}
+	if cfg.untilStr != "" {
+		until, err := parseTimeBound(cfg.untilStr, now)
+		if err != nil {
+			return fmt.Errorf("invalid --until value: %w", err)
+		}
+		statsCfg.Until = until
+	}
+	if !statsCfg.Since.IsZero() && !statsCfg.Until.IsZero() && statsCfg.Since.After(statsCfg.Until) {
+		return fmt.Errorf("--since must be before --until")
+	}
+
+	if cfg.pricingFile != "" {
+		tbl, err := sessionanalysis.LoadPricingTable(cfg.pricingFile)
+		if err != nil {
+			return fmt.Errorf("load pricing file: %w", err)
+		}
+		statsCfg.Pricing = tbl
+	}
+
+	var paths []string
+	if cfg.allProjects {
+		projects, err := sessionanalysis.ListProjects()
+		if err != nil {
+			return err
+		}
+		for i := range projects {
+			paths = append(paths, projects[i].Path)
+		}
+	} else {
+		if flags.NArg() == 0 {
+			listProjects()
+			return nil
+		}
+		paths = append(paths, flags.Args()...)
+	}
+
+	report, err := sessionanalysis.AnalyzeUsageStats(paths, statsCfg)
+	if err != nil {
+		return err
+	}
+
+	if cfg.jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	renderStatsMarkdown(os.Stdout, report, cfg.statsMaxRows)
+	return nil
 }
 
 func summarizeWithProgress(sessions []*sessionanalysis.Session, wordLimit int, query sessionanalysis.QueryFunc, concurrency int) {
@@ -163,6 +245,195 @@ func render(w io.Writer, sessions []*sessionanalysis.Session, cfg config) {
 	} else {
 		renderMarkdown(w, sessions, cfg)
 	}
+}
+
+func renderStatsMarkdown(w io.Writer, report *sessionanalysis.StatsReport, maxRows int) {
+	if maxRows <= 0 {
+		maxRows = 25
+	}
+
+	fmt.Fprintln(w, "# Usage Stats")
+	fmt.Fprintln(w)
+
+	if !report.Since.IsZero() || !report.Until.IsZero() {
+		fmt.Fprintf(w, "- Window: %s → %s\n", formatBound(report.Since), formatBound(report.Until))
+	} else {
+		fmt.Fprintln(w, "- Window: all events")
+	}
+	fmt.Fprintf(w, "- Files scanned: %d\n", report.FilesScanned)
+	fmt.Fprintf(w, "- Events scanned: %d (parse errors: %d)\n", report.EventsScanned, report.ParseErrors)
+	fmt.Fprintf(w, "- Pricing: %s (%s)\n", report.Pricing.Version, report.Pricing.Source)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "## Totals")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Metric | Value |")
+	fmt.Fprintln(w, "|---|---:|")
+	fmt.Fprintf(w, "| Sessions | %d |\n", report.Total.Sessions)
+	fmt.Fprintf(w, "| Usage Events | %d |\n", report.Total.UsageEvents)
+	fmt.Fprintf(w, "| Tool Uses | %d |\n", report.Total.ToolUses)
+	fmt.Fprintf(w, "| Input Tokens | %s |\n", formatInt(report.Total.Usage.InputTokens))
+	fmt.Fprintf(w, "| Output Tokens | %s |\n", formatInt(report.Total.Usage.OutputTokens))
+	fmt.Fprintf(w, "| Cache Read Tokens | %s |\n", formatInt(report.Total.Usage.CacheReadInputTokens))
+	fmt.Fprintf(w, "| Cache Creation Tokens | %s |\n", formatInt(report.Total.Usage.CacheCreationInputTokens))
+	fmt.Fprintf(w, "| Observed Cost (USD) | $%.4f |\n", report.Total.ObservedCostUSD)
+	fmt.Fprintf(w, "| Estimated Cost (USD) | $%.4f |\n", report.Total.EstimatedCostUSD)
+	fmt.Fprintf(w, "| Estimated Coverage | %.1f%% |\n", report.Total.Coverage()*100)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "## By Family")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Family | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
+	fmt.Fprintln(w, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+	for _, row := range limitFamilyRows(report.ByFamily, maxRows) {
+		fmt.Fprintf(w, "| `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
+			row.Family,
+			row.Sessions,
+			formatInt(row.Usage.InputTokens),
+			formatInt(row.Usage.OutputTokens),
+			formatInt(row.Usage.CacheReadInputTokens),
+			formatInt(row.Usage.CacheCreationInputTokens),
+			row.ToolUses,
+			row.ObservedCostUSD,
+			row.EstimatedCostUSD,
+			row.Coverage()*100,
+		)
+	}
+	if len(report.ByFamily) > maxRows {
+		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByFamily))
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "## By Model")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Model | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
+	fmt.Fprintln(w, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+	for _, row := range limitModelRows(report.ByModel, maxRows) {
+		fmt.Fprintf(w, "| `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
+			row.Model,
+			row.Sessions,
+			formatInt(row.Usage.InputTokens),
+			formatInt(row.Usage.OutputTokens),
+			formatInt(row.Usage.CacheReadInputTokens),
+			formatInt(row.Usage.CacheCreationInputTokens),
+			row.ToolUses,
+			row.ObservedCostUSD,
+			row.EstimatedCostUSD,
+			row.Coverage()*100,
+		)
+	}
+	if len(report.ByModel) > maxRows {
+		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByModel))
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "## By Project")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Project | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
+	fmt.Fprintln(w, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+	for _, row := range limitProjectRows(report.ByProject, maxRows) {
+		fmt.Fprintf(w, "| `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
+			row.Project,
+			row.Sessions,
+			formatInt(row.Usage.InputTokens),
+			formatInt(row.Usage.OutputTokens),
+			formatInt(row.Usage.CacheReadInputTokens),
+			formatInt(row.Usage.CacheCreationInputTokens),
+			row.ToolUses,
+			row.ObservedCostUSD,
+			row.EstimatedCostUSD,
+			row.Coverage()*100,
+		)
+	}
+	if len(report.ByProject) > maxRows {
+		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByProject))
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "## By Project + Model")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Project | Model | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
+	fmt.Fprintln(w, "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+	for _, row := range limitProjectModelRows(report.ByProjectModel, maxRows) {
+		fmt.Fprintf(w, "| `%s` | `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
+			row.Project,
+			row.Model,
+			row.Sessions,
+			formatInt(row.Usage.InputTokens),
+			formatInt(row.Usage.OutputTokens),
+			formatInt(row.Usage.CacheReadInputTokens),
+			formatInt(row.Usage.CacheCreationInputTokens),
+			row.ToolUses,
+			row.ObservedCostUSD,
+			row.EstimatedCostUSD,
+			row.Coverage()*100,
+		)
+	}
+	if len(report.ByProjectModel) > maxRows {
+		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByProjectModel))
+	}
+}
+
+func formatBound(t time.Time) string {
+	if t.IsZero() {
+		return "(unset)"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func limitModelRows(rows []sessionanalysis.ModelBucket, n int) []sessionanalysis.ModelBucket {
+	if n <= 0 || len(rows) <= n {
+		return rows
+	}
+	return rows[:n]
+}
+
+func limitFamilyRows(rows []sessionanalysis.FamilyBucket, n int) []sessionanalysis.FamilyBucket {
+	if n <= 0 || len(rows) <= n {
+		return rows
+	}
+	return rows[:n]
+}
+
+func limitProjectRows(rows []sessionanalysis.ProjectBucket, n int) []sessionanalysis.ProjectBucket {
+	if n <= 0 || len(rows) <= n {
+		return rows
+	}
+	return rows[:n]
+}
+
+func limitProjectModelRows(rows []sessionanalysis.ProjectModelBucket, n int) []sessionanalysis.ProjectModelBucket {
+	if n <= 0 || len(rows) <= n {
+		return rows
+	}
+	return rows[:n]
+}
+
+func formatInt(v int64) string {
+	s := fmt.Sprintf("%d", v)
+	if len(s) <= 3 {
+		return s
+	}
+	sign := ""
+	if s[0] == '-' {
+		sign = "-"
+		s = s[1:]
+	}
+	var out []byte
+	rem := len(s) % 3
+	if rem > 0 {
+		out = append(out, s[:rem]...)
+		if len(s) > rem {
+			out = append(out, ',')
+		}
+	}
+	for i := rem; i < len(s); i += 3 {
+		out = append(out, s[i:i+3]...)
+		if i+3 < len(s) {
+			out = append(out, ',')
+		}
+	}
+	return sign + string(out)
 }
 
 func listProjects() {
@@ -341,18 +612,24 @@ func renderTurnMD(w io.Writer, turn *sessionanalysis.Turn, cfg config) {
 
 // parseSince parses duration strings like "2d", "24h" or date strings like "2026-03-04".
 func parseSince(s string) (time.Time, error) {
+	return parseTimeBound(s, time.Now())
+}
+
+// parseTimeBound parses duration strings like "2d", "24h" or date strings.
+// Relative values are interpreted as "now - duration".
+func parseTimeBound(s string, now time.Time) (time.Time, error) {
 	// Try relative duration with day suffix.
 	if strings.HasSuffix(s, "d") {
 		days := strings.TrimSuffix(s, "d")
 		var n int
 		if _, err := fmt.Sscanf(days, "%d", &n); err == nil && n > 0 {
-			return time.Now().AddDate(0, 0, -n), nil
+			return now.AddDate(0, 0, -n), nil
 		}
 	}
 
 	// Try Go duration (e.g. "24h", "2h30m").
 	if d, err := time.ParseDuration(s); err == nil {
-		return time.Now().Add(-d), nil
+		return now.Add(-d), nil
 	}
 
 	// Try date formats.

--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -335,9 +335,19 @@ func renderBucketTable[T any](
 		var b strings.Builder
 		b.WriteByte('|')
 		for _, v := range labelVals {
-			// Strip backticks (which would break the inline code span) and pipes
-			// (which would break the table column boundary).
-			safe := strings.NewReplacer("`", "", "|", "\\|").Replace(v)
+			// Sanitize control chars, backticks, and pipes to avoid breaking
+			// the Markdown table structure.
+			safe := strings.Map(func(r rune) rune {
+				switch {
+				case r == '`':
+					return -1 // strip (breaks inline code span)
+				case r == '|':
+					return -1 // strip (breaks table column boundary; escaping isn't reliable)
+				case r < 0x20 || r == 0x7f:
+					return -1 // strip control characters
+				}
+				return r
+			}, v)
 			fmt.Fprintf(&b, " `%s` |", safe)
 		}
 		fmt.Fprintf(&b, " %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |",

--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -261,8 +261,8 @@ func renderStatsMarkdown(w io.Writer, report *sessionanalysis.StatsReport, maxRo
 	fmt.Fprintf(w, "- Files scanned: %d\n", report.FilesScanned)
 	fmt.Fprintf(w, "- Events scanned: %d (parse errors: %d)\n", report.EventsScanned, report.ParseErrors)
 	fmt.Fprintf(w, "- Pricing: %s (%s)\n",
-		strings.ReplaceAll(report.Pricing.Version, "|", "\\|"),
-		strings.ReplaceAll(report.Pricing.Source, "|", "\\|"))
+		sanitizeMarkdownText(report.Pricing.Version),
+		sanitizeMarkdownText(report.Pricing.Source))
 	fmt.Fprintln(w)
 
 	fmt.Fprintln(w, "## Totals")
@@ -335,19 +335,9 @@ func renderBucketTable[T any](
 		var b strings.Builder
 		b.WriteByte('|')
 		for _, v := range labelVals {
-			// Sanitize control chars, backticks, and pipes to avoid breaking
-			// the Markdown table structure.
-			safe := strings.Map(func(r rune) rune {
-				switch {
-				case r == '`':
-					return -1 // strip (breaks inline code span)
-				case r == '|':
-					return -1 // strip (breaks table column boundary; escaping isn't reliable)
-				case r < 0x20 || r == 0x7f:
-					return -1 // strip control characters
-				}
-				return r
-			}, v)
+			// Strip pipes (break table column boundaries) in addition to
+			// control chars and backticks stripped by sanitizeMarkdownText.
+			safe := strings.ReplaceAll(sanitizeMarkdownText(v), "|", "")
 			fmt.Fprintf(&b, " `%s` |", safe)
 		}
 		fmt.Fprintf(&b, " %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |",
@@ -367,6 +357,17 @@ func renderBucketTable[T any](
 		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(rows))
 	}
 	fmt.Fprintln(w)
+}
+
+// sanitizeMarkdownText strips characters that break markdown list items or
+// table cells: control characters (including newlines) and backticks.
+func sanitizeMarkdownText(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f || r == '`' {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 func formatBound(t time.Time) string {

--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -134,7 +134,7 @@ func parseFlags(args []string) config {
 	flags.BoolVar(&cfg.verbose, "v", false, "show full agent responses (no truncation in display)")
 	flags.BoolVar(&cfg.listProjects, "list", false, "list available projects")
 	flags.StringVar(&cfg.sinceStr, "since", "", "filter sessions after this time (e.g. '2d', '24h', '2026-03-04')")
-	flags.StringVar(&cfg.untilStr, "until", "", "filter sessions before this time (e.g. '2026-04-23T12:00:00Z')")
+	flags.StringVar(&cfg.untilStr, "until", "", "filter sessions before this time (e.g. '2026-04-23T12:00:00Z'); stats mode only")
 	flags.BoolVar(&cfg.allProjects, "all", false, "scan all projects under ~/.claude/projects/")
 	flags.BoolVar(&cfg.summarize, "summarize", false, "use an LLM to generate session summaries")
 	flags.StringVar(&cfg.modelStr, "model", "haiku", "model for summarization: haiku (default) or gemini")
@@ -333,7 +333,7 @@ func renderBucketTable[T any](
 		var b strings.Builder
 		b.WriteByte('|')
 		for _, v := range labelVals {
-			fmt.Fprintf(&b, " `%s` |", v)
+			fmt.Fprintf(&b, " `%s` |", strings.NewReplacer("`", "\\`", "|", "\\|").Replace(v))
 		}
 		fmt.Fprintf(&b, " %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |",
 			stats.Sessions,

--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -134,7 +134,7 @@ func parseFlags(args []string) config {
 	flags.BoolVar(&cfg.verbose, "v", false, "show full agent responses (no truncation in display)")
 	flags.BoolVar(&cfg.listProjects, "list", false, "list available projects")
 	flags.StringVar(&cfg.sinceStr, "since", "", "filter sessions after this time (e.g. '2d', '24h', '2026-03-04')")
-	flags.StringVar(&cfg.untilStr, "until", "", "filter sessions before this time (e.g. '2026-04-23T12:00:00Z'); stats mode only")
+	flags.StringVar(&cfg.untilStr, "until", "", "filter sessions up to and including this time (e.g. '2026-04-23T12:00:00Z'); stats mode only")
 	flags.BoolVar(&cfg.allProjects, "all", false, "scan all projects under ~/.claude/projects/")
 	flags.BoolVar(&cfg.summarize, "summarize", false, "use an LLM to generate session summaries")
 	flags.StringVar(&cfg.modelStr, "model", "haiku", "model for summarization: haiku (default) or gemini")
@@ -180,6 +180,9 @@ func runStats(cfg config) error {
 	}
 	if !statsCfg.Since.IsZero() && !statsCfg.Until.IsZero() && statsCfg.Since.After(statsCfg.Until) {
 		return fmt.Errorf("--since must be before --until")
+	}
+	if cfg.minTurns > 0 {
+		fmt.Fprintf(os.Stderr, "warning: --min-turns is ignored in --stats mode\n")
 	}
 
 	if cfg.pricingFile != "" {

--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -260,7 +260,9 @@ func renderStatsMarkdown(w io.Writer, report *sessionanalysis.StatsReport, maxRo
 	}
 	fmt.Fprintf(w, "- Files scanned: %d\n", report.FilesScanned)
 	fmt.Fprintf(w, "- Events scanned: %d (parse errors: %d)\n", report.EventsScanned, report.ParseErrors)
-	fmt.Fprintf(w, "- Pricing: %s (%s)\n", report.Pricing.Version, report.Pricing.Source)
+	fmt.Fprintf(w, "- Pricing: %s (%s)\n",
+		strings.ReplaceAll(report.Pricing.Version, "|", "\\|"),
+		strings.ReplaceAll(report.Pricing.Source, "|", "\\|"))
 	fmt.Fprintln(w)
 
 	fmt.Fprintln(w, "## Totals")
@@ -333,7 +335,10 @@ func renderBucketTable[T any](
 		var b strings.Builder
 		b.WriteByte('|')
 		for _, v := range labelVals {
-			fmt.Fprintf(&b, " `%s` |", strings.NewReplacer("`", "\\`", "|", "\\|").Replace(v))
+			// Strip backticks (which would break the inline code span) and pipes
+			// (which would break the table column boundary).
+			safe := strings.NewReplacer("`", "", "|", "\\|").Replace(v)
+			fmt.Fprintf(&b, " `%s` |", safe)
 		}
 		fmt.Fprintf(&b, " %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |",
 			stats.Sessions,

--- a/bramble/cmd/sessanalyze/main.go
+++ b/bramble/cmd/sessanalyze/main.go
@@ -121,8 +121,6 @@ func main() {
 	os.Exit(exitCode)
 }
 
-// flags is the FlagSet used by parseFlags, stored at package level so that
-// flag.NArg() / flag.Args() callers can reference it after parsing.
 var flags = flag.NewFlagSet("sessanalyze", flag.ExitOnError)
 
 func parseFlags(args []string) config {
@@ -281,97 +279,79 @@ func renderStatsMarkdown(w io.Writer, report *sessionanalysis.StatsReport, maxRo
 	fmt.Fprintf(w, "| Estimated Coverage | %.1f%% |\n", report.Total.Coverage()*100)
 	fmt.Fprintln(w)
 
-	fmt.Fprintln(w, "## By Family")
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "| Family | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
-	fmt.Fprintln(w, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
-	for _, row := range limitFamilyRows(report.ByFamily, maxRows) {
-		fmt.Fprintf(w, "| `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
-			row.Family,
-			row.Sessions,
-			formatInt(row.Usage.InputTokens),
-			formatInt(row.Usage.OutputTokens),
-			formatInt(row.Usage.CacheReadInputTokens),
-			formatInt(row.Usage.CacheCreationInputTokens),
-			row.ToolUses,
-			row.ObservedCostUSD,
-			row.EstimatedCostUSD,
-			row.Coverage()*100,
-		)
-	}
-	if len(report.ByFamily) > maxRows {
-		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByFamily))
-	}
-	fmt.Fprintln(w)
+	renderBucketTable(w, "By Family", []string{"Family"}, report.ByFamily, maxRows,
+		func(b sessionanalysis.FamilyBucket) ([]string, sessionanalysis.BucketStats) {
+			return []string{b.Family}, b.BucketStats
+		})
 
-	fmt.Fprintln(w, "## By Model")
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "| Model | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
-	fmt.Fprintln(w, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
-	for _, row := range limitModelRows(report.ByModel, maxRows) {
-		fmt.Fprintf(w, "| `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
-			row.Model,
-			row.Sessions,
-			formatInt(row.Usage.InputTokens),
-			formatInt(row.Usage.OutputTokens),
-			formatInt(row.Usage.CacheReadInputTokens),
-			formatInt(row.Usage.CacheCreationInputTokens),
-			row.ToolUses,
-			row.ObservedCostUSD,
-			row.EstimatedCostUSD,
-			row.Coverage()*100,
-		)
-	}
-	if len(report.ByModel) > maxRows {
-		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByModel))
-	}
-	fmt.Fprintln(w)
+	renderBucketTable(w, "By Model", []string{"Model"}, report.ByModel, maxRows,
+		func(b sessionanalysis.ModelBucket) ([]string, sessionanalysis.BucketStats) {
+			return []string{b.Model}, b.BucketStats
+		})
 
-	fmt.Fprintln(w, "## By Project")
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "| Project | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
-	fmt.Fprintln(w, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
-	for _, row := range limitProjectRows(report.ByProject, maxRows) {
-		fmt.Fprintf(w, "| `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
-			row.Project,
-			row.Sessions,
-			formatInt(row.Usage.InputTokens),
-			formatInt(row.Usage.OutputTokens),
-			formatInt(row.Usage.CacheReadInputTokens),
-			formatInt(row.Usage.CacheCreationInputTokens),
-			row.ToolUses,
-			row.ObservedCostUSD,
-			row.EstimatedCostUSD,
-			row.Coverage()*100,
-		)
-	}
-	if len(report.ByProject) > maxRows {
-		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByProject))
-	}
-	fmt.Fprintln(w)
+	renderBucketTable(w, "By Project", []string{"Project"}, report.ByProject, maxRows,
+		func(b sessionanalysis.ProjectBucket) ([]string, sessionanalysis.BucketStats) {
+			return []string{b.Project}, b.BucketStats
+		})
 
-	fmt.Fprintln(w, "## By Project + Model")
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "| Project | Model | Sessions | Input | Output | Cache Read | Cache Create | Tool Uses | Observed $ | Estimated $ | Coverage |")
-	fmt.Fprintln(w, "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
-	for _, row := range limitProjectModelRows(report.ByProjectModel, maxRows) {
-		fmt.Fprintf(w, "| `%s` | `%s` | %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |\n",
-			row.Project,
-			row.Model,
-			row.Sessions,
-			formatInt(row.Usage.InputTokens),
-			formatInt(row.Usage.OutputTokens),
-			formatInt(row.Usage.CacheReadInputTokens),
-			formatInt(row.Usage.CacheCreationInputTokens),
-			row.ToolUses,
-			row.ObservedCostUSD,
-			row.EstimatedCostUSD,
-			row.Coverage()*100,
+	renderBucketTable(w, "By Project + Model", []string{"Project", "Model"}, report.ByProjectModel, maxRows,
+		func(b sessionanalysis.ProjectModelBucket) ([]string, sessionanalysis.BucketStats) {
+			return []string{b.Project, b.Model}, b.BucketStats
+		})
+}
+
+// renderBucketTable writes a markdown breakdown table for a slice of bucket
+// rows. labels are the leading label-column names (rendered with backticks);
+// the remaining columns are the standard usage/cost stats. row returns the
+// label cell values plus the BucketStats for each row.
+func renderBucketTable[T any](
+	w io.Writer,
+	title string,
+	labels []string,
+	rows []T,
+	maxRows int,
+	row func(T) ([]string, sessionanalysis.BucketStats),
+) {
+	fmt.Fprintf(w, "## %s\n\n", title)
+
+	statHeaders := []string{"Sessions", "Input", "Output", "Cache Read", "Cache Create", "Tool Uses", "Observed $", "Estimated $", "Coverage"}
+	header := "|"
+	sep := "|"
+	for _, l := range labels {
+		header += " " + l + " |"
+		sep += "---|"
+	}
+	for _, h := range statHeaders {
+		header += " " + h + " |"
+		sep += "---:|"
+	}
+	fmt.Fprintln(w, header)
+	fmt.Fprintln(w, sep)
+
+	for _, r := range limitRows(rows, maxRows) {
+		labelVals, stats := row(r)
+		var b strings.Builder
+		b.WriteByte('|')
+		for _, v := range labelVals {
+			fmt.Fprintf(&b, " `%s` |", v)
+		}
+		fmt.Fprintf(&b, " %d | %s | %s | %s | %s | %d | %.4f | %.4f | %.1f%% |",
+			stats.Sessions,
+			formatInt(stats.Usage.InputTokens),
+			formatInt(stats.Usage.OutputTokens),
+			formatInt(stats.Usage.CacheReadInputTokens),
+			formatInt(stats.Usage.CacheCreationInputTokens),
+			stats.ToolUses,
+			stats.ObservedCostUSD,
+			stats.EstimatedCostUSD,
+			stats.Coverage()*100,
 		)
+		fmt.Fprintln(w, b.String())
 	}
-	if len(report.ByProjectModel) > maxRows {
-		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(report.ByProjectModel))
+	if len(rows) > maxRows {
+		fmt.Fprintf(w, "\n*Showing top %d of %d rows.*\n", maxRows, len(rows))
 	}
+	fmt.Fprintln(w)
 }
 
 func formatBound(t time.Time) string {
@@ -381,28 +361,7 @@ func formatBound(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
-func limitModelRows(rows []sessionanalysis.ModelBucket, n int) []sessionanalysis.ModelBucket {
-	if n <= 0 || len(rows) <= n {
-		return rows
-	}
-	return rows[:n]
-}
-
-func limitFamilyRows(rows []sessionanalysis.FamilyBucket, n int) []sessionanalysis.FamilyBucket {
-	if n <= 0 || len(rows) <= n {
-		return rows
-	}
-	return rows[:n]
-}
-
-func limitProjectRows(rows []sessionanalysis.ProjectBucket, n int) []sessionanalysis.ProjectBucket {
-	if n <= 0 || len(rows) <= n {
-		return rows
-	}
-	return rows[:n]
-}
-
-func limitProjectModelRows(rows []sessionanalysis.ProjectModelBucket, n int) []sessionanalysis.ProjectModelBucket {
+func limitRows[T any](rows []T, n int) []T {
 	if n <= 0 || len(rows) <= n {
 		return rows
 	}

--- a/bramble/sessionanalysis/BUILD.bazel
+++ b/bramble/sessionanalysis/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "sessionanalysis",
     srcs = [
         "analysis.go",
+        "stats.go",
         "summarize.go",
     ],
     importpath = "github.com/bazelment/yoloswe/bramble/sessionanalysis",
@@ -18,7 +19,10 @@ go_library(
 
 go_test(
     name = "sessionanalysis_test",
-    srcs = ["analysis_test.go"],
+    srcs = [
+        "analysis_test.go",
+        "stats_test.go",
+    ],
     embed = [":sessionanalysis"],
     deps = [
         "//bramble/sessionmodel",

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -11,7 +11,12 @@ import (
 	"time"
 )
 
-// UsageTotals stores token usage counters.
+// unknownLabel is the placeholder used when a model/project/family cannot be
+// determined. Centralized so renderers can recognize it consistently.
+const unknownLabel = "(unknown)"
+
+// UsageTotals stores token usage counters. The JSON tags match the on-disk
+// JSONL `usage` object so it can be unmarshaled directly during scanning.
 type UsageTotals struct {
 	InputTokens              int64 `json:"input_tokens"`
 	OutputTokens             int64 `json:"output_tokens"`
@@ -211,24 +216,8 @@ type statsMessage struct {
 	ID      string          `json:"id,omitempty"`
 	Role    string          `json:"role,omitempty"`
 	Model   string          `json:"model,omitempty"`
-	Usage   *statsUsage     `json:"usage,omitempty"`
+	Usage   *UsageTotals    `json:"usage,omitempty"`
 	Content json.RawMessage `json:"content,omitempty"`
-}
-
-type statsUsage struct {
-	InputTokens              int64 `json:"input_tokens"`
-	OutputTokens             int64 `json:"output_tokens"`
-	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
-	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
-}
-
-func (u statsUsage) totals() UsageTotals {
-	return UsageTotals{
-		InputTokens:              u.InputTokens,
-		OutputTokens:             u.OutputTokens,
-		CacheReadInputTokens:     u.CacheReadInputTokens,
-		CacheCreationInputTokens: u.CacheCreationInputTokens,
-	}
 }
 
 type modelUsage struct {
@@ -239,6 +228,13 @@ type contentBlock struct {
 	Type string `json:"type"`
 	Name string `json:"name,omitempty"`
 	ID   string `json:"id,omitempty"`
+}
+
+// projectModelKey is a struct map key — preferred over string concatenation
+// with sentinel separators because it makes the dimensionality explicit.
+type projectModelKey struct {
+	Project string
+	Model   string
 }
 
 type mutableBucket struct { //nolint:govet // fieldalignment: readability over packing
@@ -290,6 +286,24 @@ func (b *mutableBucket) finalized() BucketStats {
 	return out
 }
 
+// orDefault returns s if non-empty, otherwise unknownLabel.
+func orDefault(s string) string {
+	if s == "" {
+		return unknownLabel
+	}
+	return s
+}
+
+// getOrCreate looks up a key in m and lazy-inits a fresh bucket on miss.
+func getOrCreate[K comparable](m map[K]*mutableBucket, key K) *mutableBucket {
+	if b, ok := m[key]; ok {
+		return b
+	}
+	b := newMutableBucket()
+	m[key] = b
+	return b
+}
+
 type statsAggregator struct {
 	cfg StatsConfig
 
@@ -298,7 +312,7 @@ type statsAggregator struct {
 	byFamily       map[string]*mutableBucket
 	byModel        map[string]*mutableBucket
 	byProject      map[string]*mutableBucket
-	byProjectModel map[string]*mutableBucket
+	byProjectModel map[projectModelKey]*mutableBucket
 
 	filesScanned  int
 	eventsScanned int64
@@ -312,95 +326,49 @@ func newStatsAggregator(cfg StatsConfig) *statsAggregator {
 		byFamily:       make(map[string]*mutableBucket),
 		byModel:        make(map[string]*mutableBucket),
 		byProject:      make(map[string]*mutableBucket),
-		byProjectModel: make(map[string]*mutableBucket),
+		byProjectModel: make(map[projectModelKey]*mutableBucket),
 	}
 }
 
-func (a *statsAggregator) getFamilyBucket(family string) *mutableBucket {
-	if family == "" {
-		family = "(unknown)"
+// affectedBuckets returns the five buckets that any event for (project, model)
+// must update: total, family, model, project, project+model. Centralized so
+// adding a dimension only requires touching this method.
+func (a *statsAggregator) affectedBuckets(project, model string) []*mutableBucket {
+	project = orDefault(project)
+	model = orDefault(model)
+	family := modelFamily(model)
+	return []*mutableBucket{
+		a.total,
+		getOrCreate(a.byFamily, family),
+		getOrCreate(a.byModel, model),
+		getOrCreate(a.byProject, project),
+		getOrCreate(a.byProjectModel, projectModelKey{project, model}),
 	}
-	if b, ok := a.byFamily[family]; ok {
-		return b
-	}
-	b := newMutableBucket()
-	a.byFamily[family] = b
-	return b
-}
-
-func (a *statsAggregator) getModelBucket(model string) *mutableBucket {
-	if model == "" {
-		model = "(unknown)"
-	}
-	if b, ok := a.byModel[model]; ok {
-		return b
-	}
-	b := newMutableBucket()
-	a.byModel[model] = b
-	return b
-}
-
-func (a *statsAggregator) getProjectBucket(project string) *mutableBucket {
-	if project == "" {
-		project = "(unknown)"
-	}
-	if b, ok := a.byProject[project]; ok {
-		return b
-	}
-	b := newMutableBucket()
-	a.byProject[project] = b
-	return b
-}
-
-func (a *statsAggregator) getProjectModelBucket(project, model string) *mutableBucket {
-	if project == "" {
-		project = "(unknown)"
-	}
-	if model == "" {
-		model = "(unknown)"
-	}
-	key := project + "\x00" + model
-	if b, ok := a.byProjectModel[key]; ok {
-		return b
-	}
-	b := newMutableBucket()
-	a.byProjectModel[key] = b
-	return b
 }
 
 func (a *statsAggregator) addUsage(sessionKey, project, model string, usage UsageTotals) {
 	estimateUSD, priced, unpriced := estimateCost(model, usage, a.cfg.Pricing)
-	family := modelFamily(model)
-
-	a.total.addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
-	a.getFamilyBucket(family).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
-	a.getModelBucket(model).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
-	a.getProjectBucket(project).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
-	a.getProjectModelBucket(project, model).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+	for _, b := range a.affectedBuckets(project, model) {
+		b.addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+	}
 }
 
 func (a *statsAggregator) addToolUses(sessionKey, project, model string, toolUses int64) {
 	if toolUses <= 0 {
 		return
 	}
-	family := modelFamily(model)
-	a.total.addToolUses(sessionKey, toolUses)
-	a.getFamilyBucket(family).addToolUses(sessionKey, toolUses)
-	a.getModelBucket(model).addToolUses(sessionKey, toolUses)
-	a.getProjectBucket(project).addToolUses(sessionKey, toolUses)
-	a.getProjectModelBucket(project, model).addToolUses(sessionKey, toolUses)
+	for _, b := range a.affectedBuckets(project, model) {
+		b.addToolUses(sessionKey, toolUses)
+	}
 }
 
 func (a *statsAggregator) addObservedCost(sessionKey, project, model string, costUSD float64) {
 	if costUSD == 0 {
 		return
 	}
-	family := modelFamily(model)
-	a.total.addObservedCost(sessionKey, costUSD)
-	a.getFamilyBucket(family).addObservedCost(sessionKey, costUSD)
-	a.getModelBucket(model).addObservedCost(sessionKey, costUSD)
-	a.getProjectBucket(project).addObservedCost(sessionKey, costUSD)
-	a.getProjectModelBucket(project, model).addObservedCost(sessionKey, costUSD)
+	for _, b := range a.affectedBuckets(project, model) {
+		b.addObservedCost(sessionKey, costUSD)
+	}
 }
 
 func (a *statsAggregator) shouldIncludeEvent(ts time.Time, hasTimestamp bool) bool {
@@ -450,67 +418,57 @@ func AnalyzeUsageStatsFromFiles(files []string, cfg StatsConfig) (*StatsReport, 
 		},
 	}
 
-	for family, bucket := range a.byFamily {
-		report.ByFamily = append(report.ByFamily, FamilyBucket{
-			Family:      family,
-			BucketStats: bucket.finalized(),
-		})
-	}
-	sort.Slice(report.ByFamily, func(i, j int) bool {
-		if report.ByFamily[i].EstimatedCostUSD == report.ByFamily[j].EstimatedCostUSD {
-			return report.ByFamily[i].Family < report.ByFamily[j].Family
-		}
-		return report.ByFamily[i].EstimatedCostUSD > report.ByFamily[j].EstimatedCostUSD
+	report.ByFamily = collectBuckets(a.byFamily, func(family string, stats BucketStats) FamilyBucket {
+		return FamilyBucket{Family: family, BucketStats: stats}
+	}, func(b FamilyBucket) (float64, string) {
+		return b.EstimatedCostUSD, b.Family
 	})
 
-	for model, bucket := range a.byModel {
-		report.ByModel = append(report.ByModel, ModelBucket{
-			Model:       model,
-			BucketStats: bucket.finalized(),
-		})
-	}
-	sort.Slice(report.ByModel, func(i, j int) bool {
-		if report.ByModel[i].EstimatedCostUSD == report.ByModel[j].EstimatedCostUSD {
-			return report.ByModel[i].Model < report.ByModel[j].Model
-		}
-		return report.ByModel[i].EstimatedCostUSD > report.ByModel[j].EstimatedCostUSD
+	report.ByModel = collectBuckets(a.byModel, func(model string, stats BucketStats) ModelBucket {
+		return ModelBucket{Model: model, BucketStats: stats}
+	}, func(b ModelBucket) (float64, string) {
+		return b.EstimatedCostUSD, b.Model
 	})
 
-	for project, bucket := range a.byProject {
-		report.ByProject = append(report.ByProject, ProjectBucket{
-			Project:     project,
-			BucketStats: bucket.finalized(),
-		})
-	}
-	sort.Slice(report.ByProject, func(i, j int) bool {
-		if report.ByProject[i].EstimatedCostUSD == report.ByProject[j].EstimatedCostUSD {
-			return report.ByProject[i].Project < report.ByProject[j].Project
-		}
-		return report.ByProject[i].EstimatedCostUSD > report.ByProject[j].EstimatedCostUSD
+	report.ByProject = collectBuckets(a.byProject, func(project string, stats BucketStats) ProjectBucket {
+		return ProjectBucket{Project: project, BucketStats: stats}
+	}, func(b ProjectBucket) (float64, string) {
+		return b.EstimatedCostUSD, b.Project
 	})
 
-	for key, bucket := range a.byProjectModel {
-		parts := strings.SplitN(key, "\x00", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		report.ByProjectModel = append(report.ByProjectModel, ProjectModelBucket{
-			Project:     parts[0],
-			Model:       parts[1],
-			BucketStats: bucket.finalized(),
-		})
-	}
-	sort.Slice(report.ByProjectModel, func(i, j int) bool {
-		if report.ByProjectModel[i].EstimatedCostUSD == report.ByProjectModel[j].EstimatedCostUSD {
-			if report.ByProjectModel[i].Project == report.ByProjectModel[j].Project {
-				return report.ByProjectModel[i].Model < report.ByProjectModel[j].Model
-			}
-			return report.ByProjectModel[i].Project < report.ByProjectModel[j].Project
-		}
-		return report.ByProjectModel[i].EstimatedCostUSD > report.ByProjectModel[j].EstimatedCostUSD
+	report.ByProjectModel = collectBuckets(a.byProjectModel, func(k projectModelKey, stats BucketStats) ProjectModelBucket {
+		return ProjectModelBucket{Project: k.Project, Model: k.Model, BucketStats: stats}
+	}, func(b ProjectModelBucket) (float64, string) {
+		return b.EstimatedCostUSD, b.Project + "\x00" + b.Model
 	})
 
 	return report, nil
+}
+
+// collectBuckets materializes a map of mutable buckets into a sorted slice of
+// rows. Rows sort by descending estimated cost with a deterministic name
+// fallback so output is stable across runs.
+func collectBuckets[K comparable, R any](
+	m map[K]*mutableBucket,
+	build func(K, BucketStats) R,
+	sortKey func(R) (cost float64, name string),
+) []R {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]R, 0, len(m))
+	for k, b := range m {
+		out = append(out, build(k, b.finalized()))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ci, ni := sortKey(out[i])
+		cj, nj := sortKey(out[j])
+		if ci != cj {
+			return ci > cj
+		}
+		return ni < nj
+	})
+	return out
 }
 
 func (a *statsAggregator) scanFile(path string) error {
@@ -571,7 +529,7 @@ func (a *statsAggregator) scanFile(path string) error {
 				model = sessionModel
 			}
 			if model == "" {
-				model = "(unknown)"
+				model = unknownLabel
 			}
 
 			toolUses := extractToolUseCount(env.Message.Content, seenToolUseIDs)
@@ -588,8 +546,7 @@ func (a *statsAggregator) scanFile(path string) error {
 				seenUsageMessageIDs[msgID] = struct{}{}
 			}
 
-			usage := env.Message.Usage.totals()
-			a.addUsage(sessionKey, project, model, usage)
+			a.addUsage(sessionKey, project, model, *env.Message.Usage)
 			continue
 		}
 
@@ -611,7 +568,7 @@ func (a *statsAggregator) scanFile(path string) error {
 
 			model := sessionModel
 			if model == "" {
-				model = "(unknown)"
+				model = unknownLabel
 			}
 			a.addObservedCost(sessionKey, project, model, env.TotalCostUSD)
 		}
@@ -744,12 +701,13 @@ func perTokenCost(tokens int64, usdPerMTok float64) float64 {
 	return (float64(tokens) / 1_000_000.0) * usdPerMTok
 }
 
+// lookupPricing falls back to a family baseline (e.g. opus -> claude-opus-4-7)
+// when an exact model ID isn't in the table — needed because new versioned
+// IDs ship before pricing is added.
 func lookupPricing(model string, table map[string]ModelPricing) (ModelPricing, bool) {
 	if rate, ok := table[model]; ok {
 		return rate, true
 	}
-
-	// Family fallbacks for versioned model IDs.
 	switch {
 	case strings.Contains(model, "opus"):
 		if rate, ok := table["claude-opus-4-7"]; ok {
@@ -770,8 +728,8 @@ func lookupPricing(model string, table map[string]ModelPricing) (ModelPricing, b
 func modelFamily(model string) string {
 	m := strings.ToLower(strings.TrimSpace(model))
 	switch {
-	case m == "", m == "(unknown)":
-		return "(unknown)"
+	case m == "", m == unknownLabel:
+		return unknownLabel
 	case strings.Contains(m, "synthetic"):
 		return "synthetic"
 	case strings.Contains(m, "opus"):

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -174,9 +174,15 @@ func LoadPricingTable(path string) (PricingTable, error) {
 		t.Models = make(map[string]ModelPricing)
 	}
 	// Normalize keys to lowercase so lookupPricing's ToLower model normalization matches.
+	// Keys that collide after lowercasing are an authoring error; return an error rather
+	// than silently keeping whichever map iteration order wins.
 	normalized := make(map[string]ModelPricing, len(t.Models))
 	for k, v := range t.Models {
-		normalized[strings.ToLower(k)] = v
+		lower := strings.ToLower(k)
+		if _, exists := normalized[lower]; exists {
+			return PricingTable{}, fmt.Errorf("pricing file has duplicate key after case normalization: %q", lower)
+		}
+		normalized[lower] = v
 	}
 	t.Models = normalized
 	if t.Version == "" {
@@ -548,7 +554,10 @@ func (a *statsAggregator) scanFile(path string) error {
 				model = unknownLabel
 			}
 
-			toolUses := extractToolUseCount(env.Message.Content, seenToolUseIDs)
+			toolUses, ok := extractToolUseCount(env.Message.Content, seenToolUseIDs)
+			if !ok {
+				a.parseErrors++
+			}
 			a.addToolUses(sessionKey, project, model, toolUses)
 
 			if env.Message.Usage == nil {
@@ -602,13 +611,13 @@ func (a *statsAggregator) scanFile(path string) error {
 	return nil
 }
 
-func extractToolUseCount(contentRaw json.RawMessage, seenToolUseIDs map[string]struct{}) int64 {
+func extractToolUseCount(contentRaw json.RawMessage, seenToolUseIDs map[string]struct{}) (int64, bool) {
 	if len(contentRaw) == 0 || contentRaw[0] != '[' {
-		return 0
+		return 0, true
 	}
 	var blocks []contentBlock
 	if err := json.Unmarshal(contentRaw, &blocks); err != nil {
-		return 0
+		return 0, false
 	}
 	var n int64
 	for _, b := range blocks {
@@ -623,7 +632,7 @@ func extractToolUseCount(contentRaw json.RawMessage, seenToolUseIDs map[string]s
 		}
 		n++
 	}
-	return n
+	return n, true
 }
 
 func projectFromLogPath(path string) string {

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -673,7 +673,8 @@ func collectJSONLFiles(paths []string, includeSubagents bool) ([]string, error) 
 	for _, p := range paths {
 		info, err := os.Stat(p)
 		if err != nil {
-			return nil, err
+			// Skip individual unreadable paths rather than aborting the whole scan.
+			continue
 		}
 		if info.IsDir() {
 			top, err := filepath.Glob(filepath.Join(p, "*.jsonl"))

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -1,0 +1,786 @@
+package sessionanalysis
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// UsageTotals stores token usage counters.
+type UsageTotals struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+}
+
+// TotalTokens returns the sum of all token counters.
+func (u UsageTotals) TotalTokens() int64 {
+	return u.InputTokens + u.OutputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+}
+
+// BucketStats stores aggregated stats for one bucket (global/model/project/etc).
+type BucketStats struct {
+	Sessions int         `json:"sessions"`
+	Usage    UsageTotals `json:"usage"`
+
+	UsageEvents int64 `json:"usage_events"`
+	ToolUses    int64 `json:"tool_uses"`
+
+	ObservedCostUSD  float64 `json:"observed_cost_usd"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+
+	PricedTokens   int64 `json:"priced_tokens"`
+	UnpricedTokens int64 `json:"unpriced_tokens"`
+}
+
+// Coverage returns the fraction of tokens that were priced for estimate.
+func (b BucketStats) Coverage() float64 {
+	total := b.PricedTokens + b.UnpricedTokens
+	if total == 0 {
+		return 1
+	}
+	return float64(b.PricedTokens) / float64(total)
+}
+
+// ModelBucket is one model-level aggregate row.
+type ModelBucket struct {
+	Model string `json:"model"`
+	BucketStats
+}
+
+// FamilyBucket is one model-family aggregate row.
+type FamilyBucket struct {
+	Family string `json:"family"`
+	BucketStats
+}
+
+// ProjectBucket is one project-level aggregate row.
+type ProjectBucket struct {
+	Project string `json:"project"`
+	BucketStats
+}
+
+// ProjectModelBucket is one project+model aggregate row.
+type ProjectModelBucket struct {
+	Project string `json:"project"`
+	Model   string `json:"model"`
+	BucketStats
+}
+
+// PricingMetadata describes pricing source/version in the report.
+type PricingMetadata struct {
+	Version string `json:"version"`
+	Source  string `json:"source"`
+}
+
+// StatsReport is the output of usage/cost aggregation across JSONL sessions.
+type StatsReport struct { //nolint:govet // fieldalignment: readability over packing
+	GeneratedAt time.Time `json:"generated_at"`
+	Since       time.Time `json:"since,omitempty"`
+	Until       time.Time `json:"until,omitempty"`
+
+	FilesScanned  int   `json:"files_scanned"`
+	EventsScanned int64 `json:"events_scanned"`
+	ParseErrors   int64 `json:"parse_errors"`
+
+	Total          BucketStats          `json:"total"`
+	ByFamily       []FamilyBucket       `json:"by_family"`
+	ByModel        []ModelBucket        `json:"by_model"`
+	ByProject      []ProjectBucket      `json:"by_project"`
+	ByProjectModel []ProjectModelBucket `json:"by_project_model"`
+
+	Pricing PricingMetadata `json:"pricing"`
+}
+
+// ModelPricing defines USD price per 1M tokens for each token class.
+type ModelPricing struct {
+	InputPerMTok         float64 `json:"input_per_mtok"`
+	OutputPerMTok        float64 `json:"output_per_mtok"`
+	CacheReadPerMTok     float64 `json:"cache_read_per_mtok"`
+	CacheCreationPerMTok float64 `json:"cache_creation_per_mtok"`
+}
+
+// PricingTable contains model pricing and metadata.
+type PricingTable struct { //nolint:govet // fieldalignment: readability over packing
+	Version string                  `json:"version"`
+	Source  string                  `json:"source"`
+	Models  map[string]ModelPricing `json:"models"`
+}
+
+// DefaultPricingTable returns builtin model pricing for cost estimates.
+func DefaultPricingTable() PricingTable {
+	return PricingTable{
+		Version: "builtin-2026-04-23",
+		Source:  "builtin",
+		Models: map[string]ModelPricing{
+			"claude-opus-4-7": {
+				InputPerMTok:         15.0,
+				OutputPerMTok:        75.0,
+				CacheReadPerMTok:     1.5,
+				CacheCreationPerMTok: 18.75,
+			},
+			"claude-opus-4-6": {
+				InputPerMTok:         15.0,
+				OutputPerMTok:        75.0,
+				CacheReadPerMTok:     1.5,
+				CacheCreationPerMTok: 18.75,
+			},
+			"claude-sonnet-4-6": {
+				InputPerMTok:         3.0,
+				OutputPerMTok:        15.0,
+				CacheReadPerMTok:     0.3,
+				CacheCreationPerMTok: 3.75,
+			},
+			"claude-sonnet-4-5-20250929": {
+				InputPerMTok:         3.0,
+				OutputPerMTok:        15.0,
+				CacheReadPerMTok:     0.3,
+				CacheCreationPerMTok: 3.75,
+			},
+			"claude-haiku-4-5-20251001": {
+				InputPerMTok:         0.8,
+				OutputPerMTok:        4.0,
+				CacheReadPerMTok:     0.08,
+				CacheCreationPerMTok: 1.0,
+			},
+		},
+	}
+}
+
+// LoadPricingTable reads pricing JSON from disk.
+func LoadPricingTable(path string) (PricingTable, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return PricingTable{}, err
+	}
+	defer f.Close()
+
+	var t PricingTable
+	if err := json.NewDecoder(f).Decode(&t); err != nil {
+		return PricingTable{}, fmt.Errorf("decode pricing JSON: %w", err)
+	}
+	if t.Models == nil {
+		t.Models = make(map[string]ModelPricing)
+	}
+	if t.Version == "" {
+		t.Version = "custom"
+	}
+	if t.Source == "" {
+		t.Source = path
+	}
+	return t, nil
+}
+
+// StatsConfig controls usage/cost stats analysis behavior.
+type StatsConfig struct { //nolint:govet // fieldalignment: readability over packing
+	Since            time.Time
+	Until            time.Time
+	IncludeSubagents bool
+	Pricing          PricingTable
+}
+
+// DefaultStatsConfig returns default settings for stats analysis.
+func DefaultStatsConfig() StatsConfig {
+	return StatsConfig{
+		IncludeSubagents: true,
+		Pricing:          DefaultPricingTable(),
+	}
+}
+
+type statsEnvelope struct { //nolint:govet // fieldalignment: readability over packing
+	Type         string                `json:"type"`
+	Subtype      string                `json:"subtype,omitempty"`
+	Timestamp    string                `json:"timestamp,omitempty"`
+	SessionID    string                `json:"sessionId,omitempty"`
+	SessionIDAlt string                `json:"session_id,omitempty"`
+	AgentID      string                `json:"agentId,omitempty"`
+	Model        string                `json:"model,omitempty"`
+	UUID         string                `json:"uuid,omitempty"`
+	TotalCostUSD float64               `json:"total_cost_usd,omitempty"`
+	ModelUsage   map[string]modelUsage `json:"modelUsage,omitempty"`
+	Message      *statsMessage         `json:"message,omitempty"`
+}
+
+type statsMessage struct {
+	ID      string          `json:"id,omitempty"`
+	Role    string          `json:"role,omitempty"`
+	Model   string          `json:"model,omitempty"`
+	Usage   *statsUsage     `json:"usage,omitempty"`
+	Content json.RawMessage `json:"content,omitempty"`
+}
+
+type statsUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+}
+
+func (u statsUsage) totals() UsageTotals {
+	return UsageTotals{
+		InputTokens:              u.InputTokens,
+		OutputTokens:             u.OutputTokens,
+		CacheReadInputTokens:     u.CacheReadInputTokens,
+		CacheCreationInputTokens: u.CacheCreationInputTokens,
+	}
+}
+
+type modelUsage struct {
+	CostUSD float64 `json:"costUSD"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+type mutableBucket struct { //nolint:govet // fieldalignment: readability over packing
+	stats    BucketStats
+	sessions map[string]struct{}
+}
+
+func newMutableBucket() *mutableBucket {
+	return &mutableBucket{
+		sessions: make(map[string]struct{}),
+	}
+}
+
+func (b *mutableBucket) addSession(sessionKey string) {
+	if sessionKey == "" {
+		return
+	}
+	b.sessions[sessionKey] = struct{}{}
+}
+
+func (b *mutableBucket) addUsage(sessionKey string, usage UsageTotals, estimateUSD float64, priced, unpriced int64) {
+	b.addSession(sessionKey)
+	b.stats.UsageEvents++
+	b.stats.Usage.InputTokens += usage.InputTokens
+	b.stats.Usage.OutputTokens += usage.OutputTokens
+	b.stats.Usage.CacheReadInputTokens += usage.CacheReadInputTokens
+	b.stats.Usage.CacheCreationInputTokens += usage.CacheCreationInputTokens
+	b.stats.EstimatedCostUSD += estimateUSD
+	b.stats.PricedTokens += priced
+	b.stats.UnpricedTokens += unpriced
+}
+
+func (b *mutableBucket) addToolUses(sessionKey string, toolUses int64) {
+	if toolUses <= 0 {
+		return
+	}
+	b.addSession(sessionKey)
+	b.stats.ToolUses += toolUses
+}
+
+func (b *mutableBucket) addObservedCost(sessionKey string, costUSD float64) {
+	b.addSession(sessionKey)
+	b.stats.ObservedCostUSD += costUSD
+}
+
+func (b *mutableBucket) finalized() BucketStats {
+	out := b.stats
+	out.Sessions = len(b.sessions)
+	return out
+}
+
+type statsAggregator struct {
+	cfg StatsConfig
+
+	total *mutableBucket
+
+	byFamily       map[string]*mutableBucket
+	byModel        map[string]*mutableBucket
+	byProject      map[string]*mutableBucket
+	byProjectModel map[string]*mutableBucket
+
+	filesScanned  int
+	eventsScanned int64
+	parseErrors   int64
+}
+
+func newStatsAggregator(cfg StatsConfig) *statsAggregator {
+	return &statsAggregator{
+		cfg:            cfg,
+		total:          newMutableBucket(),
+		byFamily:       make(map[string]*mutableBucket),
+		byModel:        make(map[string]*mutableBucket),
+		byProject:      make(map[string]*mutableBucket),
+		byProjectModel: make(map[string]*mutableBucket),
+	}
+}
+
+func (a *statsAggregator) getFamilyBucket(family string) *mutableBucket {
+	if family == "" {
+		family = "(unknown)"
+	}
+	if b, ok := a.byFamily[family]; ok {
+		return b
+	}
+	b := newMutableBucket()
+	a.byFamily[family] = b
+	return b
+}
+
+func (a *statsAggregator) getModelBucket(model string) *mutableBucket {
+	if model == "" {
+		model = "(unknown)"
+	}
+	if b, ok := a.byModel[model]; ok {
+		return b
+	}
+	b := newMutableBucket()
+	a.byModel[model] = b
+	return b
+}
+
+func (a *statsAggregator) getProjectBucket(project string) *mutableBucket {
+	if project == "" {
+		project = "(unknown)"
+	}
+	if b, ok := a.byProject[project]; ok {
+		return b
+	}
+	b := newMutableBucket()
+	a.byProject[project] = b
+	return b
+}
+
+func (a *statsAggregator) getProjectModelBucket(project, model string) *mutableBucket {
+	if project == "" {
+		project = "(unknown)"
+	}
+	if model == "" {
+		model = "(unknown)"
+	}
+	key := project + "\x00" + model
+	if b, ok := a.byProjectModel[key]; ok {
+		return b
+	}
+	b := newMutableBucket()
+	a.byProjectModel[key] = b
+	return b
+}
+
+func (a *statsAggregator) addUsage(sessionKey, project, model string, usage UsageTotals) {
+	estimateUSD, priced, unpriced := estimateCost(model, usage, a.cfg.Pricing)
+	family := modelFamily(model)
+
+	a.total.addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+	a.getFamilyBucket(family).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+	a.getModelBucket(model).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+	a.getProjectBucket(project).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+	a.getProjectModelBucket(project, model).addUsage(sessionKey, usage, estimateUSD, priced, unpriced)
+}
+
+func (a *statsAggregator) addToolUses(sessionKey, project, model string, toolUses int64) {
+	if toolUses <= 0 {
+		return
+	}
+	family := modelFamily(model)
+	a.total.addToolUses(sessionKey, toolUses)
+	a.getFamilyBucket(family).addToolUses(sessionKey, toolUses)
+	a.getModelBucket(model).addToolUses(sessionKey, toolUses)
+	a.getProjectBucket(project).addToolUses(sessionKey, toolUses)
+	a.getProjectModelBucket(project, model).addToolUses(sessionKey, toolUses)
+}
+
+func (a *statsAggregator) addObservedCost(sessionKey, project, model string, costUSD float64) {
+	if costUSD == 0 {
+		return
+	}
+	family := modelFamily(model)
+	a.total.addObservedCost(sessionKey, costUSD)
+	a.getFamilyBucket(family).addObservedCost(sessionKey, costUSD)
+	a.getModelBucket(model).addObservedCost(sessionKey, costUSD)
+	a.getProjectBucket(project).addObservedCost(sessionKey, costUSD)
+	a.getProjectModelBucket(project, model).addObservedCost(sessionKey, costUSD)
+}
+
+func (a *statsAggregator) shouldIncludeEvent(ts time.Time, hasTimestamp bool) bool {
+	if !hasTimestamp {
+		return true
+	}
+	if !a.cfg.Since.IsZero() && ts.Before(a.cfg.Since) {
+		return false
+	}
+	if !a.cfg.Until.IsZero() && ts.After(a.cfg.Until) {
+		return false
+	}
+	return true
+}
+
+// AnalyzeUsageStats scans session logs from the provided paths and returns
+// token/cost aggregates.
+func AnalyzeUsageStats(paths []string, cfg StatsConfig) (*StatsReport, error) {
+	files, err := collectJSONLFiles(paths, cfg.IncludeSubagents)
+	if err != nil {
+		return nil, err
+	}
+	return AnalyzeUsageStatsFromFiles(files, cfg)
+}
+
+// AnalyzeUsageStatsFromFiles scans explicit JSONL files and returns stats.
+func AnalyzeUsageStatsFromFiles(files []string, cfg StatsConfig) (*StatsReport, error) {
+	a := newStatsAggregator(cfg)
+
+	for _, path := range files {
+		if err := a.scanFile(path); err != nil {
+			return nil, err
+		}
+	}
+
+	report := &StatsReport{
+		GeneratedAt:   time.Now().UTC(),
+		Since:         cfg.Since,
+		Until:         cfg.Until,
+		FilesScanned:  a.filesScanned,
+		EventsScanned: a.eventsScanned,
+		ParseErrors:   a.parseErrors,
+		Total:         a.total.finalized(),
+		Pricing: PricingMetadata{
+			Version: cfg.Pricing.Version,
+			Source:  cfg.Pricing.Source,
+		},
+	}
+
+	for family, bucket := range a.byFamily {
+		report.ByFamily = append(report.ByFamily, FamilyBucket{
+			Family:      family,
+			BucketStats: bucket.finalized(),
+		})
+	}
+	sort.Slice(report.ByFamily, func(i, j int) bool {
+		if report.ByFamily[i].EstimatedCostUSD == report.ByFamily[j].EstimatedCostUSD {
+			return report.ByFamily[i].Family < report.ByFamily[j].Family
+		}
+		return report.ByFamily[i].EstimatedCostUSD > report.ByFamily[j].EstimatedCostUSD
+	})
+
+	for model, bucket := range a.byModel {
+		report.ByModel = append(report.ByModel, ModelBucket{
+			Model:       model,
+			BucketStats: bucket.finalized(),
+		})
+	}
+	sort.Slice(report.ByModel, func(i, j int) bool {
+		if report.ByModel[i].EstimatedCostUSD == report.ByModel[j].EstimatedCostUSD {
+			return report.ByModel[i].Model < report.ByModel[j].Model
+		}
+		return report.ByModel[i].EstimatedCostUSD > report.ByModel[j].EstimatedCostUSD
+	})
+
+	for project, bucket := range a.byProject {
+		report.ByProject = append(report.ByProject, ProjectBucket{
+			Project:     project,
+			BucketStats: bucket.finalized(),
+		})
+	}
+	sort.Slice(report.ByProject, func(i, j int) bool {
+		if report.ByProject[i].EstimatedCostUSD == report.ByProject[j].EstimatedCostUSD {
+			return report.ByProject[i].Project < report.ByProject[j].Project
+		}
+		return report.ByProject[i].EstimatedCostUSD > report.ByProject[j].EstimatedCostUSD
+	})
+
+	for key, bucket := range a.byProjectModel {
+		parts := strings.SplitN(key, "\x00", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		report.ByProjectModel = append(report.ByProjectModel, ProjectModelBucket{
+			Project:     parts[0],
+			Model:       parts[1],
+			BucketStats: bucket.finalized(),
+		})
+	}
+	sort.Slice(report.ByProjectModel, func(i, j int) bool {
+		if report.ByProjectModel[i].EstimatedCostUSD == report.ByProjectModel[j].EstimatedCostUSD {
+			if report.ByProjectModel[i].Project == report.ByProjectModel[j].Project {
+				return report.ByProjectModel[i].Model < report.ByProjectModel[j].Model
+			}
+			return report.ByProjectModel[i].Project < report.ByProjectModel[j].Project
+		}
+		return report.ByProjectModel[i].EstimatedCostUSD > report.ByProjectModel[j].EstimatedCostUSD
+	})
+
+	return report, nil
+}
+
+func (a *statsAggregator) scanFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	a.filesScanned++
+
+	project := projectFromLogPath(path)
+	sessionKey := sessionKeyFromLogPath(path)
+	sessionModel := ""
+
+	seenUsageMessageIDs := make(map[string]struct{})
+	seenToolUseIDs := make(map[string]struct{})
+	seenResultUUIDs := make(map[string]struct{})
+
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 1024*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	for scanner.Scan() {
+		a.eventsScanned++
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var env statsEnvelope
+		if err := json.Unmarshal(line, &env); err != nil {
+			a.parseErrors++
+			continue
+		}
+
+		var eventTime time.Time
+		hasTimestamp := false
+		if env.Timestamp != "" {
+			if ts, err := time.Parse(time.RFC3339Nano, env.Timestamp); err == nil {
+				eventTime = ts
+				hasTimestamp = true
+			}
+		}
+		if !a.shouldIncludeEvent(eventTime, hasTimestamp) {
+			continue
+		}
+
+		if env.Type == "system" && env.Subtype == "init" && env.Model != "" {
+			sessionModel = env.Model
+		}
+
+		if env.Message != nil && env.Type == "assistant" {
+			msgID := strings.TrimSpace(env.Message.ID)
+
+			model := strings.TrimSpace(env.Message.Model)
+			if model == "" {
+				model = sessionModel
+			}
+			if model == "" {
+				model = "(unknown)"
+			}
+
+			toolUses := extractToolUseCount(env.Message.Content, seenToolUseIDs)
+			a.addToolUses(sessionKey, project, model, toolUses)
+
+			if env.Message.Usage == nil {
+				continue
+			}
+
+			if msgID != "" {
+				if _, seen := seenUsageMessageIDs[msgID]; seen {
+					continue
+				}
+				seenUsageMessageIDs[msgID] = struct{}{}
+			}
+
+			usage := env.Message.Usage.totals()
+			a.addUsage(sessionKey, project, model, usage)
+			continue
+		}
+
+		if env.Type == "result" {
+			uuid := strings.TrimSpace(env.UUID)
+			if uuid != "" {
+				if _, seen := seenResultUUIDs[uuid]; seen {
+					continue
+				}
+				seenResultUUIDs[uuid] = struct{}{}
+			}
+
+			if len(env.ModelUsage) > 0 {
+				for model, mu := range env.ModelUsage {
+					a.addObservedCost(sessionKey, project, model, mu.CostUSD)
+				}
+				continue
+			}
+
+			model := sessionModel
+			if model == "" {
+				model = "(unknown)"
+			}
+			a.addObservedCost(sessionKey, project, model, env.TotalCostUSD)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan %s: %w", path, err)
+	}
+	return nil
+}
+
+func extractToolUseCount(contentRaw json.RawMessage, seenToolUseIDs map[string]struct{}) int64 {
+	if len(contentRaw) == 0 || contentRaw[0] != '[' {
+		return 0
+	}
+	var blocks []contentBlock
+	if err := json.Unmarshal(contentRaw, &blocks); err != nil {
+		return 0
+	}
+	var n int64
+	for _, b := range blocks {
+		if b.Type != "tool_use" {
+			continue
+		}
+		if b.ID != "" {
+			if _, seen := seenToolUseIDs[b.ID]; seen {
+				continue
+			}
+			seenToolUseIDs[b.ID] = struct{}{}
+		}
+		n++
+	}
+	return n
+}
+
+func projectFromLogPath(path string) string {
+	clean := filepath.Clean(path)
+	parent := filepath.Base(filepath.Dir(clean))
+	if parent == "subagents" {
+		return filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(clean))))
+	}
+	return filepath.Base(filepath.Dir(clean))
+}
+
+func sessionKeyFromLogPath(path string) string {
+	clean := filepath.Clean(path)
+	parent := filepath.Base(filepath.Dir(clean))
+	if parent == "subagents" {
+		rootSession := filepath.Base(filepath.Dir(filepath.Dir(clean)))
+		agent := strings.TrimSuffix(filepath.Base(clean), filepath.Ext(clean))
+		return rootSession + "/" + agent
+	}
+	return strings.TrimSuffix(filepath.Base(clean), filepath.Ext(clean))
+}
+
+func collectJSONLFiles(paths []string, includeSubagents bool) ([]string, error) {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(path string) {
+		if !strings.HasSuffix(path, ".jsonl") {
+			return
+		}
+		clean := filepath.Clean(path)
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDir() {
+			top, err := filepath.Glob(filepath.Join(p, "*.jsonl"))
+			if err != nil {
+				return nil, err
+			}
+			for _, f := range top {
+				add(f)
+			}
+			if includeSubagents {
+				sub, err := filepath.Glob(filepath.Join(p, "*", "subagents", "*.jsonl"))
+				if err != nil {
+					return nil, err
+				}
+				for _, f := range sub {
+					add(f)
+				}
+			}
+			continue
+		}
+
+		add(p)
+		if includeSubagents {
+			base := strings.TrimSuffix(p, filepath.Ext(p))
+			sub, err := filepath.Glob(filepath.Join(base, "subagents", "*.jsonl"))
+			if err != nil {
+				return nil, err
+			}
+			for _, f := range sub {
+				add(f)
+			}
+		}
+	}
+
+	sort.Strings(out)
+	return out, nil
+}
+
+func estimateCost(model string, usage UsageTotals, pricing PricingTable) (usd float64, pricedTokens, unpricedTokens int64) {
+	model = strings.TrimSpace(strings.ToLower(model))
+	rate, ok := lookupPricing(model, pricing.Models)
+	if !ok {
+		return 0, 0, usage.TotalTokens()
+	}
+
+	usd += perTokenCost(usage.InputTokens, rate.InputPerMTok)
+	usd += perTokenCost(usage.OutputTokens, rate.OutputPerMTok)
+	usd += perTokenCost(usage.CacheReadInputTokens, rate.CacheReadPerMTok)
+	usd += perTokenCost(usage.CacheCreationInputTokens, rate.CacheCreationPerMTok)
+	return usd, usage.TotalTokens(), 0
+}
+
+func perTokenCost(tokens int64, usdPerMTok float64) float64 {
+	if tokens <= 0 || usdPerMTok <= 0 {
+		return 0
+	}
+	return (float64(tokens) / 1_000_000.0) * usdPerMTok
+}
+
+func lookupPricing(model string, table map[string]ModelPricing) (ModelPricing, bool) {
+	if rate, ok := table[model]; ok {
+		return rate, true
+	}
+
+	// Family fallbacks for versioned model IDs.
+	switch {
+	case strings.Contains(model, "opus"):
+		if rate, ok := table["claude-opus-4-7"]; ok {
+			return rate, true
+		}
+	case strings.Contains(model, "sonnet"):
+		if rate, ok := table["claude-sonnet-4-6"]; ok {
+			return rate, true
+		}
+	case strings.Contains(model, "haiku"):
+		if rate, ok := table["claude-haiku-4-5-20251001"]; ok {
+			return rate, true
+		}
+	}
+	return ModelPricing{}, false
+}
+
+func modelFamily(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case m == "", m == "(unknown)":
+		return "(unknown)"
+	case strings.Contains(m, "synthetic"):
+		return "synthetic"
+	case strings.Contains(m, "opus"):
+		return "opus"
+	case strings.Contains(m, "sonnet"):
+		return "sonnet"
+	case strings.Contains(m, "haiku"):
+		return "haiku"
+	default:
+		return "other"
+	}
+}

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -173,6 +173,12 @@ func LoadPricingTable(path string) (PricingTable, error) {
 	if t.Models == nil {
 		t.Models = make(map[string]ModelPricing)
 	}
+	// Normalize keys to lowercase so lookupPricing's ToLower model normalization matches.
+	normalized := make(map[string]ModelPricing, len(t.Models))
+	for k, v := range t.Models {
+		normalized[strings.ToLower(k)] = v
+	}
+	t.Models = normalized
 	if t.Version == "" {
 		t.Version = "custom"
 	}
@@ -371,6 +377,9 @@ func (a *statsAggregator) addObservedCost(sessionKey, project, model string, cos
 	}
 }
 
+// shouldIncludeEvent returns true when an event falls within the configured
+// time window. Events that lack a parseable timestamp are always included
+// because their position in the window cannot be determined.
 func (a *statsAggregator) shouldIncludeEvent(ts time.Time, hasTimestamp bool) bool {
 	if !hasTimestamp {
 		return true
@@ -487,6 +496,7 @@ func (a *statsAggregator) scanFile(path string) error {
 	seenUsageMessageIDs := make(map[string]struct{})
 	seenToolUseIDs := make(map[string]struct{})
 	seenResultUUIDs := make(map[string]struct{})
+	seenUUIDlessResult := false
 
 	scanner := bufio.NewScanner(f)
 	buf := make([]byte, 0, 1024*1024)
@@ -557,6 +567,13 @@ func (a *statsAggregator) scanFile(path string) error {
 					continue
 				}
 				seenResultUUIDs[uuid] = struct{}{}
+			} else {
+				// No UUID: only count the first result event to avoid double-counting
+				// sessions that were resumed or have multiple result lines.
+				if seenUUIDlessResult {
+					continue
+				}
+				seenUUIDlessResult = true
 			}
 
 			if len(env.ModelUsage) > 0 {

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -521,12 +521,16 @@ func (a *statsAggregator) scanFile(path string) error {
 			if ts, err := time.Parse(time.RFC3339Nano, env.Timestamp); err == nil {
 				eventTime = ts
 				hasTimestamp = true
+			} else {
+				// Non-empty but unparseable timestamp: count as a parse error and
+				// treat the event as timestamp-less (included in any window).
+				a.parseErrors++
 			}
 		}
 		// Always process system/init to capture the session model even when the
 		// event falls outside the configured time window.
 		if env.Type == "system" && env.Subtype == "init" && env.Model != "" {
-			sessionModel = env.Model
+			sessionModel = strings.ToLower(strings.TrimSpace(env.Model))
 		}
 
 		if !a.shouldIncludeEvent(eventTime, hasTimestamp) {
@@ -536,7 +540,7 @@ func (a *statsAggregator) scanFile(path string) error {
 		if env.Message != nil && env.Type == "assistant" {
 			msgID := strings.TrimSpace(env.Message.ID)
 
-			model := strings.TrimSpace(env.Message.Model)
+			model := strings.ToLower(strings.TrimSpace(env.Message.Model))
 			if model == "" {
 				model = sessionModel
 			}
@@ -580,7 +584,7 @@ func (a *statsAggregator) scanFile(path string) error {
 
 			if len(env.ModelUsage) > 0 {
 				for model, mu := range env.ModelUsage {
-					a.addObservedCost(sessionKey, project, model, mu.CostUSD)
+					a.addObservedCost(sessionKey, project, strings.ToLower(strings.TrimSpace(model)), mu.CostUSD)
 				}
 				continue
 			}

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -178,7 +178,7 @@ func LoadPricingTable(path string) (PricingTable, error) {
 	// than silently keeping whichever map iteration order wins.
 	normalized := make(map[string]ModelPricing, len(t.Models))
 	for k, v := range t.Models {
-		lower := strings.ToLower(k)
+		lower := strings.ToLower(strings.TrimSpace(k))
 		if _, exists := normalized[lower]; exists {
 			return PricingTable{}, fmt.Errorf("pricing file has duplicate key after case normalization: %q", lower)
 		}

--- a/bramble/sessionanalysis/stats.go
+++ b/bramble/sessionanalysis/stats.go
@@ -523,12 +523,14 @@ func (a *statsAggregator) scanFile(path string) error {
 				hasTimestamp = true
 			}
 		}
-		if !a.shouldIncludeEvent(eventTime, hasTimestamp) {
-			continue
-		}
-
+		// Always process system/init to capture the session model even when the
+		// event falls outside the configured time window.
 		if env.Type == "system" && env.Subtype == "init" && env.Model != "" {
 			sessionModel = env.Model
+		}
+
+		if !a.shouldIncludeEvent(eventTime, hasTimestamp) {
+			continue
 		}
 
 		if env.Message != nil && env.Type == "assistant" {

--- a/bramble/sessionanalysis/stats_test.go
+++ b/bramble/sessionanalysis/stats_test.go
@@ -1,0 +1,409 @@
+package sessionanalysis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeUsageStats_IncludeSubagentsByDefault(t *testing.T) {
+	projectDir := t.TempDir()
+
+	topPath := filepath.Join(projectDir, "session-top.jsonl")
+	subDir := filepath.Join(projectDir, "session-top", "subagents")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	subPath := filepath.Join(subDir, "agent-a.jsonl")
+
+	require.NoError(t, writeJSONLLines(topPath,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:00:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-top-1",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{
+					"input_tokens":                100,
+					"output_tokens":               50,
+					"cache_read_input_tokens":     10,
+					"cache_creation_input_tokens": 5,
+				},
+			},
+		}),
+	))
+
+	require.NoError(t, writeJSONLLines(subPath,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:05:00Z",
+			"agentId":   "worker-a",
+			"message": map[string]interface{}{
+				"id":    "msg-sub-1",
+				"model": "claude-opus-4-7",
+				"usage": map[string]interface{}{
+					"input_tokens":                200,
+					"output_tokens":               80,
+					"cache_read_input_tokens":     20,
+					"cache_creation_input_tokens": 10,
+				},
+			},
+		}),
+	))
+
+	report, err := AnalyzeUsageStats([]string{projectDir}, DefaultStatsConfig())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, report.FilesScanned, "top-level + subagent")
+	assert.EqualValues(t, 300, report.Total.Usage.InputTokens)
+	assert.EqualValues(t, 130, report.Total.Usage.OutputTokens)
+	assert.EqualValues(t, 30, report.Total.Usage.CacheReadInputTokens)
+	assert.EqualValues(t, 15, report.Total.Usage.CacheCreationInputTokens)
+	assert.Equal(t, 2, report.Total.Sessions)
+	assert.Len(t, report.ByModel, 2)
+}
+
+func TestAnalyzeUsageStats_TopLevelOnly(t *testing.T) {
+	projectDir := t.TempDir()
+
+	topPath := filepath.Join(projectDir, "session-top.jsonl")
+	subDir := filepath.Join(projectDir, "session-top", "subagents")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	subPath := filepath.Join(subDir, "agent-a.jsonl")
+
+	require.NoError(t, writeJSONLLines(topPath,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:00:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-top-1",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{
+					"input_tokens":                100,
+					"output_tokens":               50,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+	))
+	require.NoError(t, writeJSONLLines(subPath,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:05:00Z",
+			"agentId":   "worker-a",
+			"message": map[string]interface{}{
+				"id":    "msg-sub-1",
+				"model": "claude-opus-4-7",
+				"usage": map[string]interface{}{
+					"input_tokens":                200,
+					"output_tokens":               80,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+	))
+
+	cfg := DefaultStatsConfig()
+	cfg.IncludeSubagents = false
+	report, err := AnalyzeUsageStats([]string{projectDir}, cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.FilesScanned)
+	assert.EqualValues(t, 100, report.Total.Usage.InputTokens)
+	assert.EqualValues(t, 50, report.Total.Usage.OutputTokens)
+	assert.Equal(t, 1, report.Total.Sessions)
+}
+
+func TestAnalyzeUsageStats_DedupesAssistantUsageAndToolUse(t *testing.T) {
+	projectDir := t.TempDir()
+	path := filepath.Join(projectDir, "session.jsonl")
+
+	line := eventLine(map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": "2026-04-23T01:00:00Z",
+		"message": map[string]interface{}{
+			"id":    "msg-1",
+			"model": "claude-sonnet-4-6",
+			"usage": map[string]interface{}{
+				"input_tokens":                100,
+				"output_tokens":               10,
+				"cache_read_input_tokens":     5,
+				"cache_creation_input_tokens": 0,
+			},
+			"content": []map[string]interface{}{
+				{
+					"type": "tool_use",
+					"id":   "tool-1",
+					"name": "Read",
+				},
+			},
+		},
+	})
+	// Duplicate same message id/usage/tool_use should be counted once.
+	require.NoError(t, writeJSONLLines(path, line, line))
+
+	report, err := AnalyzeUsageStats([]string{projectDir}, DefaultStatsConfig())
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 100, report.Total.Usage.InputTokens)
+	assert.EqualValues(t, 10, report.Total.Usage.OutputTokens)
+	assert.EqualValues(t, 5, report.Total.Usage.CacheReadInputTokens)
+	assert.EqualValues(t, 1, report.Total.ToolUses)
+	assert.EqualValues(t, 1, report.Total.UsageEvents)
+}
+
+func TestAnalyzeUsageStats_CountsToolUseFromLaterDuplicateMessage(t *testing.T) {
+	projectDir := t.TempDir()
+	path := filepath.Join(projectDir, "session.jsonl")
+
+	first := eventLine(map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": "2026-04-23T01:00:00Z",
+		"message": map[string]interface{}{
+			"id":    "msg-1",
+			"model": "claude-sonnet-4-6",
+			"usage": map[string]interface{}{
+				"input_tokens":                100,
+				"output_tokens":               10,
+				"cache_read_input_tokens":     0,
+				"cache_creation_input_tokens": 0,
+			},
+			"content": []map[string]interface{}{
+				{
+					"type": "text",
+					"text": "thinking...",
+				},
+			},
+		},
+	})
+
+	second := eventLine(map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": "2026-04-23T01:00:01Z",
+		"message": map[string]interface{}{
+			"id":    "msg-1",
+			"model": "claude-sonnet-4-6",
+			"usage": map[string]interface{}{
+				"input_tokens":                100,
+				"output_tokens":               10,
+				"cache_read_input_tokens":     0,
+				"cache_creation_input_tokens": 0,
+			},
+			"content": []map[string]interface{}{
+				{
+					"type": "tool_use",
+					"id":   "tool-1",
+					"name": "Read",
+				},
+			},
+		},
+	})
+
+	require.NoError(t, writeJSONLLines(path, first, second))
+
+	report, err := AnalyzeUsageStats([]string{projectDir}, DefaultStatsConfig())
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 100, report.Total.Usage.InputTokens, "usage must be deduped by message id")
+	assert.EqualValues(t, 1, report.Total.ToolUses, "tool_use in later duplicate message must still count")
+}
+
+func TestAnalyzeUsageStats_WindowFilter(t *testing.T) {
+	projectDir := t.TempDir()
+	path := filepath.Join(projectDir, "session.jsonl")
+
+	require.NoError(t, writeJSONLLines(path,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-22T23:59:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-old",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{
+					"input_tokens":                100,
+					"output_tokens":               0,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T00:01:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-new",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{
+					"input_tokens":                200,
+					"output_tokens":               0,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+	))
+
+	cfg := DefaultStatsConfig()
+	cfg.Since = mustTime(t, "2026-04-23T00:00:00Z")
+	report, err := AnalyzeUsageStats([]string{projectDir}, cfg)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 200, report.Total.Usage.InputTokens)
+}
+
+func TestAnalyzeUsageStats_EstimatedCostWithCustomPricing(t *testing.T) {
+	projectDir := t.TempDir()
+	path := filepath.Join(projectDir, "session.jsonl")
+
+	require.NoError(t, writeJSONLLines(path,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:00:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-1",
+				"model": "my-model",
+				"usage": map[string]interface{}{
+					"input_tokens":                1000,
+					"output_tokens":               2000,
+					"cache_read_input_tokens":     3000,
+					"cache_creation_input_tokens": 4000,
+				},
+			},
+		}),
+	))
+
+	cfg := DefaultStatsConfig()
+	cfg.Pricing = PricingTable{
+		Version: "test",
+		Source:  "test",
+		Models: map[string]ModelPricing{
+			"my-model": {
+				InputPerMTok:         1,
+				OutputPerMTok:        2,
+				CacheReadPerMTok:     3,
+				CacheCreationPerMTok: 4,
+			},
+		},
+	}
+
+	report, err := AnalyzeUsageStats([]string{projectDir}, cfg)
+	require.NoError(t, err)
+
+	// (1000*1 + 2000*2 + 3000*3 + 4000*4) / 1e6 = 0.03
+	assert.InDelta(t, 0.03, report.Total.EstimatedCostUSD, 1e-9)
+	assert.EqualValues(t, 10000, report.Total.PricedTokens)
+	assert.EqualValues(t, 0, report.Total.UnpricedTokens)
+}
+
+func TestAnalyzeUsageStats_ByFamilyRollup(t *testing.T) {
+	projectDir := t.TempDir()
+	path := filepath.Join(projectDir, "session.jsonl")
+
+	require.NoError(t, writeJSONLLines(path,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:00:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-opus",
+				"model": "claude-opus-4-7",
+				"usage": map[string]interface{}{
+					"input_tokens":                100,
+					"output_tokens":               10,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:00:01Z",
+			"message": map[string]interface{}{
+				"id":    "msg-opus-v46",
+				"model": "claude-opus-4-6",
+				"usage": map[string]interface{}{
+					"input_tokens":                200,
+					"output_tokens":               20,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-23T01:00:02Z",
+			"message": map[string]interface{}{
+				"id":    "msg-sonnet",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{
+					"input_tokens":                300,
+					"output_tokens":               30,
+					"cache_read_input_tokens":     0,
+					"cache_creation_input_tokens": 0,
+				},
+			},
+		}),
+	))
+
+	report, err := AnalyzeUsageStats([]string{projectDir}, DefaultStatsConfig())
+	require.NoError(t, err)
+
+	byFamily := make(map[string]FamilyBucket)
+	for i := range report.ByFamily {
+		byFamily[report.ByFamily[i].Family] = report.ByFamily[i]
+	}
+
+	opus, ok := byFamily["opus"]
+	require.True(t, ok)
+	assert.EqualValues(t, 300, opus.Usage.InputTokens)
+	assert.EqualValues(t, 30, opus.Usage.OutputTokens)
+
+	sonnet, ok := byFamily["sonnet"]
+	require.True(t, ok)
+	assert.EqualValues(t, 300, sonnet.Usage.InputTokens)
+	assert.EqualValues(t, 30, sonnet.Usage.OutputTokens)
+}
+
+func writeJSONLLines(path string, lines ...string) error {
+	return os.WriteFile(path, []byte(stringsJoin(lines, "\n")+"\n"), 0o644)
+}
+
+func eventLine(v map[string]interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	out, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return out
+}
+
+func stringsJoin(parts []string, sep string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	}
+	n := len(sep) * (len(parts) - 1)
+	for i := range parts {
+		n += len(parts[i])
+	}
+	b := make([]byte, 0, n)
+	for i, p := range parts {
+		if i > 0 {
+			b = append(b, sep...)
+		}
+		b = append(b, p...)
+	}
+	return string(b)
+}

--- a/bramble/sessionanalysis/stats_test.go
+++ b/bramble/sessionanalysis/stats_test.go
@@ -369,6 +369,39 @@ func TestAnalyzeUsageStats_ByFamilyRollup(t *testing.T) {
 	assert.EqualValues(t, 30, sonnet.Usage.OutputTokens)
 }
 
+func TestAnalyzeUsageStats_SessionModelAttributedWhenInitBeforeWindow(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// system/init is before the --since window; result event is inside the window.
+	// The result event has no modelUsage so it must fall back to sessionModel.
+	// Without the fix, sessionModel stays empty and the result goes to "(unknown)".
+	require.NoError(t, writeJSONLLines(path,
+		eventLine(map[string]interface{}{
+			"type":      "system",
+			"subtype":   "init",
+			"timestamp": "2026-03-31T00:00:00Z", // before Since
+			"model":     "claude-sonnet-4-6",
+		}),
+		eventLine(map[string]interface{}{
+			"type":           "result",
+			"timestamp":      "2026-04-02T00:00:00Z", // inside Since
+			"total_cost_usd": 0.01,
+		}),
+	))
+
+	cfg := DefaultStatsConfig()
+	cfg.Since = mustTime(t, "2026-04-01T00:00:00Z")
+	report, err := AnalyzeUsageStats([]string{dir}, cfg)
+	require.NoError(t, err)
+
+	// The result cost must be attributed to the correct model, not "(unknown)".
+	require.Len(t, report.ByModel, 1)
+	assert.Equal(t, "claude-sonnet-4-6", report.ByModel[0].Model)
+	assert.InDelta(t, 0.01, report.ByModel[0].ObservedCostUSD, 1e-9)
+}
+
 func TestAnalyzeUsageStats_UntilFiltering(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/bramble/sessionanalysis/stats_test.go
+++ b/bramble/sessionanalysis/stats_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -369,7 +370,7 @@ func TestAnalyzeUsageStats_ByFamilyRollup(t *testing.T) {
 }
 
 func writeJSONLLines(path string, lines ...string) error {
-	return os.WriteFile(path, []byte(stringsJoin(lines, "\n")+"\n"), 0o644)
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
 }
 
 func eventLine(v map[string]interface{}) string {
@@ -385,25 +386,4 @@ func mustTime(t *testing.T, s string) time.Time {
 	out, err := time.Parse(time.RFC3339, s)
 	require.NoError(t, err)
 	return out
-}
-
-func stringsJoin(parts []string, sep string) string {
-	switch len(parts) {
-	case 0:
-		return ""
-	case 1:
-		return parts[0]
-	}
-	n := len(sep) * (len(parts) - 1)
-	for i := range parts {
-		n += len(parts[i])
-	}
-	b := make([]byte, 0, n)
-	for i, p := range parts {
-		if i > 0 {
-			b = append(b, sep...)
-		}
-		b = append(b, p...)
-	}
-	return string(b)
 }

--- a/bramble/sessionanalysis/stats_test.go
+++ b/bramble/sessionanalysis/stats_test.go
@@ -369,6 +369,113 @@ func TestAnalyzeUsageStats_ByFamilyRollup(t *testing.T) {
 	assert.EqualValues(t, 30, sonnet.Usage.OutputTokens)
 }
 
+func TestAnalyzeUsageStats_UntilFiltering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	require.NoError(t, writeJSONLLines(path,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-01T00:00:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-before",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{"input_tokens": 100, "output_tokens": 50},
+			},
+		}),
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "2026-04-10T00:00:00Z",
+			"message": map[string]interface{}{
+				"id":    "msg-after",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{"input_tokens": 200, "output_tokens": 80},
+			},
+		}),
+	))
+
+	cfg := DefaultStatsConfig()
+	cfg.Until = mustTime(t, "2026-04-05T00:00:00Z")
+	report, err := AnalyzeUsageStats([]string{dir}, cfg)
+	require.NoError(t, err)
+
+	// Only the event before the Until cutoff should be counted.
+	assert.EqualValues(t, 100, report.Total.Usage.InputTokens)
+	assert.EqualValues(t, 50, report.Total.Usage.OutputTokens)
+}
+
+func TestAnalyzeUsageStats_ResultEventObservedCost(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	require.NoError(t, writeJSONLLines(path,
+		// result with UUID — should be counted once even if duplicated
+		eventLine(map[string]interface{}{
+			"type":      "result",
+			"timestamp": "2026-04-01T00:00:00Z",
+			"uuid":      "result-uuid-1",
+			"modelUsage": map[string]interface{}{
+				"claude-sonnet-4-6": map[string]interface{}{"costUSD": 0.005},
+			},
+		}),
+		// duplicate of the same UUID — should be deduplicated
+		eventLine(map[string]interface{}{
+			"type":      "result",
+			"timestamp": "2026-04-01T00:01:00Z",
+			"uuid":      "result-uuid-1",
+			"modelUsage": map[string]interface{}{
+				"claude-sonnet-4-6": map[string]interface{}{"costUSD": 0.005},
+			},
+		}),
+		// result without UUID — should be counted once
+		eventLine(map[string]interface{}{
+			"type":           "result",
+			"timestamp":      "2026-04-01T00:02:00Z",
+			"total_cost_usd": 0.010,
+		}),
+		// second uuid-less result — should be deduplicated (only first counts)
+		eventLine(map[string]interface{}{
+			"type":           "result",
+			"timestamp":      "2026-04-01T00:03:00Z",
+			"total_cost_usd": 0.010,
+		}),
+	))
+
+	report, err := AnalyzeUsageStats([]string{dir}, DefaultStatsConfig())
+	require.NoError(t, err)
+
+	// UUID-based result: 0.005 (deduplicated from 2 identical events)
+	// UUID-less result: 0.010 (first of 2 identical events, second deduplicated)
+	assert.InDelta(t, 0.015, report.Total.ObservedCostUSD, 1e-9)
+}
+
+func TestLoadPricingTable_NormalizesKeyCasing(t *testing.T) {
+	t.Parallel()
+	f, err := os.CreateTemp(t.TempDir(), "pricing*.json")
+	require.NoError(t, err)
+	require.NoError(t, json.NewEncoder(f).Encode(map[string]interface{}{
+		"version": "test",
+		"models": map[string]interface{}{
+			// Mixed-case keys — should be normalized to lowercase so lookupPricing finds them.
+			"Claude-Sonnet-4-6": map[string]interface{}{
+				"input_per_mtok":  3.0,
+				"output_per_mtok": 15.0,
+			},
+		},
+	}))
+	require.NoError(t, f.Close())
+
+	tbl, err := LoadPricingTable(f.Name())
+	require.NoError(t, err)
+
+	// The key must exist in lowercase for lookupPricing to match.
+	_, ok := tbl.Models["claude-sonnet-4-6"]
+	assert.True(t, ok, "expected lowercase key after normalization")
+	// Original mixed-case key must not survive.
+	_, ok = tbl.Models["Claude-Sonnet-4-6"]
+	assert.False(t, ok, "mixed-case key should have been removed")
+}
+
 func writeJSONLLines(path string, lines ...string) error {
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
 }

--- a/bramble/sessionanalysis/stats_test.go
+++ b/bramble/sessionanalysis/stats_test.go
@@ -402,6 +402,35 @@ func TestAnalyzeUsageStats_SessionModelAttributedWhenInitBeforeWindow(t *testing
 	assert.InDelta(t, 0.01, report.ByModel[0].ObservedCostUSD, 1e-9)
 }
 
+func TestAnalyzeUsageStats_MalformedTimestampCounted(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// Event with non-empty but non-RFC3339Nano timestamp should increment parseErrors
+	// and still be included in the window (treated as timestamp-less).
+	require.NoError(t, writeJSONLLines(path,
+		eventLine(map[string]interface{}{
+			"type":      "assistant",
+			"timestamp": "not-a-timestamp",
+			"message": map[string]interface{}{
+				"id":    "msg-1",
+				"model": "claude-sonnet-4-6",
+				"usage": map[string]interface{}{"input_tokens": 100, "output_tokens": 10},
+			},
+		}),
+	))
+
+	cfg := DefaultStatsConfig()
+	cfg.Since = mustTime(t, "2026-01-01T00:00:00Z")
+	report, err := AnalyzeUsageStats([]string{dir}, cfg)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, report.ParseErrors, "malformed timestamp must increment ParseErrors")
+	// Event is still included (treated as timestamp-less when window is active).
+	assert.EqualValues(t, 100, report.Total.Usage.InputTokens)
+}
+
 func TestAnalyzeUsageStats_UntilFiltering(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Adds a `--stats` mode to `sessanalyze`, backed by a new `bramble/sessionanalysis` stats library.

- **`bramble/sessionanalysis/stats.go` + tests** — per-model / per-family / per-project token-usage and cost aggregation, with a pricing-table loader (`--pricing-file`) and observed-vs-estimated cost reconciliation.
- **`bramble/cmd/sessanalyze` `--stats` subcommand** — wired to `AnalyzeUsageStats`, supports `--since/--until` windowing, `--stats-max-rows`, `--top-level-only`, JSON output, and a Markdown renderer with global / model / family / project tables.

## Background

This branch was originally a port of the old `fix/jiradozer-pr2` work, but most of that work has since landed elsewhere (#160, #162, #163, #165, #167) or been obsoleted by stream-shape rewrites that removed the surfaces it touched. The reviewer NDJSON progress emitter and `code-review` wiring were dropped from this PR — only the additive sessanalyze stats work remains.

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel build //bramble/cmd/sessanalyze/... //bramble/sessionanalysis/...` clean
- [x] `bazel test //bramble/sessionanalysis/...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new stats-analysis pipeline that scans JSONL logs, deduplicates events, and estimates costs from pricing tables; correctness depends on log parsing, time-window filtering, and cost attribution across projects/models.
> 
> **Overview**
> Adds a new `--stats` mode to `sessanalyze` that outputs aggregated token/tool usage plus observed vs estimated cost, either as JSON or as a Markdown report with breakdown tables and row limiting.
> 
> Introduces `bramble/sessionanalysis/stats.go`, which scans JSONL session (and optionally subagent) logs, supports `--since/--until` windowing, dedupes assistant usage/tool-use and result events, and estimates cost via a builtin or `--pricing-file` pricing table with model-family fallbacks.
> 
> Refactors time parsing into `parseTimeBound` (used by both `--since` and stats window bounds) and extends Bazel targets to build/test the new stats library (`stats_test.go`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933d0226ecf2b3c55740813549a8290f06a53f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->