### PR TITLE
feat(jiradozer): add --thinking-level flag to control agent reasoning effort

### DIFF
--- a/agent-cli-wrapper/claude/special_commands.go
+++ b/agent-cli-wrapper/claude/special_commands.go
@@ -425,6 +425,17 @@ func (level EffortLevel) validExplicitEffort() bool {
 	}
 }
 
+// ParseEffort parses a user-supplied string into an EffortLevel. It accepts
+// EffortAuto in addition to the explicit levels — callers that need to forbid
+// "auto" should compare the result against EffortAuto themselves.
+func ParseEffort(s string) (EffortLevel, error) {
+	level := EffortLevel(s)
+	if level == EffortAuto || level.validExplicitEffort() {
+		return level, nil
+	}
+	return "", fmt.Errorf("%w: %q (valid: low, medium, high, max, auto)", ErrInvalidEffort, s)
+}
+
 type storedCredentials struct {
 	ClaudeAIOAuth *storedOAuth `json:"claudeAiOauth"`
 }

--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/bazelment/yoloswe/jiradozer",
     visibility = ["//visibility:public"],
     deps = [
+        "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/claude/render",
         "//jiradozer/tracker",
         "//multiagent/agent",

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -474,6 +474,9 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	if cfg.MaxBudgetUSD > 0 {
 		opts = append(opts, agent.WithProviderMaxBudgetUSD(cfg.MaxBudgetUSD))
 	}
+	if cfg.Effort != "" {
+		opts = append(opts, agent.WithProviderEffort(cfg.Effort))
+	}
 	if resumeSessionID != "" {
 		opts = append(opts, agent.WithProviderResumeSessionID(resumeSessionID))
 	}

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazelment/yoloswe/jiradozer/cmd/jiradozer",
     visibility = ["//visibility:private"],
     deps = [
+        "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/claude/render",
         "//jiradozer",
         "//jiradozer/tracker",

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -86,7 +86,7 @@ func main() {
 	rootCmd.Flags().StringVar(&configPath, "config", "jiradozer.yaml", "Path to config file")
 	rootCmd.Flags().StringVar(&workDir, "work-dir", "", "Working directory (overrides config)")
 	rootCmd.Flags().StringVar(&modelID, "model", "", "Agent model ID (overrides config)")
-	rootCmd.Flags().StringVar(&thinkingLevel, "thinking-level", "", "Agent reasoning effort level: low, medium, high, max (overrides config)")
+	rootCmd.Flags().StringVar(&thinkingLevel, "thinking-level", "", "Agent reasoning effort level: low, medium, high, max, auto (overrides config)")
 	rootCmd.Flags().DurationVar(&pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	rootCmd.Flags().Float64Var(&maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	rootCmd.Flags().StringVar(&runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
@@ -364,14 +364,6 @@ func run(ctx context.Context, args runArgs) error {
 	// Validate agent model.
 	if _, ok := agent.ModelByID(cfg.Agent.Model); !ok {
 		return fmt.Errorf("unknown model %q — available models: %s", cfg.Agent.Model, availableModels())
-	}
-	// Validate effort level if set.
-	if cfg.Agent.Effort != "" {
-		switch cfg.Agent.Effort {
-		case "low", "medium", "high", "max", "auto":
-		default:
-			return fmt.Errorf("unknown thinking level %q — valid values: low, medium, high, max", cfg.Agent.Effort)
-		}
 	}
 	logger.Info("using agent",
 		"model", cfg.Agent.Model,

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -87,7 +87,7 @@ func main() {
 	rootCmd.Flags().StringVar(&configPath, "config", "jiradozer.yaml", "Path to config file")
 	rootCmd.Flags().StringVar(&workDir, "work-dir", "", "Working directory (overrides config)")
 	rootCmd.Flags().StringVar(&modelID, "model", "", "Agent model ID (overrides config)")
-	rootCmd.Flags().StringVar(&thinkingLevel, "thinking-level", "", "Agent reasoning effort level: low, medium, high, max, auto (overrides config)")
+	rootCmd.Flags().StringVar(&thinkingLevel, "thinking-level", "", "Agent reasoning effort level: low, medium, high, max, auto (overrides config; Claude provider only)")
 	rootCmd.Flags().DurationVar(&pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	rootCmd.Flags().Float64Var(&maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	rootCmd.Flags().StringVar(&runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/jiradozer"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
@@ -271,6 +272,9 @@ func run(ctx context.Context, args runArgs) error {
 		cfg.Agent.Model = args.modelID
 	}
 	if args.thinkingLevel != "" {
+		if _, err := claude.ParseEffort(args.thinkingLevel); err != nil {
+			return fmt.Errorf("--thinking-level: %w", err)
+		}
 		cfg.Agent.Effort = args.thinkingLevel
 	}
 	if args.pollInterval > 0 {

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -32,6 +32,7 @@ func main() {
 		configPath      string
 		workDir         string
 		modelID         string
+		thinkingLevel   string
 		pollInterval    time.Duration
 		maxBudget       float64
 		runStep         string
@@ -59,6 +60,7 @@ func main() {
 				configPath:      configPath,
 				workDir:         workDir,
 				modelID:         modelID,
+				thinkingLevel:   thinkingLevel,
 				pollInterval:    pollInterval,
 				maxBudget:       maxBudget,
 				runStep:         runStep,
@@ -84,6 +86,7 @@ func main() {
 	rootCmd.Flags().StringVar(&configPath, "config", "jiradozer.yaml", "Path to config file")
 	rootCmd.Flags().StringVar(&workDir, "work-dir", "", "Working directory (overrides config)")
 	rootCmd.Flags().StringVar(&modelID, "model", "", "Agent model ID (overrides config)")
+	rootCmd.Flags().StringVar(&thinkingLevel, "thinking-level", "", "Agent reasoning effort level: low, medium, high, max (overrides config)")
 	rootCmd.Flags().DurationVar(&pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	rootCmd.Flags().Float64Var(&maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	rootCmd.Flags().StringVar(&runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
@@ -114,6 +117,7 @@ type runArgs struct {
 	configPath      string
 	workDir         string
 	modelID         string
+	thinkingLevel   string
 	runStep         string
 	autoApprove     string
 	branchPrefix    string
@@ -266,6 +270,9 @@ func run(ctx context.Context, args runArgs) error {
 	if args.modelID != "" {
 		cfg.Agent.Model = args.modelID
 	}
+	if args.thinkingLevel != "" {
+		cfg.Agent.Effort = args.thinkingLevel
+	}
 	if args.pollInterval > 0 {
 		cfg.PollInterval = args.pollInterval
 	}
@@ -357,6 +364,14 @@ func run(ctx context.Context, args runArgs) error {
 	// Validate agent model.
 	if _, ok := agent.ModelByID(cfg.Agent.Model); !ok {
 		return fmt.Errorf("unknown model %q — available models: %s", cfg.Agent.Model, availableModels())
+	}
+	// Validate effort level if set.
+	if cfg.Agent.Effort != "" {
+		switch cfg.Agent.Effort {
+		case "low", "medium", "high", "max", "auto":
+		default:
+			return fmt.Errorf("unknown thinking level %q — valid values: low, medium, high, max", cfg.Agent.Effort)
+		}
 	}
 	logger.Info("using agent",
 		"model", cfg.Agent.Model,
@@ -549,6 +564,9 @@ func buildChildArgs(args runArgs, absConfigPath string) []string {
 	out = append(out, "--config", absConfigPath)
 	if args.modelID != "" {
 		out = append(out, "--model", args.modelID)
+	}
+	if args.thinkingLevel != "" {
+		out = append(out, "--thinking-level", args.thinkingLevel)
 	}
 	if args.maxBudget > 0 {
 		out = append(out, "--max-budget", fmt.Sprintf("%.2f", args.maxBudget))

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -108,6 +108,47 @@ func TestResolveRepoName(t *testing.T) {
 	}
 }
 
+func TestBuildChildArgs(t *testing.T) {
+	tests := []struct {
+		wantContain []string
+		wantOmit    []string
+		name        string
+		args        runArgs
+	}{
+		{
+			name:        "thinking-level set is propagated",
+			args:        runArgs{thinkingLevel: "high"},
+			wantContain: []string{"--thinking-level", "high"},
+		},
+		{
+			name:     "thinking-level empty is omitted",
+			args:     runArgs{},
+			wantOmit: []string{"--thinking-level"},
+		},
+		{
+			name:        "model + thinking-level both propagated",
+			args:        runArgs{modelID: "opus", thinkingLevel: "max"},
+			wantContain: []string{"--model", "opus", "--thinking-level", "max"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildChildArgs(tt.args, "/tmp/jiradozer.yaml")
+			joined := ""
+			for _, a := range got {
+				joined += a + " "
+			}
+			for _, want := range tt.wantContain {
+				assert.Contains(t, joined, want)
+			}
+			for _, want := range tt.wantOmit {
+				assert.NotContains(t, joined, want)
+			}
+		})
+	}
+}
+
 func TestRedactArgs(t *testing.T) {
 	tests := []struct {
 		name string

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -38,7 +38,8 @@ type TrackerConfig struct {
 
 // AgentConfig specifies the agent backend.
 type AgentConfig struct {
-	Model string `yaml:"model"` // model ID from agent.AllModels (e.g. "sonnet", "gpt-5.3-codex")
+	Model  string `yaml:"model"`  // model ID from agent.AllModels (e.g. "sonnet", "gpt-5.3-codex")
+	Effort string `yaml:"effort"` // reasoning effort level: "low", "medium", "high", "max", "auto"
 }
 
 // SourceConfig specifies how to discover issues for multi-issue mode.
@@ -65,6 +66,7 @@ type StepConfig struct {
 	Prompt              string        `yaml:"prompt"`          // Go text/template; empty = built-in default
 	SystemPrompt        string        `yaml:"system_prompt"`   // optional system prompt passed to the agent
 	Model               string        `yaml:"model"`           // override agent.model; empty = inherit
+	Effort              string        `yaml:"effort"`          // override agent.effort; empty = inherit
 	PermissionMode      string        `yaml:"permission_mode"` // "plan", "bypass", etc.; empty = step default
 	Rounds              []RoundConfig `yaml:"rounds"`          // multi-round execution; mutually exclusive with Prompt
 	MaxBudgetUSD        float64       `yaml:"max_budget_usd"`  // override top-level; 0 = inherit
@@ -176,9 +178,14 @@ func (c *Config) validate() error {
 	if c.PollInterval <= 0 {
 		c.PollInterval = 15 * time.Second
 	}
-	for name, step := range map[string]StepConfig{
-		"plan": c.Plan, "build": c.Build, "create_pr": c.CreatePR, "validate": c.Validate, "ship": c.Ship,
-	} {
+	namedSteps := []struct {
+		step *StepConfig
+		name string
+	}{
+		{&c.Plan, "plan"}, {&c.Build, "build"}, {&c.CreatePR, "create_pr"}, {&c.Validate, "validate"}, {&c.Ship, "ship"},
+	}
+	for _, ns := range namedSteps {
+		name, step := ns.name, ns.step
 		if name == "create_pr" && len(step.Rounds) > 0 {
 			return fmt.Errorf("create_pr does not support rounds")
 		}
@@ -234,6 +241,9 @@ func (c *Config) StepByName(name string) (StepConfig, bool) {
 func (c *Config) ResolveStep(step StepConfig) StepConfig {
 	if step.Model == "" {
 		step.Model = c.Agent.Model
+	}
+	if step.Effort == "" {
+		step.Effort = c.Agent.Effort
 	}
 	if step.MaxBudgetUSD == 0 {
 		step.MaxBudgetUSD = c.MaxBudgetUSD

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
 
@@ -39,7 +40,7 @@ type TrackerConfig struct {
 // AgentConfig specifies the agent backend.
 type AgentConfig struct {
 	Model  string `yaml:"model"`  // model ID from agent.AllModels (e.g. "sonnet", "gpt-5.3-codex")
-	Effort string `yaml:"effort"` // reasoning effort level: "low", "medium", "high", "max", "auto"
+	Effort string `yaml:"effort"` // reasoning effort; see claude.EffortLevel constants
 }
 
 // SourceConfig specifies how to discover issues for multi-issue mode.
@@ -178,41 +179,61 @@ func (c *Config) validate() error {
 	if c.PollInterval <= 0 {
 		c.PollInterval = 15 * time.Second
 	}
+	if c.Agent.Effort != "" {
+		if _, err := claude.ParseEffort(c.Agent.Effort); err != nil {
+			return fmt.Errorf("agent.effort: %w", err)
+		}
+	}
 	namedSteps := []struct {
 		step *StepConfig
 		name string
 	}{
-		{&c.Plan, "plan"}, {&c.Build, "build"}, {&c.CreatePR, "create_pr"}, {&c.Validate, "validate"}, {&c.Ship, "ship"},
+		{&c.Plan, "plan"}, {&c.Build, "build"}, {&c.CreatePR, "create_pr"},
+		{&c.Validate, "validate"}, {&c.Ship, "ship"},
 	}
 	for _, ns := range namedSteps {
-		name, step := ns.name, ns.step
-		if name == "create_pr" && len(step.Rounds) > 0 {
-			return fmt.Errorf("create_pr does not support rounds")
+		if err := validateStep(ns.name, ns.step); err != nil {
+			return err
 		}
-		if step.Prompt != "" && len(step.Rounds) > 0 {
-			return fmt.Errorf("%s: prompt and rounds are mutually exclusive", name)
+	}
+	return nil
+}
+
+// validateStep checks one named step. The pointer receiver avoids copying the
+// 152-byte StepConfig per iteration in validate(); the function does not mutate
+// through the pointer.
+func validateStep(name string, step *StepConfig) error {
+	if step.Effort != "" {
+		if _, err := claude.ParseEffort(step.Effort); err != nil {
+			return fmt.Errorf("%s.effort: %w", name, err)
 		}
-		if step.Prompt != "" {
-			if _, err := template.New(name).Parse(step.Prompt); err != nil {
-				return fmt.Errorf("%s.prompt template: %w", name, err)
+	}
+	if name == "create_pr" && len(step.Rounds) > 0 {
+		return fmt.Errorf("create_pr does not support rounds")
+	}
+	if step.Prompt != "" && len(step.Rounds) > 0 {
+		return fmt.Errorf("%s: prompt and rounds are mutually exclusive", name)
+	}
+	if step.Prompt != "" {
+		if _, err := template.New(name).Parse(step.Prompt); err != nil {
+			return fmt.Errorf("%s.prompt template: %w", name, err)
+		}
+	}
+	for i, round := range step.Rounds {
+		if round.Prompt == "" && round.Command == "" {
+			return fmt.Errorf("%s.rounds[%d]: prompt or command is required", name, i)
+		}
+		if round.Prompt != "" && round.Command != "" {
+			return fmt.Errorf("%s.rounds[%d]: prompt and command are mutually exclusive", name, i)
+		}
+		if round.Prompt != "" {
+			if _, err := template.New(fmt.Sprintf("%s_round_%d", name, i)).Parse(round.Prompt); err != nil {
+				return fmt.Errorf("%s.rounds[%d].prompt template: %w", name, i, err)
 			}
 		}
-		for i, round := range step.Rounds {
-			if round.Prompt == "" && round.Command == "" {
-				return fmt.Errorf("%s.rounds[%d]: prompt or command is required", name, i)
-			}
-			if round.Prompt != "" && round.Command != "" {
-				return fmt.Errorf("%s.rounds[%d]: prompt and command are mutually exclusive", name, i)
-			}
-			if round.Prompt != "" {
-				if _, err := template.New(fmt.Sprintf("%s_round_%d", name, i)).Parse(round.Prompt); err != nil {
-					return fmt.Errorf("%s.rounds[%d].prompt template: %w", name, i, err)
-				}
-			}
-			if round.Command != "" {
-				if _, err := template.New(fmt.Sprintf("%s_round_%d_cmd", name, i)).Parse(round.Command); err != nil {
-					return fmt.Errorf("%s.rounds[%d].command template: %w", name, i, err)
-				}
+		if round.Command != "" {
+			if _, err := template.New(fmt.Sprintf("%s_round_%d_cmd", name, i)).Parse(round.Command); err != nil {
+				return fmt.Errorf("%s.rounds[%d].command template: %w", name, i, err)
 			}
 		}
 	}

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -283,6 +283,7 @@ func ResolveRound(round RoundConfig, parent StepConfig) StepConfig {
 		Prompt:         round.Prompt,
 		SystemPrompt:   systemPrompt,
 		PermissionMode: parent.PermissionMode,
+		Effort:         parent.Effort,
 	}
 	if round.Model != "" {
 		resolved.Model = round.Model

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -171,16 +171,60 @@ func TestResolveStep_InheritsFromTopLevel(t *testing.T) {
 	cfg, err := LoadConfig("testdata/with_overrides.yaml")
 	require.NoError(t, err)
 
-	// Plan step has its own model and budget.
+	// Plan step has its own model, effort, and budget.
 	plan := cfg.ResolveStep(cfg.Plan)
 	assert.Equal(t, "opus", plan.Model)
+	assert.Equal(t, "high", plan.Effort)
 	assert.Equal(t, 10.0, plan.MaxBudgetUSD)
 	assert.Equal(t, 5, plan.MaxTurns)
 
-	// Build step has empty model and zero budget — should inherit.
+	// Build step has empty fields — should inherit from agent defaults.
 	build := cfg.ResolveStep(cfg.Build)
 	assert.Equal(t, "sonnet", build.Model)
+	assert.Equal(t, "medium", build.Effort)
 	assert.Equal(t, 50.0, build.MaxBudgetUSD)
+}
+
+func TestLoadConfig_InvalidEffort(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "agent_effort",
+			yaml: "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  effort: turbo\n",
+		},
+		{
+			name: "step_effort",
+			yaml: "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\nplan:\n  effort: hihg\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(tc.yaml), 0644))
+			_, err := LoadConfig(path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "effort")
+		})
+	}
+}
+
+func TestLoadConfig_ValidEffort(t *testing.T) {
+	for _, level := range []string{"low", "medium", "high", "max", "auto"} {
+		level := level
+		t.Run(level, func(t *testing.T) {
+			t.Parallel()
+			yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  effort: " + level + "\n"
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+			cfg, err := LoadConfig(path)
+			require.NoError(t, err)
+			assert.Equal(t, level, cfg.Agent.Effort)
+		})
+	}
 }
 
 func TestStepByName(t *testing.T) {
@@ -294,6 +338,7 @@ func TestLoadConfig_RoundsInvalidTemplate(t *testing.T) {
 func TestResolveRound_InheritsFromStep(t *testing.T) {
 	parent := StepConfig{
 		Model:          "sonnet",
+		Effort:         "high",
 		SystemPrompt:   "parent system prompt",
 		PermissionMode: "bypass",
 		MaxTurns:       10,
@@ -306,6 +351,7 @@ func TestResolveRound_InheritsFromStep(t *testing.T) {
 	assert.Equal(t, "do stuff", resolved.Prompt)
 	assert.Equal(t, "parent system prompt", resolved.SystemPrompt)
 	assert.Equal(t, "sonnet", resolved.Model)
+	assert.Equal(t, "high", resolved.Effort)
 	assert.Equal(t, "bypass", resolved.PermissionMode)
 	assert.Equal(t, 10, resolved.MaxTurns)
 	assert.Equal(t, 25.0, resolved.MaxBudgetUSD)

--- a/jiradozer/testdata/with_overrides.yaml
+++ b/jiradozer/testdata/with_overrides.yaml
@@ -4,11 +4,13 @@ tracker:
 
 agent:
   model: sonnet
+  effort: medium
 
 max_budget_usd: 50.0
 
 plan:
   model: opus
+  effort: high
   max_budget_usd: 10.0
   max_turns: 5
 

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -203,7 +203,11 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		sessionOpts = append(sessionOpts, claude.WithMaxBudgetUSD(cfg.MaxBudgetUSD))
 	}
 	if cfg.Effort != "" {
-		sessionOpts = append(sessionOpts, claude.WithEffort(claude.EffortLevel(cfg.Effort)))
+		level, err := claude.ParseEffort(cfg.Effort)
+		if err != nil {
+			return nil, err
+		}
+		sessionOpts = append(sessionOpts, claude.WithEffort(level))
 	}
 	if cfg.ResumeSessionID != "" {
 		sessionOpts = append(sessionOpts, claude.WithResume(cfg.ResumeSessionID))

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -202,6 +202,9 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	if cfg.MaxBudgetUSD > 0 {
 		sessionOpts = append(sessionOpts, claude.WithMaxBudgetUSD(cfg.MaxBudgetUSD))
 	}
+	if cfg.Effort != "" {
+		sessionOpts = append(sessionOpts, claude.WithEffort(claude.EffortLevel(cfg.Effort)))
+	}
 	if cfg.ResumeSessionID != "" {
 		sessionOpts = append(sessionOpts, claude.WithResume(cfg.ResumeSessionID))
 	}

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -191,6 +191,7 @@ type ExecuteOption func(*ExecuteConfig)
 type ExecuteConfig struct {
 	EventHandler        EventHandler
 	Model               string
+	Effort              string
 	WorkDir             string
 	SystemPrompt        string
 	PermissionMode      string
@@ -204,6 +205,11 @@ type ExecuteConfig struct {
 // WithProviderModel sets the model for a provider execution.
 func WithProviderModel(model string) ExecuteOption {
 	return func(c *ExecuteConfig) { c.Model = model }
+}
+
+// WithProviderEffort sets the reasoning effort level for a provider execution.
+func WithProviderEffort(level string) ExecuteOption {
+	return func(c *ExecuteConfig) { c.Effort = level }
 }
 
 // WithProviderWorkDir sets the working directory for a provider execution.


### PR DESCRIPTION
## Summary

- Adds `--thinking-level` CLI flag to jiradozer (`low`, `medium`, `high`, `max`) that maps to Claude's reasoning effort level
- Wires effort through all three layers: `multiagent/agent` ExecuteConfig → `claude_provider` session options → jiradozer config/agent runner
- Effort inherits from `agent.effort` config to per-step `effort` overrides (same pattern as `model`)
- Validates the flag value early with a clear error; propagates to child processes in team mode

## Changes

**`multiagent/agent/provider.go`** — add `Effort string` to `ExecuteConfig` + `WithProviderEffort()` option func

**`multiagent/agent/claude_provider.go`** — map `cfg.Effort` → `claude.WithEffort(claude.EffortLevel(cfg.Effort))`

**`jiradozer/config.go`** — add `Effort string` to `AgentConfig` and `StepConfig`; `ResolveStep()` inherits agent-level effort; refactored validation loop from map range to pointer-based slice to fix `rangeValCopy` lint triggered by larger struct size

**`jiradozer/agent.go`** — pass `cfg.Effort` via `WithProviderEffort` in `runAgent()`

**`jiradozer/cmd/jiradozer/main.go`** — `--thinking-level` flag, early validation, config override, team-mode child propagation

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `bazel build //jiradozer/... //multiagent/...` succeeds
- [x] `bazel test //jiradozer/... //multiagent/... --test_timeout=60` — all 16 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the agent execution plumbing and Claude provider session options; incorrect wiring or validation could change runtime behavior or cause unexpected execution failures, but the change is narrowly scoped and covered by unit tests.
> 
> **Overview**
> Adds support for configuring Claude reasoning effort end-to-end in `jiradozer`: a new `--thinking-level` CLI flag and new YAML fields (`agent.effort` plus per-step `effort`) that inherit like `model`.
> 
> Wires the selected effort through the execution stack by extending `multiagent/agent.ExecuteConfig` with `Effort` + `WithProviderEffort`, validating user/config values via a new shared `claude.ParseEffort`, and applying it in `ClaudeProvider` session options. Team-mode subprocess spawning now propagates `--thinking-level`, with new tests covering config inheritance/validation and child-arg propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f09b054adf4c851c86baf435a2464454258b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->