### PR TITLE
[codex] Revive idle tmux sessions on pane activity

### DIFF
--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -1104,15 +1104,15 @@ func (m *Manager) monitorTrackedTmuxWindow(session *Session) {
 	// captureRecentOutput grabs the last lines from the tmux pane and updates
 	// the session's RecentOutput and status bar fields so the command center
 	// can display rich information about the session.
-	var prevCapturedOutput []string
+	var captureState trackedTmuxCaptureState
 	captureRecentOutput := func() {
 		session.mu.RLock()
 		wID := session.TmuxWindowID
 		wName := session.TmuxWindowName
-		status := session.Status
+		statusAtCapture := session.Status
 		session.mu.RUnlock()
 
-		if status != StatusRunning && status != StatusIdle {
+		if statusAtCapture != StatusRunning && statusAtCapture != StatusIdle {
 			return
 		}
 		target := wID
@@ -1140,14 +1140,15 @@ func (m *Manager) monitorTrackedTmuxWindow(session *Session) {
 		}
 
 		// Extract meaningful content lines, stripping TUI chrome.
-		displayLines := ContentLines(lines, paneStatus)
-		if len(displayLines) > sessionmodel.RecentOutputDisplayLines {
-			displayLines = displayLines[len(displayLines)-sessionmodel.RecentOutputDisplayLines:]
+		contentLines := ContentLines(lines, paneStatus)
+		contentChanged := false
+		if paneStatus != nil {
+			contentChanged = captureState.observeContentLines(contentLines)
 		}
 
-		contentChanged := !slices.Equal(displayLines, prevCapturedOutput)
-		if contentChanged {
-			prevCapturedOutput = displayLines
+		displayLines := contentLines
+		if len(displayLines) > sessionmodel.RecentOutputDisplayLines {
+			displayLines = displayLines[len(displayLines)-sessionmodel.RecentOutputDisplayLines:]
 		}
 
 		session.Progress.Update(func(p *SessionProgress) {
@@ -1169,8 +1170,8 @@ func (m *Manager) monitorTrackedTmuxWindow(session *Session) {
 		})
 
 		// If pane shows working state but session is idle, transition back to running.
-		if paneStatus != nil && paneStatus.IsWorking && status == StatusIdle {
-			m.updateSessionStatus(session, StatusRunning)
+		if shouldReviveIdleTmuxSession(statusAtCapture, paneStatus, contentChanged) {
+			m.tryUpdateSessionStatus(session, StatusIdle, StatusRunning)
 		}
 
 		// Update session model if parsed status indicates idle
@@ -1958,12 +1959,59 @@ func (m *Manager) runSession(session *Session, prompt string) {
 	}
 }
 
+type trackedTmuxCaptureState struct {
+	prevContentLines   []string
+	haveContentCapture bool
+}
+
+func (s *trackedTmuxCaptureState) observeContentLines(contentLines []string) bool {
+	contentChanged := s.haveContentCapture && !slices.Equal(contentLines, s.prevContentLines)
+	s.prevContentLines = slices.Clone(contentLines)
+	s.haveContentCapture = true
+	return contentChanged
+}
+
+func shouldReviveIdleTmuxSession(statusAtCapture SessionStatus, paneStatus *PaneStatus, contentChanged bool) bool {
+	if statusAtCapture != StatusIdle || paneStatus == nil {
+		return false
+	}
+	return contentChanged || paneStatus.IsWorking
+}
+
 // updateSessionStatus updates session status and emits event.
 func (m *Manager) updateSessionStatus(session *Session, newStatus SessionStatus) {
 	session.mu.Lock()
 	oldStatus := session.Status
-	session.Status = newStatus
+	applySessionStatusLocked(session, oldStatus, newStatus)
+	session.mu.Unlock()
 
+	m.emitSessionStateChange(SessionStateChangeEvent{
+		SessionID: session.ID,
+		OldStatus: oldStatus,
+		NewStatus: newStatus,
+	})
+}
+
+func (m *Manager) tryUpdateSessionStatus(session *Session, fromStatus, toStatus SessionStatus) bool {
+	session.mu.Lock()
+	oldStatus := session.Status
+	if oldStatus != fromStatus {
+		session.mu.Unlock()
+		return false
+	}
+	applySessionStatusLocked(session, oldStatus, toStatus)
+	session.mu.Unlock()
+
+	m.emitSessionStateChange(SessionStateChangeEvent{
+		SessionID: session.ID,
+		OldStatus: oldStatus,
+		NewStatus: toStatus,
+	})
+	return true
+}
+
+func applySessionStatusLocked(session *Session, oldStatus, newStatus SessionStatus) {
+	session.Status = newStatus
 	now := time.Now()
 	switch newStatus {
 	case StatusRunning:
@@ -1975,19 +2023,14 @@ func (m *Manager) updateSessionStatus(session *Session, newStatus SessionStatus)
 	case StatusCompleted, StatusFailed, StatusStopped:
 		session.CompletedAt = &now
 	}
-	session.mu.Unlock()
+}
 
-	evt := SessionStateChangeEvent{
-		SessionID: session.ID,
-		OldStatus: oldStatus,
-		NewStatus: newStatus,
-	}
-
+func (m *Manager) emitSessionStateChange(evt SessionStateChangeEvent) {
 	// Emit state change event
 	select {
 	case m.events <- evt:
 	default:
-		log.Printf("WARNING: events channel full, dropping state change event for session %s (%s -> %s)", session.ID, oldStatus, newStatus)
+		log.Printf("WARNING: events channel full, dropping state change event for session %s (%s -> %s)", evt.SessionID, evt.OldStatus, evt.NewStatus)
 	}
 
 	// Notify state subscribers (used by delegator child watchers)
@@ -1996,7 +2039,7 @@ func (m *Manager) updateSessionStatus(session *Session, newStatus SessionStatus)
 		select {
 		case ch <- evt:
 		default:
-			log.Printf("WARNING: state subscriber channel full, dropping state change event for session %s (%s -> %s)", session.ID, oldStatus, newStatus)
+			log.Printf("WARNING: state subscriber channel full, dropping state change event for session %s (%s -> %s)", evt.SessionID, evt.OldStatus, evt.NewStatus)
 		}
 	}
 	m.stateSubscribersMu.Unlock()

--- a/bramble/session/manager_test.go
+++ b/bramble/session/manager_test.go
@@ -1364,6 +1364,161 @@ func TestUpdateSessionStatus_PendingToRunningSetsStartedAt(t *testing.T) {
 	assert.WithinDuration(t, time.Now(), *session.StartedAt, time.Second)
 }
 
+func TestTrackedTmuxCaptureState_ObserveContentLines(t *testing.T) {
+	t.Parallel()
+
+	var state trackedTmuxCaptureState
+
+	lines := []string{"first line"}
+	assert.False(t, state.observeContentLines(lines), "first capture establishes baseline")
+
+	lines[0] = "mutated after observe"
+	assert.False(t, state.observeContentLines([]string{"first line"}), "baseline should be cloned")
+	assert.True(t, state.observeContentLines([]string{"first line", "second line"}))
+	assert.False(t, state.observeContentLines([]string{"first line", "second line"}))
+}
+
+func TestShouldReviveIdleTmuxSession(t *testing.T) {
+	t.Parallel()
+
+	parsedIdlePane := &PaneStatus{IsIdle: true}
+	workingPane := &PaneStatus{IsWorking: true}
+
+	tests := []struct { //nolint:govet // test struct
+		name           string
+		status         SessionStatus
+		paneStatus     *PaneStatus
+		contentChanged bool
+		want           bool
+	}{
+		{
+			name:           "idle content changed",
+			status:         StatusIdle,
+			paneStatus:     parsedIdlePane,
+			contentChanged: true,
+			want:           true,
+		},
+		{
+			name:       "idle sampled working state",
+			status:     StatusIdle,
+			paneStatus: workingPane,
+			want:       true,
+		},
+		{
+			name:       "idle unchanged content",
+			status:     StatusIdle,
+			paneStatus: parsedIdlePane,
+			want:       false,
+		},
+		{
+			name:           "running content changed",
+			status:         StatusRunning,
+			paneStatus:     parsedIdlePane,
+			contentChanged: true,
+			want:           false,
+		},
+		{
+			name:           "unparsed pane content changed",
+			status:         StatusIdle,
+			contentChanged: true,
+			want:           false,
+		},
+		{
+			name:           "terminal content changed",
+			status:         StatusCompleted,
+			paneStatus:     parsedIdlePane,
+			contentChanged: true,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, shouldReviveIdleTmuxSession(tt.status, tt.paneStatus, tt.contentChanged))
+		})
+	}
+}
+
+func TestTryUpdateSessionStatus_IdleToRunning(t *testing.T) {
+	m := NewManager()
+	defer m.Close()
+
+	originalStart := time.Now().Add(-5 * time.Minute)
+	session := &Session{
+		ID:        "idle-session",
+		Status:    StatusIdle,
+		StartedAt: &originalStart,
+	}
+
+	updated := m.tryUpdateSessionStatus(session, StatusIdle, StatusRunning)
+
+	assert.True(t, updated)
+	assert.Equal(t, StatusRunning, session.Status)
+	assert.Equal(t, originalStart, *session.StartedAt, "StartedAt should be preserved when resuming from idle")
+
+	evt := requireStateChangeEvent(t, m)
+	assert.Equal(t, session.ID, evt.SessionID)
+	assert.Equal(t, StatusIdle, evt.OldStatus)
+	assert.Equal(t, StatusRunning, evt.NewStatus)
+	assertNoStateChangeEvent(t, m)
+}
+
+func TestTryUpdateSessionStatus_RequiresCurrentStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status SessionStatus
+	}{
+		{name: "pending", status: StatusPending},
+		{name: "running", status: StatusRunning},
+		{name: "completed", status: StatusCompleted},
+		{name: "failed", status: StatusFailed},
+		{name: "stopped", status: StatusStopped},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager()
+			defer m.Close()
+
+			session := &Session{
+				ID:     SessionID("session-" + tt.name),
+				Status: tt.status,
+			}
+
+			updated := m.tryUpdateSessionStatus(session, StatusIdle, StatusRunning)
+
+			assert.False(t, updated)
+			assert.Equal(t, tt.status, session.Status)
+			assertNoStateChangeEvent(t, m)
+		})
+	}
+}
+
+func requireStateChangeEvent(t *testing.T, m *Manager) SessionStateChangeEvent {
+	t.Helper()
+
+	select {
+	case raw := <-m.Events():
+		evt, ok := raw.(SessionStateChangeEvent)
+		require.Truef(t, ok, "event type = %T", raw)
+		return evt
+	default:
+		require.Fail(t, "expected state change event")
+		return SessionStateChangeEvent{}
+	}
+}
+
+func assertNoStateChangeEvent(t *testing.T, m *Manager) {
+	t.Helper()
+
+	select {
+	case raw := <-m.Events():
+		require.Failf(t, "unexpected state change event", "event = %#v", raw)
+	default:
+	}
+}
+
 func TestReposWithLiveTmuxSessions_NilStore(t *testing.T) {
 	liveRepos := ReposWithLiveTmuxSessions(nil, "active-repo")
 	assert.Nil(t, liveRepos)

--- a/bramble/session/tmux_test.go
+++ b/bramble/session/tmux_test.go
@@ -563,6 +563,36 @@ func TestContentLines_NilStatus(t *testing.T) {
 	assert.Equal(t, []string{"line1", "line2"}, content)
 }
 
+func TestContentLines_StatusBarOnlyChangeDoesNotChangeContent(t *testing.T) {
+	t.Parallel()
+
+	linesWithOldStatus := []string{
+		"● Bash(git status)",
+		"  ⎿  On branch feature/x",
+		"───────── ▪▪▪ ─",
+		"❯ ",
+		"───────────────────────────────────────",
+		"  ~/project  feature/x  Opus 4.6  ctx:20%  tokens:10k",
+		"  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+	}
+	linesWithNewStatus := []string{
+		"● Bash(git status)",
+		"  ⎿  On branch feature/x",
+		"───────── ▪▪▪ ─",
+		"❯ ",
+		"───────────────────────────────────────",
+		"  ~/project  feature/x  Opus 4.6  ctx:21%  tokens:11k",
+		"  ⏵⏵ bypass permissions on (shift+tab to cycle) · PR #123",
+	}
+
+	oldStatus := ParseClaudeStatusBarWithCursor(linesWithOldStatus, len(linesWithOldStatus)-1)
+	newStatus := ParseClaudeStatusBarWithCursor(linesWithNewStatus, len(linesWithNewStatus)-1)
+	require.NotNil(t, oldStatus)
+	require.NotNil(t, newStatus)
+
+	assert.Equal(t, ContentLines(linesWithOldStatus, oldStatus), ContentLines(linesWithNewStatus, newStatus))
+}
+
 func TestParseClaudeStatusBarWithCursor(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- revive idle tmux-tracked sessions when filtered pane content changes between captures
- keep the existing spinner-based revive path, but guard the status transition so only current idle sessions can become running
- add deterministic manager and tmux parser coverage for first-capture baselines, terminal-state protection, and status-bar-only changes

## Root Cause

The tmux monitor sampled Claude Code panes every 15 seconds and only revived idle sessions when a working spinner was visible. The spinner is often transient, so resumed work could update the pane without ever being sampled as `IsWorking`, leaving Bramble stuck in `StatusIdle`.

## Validation

- `scripts/lint.sh`
- `bazel build //...`
- `bazel test --test_timeout=60 //...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6f640e00bd65b8bb3bd7c56212036215c06d02d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->