### PR TITLE
[codex] Show selected session target for Bramble new sessions

### DIFF
--- a/bramble/app/BUILD.bazel
+++ b/bramble/app/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "helpoverlay_test.go",
         "merge_test.go",
         "new_session_cross_repo_test.go",
+        "new_session_worktree_race_test.go",
         "output_test.go",
         "playback_test.go",
         "quick_switch_test.go",

--- a/bramble/app/commandcenter_test.go
+++ b/bramble/app/commandcenter_test.go
@@ -421,7 +421,9 @@ func TestCommandCenter_UpdateSessionsEmptyList(t *testing.T) {
 // then 'p'/'b'/'c' must spawn against the navigated session's worktree.
 func TestCommandCenter_NewSession_AfterReSort(t *testing.T) {
 	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
-		{Branch: "main", Path: "/tmp/wt/main"},
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+		{Branch: "C", Path: "/tmp/wt/C"},
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0)
 

--- a/bramble/app/commandcenter_test.go
+++ b/bramble/app/commandcenter_test.go
@@ -465,7 +465,7 @@ func TestCommandCenter_NewSession_AfterReSort(t *testing.T) {
 	require.NotNil(t, cmd)
 	startMsg, ok := cmd().(startSessionMsg)
 	require.True(t, ok)
-	assert.Equal(t, "/tmp/wt/B", startMsg.worktreePath,
+	assert.Equal(t, "/tmp/wt/B", startMsg.target.worktreePath,
 		"new session must target the navigated session's worktree, not the first card's")
 }
 

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -888,33 +888,9 @@ type (
 	}
 )
 
-type sessionTargetMode int
-
-const (
-	sessionTargetCapturedSelection sessionTargetMode = iota + 1
-	sessionTargetExistingSession
-)
-
 type sessionTarget struct {
 	repoName     string
 	worktreePath string
-	mode         sessionTargetMode
-}
-
-func capturedSelectionTarget(repoName, worktreePath string) sessionTarget {
-	return sessionTarget{
-		repoName:     repoName,
-		worktreePath: worktreePath,
-		mode:         sessionTargetCapturedSelection,
-	}
-}
-
-func existingSessionTarget(repoName, worktreePath string) sessionTarget {
-	return sessionTarget{
-		repoName:     repoName,
-		worktreePath: worktreePath,
-		mode:         sessionTargetExistingSession,
-	}
 }
 
 // RouteProposal wraps taskrouter.RouteProposal for use in the app.

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -775,11 +775,10 @@ type (
 	sessionsUpdated struct{}
 	promptInputMsg  struct{ value string }
 	startSessionMsg struct {
-		sessionType  session.SessionType
-		prompt       string
-		model        string
-		worktreePath string // if set, starts on this path instead of selected worktree
-		repoName     string // if set and != m.repoName, starts on that repo's manager
+		sessionType session.SessionType
+		prompt      string
+		model       string
+		target      sessionTarget
 	}
 	createWorktreeMsg struct{ branch string }
 	editorResultMsg   struct{ err error }
@@ -883,6 +882,35 @@ type (
 		action string // "delete", "reset", "keep"
 	}
 )
+
+type sessionTargetMode int
+
+const (
+	sessionTargetCapturedSelection sessionTargetMode = iota + 1
+	sessionTargetExistingSession
+)
+
+type sessionTarget struct {
+	repoName     string
+	worktreePath string
+	mode         sessionTargetMode
+}
+
+func capturedSelectionTarget(repoName, worktreePath string) sessionTarget {
+	return sessionTarget{
+		repoName:     repoName,
+		worktreePath: worktreePath,
+		mode:         sessionTargetCapturedSelection,
+	}
+}
+
+func existingSessionTarget(repoName, worktreePath string) sessionTarget {
+	return sessionTarget{
+		repoName:     repoName,
+		worktreePath: worktreePath,
+		mode:         sessionTargetExistingSession,
+	}
+}
 
 // RouteProposal wraps taskrouter.RouteProposal for use in the app.
 type RouteProposal = struct {

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -185,7 +185,11 @@ func NewModel(ctx context.Context, wtRoot, repoName, editor string, sessionManag
 	m.repoSettingsDialog.SetSize(width, height)
 	m.configureAllDropdownsForViewport()
 
-	m.worktreesLoaded = initialWorktrees != nil
+	// Treat a non-empty initial slice as a real prefetched snapshot. An empty
+	// slice (or nil) is left as "not yet loaded" so explicit-path targets
+	// fall back to the on-disk stat check until a worktreesMsg lands with
+	// the actual data.
+	m.worktreesLoaded = len(initialWorktrees) > 0
 
 	// Pre-populate worktrees so the first View() render shows branch names.
 	if len(initialWorktrees) > 0 {

--- a/bramble/app/model.go
+++ b/bramble/app/model.go
@@ -68,6 +68,7 @@ type Model struct { //nolint:govet // fieldalignment: readability over packing
 	styles                *Styles
 	inputHandler          func(value, model string, sessionType session.SessionType) tea.Cmd
 	sharedManagerConfig   session.ManagerConfig
+	pendingSessionTarget  sessionTarget
 	pendingModel          string
 	repoName              string
 	historyBranch         string
@@ -94,6 +95,7 @@ type Model struct { //nolint:govet // fieldalignment: readability over packing
 	focus                 FocusArea
 	inputMode             bool
 	confirmQuit           bool
+	worktreesLoaded       bool
 	// Voice reporting.
 	voiceReporter *VoiceReporter
 }
@@ -183,6 +185,8 @@ func NewModel(ctx context.Context, wtRoot, repoName, editor string, sessionManag
 	m.repoSettingsDialog.SetSize(width, height)
 	m.configureAllDropdownsForViewport()
 
+	m.worktreesLoaded = initialWorktrees != nil
+
 	// Pre-populate worktrees so the first View() render shows branch names.
 	if len(initialWorktrees) > 0 {
 		m.worktrees = initialWorktrees
@@ -196,6 +200,7 @@ func NewModel(ctx context.Context, wtRoot, repoName, editor string, sessionManag
 		sessionManager:   sessionManager,
 		taskRouter:       taskRouter,
 		worktrees:        m.worktrees,
+		worktreesLoaded:  m.worktreesLoaded,
 		worktreeDropdown: m.worktreeDropdown,
 		sessionDropdown:  m.sessionDropdown,
 		scrollPositions:  m.scrollPositions,

--- a/bramble/app/new_session_cross_repo_test.go
+++ b/bramble/app/new_session_cross_repo_test.go
@@ -38,6 +38,7 @@ func addTestSession(t *testing.T, mgr *session.Manager, sess *session.Session) s
 func setRepoWorktrees(m *Model, repoName string, worktrees []wt.Worktree) {
 	rc := m.repos[repoName]
 	rc.worktrees = worktrees
+	rc.worktreesLoaded = true
 
 	items := make([]DropdownItem, 0, len(worktrees))
 	for _, wt := range worktrees {
@@ -81,6 +82,7 @@ func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 	selected := m2.worktreeDropdown.SelectedItem()
 	require.NotNil(t, selected)
 	assert.Equal(t, "feature", selected.ID, "prompt view should show the selected session worktree")
+	assert.Contains(t, m2.View().Content, "Repo B session")
 
 	newModel2, cmd := m2.Update(promptInputMsg{value: "do the thing"})
 	m3 := newModel2.(Model)
@@ -137,6 +139,7 @@ func TestNewSessionFromCommandCenter_CrossRepo_UsesTargetManager(t *testing.T) {
 	selected := m2.worktreeDropdown.SelectedItem()
 	require.NotNil(t, selected)
 	assert.Equal(t, "feature", selected.ID)
+	assert.Contains(t, m2.View().Content, "Repo B session")
 
 	newModel2, cmd := m2.Update(promptInputMsg{value: "plan something"})
 	m3 := newModel2.(Model)
@@ -162,6 +165,17 @@ func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0) // start on "main"
 
+	mainSess := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "s0",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/main",
+		WorktreeName: "main",
+		RepoName:     "test-repo",
+		Title:        "Main session",
+	})
+	m.switchViewingSession(mainSess.ID)
+
 	sess := addTestSession(t, m.sessionManager, &session.Session{
 		ID:           "s1",
 		Type:         session.SessionTypeBuilder,
@@ -183,4 +197,138 @@ func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
 	assert.Equal(t, "feature", selected.ID, "same-repo overlay must sync worktree dropdown")
 	assert.Equal(t, session.SessionID("s1"), m2.viewingSessionID, "prompt view should show selected session output")
 	assert.Contains(t, m2.View().Content, "Feature session")
+	assert.NotContains(t, m2.View().Content, "Main session")
+}
+
+func TestNewSessionFromCommandCenter_CrossRepoColdContext_ShowsSelectedSessionWorktree(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	m.worktreeDropdown.SelectIndex(0)
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+	repoBSess := addTestSession(t, mgrB, &session.Session{
+		ID:           "b1",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/repoB-feature",
+		WorktreeName: "feature",
+		RepoName:     "repoB",
+		Title:        "Repo B session",
+	})
+	m.commandCenter.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('p'))
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "repoB", m2.repoName)
+	assert.True(t, m2.inputMode)
+	assert.False(t, m2.worktreesLoaded, "repoB worktrees are still loading")
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID)
+	assert.Contains(t, m2.View().Content, "Repo B session")
+
+	refreshedModel, _ := m2.Update(worktreesMsg{repoName: "repoB", worktrees: []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/repoB-feature"},
+	}})
+	m3 := refreshedModel.(Model)
+
+	assert.True(t, m3.inputMode)
+	assert.True(t, m3.worktreesLoaded)
+	selected = m3.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID)
+}
+
+func TestNewSessionFromOverlay_CrossRepoColdContext_ShowsSelectedSessionWorktree(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	m.worktreeDropdown.SelectIndex(0)
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+	repoBSess := addTestSession(t, mgrB, &session.Session{
+		ID:           "b1",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/repoB-feature",
+		WorktreeName: "feature",
+		RepoName:     "repoB",
+		Title:        "Repo B session",
+	})
+	m.allSessionsOverlay.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
+	m.focus = FocusAllSessions
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "repoB", m2.repoName)
+	assert.True(t, m2.inputMode)
+	assert.False(t, m2.worktreesLoaded, "repoB worktrees are still loading")
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID)
+	assert.Contains(t, m2.View().Content, "Repo B session")
+}
+
+func TestNewSessionFromCommandCenter_MissingRepoDoesNotOpenPrompt(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	m.worktreeDropdown.SelectIndex(0)
+
+	m.commandCenter.Show([]session.SessionInfo{{
+		ID:           "b1",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/repoB-feature",
+		WorktreeName: "feature",
+		RepoName:     "repoB",
+		Title:        "Repo B session",
+	}}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('p'))
+	m2 := newModel.(Model)
+
+	assert.False(t, m2.inputMode)
+	assert.True(t, m2.commandCenter.IsVisible(), "command center should stay visible on validation error")
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target repo no longer available")
+}
+
+func TestNewSessionPrompt_WorktreeRefreshCancelsWhenSelectedWorktreeDisappears(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	m.worktreeDropdown.SelectIndex(0)
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+	repoBSess := addTestSession(t, mgrB, &session.Session{
+		ID:           "b1",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/repoB-feature",
+		WorktreeName: "feature",
+		RepoName:     "repoB",
+		Title:        "Repo B session",
+	})
+	m.commandCenter.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('p'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+
+	refreshedModel, _ := m2.Update(worktreesMsg{repoName: "repoB", worktrees: []wt.Worktree{
+		{Branch: "other", Path: "/tmp/wt/repoB-other"},
+	}})
+	m3 := refreshedModel.(Model)
+
+	assert.False(t, m3.inputMode)
+	assert.Equal(t, FocusOutput, m3.focus)
+	assert.True(t, m3.toasts.HasToasts())
+	assert.Contains(t, m3.toasts.toasts[0].Message, "Target worktree no longer available")
 }

--- a/bramble/app/new_session_cross_repo_test.go
+++ b/bramble/app/new_session_cross_repo_test.go
@@ -27,6 +27,28 @@ func injectSecondRepo(t *testing.T, m *Model, repoName string) *session.Manager 
 	return mgr
 }
 
+func addTestSession(t *testing.T, mgr *session.Manager, sess *session.Session) session.SessionInfo {
+	t.Helper()
+	mgr.AddSession(sess)
+	info, ok := mgr.GetSessionInfo(sess.ID)
+	require.True(t, ok)
+	return info
+}
+
+func setRepoWorktrees(m *Model, repoName string, worktrees []wt.Worktree) {
+	rc := m.repos[repoName]
+	rc.worktrees = worktrees
+
+	items := make([]DropdownItem, 0, len(worktrees))
+	for _, wt := range worktrees {
+		items = append(items, DropdownItem{ID: wt.Branch, Label: wt.Branch})
+	}
+	rc.worktreeDropdown.SetItems(items)
+	if len(items) > 0 {
+		rc.worktreeDropdown.SelectIndex(0)
+	}
+}
+
 func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
 		{Branch: "main", Path: "/tmp/wt/repoA-main"},
@@ -34,29 +56,31 @@ func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	mgrB := injectSecondRepo(t, &m, "repoB")
+	setRepoWorktrees(&m, "repoB", []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/repoB-feature"},
+	})
 
-	repoBSess := session.SessionInfo{
+	repoBSess := addTestSession(t, mgrB, &session.Session{
 		ID:           "b1",
+		Type:         session.SessionTypePlanner,
 		Status:       session.StatusRunning,
 		WorktreePath: "/tmp/wt/repoB-feature",
 		WorktreeName: "feature",
 		RepoName:     "repoB",
-	}
+		Title:        "Repo B session",
+	})
 	m.allSessionsOverlay.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
 	m.focus = FocusAllSessions
-
-	dropdownBefore := m.worktreeDropdown.SelectedItem()
 
 	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
 	m2 := newModel.(Model)
 
-	assert.Equal(t, "repoA", m2.repoName, "main view must stay on repoA")
+	assert.Equal(t, "repoB", m2.repoName, "main view should show the selected session repo")
 	assert.True(t, m2.inputMode, "should be in input mode waiting for prompt")
-	if dropdownBefore != nil {
-		after := m2.worktreeDropdown.SelectedItem()
-		require.NotNil(t, after)
-		assert.Equal(t, dropdownBefore.ID, after.ID, "worktree dropdown must not change for cross-repo")
-	}
+	assert.Equal(t, session.SessionID("b1"), m2.viewingSessionID)
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID, "prompt view should show the selected session worktree")
 
 	newModel2, cmd := m2.Update(promptInputMsg{value: "do the thing"})
 	m3 := newModel2.(Model)
