### PR TITLE
feat(multiagent): prefix-based provider routing for unknown model IDs

### DIFF
--- a/bramble/session/BUILD.bazel
+++ b/bramble/session/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "manager_test.go",
         "provider_runner_test.go",
         "registry_test.go",
+        "resolve_agent_model_test.go",
         "store_test.go",
         "summary_test.go",
         "tmux_name_test.go",

--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -1322,11 +1322,6 @@ func (m *Manager) monitorTrackedTmuxWindow(session *Session) {
 	}
 }
 
-// resolveAgentModel resolves a model ID to an AgentModel using:
-// 1. The filtered registry (if non-nil).
-// 2. The global AllModels list (exact match).
-// 3. Prefix-based provider inference for forward-compat IDs.
-// Returns an error if none of the above succeed.
 func resolveAgentModel(modelID string, registry *agent.ModelRegistry) (agent.AgentModel, error) {
 	if registry != nil {
 		if m, ok := registry.ModelByID(modelID); ok {
@@ -1336,10 +1331,10 @@ func resolveAgentModel(modelID string, registry *agent.ModelRegistry) (agent.Age
 	if m, ok := agent.ModelByID(modelID); ok {
 		return m, nil
 	}
-	if provider, ok := agent.ProviderForModelID(modelID); ok {
+	if provider, ok := agent.ProviderByModelPrefix(modelID); ok {
 		return agent.AgentModel{ID: modelID, Provider: provider, Label: modelID}, nil
 	}
-	return agent.AgentModel{}, fmt.Errorf("unknown model %q (no curated entry and no recognized prefix; supported prefixes: gpt-, gemini-, cursor-, composer-, claude-)", modelID)
+	return agent.AgentModel{}, fmt.Errorf("unknown model %q: no curated entry and no recognized prefix (%s)", modelID, agent.KnownModelPrefixes())
 }
 
 // runSession runs a session in a goroutine, handling both planner and builder types.

--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -1520,6 +1520,14 @@ func (m *Manager) runSession(session *Session, prompt string) {
 				model:        session.Model,
 				workDir:      session.WorktreePath,
 			}
+		} else if agentModel.Provider == ProviderCursor {
+			// Cursor provider backend
+			runner = &providerRunner{
+				provider:     agent.NewCursorProvider(),
+				eventHandler: eventHandler,
+				model:        session.Model,
+				workDir:      session.WorktreePath,
+			}
 		} else {
 			// Default: use hardcoded planner/builder runners with model from session
 			switch session.Type {

--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -1322,6 +1322,26 @@ func (m *Manager) monitorTrackedTmuxWindow(session *Session) {
 	}
 }
 
+// resolveAgentModel resolves a model ID to an AgentModel using:
+// 1. The filtered registry (if non-nil).
+// 2. The global AllModels list (exact match).
+// 3. Prefix-based provider inference for forward-compat IDs.
+// Returns an error if none of the above succeed.
+func resolveAgentModel(modelID string, registry *agent.ModelRegistry) (agent.AgentModel, error) {
+	if registry != nil {
+		if m, ok := registry.ModelByID(modelID); ok {
+			return m, nil
+		}
+	}
+	if m, ok := agent.ModelByID(modelID); ok {
+		return m, nil
+	}
+	if provider, ok := agent.ProviderForModelID(modelID); ok {
+		return agent.AgentModel{ID: modelID, Provider: provider, Label: modelID}, nil
+	}
+	return agent.AgentModel{}, fmt.Errorf("unknown model %q (no curated entry and no recognized prefix; supported prefixes: gpt-, gemini-, cursor-, composer-, claude-)", modelID)
+}
+
 // runSession runs a session in a goroutine, handling both planner and builder types.
 // Both types follow the same lifecycle: start → run turns → idle → follow-up → ...
 func (m *Manager) runSession(session *Session, prompt string) {
@@ -1334,17 +1354,19 @@ func (m *Manager) runSession(session *Session, prompt string) {
 
 	// Resolve model provider for runner routing.
 	// Prefer the filtered registry if available, fall back to the full list.
-	var agentModel AgentModel
-	var modelFound bool
-	if m.config.ModelRegistry != nil {
-		agentModel, modelFound = m.config.ModelRegistry.ModelByID(session.Model)
-	}
-	if !modelFound {
-		agentModel, modelFound = ModelByID(session.Model)
-	}
-	if !modelFound {
-		// Unknown model — default to claude provider
-		agentModel = AgentModel{ID: session.Model, Provider: ProviderClaude}
+	agentModel, resolveErr := resolveAgentModel(session.Model, m.config.ModelRegistry)
+	if resolveErr != nil {
+		m.updateSessionStatus(session, StatusFailed)
+		session.mu.Lock()
+		session.Error = resolveErr
+		session.mu.Unlock()
+		m.addOutput(session.ID, OutputLine{
+			Timestamp: time.Now(),
+			Type:      OutputTypeError,
+			Content:   resolveErr.Error(),
+		})
+		m.persistSession(session)
+		return
 	}
 
 	// If a registry is configured and the model's provider is not available,

--- a/bramble/session/resolve_agent_model_test.go
+++ b/bramble/session/resolve_agent_model_test.go
@@ -78,6 +78,64 @@ func TestResolveAgentModel_EmptyModelFails(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestManager_PrefixModelRoutesToCorrectProvider verifies that a model ID
+// resolved only by prefix rule selects the right provider in runSession — not
+// the Claude default. The assertion strategy: mark the expected provider as
+// not installed so the session fails with "provider X is not available"; if
+// routing fell through to Claude, the error would name "claude" instead.
+func TestManager_PrefixModelRoutesToCorrectProvider(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		modelID         string
+		unavailProvider string
+		availProvider   string // must be installed so the registry accepts the session
+	}{
+		{"gpt-future-9000", agent.ProviderCodex, agent.ProviderClaude},
+		{"gemini-99-ultra", agent.ProviderGemini, agent.ProviderClaude},
+		{"cursor-fast-99", agent.ProviderCursor, agent.ProviderClaude},
+		{"composer-v9", agent.ProviderCursor, agent.ProviderClaude},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.modelID, func(t *testing.T) {
+			t.Parallel()
+
+			statusMap := map[string]agent.ProviderStatus{
+				agent.ProviderClaude: {Provider: agent.ProviderClaude, Installed: true},
+				agent.ProviderCodex:  {Provider: agent.ProviderCodex, Installed: true},
+				agent.ProviderGemini: {Provider: agent.ProviderGemini, Installed: true},
+				agent.ProviderCursor: {Provider: agent.ProviderCursor, Installed: true},
+			}
+			// Mark the target provider as not installed so runSession rejects it
+			// with a message naming that provider — proving routing chose it.
+			statusMap[tc.unavailProvider] = agent.ProviderStatus{Provider: tc.unavailProvider, Installed: false}
+			avail := agent.NewProviderAvailabilityFromMap(statusMap)
+			reg := agent.NewModelRegistry(avail, nil)
+
+			mgr := NewManagerWithConfig(ManagerConfig{
+				ModelRegistry: reg,
+				SessionMode:   SessionModeTUI,
+			})
+			t.Cleanup(mgr.Close)
+
+			sid, err := mgr.StartSession(SessionTypeBuilder, t.TempDir(), "test prompt", tc.modelID)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				s, ok := mgr.GetSession(sid)
+				return ok && s.Status == StatusFailed
+			}, 5*time.Second, 10*time.Millisecond)
+
+			s, ok := mgr.GetSession(sid)
+			require.True(t, ok)
+			require.NotNil(t, s.Error)
+			assert.Contains(t, s.Error.Error(), tc.unavailProvider,
+				"error should name the resolved provider, not the Claude fallback")
+		})
+	}
+}
+
 // TestManager_UnknownModelLandsInStatusFailed verifies that the full manager
 // path fails clearly when a session is started with an unrecognized model ID
 // that has no curated entry and no recognized prefix.

--- a/bramble/session/resolve_agent_model_test.go
+++ b/bramble/session/resolve_agent_model_test.go
@@ -68,7 +68,7 @@ func TestResolveAgentModel_UnknownModelFails(t *testing.T) {
 	_, err := resolveAgentModel("foo-bar", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "foo-bar")
-	assert.Contains(t, err.Error(), "supported prefixes")
+	assert.Contains(t, err.Error(), "gpt-")
 }
 
 func TestResolveAgentModel_EmptyModelFails(t *testing.T) {
@@ -110,7 +110,7 @@ func TestManager_UnknownModelLandsInStatusFailed(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, s.Error)
 	assert.Contains(t, s.Error.Error(), "foo-bar")
-	assert.Contains(t, s.Error.Error(), "supported prefixes")
+	assert.Contains(t, s.Error.Error(), "gpt-")
 
 	lines := mgr.GetSessionOutput(sid)
 	var hasError bool

--- a/bramble/session/resolve_agent_model_test.go
+++ b/bramble/session/resolve_agent_model_test.go
@@ -1,0 +1,123 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/multiagent/agent"
+)
+
+func TestResolveAgentModel_ExactMatchFromGlobalList(t *testing.T) {
+	t.Parallel()
+
+	m, err := resolveAgentModel("opus", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "opus", m.ID)
+	assert.Equal(t, agent.ProviderClaude, m.Provider)
+}
+
+func TestResolveAgentModel_ExactMatchFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	avail := agent.NewProviderAvailabilityFromMap(map[string]agent.ProviderStatus{
+		agent.ProviderClaude: {Provider: agent.ProviderClaude, Installed: true},
+		agent.ProviderCodex:  {Provider: agent.ProviderCodex, Installed: false},
+		agent.ProviderGemini: {Provider: agent.ProviderGemini, Installed: false},
+		agent.ProviderCursor: {Provider: agent.ProviderCursor, Installed: false},
+	})
+	reg := agent.NewModelRegistry(avail, nil)
+
+	m, err := resolveAgentModel("opus", reg)
+	require.NoError(t, err)
+	assert.Equal(t, "opus", m.ID)
+	assert.Equal(t, agent.ProviderClaude, m.Provider)
+}
+
+func TestResolveAgentModel_PrefixFallback(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		modelID  string
+		provider string
+	}{
+		{"gpt-future-9000", agent.ProviderCodex},
+		{"gemini-99-ultra", agent.ProviderGemini},
+		{"cursor-fast", agent.ProviderCursor},
+		{"composer-3", agent.ProviderCursor},
+		{"claude-opus-5", agent.ProviderClaude},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.modelID, func(t *testing.T) {
+			t.Parallel()
+			m, err := resolveAgentModel(tc.modelID, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.modelID, m.ID)
+			assert.Equal(t, tc.provider, m.Provider)
+			assert.Equal(t, tc.modelID, m.Label)
+		})
+	}
+}
+
+func TestResolveAgentModel_UnknownModelFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveAgentModel("foo-bar", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "foo-bar")
+	assert.Contains(t, err.Error(), "supported prefixes")
+}
+
+func TestResolveAgentModel_EmptyModelFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveAgentModel("", nil)
+	require.Error(t, err)
+}
+
+// TestManager_UnknownModelLandsInStatusFailed verifies that the full manager
+// path fails clearly when a session is started with an unrecognized model ID
+// that has no curated entry and no recognized prefix.
+func TestManager_UnknownModelLandsInStatusFailed(t *testing.T) {
+	t.Parallel()
+
+	avail := agent.NewProviderAvailabilityFromMap(map[string]agent.ProviderStatus{
+		agent.ProviderClaude: {Provider: agent.ProviderClaude, Installed: true},
+		agent.ProviderCodex:  {Provider: agent.ProviderCodex, Installed: true},
+		agent.ProviderGemini: {Provider: agent.ProviderGemini, Installed: true},
+		agent.ProviderCursor: {Provider: agent.ProviderCursor, Installed: true},
+	})
+	reg := agent.NewModelRegistry(avail, nil)
+
+	mgr := NewManagerWithConfig(ManagerConfig{
+		ModelRegistry: reg,
+		SessionMode:   SessionModeTUI,
+	})
+	t.Cleanup(mgr.Close)
+
+	sid, err := mgr.StartSession(SessionTypeBuilder, t.TempDir(), "test prompt", "foo-bar")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		s, ok := mgr.GetSession(sid)
+		return ok && s.Status == StatusFailed
+	}, 5*time.Second, 10*time.Millisecond)
+
+	s, ok := mgr.GetSession(sid)
+	require.True(t, ok)
+	require.NotNil(t, s.Error)
+	assert.Contains(t, s.Error.Error(), "foo-bar")
+	assert.Contains(t, s.Error.Error(), "supported prefixes")
+
+	lines := mgr.GetSessionOutput(sid)
+	var hasError bool
+	for _, l := range lines {
+		if l.Type == OutputTypeError && l.Content != "" {
+			hasError = true
+		}
+	}
+	assert.True(t, hasError, "expected at least one OutputTypeError line")
+}

