### PR TITLE
fix(codetalk): fail fast with clear error for non-Claude models in standalone CLI

### DIFF
--- a/bramble/main.go
+++ b/bramble/main.go
@@ -667,6 +667,10 @@ After the initial exploration, it accepts follow-up questions interactively.`,
 		systemPrompt, _ := cmd.Flags().GetString("system")
 		verbose, _ := cmd.Flags().GetBool("verbose")
 
+		if err := checkCodetalkModel(model); err != nil {
+			return err
+		}
+
 		if workDir == "" {
 			var err error
 			workDir, err = os.Getwd()
@@ -732,6 +736,17 @@ After the initial exploration, it accepts follow-up questions interactively.`,
 		}
 		return nil
 	},
+}
+
+// checkCodetalkModel returns an error if the model ID belongs to a non-Claude
+// provider. The standalone codetalk CLI is Claude-only; non-Claude models must
+// use the bramble TUI, which has full provider routing built in.
+func checkCodetalkModel(modelID string) error {
+	provider, ok := agent.ProviderForModelID(modelID)
+	if ok && provider != agent.ProviderClaude {
+		return fmt.Errorf("bramble codetalk only supports Claude models; %q uses provider %q — use the bramble TUI (bramble) to start a CodeTalk session with non-Claude models", modelID, provider)
+	}
+	return nil
 }
 
 func init() {

--- a/bramble/main_test.go
+++ b/bramble/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,4 +80,77 @@ func TestDetectRepoFromPath_NoBareDir(t *testing.T) {
 
 	_, err := detectRepoFromPath(cwd, wtRoot)
 	assert.Error(t, err)
+}
+
+func TestCheckCodetalkModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modelID   string
+		errSubstr string
+		wantErr   bool
+	}{
+		{
+			name:    "opus is Claude — no error",
+			modelID: "opus",
+			wantErr: false,
+		},
+		{
+			name:    "sonnet is Claude — no error",
+			modelID: "sonnet",
+			wantErr: false,
+		},
+		{
+			name:    "unknown model ID — no error (not routed to non-Claude)",
+			modelID: "some-future-model",
+			wantErr: false,
+		},
+		{
+			name:      "gpt-5.5 is Codex — error with TUI hint",
+			modelID:   "gpt-5.5",
+			wantErr:   true,
+			errSubstr: "bramble TUI",
+		},
+		{
+			name:      "gemini-3-pro-preview is Gemini — error with TUI hint",
+			modelID:   "gemini-3-pro-preview",
+			wantErr:   true,
+			errSubstr: "bramble TUI",
+		},
+		{
+			name:      "cursor-default is Cursor — error with TUI hint",
+			modelID:   "cursor-default",
+			wantErr:   true,
+			errSubstr: "bramble TUI",
+		},
+		{
+			name:      "gpt- prefix triggers Codex routing — error",
+			modelID:   "gpt-9-future",
+			wantErr:   true,
+			errSubstr: "codex",
+		},
+		{
+			name:      "gemini- prefix triggers Gemini routing — error",
+			modelID:   "gemini-99",
+			wantErr:   true,
+			errSubstr: "gemini",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkCodetalkModel(tt.modelID)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.True(t, strings.Contains(err.Error(), tt.errSubstr),
+						"expected error to contain %q, got: %v", tt.errSubstr, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- `bramble codetalk --model gpt-5.5 "..."` previously silently passed the model ID straight to the Claude binary, which rejected it with an opaque error
- Added `checkCodetalkModel()` in `bramble/main.go` that calls `agent.ProviderForModelID()` early in `codetalkCmd.RunE`; if the provider is anything other than Claude, it returns a clear actionable error pointing users at the bramble TUI
- **No TUI changes needed**: the `manager.go` Codex/Gemini/Cursor `else if` branches already fire for `SessionTypeCodeTalk` (they're gated on provider, not session type), and the `permissionMode`/`PermissionHandler` blocks inside those branches already reference `SessionTypeCodeTalk` explicitly — CodeTalk with non-Claude models already works correctly through the TUI

## Option chosen: A (clear error + TUI redirect)

Option B (full parallel CLI implementation) wasn't warranted — the TUI already does the job, and the user's pain point was the silent failure, not the lack of standalone CLI support.

## Test plan

- [ ] `bazel test //bramble:bramble_test` — 8 new `TestCheckCodetalkModel` subtests (Claude models pass, codex/gemini/cursor fail with actionable message)
- [ ] `scripts/lint.sh` — passes
- [ ] `bazel test //...` — all 48 runnable tests pass
- [ ] Manually verify: `bramble codetalk --model gpt-5.5 "hi"` → clear error mentioning provider and TUI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI validation change with unit tests; only affects the standalone `codetalk` command’s error behavior for non-Claude model IDs.
> 
> **Overview**
> `bramble codetalk` now validates `--model` up front and **fails fast with a clear, actionable error** when the model routes to a non-Claude provider (Codex/Gemini/Cursor), directing users to use the Bramble TUI for multi-provider CodeTalk.
> 
> Adds `checkCodetalkModel()` (using `agent.ProviderForModelID`) and introduces focused unit tests covering Claude models, unknown IDs, and provider-prefix routing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5355f3d663712a964e7e4261cac1c15ef883c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->