### PR TITLE
fix(wt): pass --no-optional-locks to git status polls

### DIFF
--- a/wt/git.go
+++ b/wt/git.go
@@ -32,8 +32,6 @@ var readOnlyGitSubcmds = map[string]bool{
 	"rev-parse":    true,
 	"symbolic-ref": true,
 	"ls-remote":    true,
-	"worktree":     true,
-	"branch":       true,
 	"show":         true,
 }
 

--- a/wt/git.go
+++ b/wt/git.go
@@ -24,17 +24,17 @@ type GitRunner interface {
 // DefaultGitRunner prepends --no-optional-locks for these to avoid creating
 // index.lock files that would block concurrent git operations in other worktrees.
 var readOnlyGitSubcmds = map[string]bool{
-	"status":      true,
-	"diff":        true,
-	"log":         true,
-	"ls-files":    true,
-	"rev-list":    true,
-	"rev-parse":   true,
+	"status":       true,
+	"diff":         true,
+	"log":          true,
+	"ls-files":     true,
+	"rev-list":     true,
+	"rev-parse":    true,
 	"symbolic-ref": true,
-	"ls-remote":   true,
-	"worktree":    true,
-	"branch":      true,
-	"show":        true,
+	"ls-remote":    true,
+	"worktree":     true,
+	"branch":       true,
+	"show":         true,
 }
 
 // DefaultGitRunner implements GitRunner using os/exec.

--- a/wt/git.go
+++ b/wt/git.go
@@ -20,12 +20,35 @@ type GitRunner interface {
 	Run(ctx context.Context, args []string, dir string) (*CmdResult, error)
 }
 
+// readOnlyGitSubcmds is the set of git subcommands that never write the index.
+// DefaultGitRunner prepends --no-optional-locks for these to avoid creating
+// index.lock files that would block concurrent git operations in other worktrees.
+var readOnlyGitSubcmds = map[string]bool{
+	"status":      true,
+	"diff":        true,
+	"log":         true,
+	"ls-files":    true,
+	"rev-list":    true,
+	"rev-parse":   true,
+	"symbolic-ref": true,
+	"ls-remote":   true,
+	"worktree":    true,
+	"branch":      true,
+	"show":        true,
+}
+
 // DefaultGitRunner implements GitRunner using os/exec.
 type DefaultGitRunner struct{}
 
 // Run executes a git command.
 func (r *DefaultGitRunner) Run(ctx context.Context, args []string, dir string) (*CmdResult, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	finalArgs := args
+	if len(args) > 0 && readOnlyGitSubcmds[args[0]] {
+		finalArgs = make([]string, 0, len(args)+1)
+		finalArgs = append(finalArgs, "--no-optional-locks")
+		finalArgs = append(finalArgs, args...)
+	}
+	cmd := exec.CommandContext(ctx, "git", finalArgs...)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if dir != "" {
 		cmd.Dir = dir

--- a/wt/git_test.go
+++ b/wt/git_test.go
@@ -6,6 +6,57 @@ import (
 	"testing"
 )
 
+// captureGitRunner records the full args slice (including any injected flags)
+// passed to exec.Command so tests can assert on them without spawning git.
+type captureGitRunner struct {
+	lastArgs []string
+}
+
+func (c *captureGitRunner) Run(_ context.Context, args []string, _ string) (*CmdResult, error) {
+	r := DefaultGitRunner{}
+	// Replicate the injection logic without actually running git.
+	finalArgs := args
+	if len(args) > 0 && readOnlyGitSubcmds[args[0]] {
+		finalArgs = make([]string, 0, len(args)+1)
+		finalArgs = append(finalArgs, "--no-optional-locks")
+		finalArgs = append(finalArgs, args...)
+	}
+	c.lastArgs = finalArgs
+	_ = r
+	return &CmdResult{}, nil
+}
+
+func TestDefaultGitRunnerNoOptionalLocks(t *testing.T) {
+	t.Parallel()
+
+	readOnly := []string{"status", "diff", "log", "ls-files", "rev-list", "rev-parse", "symbolic-ref", "ls-remote", "worktree", "branch", "show"}
+	readWrite := []string{"fetch", "rebase", "config", "push", "worktree add"}
+
+	for _, sub := range readOnly {
+		sub := sub
+		t.Run("injects_"+sub, func(t *testing.T) {
+			t.Parallel()
+			c := &captureGitRunner{}
+			c.Run(context.Background(), []string{sub, "--some-flag"}, "")
+			if len(c.lastArgs) == 0 || c.lastArgs[0] != "--no-optional-locks" {
+				t.Errorf("expected --no-optional-locks prepended for %q, got %v", sub, c.lastArgs)
+			}
+		})
+	}
+
+	for _, sub := range readWrite {
+		sub := sub
+		t.Run("no_inject_"+sub, func(t *testing.T) {
+			t.Parallel()
+			c := &captureGitRunner{}
+			c.Run(context.Background(), []string{sub}, "")
+			if len(c.lastArgs) > 0 && c.lastArgs[0] == "--no-optional-locks" {
+				t.Errorf("did not expect --no-optional-locks for %q, got %v", sub, c.lastArgs)
+			}
+		})
+	}
+}
+
 func TestGetRepoNameFromURL(t *testing.T) {
 	tests := []struct {
 		url      string

--- a/wt/git_test.go
+++ b/wt/git_test.go
@@ -2,58 +2,63 @@ package wt
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 )
 
-// captureGitRunner records the full args slice (including any injected flags)
-// passed to exec.Command so tests can assert on them without spawning git.
-type captureGitRunner struct {
-	lastArgs []string
-}
-
-func (c *captureGitRunner) Run(_ context.Context, args []string, _ string) (*CmdResult, error) {
-	r := DefaultGitRunner{}
-	// Replicate the injection logic without actually running git.
-	finalArgs := args
-	if len(args) > 0 && readOnlyGitSubcmds[args[0]] {
-		finalArgs = make([]string, 0, len(args)+1)
-		finalArgs = append(finalArgs, "--no-optional-locks")
-		finalArgs = append(finalArgs, args...)
+// initTempRepo creates a minimal git repo in a temp dir suitable for read-only
+// git commands (status, log, etc.) in tests.
+func initTempRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", dir},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+		{"commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
 	}
-	c.lastArgs = finalArgs
-	_ = r
-	return &CmdResult{}, nil
+	return dir
 }
 
 func TestDefaultGitRunnerNoOptionalLocks(t *testing.T) {
 	t.Parallel()
+	dir := initTempRepo(t)
+	runner := &DefaultGitRunner{}
+	ctx := context.Background()
 
-	readOnly := []string{"status", "diff", "log", "ls-files", "rev-list", "rev-parse", "symbolic-ref", "ls-remote", "worktree", "branch", "show"}
-	readWrite := []string{"fetch", "rebase", "config", "push", "worktree add"}
-
-	for _, sub := range readOnly {
-		sub := sub
-		t.Run("injects_"+sub, func(t *testing.T) {
+	// These subcommands must succeed with --no-optional-locks prepended.
+	readOnly := [][]string{
+		{"status", "--porcelain"},
+		{"diff"},
+		{"log", "--oneline"},
+		{"ls-files"},
+		{"rev-parse", "HEAD"},
+		{"show", "HEAD"},
+	}
+	for _, args := range readOnly {
+		args := args
+		t.Run("injects_"+args[0], func(t *testing.T) {
 			t.Parallel()
-			c := &captureGitRunner{}
-			c.Run(context.Background(), []string{sub, "--some-flag"}, "")
-			if len(c.lastArgs) == 0 || c.lastArgs[0] != "--no-optional-locks" {
-				t.Errorf("expected --no-optional-locks prepended for %q, got %v", sub, c.lastArgs)
+			if _, err := runner.Run(ctx, args, dir); err != nil {
+				t.Errorf("Run(%v) failed: %v — --no-optional-locks may have broken a read-only subcommand", args, err)
 			}
 		})
 	}
 
-	for _, sub := range readWrite {
-		sub := sub
-		t.Run("no_inject_"+sub, func(t *testing.T) {
-			t.Parallel()
-			c := &captureGitRunner{}
-			c.Run(context.Background(), []string{sub}, "")
-			if len(c.lastArgs) > 0 && c.lastArgs[0] == "--no-optional-locks" {
-				t.Errorf("did not expect --no-optional-locks for %q, got %v", sub, c.lastArgs)
-			}
-		})
+	// Write subcommands must NOT get --no-optional-locks. We verify by checking
+	// the map directly — these must not be in readOnlyGitSubcmds.
+	writeSubcmds := []string{"fetch", "rebase", "config", "push", "worktree", "branch"}
+	for _, sub := range writeSubcmds {
+		if readOnlyGitSubcmds[sub] {
+			t.Errorf("write subcommand %q is in readOnlyGitSubcmds — would inject --no-optional-locks into write operations", sub)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `GetGitStatus` runs `git status --porcelain` every 30 seconds per worktree via `tea.Batch`, which spawns N concurrent status calls
- Without `--no-optional-locks`, each call acquires `index.lock`, blocking concurrent git operations (rebase, commit) in other worktrees
- Fix: prepend `--no-optional-locks` as a global git flag so the read-only dirty check skips index locking entirely

## Test plan

- [ ] `bazel test //wt:wt_test` passes (mock keys updated to match new args)
- [ ] Manually verify bramble --yolo no longer blocks rebase in concurrent worktrees

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `DefaultGitRunner` constructs arguments for several git subcommands, affecting every call site that uses the runner and potentially altering behavior on older git versions or for commands that actually require locks.
> 
> **Overview**
> Reduces worktree contention by having `DefaultGitRunner.Run` automatically prepend the global git flag `--no-optional-locks` for a curated set of *read-only* subcommands (e.g. `status`, `diff`, `log`, `rev-parse`), preventing creation of `index.lock` during polling/concurrent operations.
> 
> Adds an integration-style test that initializes a temporary repo and verifies read-only commands still run successfully with the injected flag, while ensuring common write subcommands are not classified as read-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78713b0999f98e69f8763b0337c80de40b4e2e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->