--- a/bramble/session/types.go
+++ b/bramble/session/types.go
@@ -25,6 +25,7 @@ const (
 	ProviderClaude = agent.ProviderClaude
 	ProviderCodex  = agent.ProviderCodex
 	ProviderGemini = agent.ProviderGemini
+	ProviderCursor = agent.ProviderCursor
 )
 
 // AgentModel is an alias for agent.AgentModel.

--- a/multiagent/agent/model_registry.go
+++ b/multiagent/agent/model_registry.go
@@ -1,6 +1,9 @@
 package agent
 
-import "sync"
+import (
+	"strings"
+	"sync"
+)
 
 // AgentModel describes a model available for session execution.
 type AgentModel struct {
@@ -35,6 +38,41 @@ func ModelByID(id string) (AgentModel, bool) {
 		}
 	}
 	return AgentModel{}, false
+}
+
+// modelPrefixRules maps hyphenated prefixes (e.g. "gpt-") to providers.
+// Order matters: first match wins.
+var modelPrefixRules = []struct {
+	prefix   string
+	provider string
+}{
+	{"gpt-", ProviderCodex},
+	{"gemini-", ProviderGemini},
+	{"cursor-", ProviderCursor},
+	{"composer-", ProviderCursor},
+	{"claude-", ProviderClaude},
+}
+
+// ProviderForModelID resolves the provider for a model ID.
+// 1. Exact match in AllModels — return that provider.
+// 2. Prefix rules (forward-compat for IDs not yet in AllModels):
+//
+//	gpt-*                   → ProviderCodex
+//	gemini-*                → ProviderGemini
+//	cursor-* | composer-*   → ProviderCursor
+//	claude-*                → ProviderClaude
+//
+// 3. Otherwise return ("", false).
+func ProviderForModelID(id string) (provider string, ok bool) {
+	if m, found := ModelByID(id); found {
+		return m.Provider, true
+	}
+	for _, rule := range modelPrefixRules {
+		if strings.HasPrefix(id, rule.prefix) {
+			return rule.provider, true
+		}
+	}
+	return "", false
 }
 
 // ModelRegistry provides a filtered view of models based on provider