@@ -64,20 +88,20 @@ func TestNewSessionFromOverlay_CrossRepo_UsesTargetManager(t *testing.T) {
 	msg := cmd()
 	startMsg, ok := msg.(startSessionMsg)
 	require.True(t, ok, "expected startSessionMsg, got %T", msg)
-	assert.Equal(t, "repoB", startMsg.repoName)
-	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.worktreePath)
+	assert.Equal(t, "repoB", startMsg.target.repoName)
+	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.target.worktreePath)
 
 	newModel3, _ := m3.Update(startMsg)
 	m4 := newModel3.(Model)
 
-	assert.Equal(t, "repoA", m4.repoName, "main view must still be on repoA")
+	assert.Equal(t, "repoB", m4.repoName, "main view should stay on the visible target repo")
 
 	bSessions := mgrB.GetAllSessions()
-	require.Len(t, bSessions, 1, "new session should be on repoB's manager")
+	require.Len(t, bSessions, 2, "new session should be on repoB's manager")
 	assert.Equal(t, "repoB", bSessions[0].RepoName)
 	assert.Equal(t, "/tmp/wt/repoB-feature", bSessions[0].WorktreePath)
 
-	aSessions := m4.sessionManager.GetAllSessions()
+	aSessions := m4.repos["repoA"].sessionManager.GetAllSessions()
 	assert.Empty(t, aSessions, "repoA manager must not receive the new session")
 }
 
@@ -88,38 +112,47 @@ func TestNewSessionFromCommandCenter_CrossRepo_UsesTargetManager(t *testing.T) {
 	m.worktreeDropdown.SelectIndex(0)
 
 	mgrB := injectSecondRepo(t, &m, "repoB")
+	setRepoWorktrees(&m, "repoB", []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/repoB-feature"},
+	})
 
-	repoBSess := session.SessionInfo{
+	repoBSess := addTestSession(t, mgrB, &session.Session{
 		ID:           "b1",
+		Type:         session.SessionTypePlanner,
 		Status:       session.StatusRunning,
 		WorktreePath: "/tmp/wt/repoB-feature",
 		WorktreeName: "feature",
 		RepoName:     "repoB",
-	}
+		Title:        "Repo B session",
+	})
 	m.commandCenter.Show([]session.SessionInfo{repoBSess}, m.width, m.height)
 	m.focus = FocusCommandCenter
 
 	newModel, _ := m.handleCommandCenter(keyPress('p'))
 	m2 := newModel.(Model)
 
-	assert.Equal(t, "repoA", m2.repoName)
+	assert.Equal(t, "repoB", m2.repoName)
 	assert.True(t, m2.inputMode)
+	assert.Equal(t, session.SessionID("b1"), m2.viewingSessionID)
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID)
 
 	newModel2, cmd := m2.Update(promptInputMsg{value: "plan something"})
 	m3 := newModel2.(Model)
 	require.NotNil(t, cmd)
 	startMsg, ok := cmd().(startSessionMsg)
 	require.True(t, ok)
-	assert.Equal(t, "repoB", startMsg.repoName)
+	assert.Equal(t, "repoB", startMsg.target.repoName)
 	assert.Equal(t, session.SessionTypePlanner, startMsg.sessionType)
-	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.worktreePath)
+	assert.Equal(t, "/tmp/wt/repoB-feature", startMsg.target.worktreePath)
 
 	newModel3, _ := m3.Update(startMsg)
 	m4 := newModel3.(Model)
 
-	assert.Equal(t, "repoA", m4.repoName)
-	assert.Len(t, mgrB.GetAllSessions(), 1)
-	assert.Empty(t, m4.sessionManager.GetAllSessions())
+	assert.Equal(t, "repoB", m4.repoName)
+	assert.Len(t, mgrB.GetAllSessions(), 2)
+	assert.Empty(t, m4.repos["repoA"].sessionManager.GetAllSessions())
 }
 
 func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
@@ -129,13 +162,15 @@ func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
 	}, "test-repo")
 	m.worktreeDropdown.SelectIndex(0) // start on "main"
 
-	sess := session.SessionInfo{
+	sess := addTestSession(t, m.sessionManager, &session.Session{
 		ID:           "s1",
+		Type:         session.SessionTypeBuilder,
 		Status:       session.StatusRunning,
 		WorktreePath: "/tmp/wt/feature",
 		WorktreeName: "feature",
 		RepoName:     "test-repo",
-	}
+		Title:        "Feature session",
+	})
 	m.allSessionsOverlay.Show([]session.SessionInfo{sess}, m.width, m.height)
 	m.focus = FocusAllSessions
 
@@ -146,4 +181,6 @@ func TestNewSessionFromOverlay_SameRepo_SyncsWorktreeDropdown(t *testing.T) {
 	selected := m2.worktreeDropdown.SelectedItem()
 	require.NotNil(t, selected)
 	assert.Equal(t, "feature", selected.ID, "same-repo overlay must sync worktree dropdown")
+	assert.Equal(t, session.SessionID("s1"), m2.viewingSessionID, "prompt view should show selected session output")
+	assert.Contains(t, m2.View().Content, "Feature session")
 }

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -213,6 +213,77 @@ func TestCommandCenterNewSession_ShowsSelectedSessionWorktreeWhilePromptOpen(t *
 	assert.NotContains(t, view, "Session A")
 }
 