--- a/multiagent/agent/model_registry.go
+++ b/multiagent/agent/model_registry.go
@@ -53,26 +53,34 @@ var modelPrefixRules = []struct {
 	{"claude-", ProviderClaude},
 }
 
-// ProviderForModelID resolves the provider for a model ID.
-// 1. Exact match in AllModels — return that provider.
-// 2. Prefix rules (forward-compat for IDs not yet in AllModels):
-//
-//	gpt-*                   → ProviderCodex
-//	gemini-*                → ProviderGemini
-//	cursor-* | composer-*   → ProviderCursor
-//	claude-*                → ProviderClaude
-//
-// 3. Otherwise return ("", false).
+// ProviderForModelID resolves the provider for a model ID via exact match then
+// prefix rules (forward-compat for IDs not yet in AllModels).
 func ProviderForModelID(id string) (provider string, ok bool) {
 	if m, found := ModelByID(id); found {
 		return m.Provider, true
 	}
+	return ProviderByModelPrefix(id)
+}
+
+// ProviderByModelPrefix infers a provider from a model ID prefix only.
+// Does not consult AllModels — callers that already did an exact-match lookup
+// should call this instead of ProviderForModelID to avoid a redundant scan.
+func ProviderByModelPrefix(id string) (provider string, ok bool) {
 	for _, rule := range modelPrefixRules {
 		if strings.HasPrefix(id, rule.prefix) {
 			return rule.provider, true
 		}
 	}
 	return "", false
+}
+
+// KnownModelPrefixes returns a comma-separated list of recognized prefixes.
+func KnownModelPrefixes() string {
+	prefixes := make([]string, len(modelPrefixRules))
+	for i, r := range modelPrefixRules {
+		prefixes[i] = r.prefix
+	}
+	return strings.Join(prefixes, ", ")
 }
 
 // ModelRegistry provides a filtered view of models based on provider

--- a/multiagent/agent/model_registry_test.go
+++ b/multiagent/agent/model_registry_test.go
@@ -203,3 +203,42 @@ func TestProviderForModelID(t *testing.T) {
 		})
 	}
 }
+
+func TestProviderByModelPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		id       string
+		provider string
+		ok       bool
+	}{
+		{"gpt-future-9000", ProviderCodex, true},
+		{"gemini-99-ultra", ProviderGemini, true},
+		{"cursor-fast", ProviderCursor, true},
+		{"composer-3", ProviderCursor, true},
+		{"claude-opus-5", ProviderClaude, true},
+		// Exact-match IDs still work via prefix
+		{"gpt-5.5", ProviderCodex, true},
+		// Non-matching
+		{"foo-bar", "", false},
+		{"", "", false},
+		{"opus", "", false}, // no prefix match for bare IDs
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+			provider, ok := ProviderByModelPrefix(tc.id)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.provider, provider)
+		})
+	}
+}
+
+func TestKnownModelPrefixes(t *testing.T) {
+	t.Parallel()
+	s := KnownModelPrefixes()
+	assert.Contains(t, s, "gpt-")
+	assert.Contains(t, s, "gemini-")
+	assert.Contains(t, s, "claude-")
+}

--- a/multiagent/agent/model_registry_test.go
+++ b/multiagent/agent/model_registry_test.go
@@ -169,3 +169,37 @@ func TestModelByID_Global(t *testing.T) {
 	_, ok = ModelByID("nonexistent")
 	assert.False(t, ok)
 }