+func TestCommandCenterNewSession_SelectsByWorktreePathWhenNameIsStale(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/main"},
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("main"))
+
+	sess := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "s1",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/feature",
+		WorktreeName: "stale-name",
+		RepoName:     "repoA",
+		Title:        "Feature session",
+	})
+	m.commandCenter.Show([]session.SessionInfo{sess}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('p'))
+	m2 := newModel.(Model)
+
+	require.True(t, m2.inputMode)
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "feature", selected.ID)
+	assert.Equal(t, session.SessionID("s1"), m2.viewingSessionID)
+	assert.Contains(t, m2.View().Content, "Feature session")
+}
+
+func TestStartSessionMsg_ExistingSessionWorktreeRemovedBeforeDispatch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	sess := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sB",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/B",
+		WorktreeName: "B",
+		RepoName:     "repoA",
+		Title:        "Session B",
+	})
+	m.commandCenter.Show([]session.SessionInfo{sess}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	newModel, _ := m.handleCommandCenter(keyPress('b'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+
+	newModel2, cmd := m2.Update(promptInputMsg{value: "build on B"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd)
+	startMsg, ok := cmd().(startSessionMsg)
+	require.True(t, ok)
+	require.Equal(t, sessionTargetExistingSession, startMsg.target.mode)
+
+	m3.worktrees = []wt.Worktree{{Branch: "A", Path: "/tmp/wt/A"}}
+	m3.updateWorktreeDropdown()
+
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	assert.True(t, m4.toasts.HasToasts())
+	assert.Contains(t, m4.toasts.toasts[0].Message, "Target worktree no longer available")
+	assert.Len(t, m4.sessionManager.GetAllSessions(), 1, "removed target must not receive a new session")
+}
+
 func TestConfirmTask_UnknownExistingWorktreeDoesNotFallBackToCurrentSelection(t *testing.T) {
 	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
 		{Branch: "A", Path: "/tmp/wt/A"},

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -459,6 +459,78 @@ func TestStartSessionMsg_AcceptsColdCrossRepoTargetWhenPathExists(t *testing.T) 
 	assert.Equal(t, "/tmp/wt/repoB-main", mgrB.GetAllSessions()[0].WorktreePath)
 }
 
+// Main view plan approval (handleKeyPress 'a') must reject a removed
+// worktree before it completes the planner — otherwise the planner is lost
+// and the builder cannot start. Mirrors the command-center variant.
+func TestMainView_PlanApproval_RejectsRemovedWorktree(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("feature"))
+
+	planner := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sP",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusIdle,
+		WorktreePath: "/tmp/wt/feature",
+		WorktreeName: "feature",
+		RepoName:     "repoA",
+		PlanFilePath: "/tmp/wt/feature/PLAN.md",
+		Title:        "Planner",
+	})
+	m.switchViewingSession(planner.ID)
+
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "/tmp/wt/feature" }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	newModel, _ := m.handleKeyPress(keyPress('a'))
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
+	require.Len(t, m2.sessionManager.GetAllSessions(), 1,
+		"original planner must not be completed when preflight rejects")
+	assert.Equal(t, session.SessionTypePlanner, m2.sessionManager.GetAllSessions()[0].Type)
+}
+
+// Command-center plan approval should keep the overlay visible when the
+// preflight rejects, instead of dumping the user onto FocusOutput with only
+// a toast.
+func TestCommandCenter_PlanApproval_KeepsOverlayOnReject(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("feature"))
+
+	planner := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sP",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusIdle,
+		WorktreePath: "/tmp/wt/feature",
+		WorktreeName: "feature",
+		RepoName:     "repoA",
+		PlanFilePath: "/tmp/wt/feature/PLAN.md",
+		Title:        "Planner",
+	})
+	m.commandCenter.Show([]session.SessionInfo{planner}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "/tmp/wt/feature" }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	newModel, _ := m.handleCommandCenter(keyPress('a'))
+	m2 := newModel.(Model)
+
+	assert.Equal(t, FocusCommandCenter, m2.focus,
+		"rejection should leave focus on the command center")
+	assert.True(t, m2.commandCenter.IsVisible(),
+		"rejection should keep the command center visible")
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
+}
+
 // Plan approval (command-center "a") must apply the same disk-stat
 // preflight as confirmTask / startSessionMsg. A planner left idle with a
 // plan file can become stale if its worktree is removed between idle review

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -35,7 +35,6 @@ func TestMainViewNewSession_CapturesWorktreeBeforePrompt(t *testing.T) {
 			assert.Equal(t, sessionType, startMsg.sessionType)
 			assert.Equal(t, "repoA", startMsg.target.repoName)
 			assert.Equal(t, "/tmp/wt/A", startMsg.target.worktreePath)
-			assert.Equal(t, sessionTargetCapturedSelection, startMsg.target.mode)
 
 			newModel3, _ := m3.Update(startMsg)
 			m4 := newModel3.(Model)
@@ -55,9 +54,9 @@ func TestMainViewNewSession_CapturedRepoSurvivesRepoSwitchBeforePromptSubmit(t *
 	require.True(t, m.worktreeDropdown.SelectByID("main"))
 
 	mgrB := injectSecondRepo(t, &m, "repoB")
-	m.repos["repoB"].worktrees = []wt.Worktree{
+	setRepoWorktrees(&m, "repoB", []wt.Worktree{
 		{Branch: "main", Path: "/tmp/wt/repoB-main"},
-	}
+	})
 
 	newModel, _ := m.handleKeyPress(keyPress('p'))
 	m2 := newModel.(Model)
@@ -75,7 +74,6 @@ func TestMainViewNewSession_CapturedRepoSurvivesRepoSwitchBeforePromptSubmit(t *
 	require.True(t, ok)
 	assert.Equal(t, "repoA", startMsg.target.repoName)
 	assert.Equal(t, "/tmp/wt/repoA-main", startMsg.target.worktreePath)
-	assert.Equal(t, sessionTargetCapturedSelection, startMsg.target.mode)
 
 	newModel3, _ := m3.Update(startMsg)
 	m4 := newModel3.(Model)
@@ -152,7 +150,6 @@ func TestAllSessionsOverlayNewSession_UsesCapturedSessionWorktreeAfterSelectionC
 	assert.Equal(t, session.SessionTypeBuilder, startMsg.sessionType)
 	assert.Equal(t, "repoA", startMsg.target.repoName)
 	assert.Equal(t, "/tmp/wt/B", startMsg.target.worktreePath)
-	assert.Equal(t, sessionTargetExistingSession, startMsg.target.mode)
 
 	newModel3, _ := m3.Update(startMsg)
 	m4 := newModel3.(Model)
@@ -271,7 +268,7 @@ func TestStartSessionMsg_ExistingSessionWorktreeRemovedBeforeDispatch(t *testing
 	require.NotNil(t, cmd)
 	startMsg, ok := cmd().(startSessionMsg)
 	require.True(t, ok)
-	require.Equal(t, sessionTargetExistingSession, startMsg.target.mode)
+	require.Equal(t, "/tmp/wt/B", startMsg.target.worktreePath)
 
 	m3.worktrees = []wt.Worktree{{Branch: "A", Path: "/tmp/wt/A"}}
 	m3.updateWorktreeDropdown()

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -299,3 +299,65 @@ func TestConfirmTask_UnknownExistingWorktreeDoesNotFallBackToCurrentSelection(t 
 	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
 	assert.Empty(t, m2.sessionManager.GetAllSessions())
 }
+
+// A worktreesMsg that strips the pending target must both cancel the prompt
+// and run the rest of the refresh flow (auto-select + deferred refresh) so
+// that pendingWorktreeSelect, the session dropdown, and downstream refreshes
+// stay coherent in the same update cycle.
+func TestWorktreesMsg_PendingTargetGoneStillRunsRefreshFlow(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	newModel, _ := m.handleKeyPress(keyPress('p'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+	require.Equal(t, "/tmp/wt/A", m2.pendingSessionTarget.worktreePath)
+
+	// Simulate a refresh that drops "A" and offers "B" instead.
+	refreshedModel, cmd := m2.Update(worktreesMsg{
+		repoName:  "repoA",
+		worktrees: []wt.Worktree{{Branch: "B", Path: "/tmp/wt/B"}},
+	})
+	m3 := refreshedModel.(Model)
+
+	assert.False(t, m3.inputMode, "pending prompt must be cancelled")
+	assert.Equal(t, sessionTarget{}, m3.pendingSessionTarget)
+	assert.True(t, m3.toasts.HasToasts())
+	assert.Contains(t, m3.toasts.toasts[0].Message, "Target worktree no longer available")
+	require.NotNil(t, m3.worktreeDropdown.SelectedItem(),
+		"refresh flow must auto-select the surviving worktree")
+	assert.Equal(t, "B", m3.worktreeDropdown.SelectedItem().ID)
+	require.NotNil(t, cmd, "deferred refresh must still fire after cancellation")
+}
+
+// Snapshot can lag behind reality: the worktree slice still lists the path
+// after the directory was removed on disk. Submit must reject in that case.
+func TestStartSessionMsg_TargetGoneOnDiskBetweenPromptAndSubmit(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	newModel, _ := m.handleKeyPress(keyPress('p'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+
+	newModel2, cmd := m2.Update(promptInputMsg{value: "plan"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd)
+	startMsg, ok := cmd().(startSessionMsg)
+	require.True(t, ok)
+
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "/tmp/wt/A" }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	assert.True(t, m4.toasts.HasToasts())
+	assert.Contains(t, m4.toasts.toasts[0].Message, "Target worktree no longer available")
+	assert.Empty(t, m4.sessionManager.GetAllSessions())
+}

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -1,0 +1,233 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/bramble/session"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+func TestMainViewNewSession_CapturesWorktreeBeforePrompt(t *testing.T) {
+	for _, key := range []rune{'p', 'b', 'c'} {
+		t.Run(string(key), func(t *testing.T) {
+			sessionType := sessionTypeFromKey(string(key))
+			m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+				{Branch: "A", Path: "/tmp/wt/A"},
+				{Branch: "B", Path: "/tmp/wt/B"},
+			}, "repoA")
+			require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+			newModel, _ := m.handleKeyPress(keyPress(key))
+			m2 := newModel.(Model)
+			require.True(t, m2.inputMode)
+
+			require.True(t, m2.worktreeDropdown.SelectByID("B"))
+
+			newModel2, cmd := m2.Update(promptInputMsg{value: "do the thing"})
+			m3 := newModel2.(Model)
+			require.NotNil(t, cmd)
+
+			startMsg, ok := cmd().(startSessionMsg)
+			require.True(t, ok)
+			assert.Equal(t, sessionType, startMsg.sessionType)
+			assert.Equal(t, "repoA", startMsg.target.repoName)
+			assert.Equal(t, "/tmp/wt/A", startMsg.target.worktreePath)
+			assert.Equal(t, sessionTargetCapturedSelection, startMsg.target.mode)
+
+			newModel3, _ := m3.Update(startMsg)
+			m4 := newModel3.(Model)
+
+			sessions := m4.sessionManager.GetAllSessions()
+			require.Len(t, sessions, 1)
+			assert.Equal(t, sessionType, sessions[0].Type)
+			assert.Equal(t, "/tmp/wt/A", sessions[0].WorktreePath)
+		})
+	}
+}
+
+func TestMainViewNewSession_CapturedRepoSurvivesRepoSwitchBeforePromptSubmit(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoA-main"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("main"))
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+	m.repos["repoB"].worktrees = []wt.Worktree{
+		{Branch: "main", Path: "/tmp/wt/repoB-main"},
+	}
+
+	newModel, _ := m.handleKeyPress(keyPress('p'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+
+	switchedModel, _ := m2.switchRepo("repoB")
+	mOnB := switchedModel.(Model)
+	require.Equal(t, "repoB", mOnB.repoName)
+
+	newModel2, cmd := mOnB.Update(promptInputMsg{value: "plan from original repo"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd)
+
+	startMsg, ok := cmd().(startSessionMsg)
+	require.True(t, ok)
+	assert.Equal(t, "repoA", startMsg.target.repoName)
+	assert.Equal(t, "/tmp/wt/repoA-main", startMsg.target.worktreePath)
+	assert.Equal(t, sessionTargetCapturedSelection, startMsg.target.mode)
+
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	assert.Equal(t, "repoB", m4.repoName, "active repo should not be switched by dispatch")
+	assert.Empty(t, mgrB.GetAllSessions(), "current repo manager must not receive the captured repo session")
+
+	repoASessions := m4.repos["repoA"].sessionManager.GetAllSessions()
+	require.Len(t, repoASessions, 1)
+	assert.Equal(t, "/tmp/wt/repoA-main", repoASessions[0].WorktreePath)
+}
+
+func TestStartSessionMsg_CapturedWorktreeRemovedBeforeDispatch(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	newModel, _ := m.handleKeyPress(keyPress('p'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+
+	newModel2, cmd := m2.Update(promptInputMsg{value: "plan removed worktree"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd)
+
+	startMsg, ok := cmd().(startSessionMsg)
+	require.True(t, ok)
+	require.Equal(t, "/tmp/wt/A", startMsg.target.worktreePath)
+
+	m3.worktrees = nil
+	m3.updateWorktreeDropdown()
+
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	assert.True(t, m4.toasts.HasToasts())
+	assert.Contains(t, m4.toasts.toasts[0].Message, "Target worktree no longer available")
+	assert.Empty(t, m4.sessionManager.GetAllSessions())
+}
+
+func TestAllSessionsOverlayNewSession_UsesCapturedSessionWorktreeAfterSelectionChanges(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	sessions := []session.SessionInfo{
+		{
+			ID:           "s1",
+			Status:       session.StatusRunning,
+			WorktreePath: "/tmp/wt/B",
+			WorktreeName: "B",
+			RepoName:     "repoA",
+		},
+	}
+	m.allSessionsOverlay.Show(sessions, m.width, m.height)
+	m.focus = FocusAllSessions
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
+	m2 := newModel.(Model)
+	require.True(t, m2.inputMode)
+
+	require.True(t, m2.worktreeDropdown.SelectByID("A"))
+
+	newModel2, cmd := m2.Update(promptInputMsg{value: "build on B"})
+	m3 := newModel2.(Model)
+	require.NotNil(t, cmd)
+
+	startMsg, ok := cmd().(startSessionMsg)
+	require.True(t, ok)
+	assert.Equal(t, session.SessionTypeBuilder, startMsg.sessionType)
+	assert.Equal(t, "repoA", startMsg.target.repoName)
+	assert.Equal(t, "/tmp/wt/B", startMsg.target.worktreePath)
+	assert.Equal(t, sessionTargetExistingSession, startMsg.target.mode)
+
+	newModel3, _ := m3.Update(startMsg)
+	m4 := newModel3.(Model)
+
+	sessionsAfter := m4.sessionManager.GetAllSessions()
+	require.Len(t, sessionsAfter, 1)
+	assert.Equal(t, "/tmp/wt/B", sessionsAfter[0].WorktreePath)
+}
+
+func TestCommandCenterNewSession_ShowsSelectedSessionWorktreeWhilePromptOpen(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	sessionA := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sA",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/A",
+		WorktreeName: "A",
+		RepoName:     "repoA",
+		Title:        "Session A",
+	})
+	sessionB := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sB",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/B",
+		WorktreeName: "B",
+		RepoName:     "repoA",
+		Title:        "Session B",
+	})
+	m.switchViewingSession(sessionA.ID)
+
+	m.commandCenter.Show([]session.SessionInfo{sessionA, sessionB}, m.width, m.height)
+	m.focus = FocusCommandCenter
+	selectedB := false
+	for i, sess := range m.commandCenter.Sessions() {
+		if sess.ID == session.SessionID("sB") {
+			selectedB = m.commandCenter.SelectByNumber(i + 1)
+			break
+		}
+	}
+	require.True(t, selectedB)
+
+	newModel, _ := m.handleCommandCenter(keyPress('b'))
+	m2 := newModel.(Model)
+
+	require.True(t, m2.inputMode)
+	assert.Equal(t, session.SessionID("sB"), m2.viewingSessionID)
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "B", selected.ID)
+	view := m2.View().Content
+	assert.Contains(t, view, "Session B")
+	assert.NotContains(t, view, "Session A")
+}
+
+func TestConfirmTask_UnknownExistingWorktreeDoesNotFallBackToCurrentSelection(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("B"))
+
+	newModel, _ := m.confirmTask(taskConfirmMsg{
+		worktree: "missing",
+		prompt:   "plan missing worktree",
+		isNew:    false,
+	})
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
+	assert.Empty(t, m2.sessionManager.GetAllSessions())
+}

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -332,6 +332,67 @@ func TestWorktreesMsg_PendingTargetGoneStillRunsRefreshFlow(t *testing.T) {
 	require.NotNil(t, cmd, "deferred refresh must still fire after cancellation")
 }
 
+// Cold target repo: when the captured target points at a repo whose worktree
+// snapshot has not finished loading, sessionTargetAvailability returns
+// Unknown. Submit must still reject if the path is gone on disk.
+func TestStartSessionMsg_RejectsColdTargetWhenPathMissingOnDisk(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	// Register repoB but leave its worktrees unloaded — simulates the cold
+	// cross-repo path added by this branch.
+	injectSecondRepo(t, &m, "repoB")
+	rcB := m.repos["repoB"]
+	rcB.worktreesLoaded = false
+	rcB.worktrees = nil
+
+	startMsg := startSessionMsg{
+		sessionType: session.SessionTypePlanner,
+		prompt:      "plan on cold repo",
+		model:       "claude-opus-4-7",
+		target: sessionTarget{
+			repoName:     "repoB",
+			worktreePath: "/tmp/wt/repoB-gone",
+		},
+	}
+
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "/tmp/wt/repoB-gone" }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	newModel, _ := m.Update(startMsg)
+	m2 := newModel.(Model)
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
+	assert.Empty(t, rcB.sessionManager.GetAllSessions())
+}
+
+// confirmTask should reject a worktree that the snapshot still lists but that
+// no longer exists on disk — same disk-stat policy as startSessionMsg.
+func TestConfirmTask_RejectsWorktreeMissingOnDisk(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("feature"))
+
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "/tmp/wt/feature" }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	newModel, _ := m.confirmTask(taskConfirmMsg{
+		worktree: "feature",
+		prompt:   "plan on removed worktree",
+		isNew:    false,
+	})
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
+	assert.Empty(t, m2.sessionManager.GetAllSessions())
+}
+
 // Snapshot can lag behind reality: the worktree slice still lists the path
 // after the directory was removed on disk. Submit must reject in that case.
 func TestStartSessionMsg_TargetGoneOnDiskBetweenPromptAndSubmit(t *testing.T) {

--- a/bramble/app/new_session_worktree_race_test.go
+++ b/bramble/app/new_session_worktree_race_test.go
@@ -422,3 +422,97 @@ func TestStartSessionMsg_TargetGoneOnDiskBetweenPromptAndSubmit(t *testing.T) {
 	assert.Contains(t, m4.toasts.toasts[0].Message, "Target worktree no longer available")
 	assert.Empty(t, m4.sessionManager.GetAllSessions())
 }
+
+// Happy path for the cold cross-repo case: target repo's worktrees are still
+// loading (worktreesLoaded=false), but the path exists on disk. Submit must
+// proceed and start the session against the target repo's manager.
+func TestStartSessionMsg_AcceptsColdCrossRepoTargetWhenPathExists(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	mgrB := injectSecondRepo(t, &m, "repoB")
+	rcB := m.repos["repoB"]
+	rcB.worktreesLoaded = false
+	rcB.worktrees = nil
+
+	prev := worktreePathExists
+	worktreePathExists = func(string) bool { return true }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	startMsg := startSessionMsg{
+		sessionType: session.SessionTypePlanner,
+		prompt:      "plan on cold repo",
+		model:       "claude-opus-4-7",
+		target: sessionTarget{
+			repoName:     "repoB",
+			worktreePath: "/tmp/wt/repoB-main",
+		},
+	}
+
+	newModel, _ := m.Update(startMsg)
+	m2 := newModel.(Model)
+
+	assert.Equal(t, "repoA", m2.repoName, "cross-repo dispatch must not switch active repo")
+	require.Len(t, mgrB.GetAllSessions(), 1)
+	assert.Equal(t, "/tmp/wt/repoB-main", mgrB.GetAllSessions()[0].WorktreePath)
+}
+
+// Plan approval (command-center "a") must apply the same disk-stat
+// preflight as confirmTask / startSessionMsg. A planner left idle with a
+// plan file can become stale if its worktree is removed between idle review
+// and approval — the builder must not launch in that case.
+func TestCommandCenter_PlanApproval_RejectsRemovedWorktree(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("feature"))
+
+	planner := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sP",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusIdle,
+		WorktreePath: "/tmp/wt/feature",
+		WorktreeName: "feature",
+		RepoName:     "repoA",
+		PlanFilePath: "/tmp/wt/feature/PLAN.md",
+		Title:        "Planner",
+	})
+	m.commandCenter.Show([]session.SessionInfo{planner}, m.width, m.height)
+	m.focus = FocusCommandCenter
+
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "/tmp/wt/feature" }
+	t.Cleanup(func() { worktreePathExists = prev })
+
+	newModel, _ := m.handleCommandCenter(keyPress('a'))
+	m2 := newModel.(Model)
+
+	assert.True(t, m2.toasts.HasToasts())
+	assert.Contains(t, m2.toasts.toasts[0].Message, "Target worktree no longer available")
+	// Original planner session must remain — CompleteSession should not fire.
+	require.Len(t, m2.sessionManager.GetAllSessions(), 1)
+	assert.Equal(t, session.SessionTypePlanner, m2.sessionManager.GetAllSessions()[0].Type)
+}
+
+// Happy path for confirmTask: existing worktree, snapshot is loaded, disk
+// stat agrees the path exists. Planner session must start.
+func TestConfirmTask_AcceptsExistingWorktreeWhenPathExists(t *testing.T) {
+	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
+		{Branch: "feature", Path: "/tmp/wt/feature"},
+	}, "repoA")
+	require.True(t, m.worktreeDropdown.SelectByID("feature"))
+
+	newModel, _ := m.confirmTask(taskConfirmMsg{
+		worktree: "feature",
+		prompt:   "plan on feature",
+		isNew:    false,
+	})
+	m2 := newModel.(Model)
+
+	require.Len(t, m2.sessionManager.GetAllSessions(), 1)
+	sess := m2.sessionManager.GetAllSessions()[0]
+	assert.Equal(t, session.SessionTypePlanner, sess.Type)
+	assert.Equal(t, "/tmp/wt/feature", sess.WorktreePath)
+}