+
+func TestProviderForModelID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		id       string
+		provider string
+		ok       bool
+	}{
+		// Exact match wins over prefix
+		{"opus", ProviderClaude, true},
+		{"gpt-5.5", ProviderCodex, true},
+		// Prefix-only matches (forward-compat IDs not in AllModels)
+		{"gpt-future-9000", ProviderCodex, true},
+		{"gemini-99-ultra", ProviderGemini, true},
+		{"cursor-fast", ProviderCursor, true},
+		{"composer-3", ProviderCursor, true},
+		{"claude-opus-5", ProviderClaude, true},
+		// Non-matching
+		{"foo-bar", "", false},
+		{"", "", false},
+		{"gpt", "", false},    // bare token without hyphen must NOT match
+		{"gemini", "", false}, // bare token without hyphen must NOT match
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+			provider, ok := ProviderForModelID(tc.id)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.provider, provider)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The bramble daemon routes sessions to the right agent CLI (claude/codex/gemini/cursor) via `ModelByID` against the hand-curated `AllModels` list. When a model ID isn't in the list, the old code silently fell back to `ProviderClaude`:

```go
if !modelFound {
    agentModel = AgentModel{ID: session.Model, Provider: ProviderClaude}
}
```

This caused a stale-daemon bug: a running bramble built before `gpt-5.5` was added to `AllModels` would route `--model gpt-5.5` to `claude --model gpt-5.5` instead of `codex --model gpt-5.5`. The session record still showed `model: gpt-5.5`, making the misroute invisible.

## Solution

Two additions:

**`ProviderForModelID(id string) (string, bool)`** in `multiagent/agent/model_registry.go` — a forward-compat lookup that:
1. Tries exact match in `AllModels` first (so curated entries always win).
2. Falls back to hyphenated prefix rules: `gpt-*` → codex, `gemini-*` → gemini, `cursor-*/composer-*` → cursor, `claude-*` → claude.
3. Returns `("", false)` if nothing matches — bare tokens like `gpt` (no hyphen) intentionally do NOT match.

**`resolveAgentModel(modelID, registry)`** in `bramble/session/manager.go` — replaces the inline fallback block with a helper that:
1. Tries the filtered registry.
2. Falls back to global `ModelByID`.
3. Falls back to `ProviderForModelID`.
4. Fails loudly (→ `StatusFailed`, `OutputTypeError`) if all three miss, naming the supported prefixes.

The existing `HasProvider` availability check still runs after resolution, so prefix-matched models still fail clearly if the provider isn't installed.

## What doesn't change

- `AllModels` contents and order — no new entries.
- `Models()`, `NextModel()`, `HasProvider()` — all read from the curated list only.
- The dropdown surface — prefix-matched IDs don't appear there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session runner routing for model IDs not present in the curated list and alters failure behavior (now explicit errors instead of silently defaulting to Claude), which could affect existing workflows if prefixes are misclassified.
> 
> **Overview**
> **Improves model→provider routing for forward-compat model IDs.** Adds prefix-based provider inference in `multiagent/agent` (e.g. `gpt-`→Codex, `gemini-`→Gemini, `cursor-`/`composer-`→Cursor, `claude-`→Claude) plus helpers to surface recognized prefixes.
> 
> In `bramble/session`, replaces the silent Claude fallback with `resolveAgentModel`, which first consults the filtered registry, then the global curated list, then prefix inference; unknown IDs now *fail fast* by marking the session `StatusFailed` and emitting an `OutputTypeError`. Also adds Cursor provider routing in `runSession` and expands unit tests to cover prefix resolution and failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a5e0d7b5f0a9164334054f8c9a934cf884bc22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->