--- a/bramble/app/repocontext.go
+++ b/bramble/app/repocontext.go
@@ -25,6 +25,7 @@ type RepoContext struct {
 	worktrees            []wt.Worktree
 	selectedSessionIndex int
 	scrollOffset         int
+	worktreesLoaded      bool
 }
 
 // saveActiveContext copies per-repo fields from Model into the active RepoContext.
@@ -41,6 +42,7 @@ func (m *Model) saveActiveContext() {
 	rc.historyBranch = m.historyBranch
 	rc.sessions = m.sessions
 	rc.worktreeDropdown = m.worktreeDropdown
+	rc.worktreesLoaded = m.worktreesLoaded
 	rc.sessionDropdown = m.sessionDropdown
 	rc.viewingSessionID = m.viewingSessionID
 	rc.viewingHistoryData = m.viewingHistoryData
@@ -72,6 +74,7 @@ func (m *Model) loadContext(repoName string) {
 	m.sessionManager = rc.sessionManager
 	m.taskRouter = rc.taskRouter
 	m.worktrees = rc.worktrees
+	m.worktreesLoaded = rc.worktreesLoaded
 	m.worktreeStatuses = rc.worktreeStatuses
 	m.cachedHistory = rc.cachedHistory
 	m.historyBranch = rc.historyBranch

--- a/bramble/app/show_all_sessions_test.go
+++ b/bramble/app/show_all_sessions_test.go
@@ -328,6 +328,48 @@ func TestAllSessionsOverlay_NewSession_PBC(t *testing.T) {
 	}
 }
 
+func TestAllSessionsOverlay_NewSession_TmuxModeShowsSelectedSessionContext(t *testing.T) {
+	m := setupModel(t, session.SessionModeTmux, []wt.Worktree{
+		{Branch: "A", Path: "/tmp/wt/A"},
+		{Branch: "B", Path: "/tmp/wt/B"},
+	}, "test-repo")
+	require.True(t, m.worktreeDropdown.SelectByID("A"))
+
+	sessionA := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sA",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/A",
+		WorktreeName: "A",
+		RepoName:     "test-repo",
+		Title:        "Session A",
+	})
+	sessionB := addTestSession(t, m.sessionManager, &session.Session{
+		ID:           "sB",
+		Type:         session.SessionTypePlanner,
+		Status:       session.StatusRunning,
+		WorktreePath: "/tmp/wt/B",
+		WorktreeName: "B",
+		RepoName:     "test-repo",
+		Title:        "Session B",
+	})
+	m.switchViewingSession(sessionA.ID)
+	m.allSessionsOverlay.Show([]session.SessionInfo{sessionA, sessionB}, m.width, m.height)
+	m.focus = FocusAllSessions
+	require.True(t, m.allSessionsOverlay.SelectByNumber(2))
+
+	newModel, _ := m.handleAllSessionsOverlay(keyPress('b'))
+	m2 := newModel.(Model)
+
+	require.True(t, m2.inputMode)
+	assert.Equal(t, session.SessionID("sB"), m2.viewingSessionID)
+	selected := m2.worktreeDropdown.SelectedItem()
+	require.NotNil(t, selected)
+	assert.Equal(t, "B", selected.ID)
+	assert.Contains(t, m2.View().Content, "sB")
+	assert.NotContains(t, m2.View().Content, "sA")
+}
+
 func TestAllSessionsOverlay_NewSession_NoSession(t *testing.T) {
 	m := setupModel(t, session.SessionModeTUI, []wt.Worktree{
 		{Branch: "main", Path: "/tmp/wt/main"},

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -385,16 +385,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case startSessionMsg:
 		m.saveDefaultModel(msg.sessionType, msg.model)
-		// At submit time, refuse explicit worktree targets that the snapshot
-		// flags as gone OR that no longer exist on disk. The disk check fires
-		// even when the in-memory snapshot is unloaded (cold repo context),
-		// so a session can never launch against a stale or missing path.
-		if msg.target.worktreePath != "" {
-			if m.sessionTargetAvailability(msg.target) == sessionTargetUnavailable ||
-				!worktreePathExists(msg.target.worktreePath) {
-				toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
-				return m, toastCmd
-			}
+		if msg.target.worktreePath != "" && !m.canLaunchSessionOnTarget(msg.target) {
+			toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
+			return m, toastCmd
 		}
 		if msg.target.repoName != "" && msg.target.repoName != m.repoName {
 			return m.startSessionOnRepo(msg.target.repoName, msg.sessionType, msg.prompt, msg.model, msg.target.worktreePath)
@@ -1406,6 +1399,22 @@ var worktreePathExists = func(worktreePath string) bool {
 	return info.IsDir()
 }
 
+// canLaunchSessionOnTarget reports whether an explicit-target session may be
+// launched. Available targets pass directly; Unknown (cold context, no
+// snapshot yet) falls back to a single on-disk stat. The Available branch
+// already statted inside sessionTargetAvailability, so this routes around the
+// double stat the previous implementation performed on the happy path.
+func (m Model) canLaunchSessionOnTarget(target sessionTarget) bool {
+	switch m.sessionTargetAvailability(target) {
+	case sessionTargetAvailable:
+		return true
+	case sessionTargetUnavailable:
+		return false
+	default:
+		return worktreePathExists(target.worktreePath)
+	}
+}
+
 func (m *Model) selectWorktreeByPath(path string) bool {
 	if path == "" {
 		return false
@@ -2217,7 +2226,7 @@ func (m Model) confirmTask(msg taskConfirmMsg) (tea.Model, tea.Cmd) {
 		return m, errToastCmd
 	}
 	wt := m.selectedWorktree()
-	if wt == nil || wt.IsGone || !worktreePathExists(wt.Path) {
+	if wt == nil || !m.canLaunchSessionOnTarget(sessionTarget{repoName: m.repoName, worktreePath: wt.Path}) {
 		errToastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 		return m, errToastCmd
 	}
@@ -2444,6 +2453,13 @@ func (m Model) handleCommandCenter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		worktreePath := sess.WorktreePath
 		planPath := sess.PlanFilePath
+		// Match the disk-stat preflight used by confirmTask / startSessionMsg:
+		// the plan was authored against this worktree, but the directory may
+		// have been removed between idle plan review and approval.
+		if !m.canLaunchSessionOnTarget(sessionTarget{repoName: m.repoName, worktreePath: worktreePath}) {
+			toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
+			return m, toastCmd
+		}
 		_ = m.sessionManager.CompleteSession(sess.ID)
 		m.sessions = m.sessionManager.GetAllSessions()
 		m.updateSessionDropdown()

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -385,10 +385,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case startSessionMsg:
 		m.saveDefaultModel(msg.sessionType, msg.model)
-		if msg.target.worktreePath != "" &&
-			m.sessionTargetAvailability(msg.target) == sessionTargetUnavailable {
-			toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
-			return m, toastCmd
+		// At submit time, refuse explicit worktree targets that the snapshot
+		// flags as gone OR that no longer exist on disk. The disk check fires
+		// even when the in-memory snapshot is unloaded (cold repo context),
+		// so a session can never launch against a stale or missing path.
+		if msg.target.worktreePath != "" {
+			if m.sessionTargetAvailability(msg.target) == sessionTargetUnavailable ||
+				!worktreePathExists(msg.target.worktreePath) {
+				toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
+				return m, toastCmd
+			}
 		}
 		if msg.target.repoName != "" && msg.target.repoName != m.repoName {
 			return m.startSessionOnRepo(msg.target.repoName, msg.sessionType, msg.prompt, msg.model, msg.target.worktreePath)
@@ -2211,7 +2217,7 @@ func (m Model) confirmTask(msg taskConfirmMsg) (tea.Model, tea.Cmd) {
 		return m, errToastCmd
 	}
 	wt := m.selectedWorktree()
-	if wt == nil || wt.IsGone {
+	if wt == nil || wt.IsGone || !worktreePathExists(wt.Path) {
 		errToastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 		return m, errToastCmd
 	}

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -889,32 +889,14 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case "a":
 		// Approve plan and start builder session
-		if sess := m.selectedSession(); sess != nil &&
-			sess.Status == session.StatusIdle &&
-			sess.Type == session.SessionTypePlanner &&
-			sess.PlanFilePath != "" {
-			worktreePath := sess.WorktreePath
-			planPath := sess.PlanFilePath
-			_ = m.sessionManager.CompleteSession(sess.ID)
-			m.sessions = m.sessionManager.GetAllSessions()
-			m.updateSessionDropdown()
-			planPrompt := fmt.Sprintf("Implement the plan in %s", planPath)
-			sessionID, err := m.sessionManager.StartSession(session.SessionTypeBuilder, worktreePath, planPrompt, m.defaultBuildModel)
-			if err != nil {
-				toastCmd := m.addToast(err.Error(), ToastError)
-				return m, toastCmd
-			}
-			if m.viewingSessionID != "" {
-				m.scrollPositions[m.viewingSessionID] = m.scrollOffset
-			}
-			m.viewingSessionID = sessionID
-			m.scrollOffset = 0 // New builder session starts at bottom
-			m.sessions = m.sessionManager.GetAllSessions()
-			m.updateSessionDropdown()
-			return m, nil
+		sess := m.selectedSession()
+		if sess == nil || sess.Status != session.StatusIdle ||
+			sess.Type != session.SessionTypePlanner || sess.PlanFilePath == "" {
+			toastCmd := m.addToast("No plan ready to approve", ToastInfo)
+			return m, toastCmd
 		}
-		toastCmd := m.addToast("No plan ready to approve", ToastInfo)
-		return m, toastCmd
+		newM, cmd, _ := m.approveAndStartBuilder(sess)
+		return newM, cmd
 
 	case "m":
 		// Merge PR
@@ -1413,6 +1395,40 @@ func (m Model) canLaunchSessionOnTarget(target sessionTarget) bool {
 	default:
 		return worktreePathExists(target.worktreePath)
 	}
+}
+
+// approveAndStartBuilder completes the planner session and launches a builder
+// against the same worktree. Used by both plan-approval entry points (main
+// view 'a' and command-center 'a') so the preflight, completion, and start
+// logic stay in lockstep.
+func (m Model) approveAndStartBuilder(sess *session.SessionInfo) (Model, tea.Cmd, bool) {
+	if sess == nil {
+		toastCmd := m.addToast("No plan ready to approve", ToastInfo)
+		return m, toastCmd, false
+	}
+	if !m.canLaunchSessionOnTarget(sessionTarget{repoName: m.repoName, worktreePath: sess.WorktreePath}) {
+		toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
+		return m, toastCmd, false
+	}
+	worktreePath := sess.WorktreePath
+	planPath := sess.PlanFilePath
+	_ = m.sessionManager.CompleteSession(sess.ID)
+	m.sessions = m.sessionManager.GetAllSessions()
+	m.updateSessionDropdown()
+	planPrompt := fmt.Sprintf("Implement the plan in %s", planPath)
+	sessionID, err := m.sessionManager.StartSession(session.SessionTypeBuilder, worktreePath, planPrompt, m.defaultBuildModel)
+	if err != nil {
+		toastCmd := m.addToast(err.Error(), ToastError)
+		return m, toastCmd, false
+	}
+	if m.viewingSessionID != "" {
+		m.scrollPositions[m.viewingSessionID] = m.scrollOffset
+	}
+	m.viewingSessionID = sessionID
+	m.scrollOffset = 0
+	m.sessions = m.sessionManager.GetAllSessions()
+	m.updateSessionDropdown()
+	return m, nil, true
 }
 
 func (m *Model) selectWorktreeByPath(path string) bool {
@@ -2441,42 +2457,28 @@ func (m Model) handleCommandCenter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			toastCmd := m.addToast("No plan ready to approve", ToastInfo)
 			return m, toastCmd
 		}
-		sessRepoName := sess.RepoName
-		m.commandCenter.Hide()
-		m.focus = FocusOutput
-		// Switch repo if needed
-		if sessRepoName != "" && sessRepoName != m.repoName {
-			if _, ok := m.repos[sessRepoName]; ok {
-				m.saveActiveContext()
-				m.loadContext(sessRepoName)
-			}
+		// Run the disk-stat preflight against the destination repo *before*
+		// dismissing the overlay, so a rejection keeps the user in the
+		// command center instead of dumping them onto FocusOutput with only
+		// a toast as feedback.
+		destRepo := sess.RepoName
+		if destRepo == "" {
+			destRepo = m.repoName
 		}
-		worktreePath := sess.WorktreePath
-		planPath := sess.PlanFilePath
-		// Match the disk-stat preflight used by confirmTask / startSessionMsg:
-		// the plan was authored against this worktree, but the directory may
-		// have been removed between idle plan review and approval.
-		if !m.canLaunchSessionOnTarget(sessionTarget{repoName: m.repoName, worktreePath: worktreePath}) {
+		if !m.canLaunchSessionOnTarget(sessionTarget{repoName: destRepo, worktreePath: sess.WorktreePath}) {
 			toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 			return m, toastCmd
 		}
-		_ = m.sessionManager.CompleteSession(sess.ID)
-		m.sessions = m.sessionManager.GetAllSessions()
-		m.updateSessionDropdown()
-		planPrompt := fmt.Sprintf("Implement the plan in %s", planPath)
-		sessionID, err := m.sessionManager.StartSession(session.SessionTypeBuilder, worktreePath, planPrompt, m.defaultBuildModel)
-		if err != nil {
-			toastCmd := m.addToast(err.Error(), ToastError)
-			return m, toastCmd
+		m.commandCenter.Hide()
+		m.focus = FocusOutput
+		if destRepo != m.repoName {
+			if _, ok := m.repos[destRepo]; ok {
+				m.saveActiveContext()
+				m.loadContext(destRepo)
+			}
 		}
-		if m.viewingSessionID != "" {
-			m.scrollPositions[m.viewingSessionID] = m.scrollOffset
-		}
-		m.viewingSessionID = sessionID
-		m.scrollOffset = 0
-		m.sessions = m.sessionManager.GetAllSessions()
-		m.updateSessionDropdown()
-		return m, nil
+		newM, cmd, _ := m.approveAndStartBuilder(sess)
+		return newM, cmd
 
 	case "p", "b", "c":
 		st := sessionTypeFromKey(msg.String())

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -372,11 +372,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case startSessionMsg:
 		m.saveDefaultModel(msg.sessionType, msg.model)
-		if msg.repoName != "" && msg.repoName != m.repoName {
-			return m.startSessionOnRepo(msg.repoName, msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
+		if msg.target.mode == sessionTargetCapturedSelection &&
+			m.sessionTargetAvailability(msg.target) == sessionTargetUnavailable {
+			toastCmd := m.addToast("Target worktree no longer available", ToastError)
+			return m, toastCmd
 		}
-		if msg.worktreePath != "" {
-			return m.startSessionOnPath(msg.sessionType, msg.prompt, msg.model, msg.worktreePath)
+		if msg.target.repoName != "" && msg.target.repoName != m.repoName {
+			return m.startSessionOnRepo(msg.target.repoName, msg.sessionType, msg.prompt, msg.model, msg.target.worktreePath)
+		}
+		if msg.target.worktreePath != "" {
+			return m.startSessionOnPath(msg.sessionType, msg.prompt, msg.model, msg.target.worktreePath)
 		}
 		return m.startSession(msg.sessionType, msg.prompt, msg.model)
 
@@ -700,15 +705,8 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case "p", "b", "c":
 		st := sessionTypeFromKey(msg.String())
-		if m.selectedWorktree() != nil {
-			defaultModel, promptLabel, placeholder := m.sessionPromptConfig(st)
-			m.pendingModel = defaultModel
-			m.pendingSessionType = st
-			return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
-				return func() tea.Msg {
-					return startSessionMsg{sessionType: st, prompt: prompt, model: model}
-				}
-			}, placeholder)
+		if wt := m.selectedWorktree(); wt != nil {
+			return m.promptNewSession(st, capturedSelectionTarget(m.repoName, wt.Path))
 		}
 		toastCmd := m.addToast("Select a worktree first (Alt-W)", ToastInfo)
 		return m, toastCmd
@@ -1327,6 +1325,40 @@ func (m Model) startSession(sessionType session.SessionType, prompt, model strin
 	return m.startSessionOnPath(sessionType, prompt, model, wt.Path)
 }
 
+type sessionTargetAvailability int
+
+const (
+	sessionTargetUnknown sessionTargetAvailability = iota
+	sessionTargetAvailable
+	sessionTargetUnavailable
+)
+
+func (m Model) sessionTargetAvailability(target sessionTarget) sessionTargetAvailability {
+	if target.worktreePath == "" {
+		return sessionTargetUnknown
+	}
+
+	worktrees := m.worktrees
+	if target.repoName != "" && target.repoName != m.repoName {
+		rc, ok := m.repos[target.repoName]
+		if !ok {
+			return sessionTargetUnknown
+		}
+		worktrees = rc.worktrees
+	}
+
+	for _, wt := range worktrees {
+		if wt.Path == target.worktreePath {
+			if wt.IsGone {
+				return sessionTargetUnavailable
+			}
+			return sessionTargetAvailable
+		}
+	}
+
+	return sessionTargetUnavailable
+}
+
 func truncateSessionID(id session.SessionID) string {
 	s := string(id)
 	if len(s) > 12 {
@@ -1378,6 +1410,63 @@ func (m Model) startSessionOnRepo(repoName string, sessionType session.SessionTy
 	return m, toastCmd
 }
 
+func (m Model) promptNewSession(sessionType session.SessionType, target sessionTarget) (tea.Model, tea.Cmd) {
+	defaultModel, promptLabel, placeholder := m.sessionPromptConfig(sessionType)
+	m.pendingModel = defaultModel
+	m.pendingSessionType = sessionType
+	return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
+		return func() tea.Msg {
+			return startSessionMsg{
+				sessionType: sessionType,
+				prompt:      prompt,
+				model:       model,
+				target:      target,
+			}
+		}
+	}, placeholder)
+}
+
+func (m *Model) selectSessionWorktree(sess *session.SessionInfo) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.WorktreeName != "" && m.worktreeDropdown.SelectByID(sess.WorktreeName) {
+		return true
+	}
+	for _, wt := range m.worktrees {
+		if wt.Path == sess.WorktreePath {
+			return m.worktreeDropdown.SelectByID(wt.Branch)
+		}
+	}
+	return false
+}
+
+func (m Model) showSessionContext(sess *session.SessionInfo) (Model, tea.Cmd) {
+	if sess == nil {
+		return m, nil
+	}
+
+	var cmds []tea.Cmd
+	if sess.RepoName != "" && sess.RepoName != m.repoName {
+		if _, ok := m.repos[sess.RepoName]; ok {
+			m.saveActiveContext()
+			m.loadContext(sess.RepoName)
+			cmds = append(cmds, m.refreshWorktrees())
+		}
+	}
+
+	if m.selectSessionWorktree(sess) {
+		m.updateSessionDropdown()
+		cmds = append(cmds, m.refreshFileTree(), m.refreshHistorySessions())
+	}
+
+	if _, ok := m.sessionManager.GetSessionInfo(sess.ID); ok {
+		m.switchViewingSession(sess.ID)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
 // startNewSessionFromOverlay prompts the user for input to start a session on
 // the given session's worktree. hideOverlay is called only after validation
 // succeeds, so the overlay stays visible on error (preventing focus-state bugs).
@@ -1394,33 +1483,15 @@ func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType
 	hideOverlay()
 	m.focus = FocusOutput
 
-	// Capture target repo/worktree up front so the main view stays on its
-	// current repo (avoids race if background messages reset active context).
 	targetRepo := sess.RepoName
 	if targetRepo == "" {
 		targetRepo = m.repoName
 	}
 	worktreePath := sess.WorktreePath
 
-	if targetRepo == m.repoName && sess.WorktreeName != "" {
-		m.worktreeDropdown.SelectByID(sess.WorktreeName)
-		m.updateSessionDropdown()
-	}
-
-	defaultModel, promptLabel, placeholder := m.sessionPromptConfig(sessionType)
-	m.pendingModel = defaultModel
-	m.pendingSessionType = sessionType
-	return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
-		return func() tea.Msg {
-			return startSessionMsg{
-				sessionType:  sessionType,
-				prompt:       prompt,
-				model:        model,
-				worktreePath: worktreePath,
-				repoName:     targetRepo,
-			}
-		}
-	}, placeholder)
+	m, contextCmd := m.showSessionContext(sess)
+	model, promptCmd := m.promptNewSession(sessionType, existingSessionTarget(targetRepo, worktreePath))
+	return model, tea.Batch(contextCmd, promptCmd)
 }
 
 // createWorktree creates a new worktree asynchronously with captured output.
@@ -1958,14 +2029,13 @@ func (m Model) confirmTask(msg taskConfirmMsg) (tea.Model, tea.Cmd) {
 	m.taskModal.Hide()
 	m.focus = FocusOutput
 
-	toastCmd := m.addToast("Task confirmed, starting session...", ToastSuccess)
-
 	// If creating a new worktree, do that first
 	if msg.isNew {
 		if m.repoName == "" {
 			errToastCmd := m.addToast("No repository selected", ToastError)
 			return m, errToastCmd
 		}
+		toastCmd := m.addToast("Task confirmed, starting session...", ToastSuccess)
 
 		// Show pending message
 		m.worktreeOpMessages = []string{"Creating worktree " + msg.worktree + "..."}
@@ -2011,8 +2081,18 @@ func (m Model) confirmTask(msg taskConfirmMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Use existing worktree - select it and start planner
-	m.worktreeDropdown.SelectByID(msg.worktree)
-	model, cmd := m.startSession(session.SessionTypePlanner, msg.prompt, m.defaultPlanModel)
+	if !m.worktreeDropdown.SelectByID(msg.worktree) {
+		errToastCmd := m.addToast("Target worktree no longer available", ToastError)
+		return m, errToastCmd
+	}
+	wt := m.selectedWorktree()
+	if wt == nil || wt.IsGone {
+		errToastCmd := m.addToast("Target worktree no longer available", ToastError)
+		return m, errToastCmd
+	}
+
+	toastCmd := m.addToast("Task confirmed, starting session...", ToastSuccess)
+	model, cmd := m.startSessionOnPath(session.SessionTypePlanner, msg.prompt, m.defaultPlanModel, wt.Path)
 	return model, tea.Batch(toastCmd, cmd)
 }
 
@@ -2097,8 +2177,7 @@ func (m Model) switchToSession(sess *session.SessionInfo) (tea.Model, tea.Cmd) {
 	}
 	m.switchViewingSession(sess.ID)
 	// Also select the correct worktree for this session.
-	if sess.WorktreeName != "" {
-		m.worktreeDropdown.SelectByID(sess.WorktreeName)
+	if m.selectSessionWorktree(sess) {
 		m.updateSessionDropdown()
 	}
 	return m, tea.Batch(m.refreshWorktrees(), m.refreshFileTree(), m.refreshHistorySessions())

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -112,12 +112,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.worktreesLoaded = true
 		m.updateWorktreeDropdown()
 
-		if m.inputMode && m.pendingSessionTarget.mode != 0 && m.pendingTargetAppliesToCurrentRepo() {
-			switch m.sessionTargetAvailability(m.pendingSessionTarget) {
+		pending := m.pendingSessionTarget
+		if m.inputMode && pending.worktreePath != "" &&
+			(pending.repoName == "" || pending.repoName == m.repoName) {
+			switch m.sessionTargetAvailability(pending) {
 			case sessionTargetUnavailable:
-				return m.cancelPendingSessionPrompt("Target worktree no longer available")
+				return m.cancelPendingSessionPrompt(errTargetWorktreeUnavailable)
 			case sessionTargetAvailable:
-				if m.selectTargetWorktree(m.pendingSessionTarget) {
+				if m.selectWorktreeByPath(pending.worktreePath) {
 					m.updateSessionDropdown()
 				}
 			}
@@ -368,27 +370,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case promptInputMsg:
-		// Input completed
-		m.inputMode = false
-		// Save pending state before clearing — closures created at prompt-open
-		// time capture a stale copy of m, so we snapshot the live values here.
 		pendingModel := m.pendingModel
 		pendingSessionType := m.pendingSessionType
-		m.pendingModel = ""
-		m.pendingSessionType = ""
-		m.pendingSessionTarget = sessionTarget{}
-		if m.inputHandler != nil {
-			cmd := m.inputHandler(msg.value, pendingModel, pendingSessionType)
-			m.inputHandler = nil
-			return m, cmd
+		handler := m.inputHandler
+		m.clearPendingPrompt()
+		if handler != nil {
+			return m, handler(msg.value, pendingModel, pendingSessionType)
 		}
 		return m, nil
 
 	case startSessionMsg:
 		m.saveDefaultModel(msg.sessionType, msg.model)
-		if msg.target.mode != 0 &&
+		if msg.target.worktreePath != "" &&
 			m.sessionTargetAvailability(msg.target) == sessionTargetUnavailable {
-			toastCmd := m.addToast("Target worktree no longer available", ToastError)
+			toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 			return m, toastCmd
 		}
 		if msg.target.repoName != "" && msg.target.repoName != m.repoName {
@@ -720,7 +715,7 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "p", "b", "c":
 		st := sessionTypeFromKey(msg.String())
 		if wt := m.selectedWorktree(); wt != nil {
-			return m.promptNewSession(st, capturedSelectionTarget(m.repoName, wt.Path))
+			return m.promptNewSession(st, sessionTarget{repoName: m.repoName, worktreePath: wt.Path})
 		}
 		toastCmd := m.addToast("Select a worktree first (Alt-W)", ToastInfo)
 		return m, toastCmd
@@ -1209,12 +1204,8 @@ func (m Model) handleInputMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case TextAreaCancel:
-		m.inputMode = false
+		m.clearPendingPrompt()
 		m.inputArea.Reset()
-		m.inputHandler = nil
-		m.pendingModel = ""
-		m.pendingSessionType = ""
-		m.pendingSessionTarget = sessionTarget{}
 		return m, nil
 
 	case TextAreaQuit:
@@ -1340,6 +1331,11 @@ func (m Model) startSession(sessionType session.SessionType, prompt, model strin
 	return m.startSessionOnPath(sessionType, prompt, model, wt.Path)
 }
 
+const (
+	errTargetWorktreeUnavailable = "Target worktree no longer available"
+	errTargetRepoUnavailable     = "Target repo no longer available"
+)
+
 type sessionTargetAvailability int
 
 const (
@@ -1380,21 +1376,29 @@ func (m Model) sessionTargetAvailability(target sessionTarget) sessionTargetAvai
 	return sessionTargetUnavailable
 }
 
-func (m Model) pendingTargetAppliesToCurrentRepo() bool {
-	return m.pendingSessionTarget.repoName == "" || m.pendingSessionTarget.repoName == m.repoName
+func (m *Model) selectWorktreeByPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	for _, wt := range m.worktrees {
+		if wt.Path == path {
+			return m.worktreeDropdown.SelectByID(wt.Branch)
+		}
+	}
+	return false
 }
 
-func (m *Model) selectTargetWorktree(target sessionTarget) bool {
-	return m.selectSessionWorktree(&session.SessionInfo{WorktreePath: target.worktreePath})
-}
-
-func (m Model) cancelPendingSessionPrompt(message string) (Model, tea.Cmd) {
+func (m *Model) clearPendingPrompt() {
 	m.inputMode = false
-	m.inputArea.Reset()
 	m.inputHandler = nil
 	m.pendingModel = ""
 	m.pendingSessionType = ""
 	m.pendingSessionTarget = sessionTarget{}
+}
+
+func (m Model) cancelPendingSessionPrompt(message string) (Model, tea.Cmd) {
+	m.clearPendingPrompt()
+	m.inputArea.Reset()
 	m.focus = FocusOutput
 	toastCmd := m.addToast(message, ToastError)
 	return m, toastCmd
@@ -1530,18 +1534,18 @@ func (m Model) validateExistingSessionTarget(sess *session.SessionInfo) (session
 	if targetRepo == "" {
 		targetRepo = m.repoName
 	}
-	target := existingSessionTarget(targetRepo, sess.WorktreePath)
+	target := sessionTarget{repoName: targetRepo, worktreePath: sess.WorktreePath}
 
 	if targetRepo != "" && targetRepo != m.repoName {
 		rc, ok := m.repos[targetRepo]
 		if !ok || rc.sessionManager == nil {
-			toastCmd := m.addToast("Target repo no longer available", ToastError)
+			toastCmd := m.addToast(errTargetRepoUnavailable, ToastError)
 			return target, toastCmd, false
 		}
 	}
 
 	if m.sessionTargetAvailability(target) == sessionTargetUnavailable {
-		toastCmd := m.addToast("Target worktree no longer available", ToastError)
+		toastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 		return target, toastCmd, false
 	}
 
@@ -2179,12 +2183,12 @@ func (m Model) confirmTask(msg taskConfirmMsg) (tea.Model, tea.Cmd) {
 
 	// Use existing worktree - select it and start planner
 	if !m.worktreeDropdown.SelectByID(msg.worktree) {
-		errToastCmd := m.addToast("Target worktree no longer available", ToastError)
+		errToastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 		return m, errToastCmd
 	}
 	wt := m.selectedWorktree()
 	if wt == nil || wt.IsGone {
-		errToastCmd := m.addToast("Target worktree no longer available", ToastError)
+		errToastCmd := m.addToast(errTargetWorktreeUnavailable, ToastError)
 		return m, errToastCmd
 	}
 

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -112,12 +112,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.worktreesLoaded = true
 		m.updateWorktreeDropdown()
 
+		var pendingCancelCmd tea.Cmd
 		pending := m.pendingSessionTarget
 		if m.inputMode && pending.worktreePath != "" &&
 			(pending.repoName == "" || pending.repoName == m.repoName) {
 			switch m.sessionTargetAvailability(pending) {
 			case sessionTargetUnavailable:
-				return m.cancelPendingSessionPrompt(errTargetWorktreeUnavailable)
+				// Cancel the pending prompt but fall through so the rest of
+				// the worktree-refresh flow (auto-select, session dropdown,
+				// deferred refresh) still runs in the same update cycle.
+				m, pendingCancelCmd = m.cancelPendingSessionPrompt(errTargetWorktreeUnavailable)
 			case sessionTargetAvailable:
 				if m.selectWorktreeByPath(pending.worktreePath) {
 					m.updateSessionDropdown()
@@ -136,9 +140,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if prompt != "" {
 				model, cmd := m.startSession(session.SessionTypePlanner, prompt, m.defaultPlanModel)
 				// Defer heavy loading so the UI renders the worktree name first
-				return model, tea.Batch(cmd, deferredRefreshCmd())
+				return model, tea.Batch(pendingCancelCmd, cmd, deferredRefreshCmd())
 			}
-			return m, deferredRefreshCmd()
+			return m, tea.Batch(pendingCancelCmd, deferredRefreshCmd())
 		}
 
 		// Auto-select first worktree if none selected
@@ -148,7 +152,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Update session dropdown with live sessions immediately;
 		// defer git statuses, file tree, and history to let the UI render first.
 		m.updateSessionDropdown()
-		return m, deferredRefreshCmd()
+		return m, tea.Batch(pendingCancelCmd, deferredRefreshCmd())
 
 	case deferredRefreshMsg:
 		return m, tea.Batch(
@@ -1365,15 +1369,35 @@ func (m Model) sessionTargetAvailability(target sessionTarget) sessionTargetAvai
 	}
 
 	for _, wt := range worktrees {
-		if wt.Path == target.worktreePath {
-			if wt.IsGone {
-				return sessionTargetUnavailable
-			}
-			return sessionTargetAvailable
+		if wt.Path != target.worktreePath {
+			continue
 		}
+		if wt.IsGone {
+			return sessionTargetUnavailable
+		}
+		// Re-validate on disk: the snapshot can lag behind reality if the
+		// worktree was removed/renamed after the last refresh. Treat any
+		// stat failure as unavailable so the submit path can never launch a
+		// session against a stale path.
+		if !worktreePathExists(target.worktreePath) {
+			return sessionTargetUnavailable
+		}
+		return sessionTargetAvailable
 	}
 
 	return sessionTargetUnavailable
+}
+
+// worktreePathExists reports whether worktreePath still resolves to a directory
+// on disk. Symlinks are followed so an externally-managed link target moving
+// also counts as gone. Indirected through a package var so tests can stub the
+// disk check without creating real directories for every fake path.
+var worktreePathExists = func(worktreePath string) bool {
+	info, err := os.Stat(worktreePath)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
 }
 
 func (m *Model) selectWorktreeByPath(path string) bool {

--- a/bramble/app/update.go
+++ b/bramble/app/update.go
@@ -104,11 +104,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.repoName != m.repoName {
 			if rc, ok := m.repos[msg.repoName]; ok {
 				rc.worktrees = msg.worktrees
+				rc.worktreesLoaded = true
 			}
 			return m, nil
 		}
 		m.worktrees = msg.worktrees
+		m.worktreesLoaded = true
 		m.updateWorktreeDropdown()
+
+		if m.inputMode && m.pendingSessionTarget.mode != 0 && m.pendingTargetAppliesToCurrentRepo() {
+			switch m.sessionTargetAvailability(m.pendingSessionTarget) {
+			case sessionTargetUnavailable:
+				return m.cancelPendingSessionPrompt("Target worktree no longer available")
+			case sessionTargetAvailable:
+				if m.selectTargetWorktree(m.pendingSessionTarget) {
+					m.updateSessionDropdown()
+				}
+			}
+		}
 
 		// Check for pending worktree selection (from worktree creation)
 		if m.pendingWorktreeSelect != "" {
@@ -363,6 +376,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		pendingSessionType := m.pendingSessionType
 		m.pendingModel = ""
 		m.pendingSessionType = ""
+		m.pendingSessionTarget = sessionTarget{}
 		if m.inputHandler != nil {
 			cmd := m.inputHandler(msg.value, pendingModel, pendingSessionType)
 			m.inputHandler = nil
@@ -372,7 +386,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case startSessionMsg:
 		m.saveDefaultModel(msg.sessionType, msg.model)
-		if msg.target.mode == sessionTargetCapturedSelection &&
+		if msg.target.mode != 0 &&
 			m.sessionTargetAvailability(msg.target) == sessionTargetUnavailable {
 			toastCmd := m.addToast("Target worktree no longer available", ToastError)
 			return m, toastCmd
@@ -1200,6 +1214,7 @@ func (m Model) handleInputMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.inputHandler = nil
 		m.pendingModel = ""
 		m.pendingSessionType = ""
+		m.pendingSessionTarget = sessionTarget{}
 		return m, nil
 
 	case TextAreaQuit:
@@ -1339,12 +1354,18 @@ func (m Model) sessionTargetAvailability(target sessionTarget) sessionTargetAvai
 	}
 
 	worktrees := m.worktrees
+	worktreesLoaded := m.worktreesLoaded
 	if target.repoName != "" && target.repoName != m.repoName {
 		rc, ok := m.repos[target.repoName]
 		if !ok {
 			return sessionTargetUnknown
 		}
 		worktrees = rc.worktrees
+		worktreesLoaded = rc.worktreesLoaded
+	}
+
+	if !worktreesLoaded {
+		return sessionTargetUnknown
 	}
 
 	for _, wt := range worktrees {
@@ -1357,6 +1378,26 @@ func (m Model) sessionTargetAvailability(target sessionTarget) sessionTargetAvai
 	}
 
 	return sessionTargetUnavailable
+}
+
+func (m Model) pendingTargetAppliesToCurrentRepo() bool {
+	return m.pendingSessionTarget.repoName == "" || m.pendingSessionTarget.repoName == m.repoName
+}
+
+func (m *Model) selectTargetWorktree(target sessionTarget) bool {
+	return m.selectSessionWorktree(&session.SessionInfo{WorktreePath: target.worktreePath})
+}
+
+func (m Model) cancelPendingSessionPrompt(message string) (Model, tea.Cmd) {
+	m.inputMode = false
+	m.inputArea.Reset()
+	m.inputHandler = nil
+	m.pendingModel = ""
+	m.pendingSessionType = ""
+	m.pendingSessionTarget = sessionTarget{}
+	m.focus = FocusOutput
+	toastCmd := m.addToast(message, ToastError)
+	return m, toastCmd
 }
 
 func truncateSessionID(id session.SessionID) string {
@@ -1414,6 +1455,7 @@ func (m Model) promptNewSession(sessionType session.SessionType, target sessionT
 	defaultModel, promptLabel, placeholder := m.sessionPromptConfig(sessionType)
 	m.pendingModel = defaultModel
 	m.pendingSessionType = sessionType
+	m.pendingSessionTarget = target
 	return m.promptInput(promptLabel, func(prompt, model string, _ session.SessionType) tea.Cmd {
 		return func() tea.Msg {
 			return startSessionMsg{
@@ -1441,6 +1483,71 @@ func (m *Model) selectSessionWorktree(sess *session.SessionInfo) bool {
 	return false
 }
 
+func sessionWorktreeBranch(sess *session.SessionInfo) string {
+	if sess == nil {
+		return ""
+	}
+	if sess.WorktreeName != "" {
+		return sess.WorktreeName
+	}
+	if sess.WorktreePath != "" {
+		return filepath.Base(sess.WorktreePath)
+	}
+	return ""
+}
+
+func (m *Model) ensureSessionWorktreeVisible(sess *session.SessionInfo) bool {
+	if m.selectSessionWorktree(sess) {
+		return true
+	}
+	if sess == nil || sess.WorktreePath == "" || m.worktreesLoaded {
+		return false
+	}
+
+	branch := sessionWorktreeBranch(sess)
+	if branch == "" {
+		return false
+	}
+	m.worktrees = append(m.worktrees, wt.Worktree{
+		Branch: branch,
+		Path:   sess.WorktreePath,
+	})
+	m.updateWorktreeDropdown()
+	return m.worktreeDropdown.SelectByID(branch)
+}
+
+func (m Model) validateExistingSessionTarget(sess *session.SessionInfo) (sessionTarget, tea.Cmd, bool) {
+	if sess == nil {
+		toastCmd := m.addToast("No session selected", ToastInfo)
+		return sessionTarget{}, toastCmd, false
+	}
+	if sess.WorktreePath == "" {
+		toastCmd := m.addToast("Selected session has no worktree", ToastInfo)
+		return sessionTarget{}, toastCmd, false
+	}
+
+	targetRepo := sess.RepoName
+	if targetRepo == "" {
+		targetRepo = m.repoName
+	}
+	target := existingSessionTarget(targetRepo, sess.WorktreePath)
+
+	if targetRepo != "" && targetRepo != m.repoName {
+		rc, ok := m.repos[targetRepo]
+		if !ok || rc.sessionManager == nil {
+			toastCmd := m.addToast("Target repo no longer available", ToastError)
+			return target, toastCmd, false
+		}
+	}
+
+	if m.sessionTargetAvailability(target) == sessionTargetUnavailable {
+		toastCmd := m.addToast("Target worktree no longer available", ToastError)
+		return target, toastCmd, false
+	}
+
+	return target, nil, true
+}
+
 func (m Model) showSessionContext(sess *session.SessionInfo) (Model, tea.Cmd) {
 	if sess == nil {
 		return m, nil
@@ -1455,7 +1562,7 @@ func (m Model) showSessionContext(sess *session.SessionInfo) (Model, tea.Cmd) {
 		}
 	}
 
-	if m.selectSessionWorktree(sess) {
+	if m.ensureSessionWorktreeVisible(sess) {
 		m.updateSessionDropdown()
 		cmds = append(cmds, m.refreshFileTree(), m.refreshHistorySessions())
 	}
@@ -1471,26 +1578,16 @@ func (m Model) showSessionContext(sess *session.SessionInfo) (Model, tea.Cmd) {
 // the given session's worktree. hideOverlay is called only after validation
 // succeeds, so the overlay stays visible on error (preventing focus-state bugs).
 func (m Model) startNewSessionFromOverlay(sess *session.SessionInfo, sessionType session.SessionType, hideOverlay func()) (tea.Model, tea.Cmd) {
-	if sess == nil {
-		toastCmd := m.addToast("No session selected", ToastInfo)
-		return m, toastCmd
-	}
-	if sess.WorktreePath == "" {
-		toastCmd := m.addToast("Selected session has no worktree", ToastInfo)
+	target, toastCmd, ok := m.validateExistingSessionTarget(sess)
+	if !ok {
 		return m, toastCmd
 	}
 
 	hideOverlay()
 	m.focus = FocusOutput
 
-	targetRepo := sess.RepoName
-	if targetRepo == "" {
-		targetRepo = m.repoName
-	}
-	worktreePath := sess.WorktreePath
-
 	m, contextCmd := m.showSessionContext(sess)
-	model, promptCmd := m.promptNewSession(sessionType, existingSessionTarget(targetRepo, worktreePath))
+	model, promptCmd := m.promptNewSession(sessionType, target)
 	return model, tea.Batch(contextCmd, promptCmd)
 }
 

--- a/bramble/app/update_feedback_test.go
+++ b/bramble/app/update_feedback_test.go
@@ -17,8 +17,22 @@ func setupModel(t *testing.T, mode session.SessionMode, worktrees []wt.Worktree,
 	ctx := context.Background()
 	mgr := session.NewManagerWithConfig(session.ManagerConfig{SessionMode: mode})
 	t.Cleanup(func() { mgr.Close() })
+	// Tests use synthetic worktree paths like "/tmp/wt/A" that don't exist on
+	// disk. Treat the in-memory snapshot as ground truth so the production
+	// stat fallback never spuriously rejects a fake path.
+	stubWorktreePathExists(t)
 	m := NewModel(ctx, "/tmp/wt", repoName, "", mgr, nil, worktrees, 80, 24, nil, nil, session.ManagerConfig{}, nil)
 	return m
+}
+
+// stubWorktreePathExists overrides the package-level on-disk worktree check so
+// any non-empty path is treated as existing for the duration of the test. The
+// previous value is restored on cleanup.
+func stubWorktreePathExists(t *testing.T) {
+	t.Helper()
+	prev := worktreePathExists
+	worktreePathExists = func(p string) bool { return p != "" }
+	t.Cleanup(func() { worktreePathExists = prev })
 }
 
 func TestKeyFeedback_P_NoWorktree(t *testing.T) {

--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -1146,13 +1146,12 @@ func (m *Manager) monitorTrackedTmuxWindow(session *Session) {
 			contentChanged = captureState.observeContentLines(contentLines)
 		}
 
-		displayLines := contentLines
-		if len(displayLines) > sessionmodel.RecentOutputDisplayLines {
-			displayLines = displayLines[len(displayLines)-sessionmodel.RecentOutputDisplayLines:]
+		if len(contentLines) > sessionmodel.RecentOutputDisplayLines {
+			contentLines = contentLines[len(contentLines)-sessionmodel.RecentOutputDisplayLines:]
 		}
 
 		session.Progress.Update(func(p *SessionProgress) {
-			p.RecentOutput = displayLines
+			p.RecentOutput = contentLines
 			if contentChanged {
 				p.LastActivity = time.Now()
 			}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -28,6 +28,17 @@ if ! command -v golangci-lint &> /dev/null; then
     exit 1
 fi
 
+# Use a persistent per-worktree cache so concurrent worktrees do not fight over
+# golangci-lint's global cache lock, while repeated runs still stay warm.
+if [[ -z "${GOLANGCI_LINT_CACHE:-}" ]]; then
+    cache_root="${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}/golangci-lint/workspaces"
+    workspace_key="$(printf '%s' "${WORKSPACE_ROOT}" | cksum | cut -d ' ' -f 1)"
+    workspace_slug="$(basename "${WORKSPACE_ROOT}" | tr -c '[:alnum:]_.-' '_')"
+    GOLANGCI_LINT_CACHE="${cache_root}/${workspace_slug}-${workspace_key}"
+    mkdir -p "${GOLANGCI_LINT_CACHE}"
+    export GOLANGCI_LINT_CACHE
+fi
+
 # Run golangci-lint on each module in go.work
 GO_LINT_FAILED=0
 


### PR DESCRIPTION
## Summary

Fixes the session-list / command-center new-session flow so the interface shows the repo, worktree, and session the user selected before opening the planner/builder/CodeTalk prompt.

## What changed

- When pressing `p`, `b`, or `c` from the all-sessions overlay or command center, Bramble now switches the visible context to the selected session's repo/worktree/session before opening the prompt.
- The prompt captures an explicit selected-session target so the new session starts on that selected worktree, not whatever worktree is ambient when the prompt is submitted.
- Cold cross-repo contexts now show the selected session's worktree immediately while the real worktree list refreshes.
- If that refresh proves the selected worktree disappeared, or the selected session's repo is no longer opened, Bramble fails closed instead of showing a wrong-context prompt or starting on the current selection.
- Selected-session targets are revalidated at dispatch time, including stale/gone worktrees, and stale `WorktreeName` values fall back to matching by `WorktreePath`.
- Task confirmation still fails closed when an existing worktree disappears, avoiding fallback to the current selection.
- `scripts/lint.sh` uses a persistent per-worktree `golangci-lint` cache to avoid cross-worktree cache lock collisions without forcing cold caches every run.

## Validation

- `bazel test --nocache_test_results --test_timeout=60 //bramble/app:app_test`
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test --test_timeout=120 //...`

Note: earlier full-suite validation showed `//multiagent/agent:agent_test` needs more than 60s locally; the 120s run passes all 59 test targets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session-launch and plan-approval flows with new target-capture and availability checks, which could affect when sessions start or prompts cancel across repos/worktrees.
> 
> **Overview**
> New-session flows from the main view, all-sessions overlay, and command center now **switch the visible context to the selected session (repo/worktree/output) before opening the prompt** and **capture an explicit `sessionTarget`** so submit cannot accidentally start on a different worktree after re-sorts, dropdown changes, or repo switches.
> 
> Dispatch paths (`startSessionMsg`, task confirm, and plan approval) now *fail closed* by revalidating target worktrees (including an on-disk `os.Stat` check and handling “cold” repo contexts via `worktreesLoaded`) and by cancelling open prompts if a subsequent `worktreesMsg` refresh removes the pending target; command-center plan approval keeps the overlay visible on rejection. The PR also tweaks session capture to avoid extra allocations and updates `scripts/lint.sh` to use a per-workspace `GOLANGCI_LINT_CACHE` to prevent cache-lock contention across concurrent worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144c9a2df2799634317a21298bf5c5338d143390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->