### PR TITLE
feat(reviewer): per-issue confidence field + caller/callee scope framing

### DIFF
--- a/bramble/cmd/codereview/codereview_test.go
+++ b/bramble/cmd/codereview/codereview_test.go
@@ -376,6 +376,39 @@ func TestBuildPromptForRun_WidensWithRealHintsFile(t *testing.T) {
 	}
 }
 
+func TestBuildPromptForRun_V2HintsThreadCallerCalleeFraming(t *testing.T) {
+	// End-to-end seam for the v2 scope-hints shape: changed_packages and
+	// dependency_packages should reach the prompt builder and select the
+	// caller/callee framing instead of the generic flat-list framing.
+	// Guards against a regression that drops the new fields somewhere
+	// between LoadScopeHints and BuildJSONPromptWithScope.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hints.json")
+	contents := `{
+		"schema_version": 2,
+		"test_paths": ["pkg/test_x.py"],
+		"cross_service_packages": ["svc/a/", "svc/b/"],
+		"changed_packages": ["svc/a/"],
+		"dependency_packages": ["svc/b/"]
+	}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write hints: %v", err)
+	}
+	got := buildPromptForRun("review goal", path, false)
+	if !strings.Contains(got, "## Cross-service contract sweep") {
+		t.Errorf("prompt missing cross-service clause; got:\n%s", got)
+	}
+	if !strings.Contains(got, "primarily modifies") {
+		t.Errorf("prompt missing caller/callee framing; got:\n%s", got)
+	}
+	if !strings.Contains(got, "callers or dependencies") {
+		t.Errorf("prompt missing callers/dependencies line; got:\n%s", got)
+	}
+	if !strings.Contains(got, "svc/a/") || !strings.Contains(got, "svc/b/") {
+		t.Errorf("prompt missing changed/dependency packages; got:\n%s", got)
+	}
+}
+
 func TestBuildPromptForRun_NoHintsMatchesLegacy(t *testing.T) {
 	// Empty hints path must produce today's narrow prompt, byte-equal to
 	// the legacy BuildJSONPrompt output. This is the no-regressions

--- a/yoloswe/reviewer/json_output.go
+++ b/yoloswe/reviewer/json_output.go
@@ -12,11 +12,12 @@ const JSONSchemaVersion = 1
 
 // ReviewIssue mirrors the per-issue shape requested by BuildJSONPrompt.
 type ReviewIssue struct {
-	Severity   string `json:"severity"`
-	File       string `json:"file"`
-	Message    string `json:"message"`
-	Suggestion string `json:"suggestion,omitempty"`
-	Line       int    `json:"line,omitempty"`
+	Severity   string  `json:"severity"`
+	File       string  `json:"file"`
+	Message    string  `json:"message"`
+	Suggestion string  `json:"suggestion,omitempty"`
+	Line       int     `json:"line,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
 }
 
 // ReviewBody is the parsed reviewer-level JSON. When the reviewer's response

--- a/yoloswe/reviewer/json_output.go
+++ b/yoloswe/reviewer/json_output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 )
 
@@ -11,13 +12,20 @@ import (
 const JSONSchemaVersion = 1
 
 // ReviewIssue mirrors the per-issue shape requested by BuildJSONPrompt.
+//
+// Confidence is *float64 so JSON omission and an explicit value are
+// distinguishable. The prompt contract is "omit when unassessed; otherwise
+// emit a value in (0.0, 1.0]" — a plain float64 with omitempty would treat
+// the boundary value 0 as missing and leave the validator unable to reject
+// out-of-range values. Consumers should treat nil as "no signal" rather
+// than synthesizing a default.
 type ReviewIssue struct {
-	Severity   string  `json:"severity"`
-	File       string  `json:"file"`
-	Message    string  `json:"message"`
-	Suggestion string  `json:"suggestion,omitempty"`
-	Line       int     `json:"line,omitempty"`
-	Confidence float64 `json:"confidence,omitempty"`
+	Confidence *float64 `json:"confidence,omitempty"`
+	Severity   string   `json:"severity"`
+	File       string   `json:"file"`
+	Message    string   `json:"message"`
+	Suggestion string   `json:"suggestion,omitempty"`
+	Line       int      `json:"line,omitempty"`
 }
 
 // ReviewBody is the parsed reviewer-level JSON. When the reviewer's response
@@ -144,6 +152,7 @@ func BuildEnvelope(result *ReviewResult, backend BackendType, model, sessionID s
 //   - each issue has severity ∈ {low, medium, high, critical}, message, file, line ≥ 1
 //   - "rejected" carries at least one issue (otherwise nothing was rejected)
 //   - "accepted" carries no high/critical issues (those block merge by definition)
+//   - confidence, when present, is in (0.0, 1.0] and finite (no NaN/Inf)
 //
 // The line requirement matches the prompt contract in buildBasePrompt, which
 // instructs the reviewer to "cite the affected file and line range" — without
@@ -168,6 +177,15 @@ func validateReviewBody(body ReviewBody) error {
 		}
 		if issue.Line < 1 {
 			return fmt.Errorf("issue[%d] missing line", i)
+		}
+		if issue.Confidence != nil {
+			c := *issue.Confidence
+			if math.IsNaN(c) || math.IsInf(c, 0) {
+				return fmt.Errorf("issue[%d] confidence not finite: %v", i, c)
+			}
+			if c <= 0 || c > 1 {
+				return fmt.Errorf("issue[%d] confidence %v not in (0.0, 1.0]", i, c)
+			}
 		}
 		if _, blocks := blockingSeverities[issue.Severity]; blocks {
 			hasBlocking = true

--- a/yoloswe/reviewer/json_output.go
+++ b/yoloswe/reviewer/json_output.go
@@ -143,13 +143,21 @@ func BuildEnvelope(result *ReviewResult, backend BackendType, model, sessionID s
 	return env
 }
 
-// ValidateReviewJSON parses raw reviewer JSON and runs the same schema
-// validation that BuildEnvelope applies. Returns nil on a well-formed,
-// schema-compliant body. Callers outside this package (e.g. yoloswe/swe.go's
-// parseVerdict) should run this before acting on reviewer JSON so the
-// builder-feedback path enforces the same contract as the envelope path —
-// otherwise out-of-range confidence, missing line numbers, etc. would slip
-// past one entrypoint while being rejected by the other.
+// ValidateReviewJSON parses an extracted reviewer JSON object and runs the
+// same schema validation that BuildEnvelope applies to ResultEnvelope.Review.
+// Returns nil on a well-formed, schema-compliant body.
+//
+// Input contract: raw must be the bare JSON object the reviewer emitted,
+// without any narration prefix or fenced code block — same shape that
+// extractReviewBody returns. Feeding it raw model response text (which may
+// be wrapped in ``` fences or follow narration) will fail to unmarshal.
+// Callers wanting a one-shot "extract + validate" should go through
+// BuildEnvelope, which composes both steps.
+//
+// Use case: callers outside this package (e.g. yoloswe/swe.go's parseVerdict)
+// that already have the JSON blob in hand and want strict schema semantics
+// — confidence ∈ (0.0, 1.0], line ≥ 1, valid severity/verdict — without
+// constructing a full ResultEnvelope.
 func ValidateReviewJSON(raw []byte) error {
 	var body ReviewBody
 	if err := json.Unmarshal(raw, &body); err != nil {

--- a/yoloswe/reviewer/json_output.go
+++ b/yoloswe/reviewer/json_output.go
@@ -143,6 +143,21 @@ func BuildEnvelope(result *ReviewResult, backend BackendType, model, sessionID s
 	return env
 }
 
+// ValidateReviewJSON parses raw reviewer JSON and runs the same schema
+// validation that BuildEnvelope applies. Returns nil on a well-formed,
+// schema-compliant body. Callers outside this package (e.g. yoloswe/swe.go's
+// parseVerdict) should run this before acting on reviewer JSON so the
+// builder-feedback path enforces the same contract as the envelope path —
+// otherwise out-of-range confidence, missing line numbers, etc. would slip
+// past one entrypoint while being rejected by the other.
+func ValidateReviewJSON(raw []byte) error {
+	var body ReviewBody
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("unmarshal reviewer JSON: %w", err)
+	}
+	return validateReviewBody(body)
+}
+
 // validateReviewBody checks the parsed body against the required reviewer
 // schema. A non-nil error means the envelope must report status="error" so
 // downstream automation never acts on malformed reviewer output.

--- a/yoloswe/reviewer/json_output_test.go
+++ b/yoloswe/reviewer/json_output_test.go
@@ -295,6 +295,35 @@ func TestBuildEnvelope_ConfidenceOutOfRange(t *testing.T) {
 	}
 }
 
+func TestValidateReviewJSON(t *testing.T) {
+	// The exported helper lets callers outside this package (e.g.
+	// yoloswe/swe.go) reuse the envelope's schema check without going
+	// through BuildEnvelope. Cover the boundary cases of the contract.
+	cases := []struct {
+		name      string
+		json      string
+		expectErr bool
+	}{
+		{"valid_accepted_with_confidence", `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit","confidence":0.7}]}`, false},
+		{"valid_accepted_no_issues", `{"verdict":"accepted","issues":[]}`, false},
+		{"unknown_verdict", `{"verdict":"maybe","issues":[]}`, true},
+		{"confidence_out_of_range", `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit","confidence":2.0}]}`, true},
+		{"missing_line", `{"verdict":"rejected","issues":[{"severity":"high","file":"a.go","message":"bug"}]}`, true},
+		{"malformed_json", `not json at all`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateReviewJSON([]byte(tc.json))
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestBuildEnvelope_UnparseableText(t *testing.T) {
 	result := &ReviewResult{
 		ResponseText: "the reviewer refused to produce JSON",

--- a/yoloswe/reviewer/json_output_test.go
+++ b/yoloswe/reviewer/json_output_test.go
@@ -235,6 +235,66 @@ func TestBuildEnvelope_AcceptedWithLowIssue(t *testing.T) {
 	}
 }
 
+func TestBuildEnvelope_ConfidenceValid(t *testing.T) {
+	// A valid confidence in (0.0, 1.0] passes validation and round-trips
+	// through to the envelope.
+	result := &ReviewResult{
+		ResponseText: `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit","confidence":0.7}]}`,
+		Success:      true,
+	}
+	env := BuildEnvelope(result, BackendCodex, "m", "")
+	if env.Status != StatusOK {
+		t.Errorf("status = %s, want ok for valid confidence", env.Status)
+	}
+	if len(env.Review.Issues) != 1 || env.Review.Issues[0].Confidence == nil {
+		t.Fatalf("confidence not preserved: %+v", env.Review.Issues)
+	}
+	if got := *env.Review.Issues[0].Confidence; got != 0.7 {
+		t.Errorf("confidence = %v, want 0.7", got)
+	}
+}
+
+func TestBuildEnvelope_ConfidenceOmitted(t *testing.T) {
+	// An issue without a confidence field is valid — the prompt makes the
+	// field optional ("omit when you cannot assess").
+	result := &ReviewResult{
+		ResponseText: `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit"}]}`,
+		Success:      true,
+	}
+	env := BuildEnvelope(result, BackendCodex, "m", "")
+	if env.Status != StatusOK {
+		t.Errorf("status = %s, want ok when confidence is omitted", env.Status)
+	}
+	if len(env.Review.Issues) != 1 {
+		t.Fatalf("issue count = %d, want 1", len(env.Review.Issues))
+	}
+	if env.Review.Issues[0].Confidence != nil {
+		t.Errorf("confidence = %v, want nil for omitted field", *env.Review.Issues[0].Confidence)
+	}
+}
+
+func TestBuildEnvelope_ConfidenceOutOfRange(t *testing.T) {
+	// Confidence must be in (0.0, 1.0]. The boundary 0.0 is excluded so a
+	// reviewer cannot use it to mean "speculative" — that intent should be
+	// expressed as a small positive value or by omitting the field.
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"zero", `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit","confidence":0.0}]}`},
+		{"negative", `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit","confidence":-0.1}]}`},
+		{"above_one", `{"verdict":"accepted","issues":[{"severity":"low","file":"a.go","line":1,"message":"nit","confidence":1.5}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := BuildEnvelope(&ReviewResult{ResponseText: tc.json, Success: true}, BackendCodex, "m", "")
+			if env.Status != StatusError {
+				t.Errorf("status = %s, want error for confidence=%s", env.Status, tc.name)
+			}
+		})
+	}
+}
+
 func TestBuildEnvelope_UnparseableText(t *testing.T) {
 	result := &ReviewResult{
 		ResponseText: "the reviewer refused to produce JSON",

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -440,7 +440,7 @@ func BuildPromptWithOptions(goal string, skipTestExecution bool) string {
 func BuildPromptWithScope(goal string, opts PromptOptions) string {
 	return buildBasePrompt(goal, opts.SkipTestExecution) + buildScopeSuffix(opts) + `
 
-After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and a confidence score between 0 and 1.`
+After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and an overall confidence score in [0.0, 1.0]. This overall score is distinct from the optional per-issue confidence in the JSON output format (which is in (0.0, 1.0]); it summarizes confidence in the verdict itself.`
 }
 
 // BuildJSONPrompt creates a review prompt that requests JSON output format.

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -397,13 +397,25 @@ to its consumers. Read both sides of each surface and flag:` + crossServiceContr
 // clause is gated purely by data presence so callers without scope info pay
 // no cost — the returned string is empty when neither clause applies, which
 // keeps legacy callers byte-equal to today's prompt.
+//
+// The caller/callee branch tries to emit first (it's the more informative
+// framing), but if every ChangedPackages entry was filtered out by
+// SanitizePromptHint the clause comes back empty — in that case we fall
+// back to the generic flat-list framing rather than dropping the entire
+// cross-service section. A direct PromptOptions caller that bypassed
+// LoadScopeHints could otherwise lose all cross-service guidance just
+// because their ChangedPackages list happened to be unsanitary.
 func buildScopeSuffix(opts PromptOptions) string {
 	var s string
 	if len(opts.TestScopeHints) > 0 {
 		s += testQualityClause(opts.TestScopeHints)
 	}
 	if len(opts.ChangedPackages) > 0 {
-		s += crossServiceClauseCallerCallee(opts.ChangedPackages, opts.DependencyPackages)
+		clause := crossServiceClauseCallerCallee(opts.ChangedPackages, opts.DependencyPackages)
+		if clause == "" && len(opts.CrossServicePackages) >= 2 {
+			clause = crossServiceClauseGeneric(opts.CrossServicePackages)
+		}
+		s += clause
 	} else if len(opts.CrossServicePackages) >= 2 {
 		s += crossServiceClauseGeneric(opts.CrossServicePackages)
 	}

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -115,11 +115,19 @@ Do NOT run tests or build commands. The caller runs tests separately. Read test 
 
 // PromptOptions configures the optional clauses appended to a review prompt.
 //
-// Each clause is gated by data presence rather than a separate boolean: an
-// empty TestScopeHints means "no test-quality clause", and fewer than two
-// CrossServicePackages means "no cross-service clause". This collapses the
-// (boolean, list) cartesian product into a single source of truth — the
-// caller controls everything by what they put in the lists.
+// Each clause is gated by data presence rather than a separate boolean. The
+// test-quality clause is appended when TestScopeHints is non-empty. The
+// cross-service clause has two framings, picked in this order:
+//
+//   - When ChangedPackages is non-empty, the caller/callee framing names the
+//     changed packages explicitly and uses DependencyPackages (when set) to
+//     name the other side; a single changed package is fine.
+//   - Otherwise, when CrossServicePackages has at least two entries, the
+//     generic flat-list framing is used (v1 compat — kept so old scope-hints
+//     producers still get the clause without ChangedPackages).
+//
+// This collapses the (boolean, list) cartesian product into a single source
+// of truth — the caller controls everything by what they put in the lists.
 type PromptOptions struct {
 	// TestScopeHints lists co-located test paths the agent should read. When
 	// non-empty, the test-quality clause is appended to the prompt and the
@@ -469,7 +477,7 @@ You MUST respond with valid JSON in this exact format:
 - If there are any critical or high severity issues, verdict MUST be "rejected"
 - issues array can be empty if verdict is "accepted"
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
-- confidence is a float in (0.0, 1.0]: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified); omit when certain or when you can't assess
+- confidence is an optional float in (0.0, 1.0]: 1.0 = certain, 0.5 = plausible but unverified; omit only when you cannot assess (the field is treated as "no signal", not as a default value)
 - Output ONLY the JSON object, no other text`
 }
 

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -126,19 +126,20 @@ type PromptOptions struct {
 	// paths are inlined under it (capped at testScopeHintsCap entries).
 	TestScopeHints []string
 
-	// CrossServicePackages names all top-level packages this PR touches. When
-	// it has at least two entries and ChangedPackages is empty, the generic
-	// cross-service contract-sweep clause is appended.
+	// CrossServicePackages names all top-level packages this PR touches.
+	// When it has at least two entries and ChangedPackages is empty, the
+	// generic flat-list cross-service contract-sweep clause is appended.
 	CrossServicePackages []string
 
-	// ChangedPackages names the top-level packages directly modified by this
-	// diff (v2+ scope hints). When non-empty, the cross-service clause uses
-	// explicit caller/callee framing instead of the generic multi-package list.
+	// ChangedPackages names the top-level packages directly modified by
+	// this diff. When non-empty, the cross-service clause uses explicit
+	// caller/callee framing — naming the changed packages and the
+	// callers/dependencies separately — instead of the flat list.
 	ChangedPackages []string
 
 	// DependencyPackages names packages that import or are imported by the
-	// changed packages (v2+ scope hints). Used alongside ChangedPackages in
-	// the explicit caller/callee framing.
+	// changed packages. Inlined as the "callers or dependencies" side in
+	// the caller/callee framing.
 	DependencyPackages []string
 
 	// SkipTestExecution discourages the agent from spawning bazel/go test/etc.
@@ -258,6 +259,22 @@ func filterPromptHints(items []string) []string {
 	return out
 }
 
+// capAndJoin caps items at max entries and returns a comma-separated string
+// with " (and N more)" appended when items were dropped. Returns "" when
+// items is empty. Caller is responsible for any sanitization.
+func capAndJoin(items []string, max int) string {
+	if len(items) == 0 {
+		return ""
+	}
+	suffix := ""
+	if len(items) > max {
+		extra := len(items) - max
+		items = items[:max]
+		suffix = fmt.Sprintf(" (and %d more)", extra)
+	}
+	return strings.Join(items, ", ") + suffix
+}
+
 // testQualityClause returns the test-quality scrutiny clause with the given
 // co-located test paths inlined.
 //
@@ -304,50 +321,15 @@ Co-located test files to read (in addition to anything in the diff):
 ` + strings.Join(displayed, "\n") + suffix
 }
 
-// crossServiceClause returns the cross-service contract-sweep clause.
-//
-// When changedPkgs is non-empty, the clause uses explicit caller/callee
-// framing: it names the directly modified packages and tells the reviewer
-// which packages are the callers/dependencies to check. When changedPkgs is
-// empty (v1 hints or no split available), it falls back to the generic
-// multi-package framing using allPkgs.
+// crossServiceContractItems is the trailing checklist shared by both
+// framings of the cross-service contract-sweep clause.
 //
 // The four numbered items track the issue body's draft (#175). An earlier
 // version added a fifth item naming specific shapes (FastAPI path-parameter
 // ordering, ORM mixins, OpenAPI tag collisions) drawn from kernel-2998; it
 // was removed for the same anti-overfitting reason as testQualityClause.
 // New items should describe failure modes, not specific framework bugs.
-func crossServiceClause(allPkgs, changedPkgs, depPkgs []string) string {
-	if len(changedPkgs) > 0 {
-		return crossServiceClauseCallerCallee(changedPkgs, depPkgs)
-	}
-	return crossServiceClauseGeneric(allPkgs)
-}
-
-// crossServiceClauseGeneric is the v1 fallback: a flat list of touched
-// packages with no caller/callee distinction. The caller must guarantee
-// len(packages) >= 2.
-func crossServiceClauseGeneric(packages []string) string {
-	packages = filterPromptHints(packages)
-	if len(packages) < 2 {
-		// Sanitization filtered the list below the >=2 threshold the
-		// caller's gate assumed. Drop the clause rather than emit one
-		// with a single (or zero) package — the prompt would read
-		// nonsensically.
-		return ""
-	}
-	suffix := ""
-	if len(packages) > crossServicePackagesCap {
-		extra := len(packages) - crossServicePackagesCap
-		packages = packages[:crossServicePackagesCap]
-		suffix = fmt.Sprintf(" (and %d more)", extra)
-	}
-	return `
-
-## Cross-service contract sweep
-This PR touches multiple top-level packages: ` + strings.Join(packages, ", ") + suffix + `.
-Trace every public API/handler/exported symbol modified in one package to its
-consumers in the others. Read both sides of each surface and flag:
+const crossServiceContractItems = `
 1. Signature or shape changes that don't match consumer expectations
    (request/response field names, types, optionality, enum values).
 2. Async state updates that desync between producer and consumer
@@ -361,59 +343,46 @@ consumers in the others. Read both sides of each surface and flag:
 
 When citing an issue, name both sides (file:line) and explain the desync
 explicitly. If both sides agree, do not flag the surface.`
-}
 
-// crossServiceClauseCallerCallee is the v2 explicit framing: it names which
-// packages were changed and which are the callers/dependencies to check.
-func crossServiceClauseCallerCallee(changedPkgs, depPkgs []string) string {
-	changedPkgs = filterPromptHints(changedPkgs)
-	depPkgs = filterPromptHints(depPkgs)
-	if len(changedPkgs) == 0 {
+// crossServiceClauseGeneric is a flat list of touched packages with no
+// caller/callee distinction, used when only CrossServicePackages is set.
+// The caller must guarantee len(packages) >= 2.
+func crossServiceClauseGeneric(packages []string) string {
+	// Sanitization may have filtered the list below the >=2 threshold the
+	// caller's gate assumed. Drop the clause rather than emit one with a
+	// single (or zero) package — the prompt would read nonsensically.
+	filtered := filterPromptHints(packages)
+	if len(filtered) < 2 {
 		return ""
 	}
+	return `
 
-	changedSuffix := ""
-	if len(changedPkgs) > crossServicePackagesCap {
-		extra := len(changedPkgs) - crossServicePackagesCap
-		changedPkgs = changedPkgs[:crossServicePackagesCap]
-		changedSuffix = fmt.Sprintf(" (and %d more)", extra)
+## Cross-service contract sweep
+This PR touches multiple top-level packages: ` + capAndJoin(filtered, crossServicePackagesCap) + `.
+Trace every public API/handler/exported symbol modified in one package to its
+consumers in the others. Read both sides of each surface and flag:` + crossServiceContractItems
+}
+
+// crossServiceClauseCallerCallee names which packages were changed and which
+// are the callers/dependencies to check. Used when ChangedPackages is set.
+func crossServiceClauseCallerCallee(changedPkgs, depPkgs []string) string {
+	changed := filterPromptHints(changedPkgs)
+	if len(changed) == 0 {
+		return ""
 	}
-	changedLine := strings.Join(changedPkgs, ", ") + changedSuffix
-
 	depSection := ""
-	if len(depPkgs) > 0 {
-		depSuffix := ""
-		if len(depPkgs) > crossServicePackagesCap {
-			extra := len(depPkgs) - crossServicePackagesCap
-			depPkgs = depPkgs[:crossServicePackagesCap]
-			depSuffix = fmt.Sprintf(" (and %d more)", extra)
-		}
-		depLine := strings.Join(depPkgs, ", ") + depSuffix
+	if deps := filterPromptHints(depPkgs); len(deps) > 0 {
 		depSection = `
 The following packages are callers or dependencies — check whether the interface
 contract (HTTP request shape, event schema, error codes, async message format)
-changed on the modified side without a matching update on these sides: ` + depLine + `.`
+changed on the modified side without a matching update on these sides: ` + capAndJoin(deps, crossServicePackagesCap) + `.`
 	}
-
 	return `
 
 ## Cross-service contract sweep
-The diff primarily modifies: ` + changedLine + `.` + depSection + `
+The diff primarily modifies: ` + capAndJoin(changed, crossServicePackagesCap) + `.` + depSection + `
 Trace every public API/handler/exported symbol modified in the changed packages
-to its consumers. Read both sides of each surface and flag:
-1. Signature or shape changes that don't match consumer expectations
-   (request/response field names, types, optionality, enum values).
-2. Async state updates that desync between producer and consumer
-   (optimistic UI updates that diverge from refetched server state,
-   stale-while-revalidate paths returning prior values).
-3. Error or loading paths whose handling differs across packages
-   (one side throws, the other silently falls back; one side surfaces a
-   typed error, the other treats it as success).
-4. Silent fallbacks that swallow values from another service (default
-   values masking missing fields, empty arrays masking failed lookups).
-
-When citing an issue, name both sides (file:line) and explain the desync
-explicitly. If both sides agree, do not flag the surface.`
+to its consumers. Read both sides of each surface and flag:` + crossServiceContractItems
 }
 
 // buildScopeSuffix concatenates the optional clauses dictated by opts. Each
@@ -425,10 +394,10 @@ func buildScopeSuffix(opts PromptOptions) string {
 	if len(opts.TestScopeHints) > 0 {
 		s += testQualityClause(opts.TestScopeHints)
 	}
-	// v2: use explicit caller/callee framing when ChangedPackages is set.
-	// v1 fallback: generic framing when only CrossServicePackages is set.
-	if len(opts.ChangedPackages) >= 1 || len(opts.CrossServicePackages) >= 2 {
-		s += crossServiceClause(opts.CrossServicePackages, opts.ChangedPackages, opts.DependencyPackages)
+	if len(opts.ChangedPackages) > 0 {
+		s += crossServiceClauseCallerCallee(opts.ChangedPackages, opts.DependencyPackages)
+	} else if len(opts.CrossServicePackages) >= 2 {
+		s += crossServiceClauseGeneric(opts.CrossServicePackages)
 	}
 	return s
 }
@@ -500,7 +469,7 @@ You MUST respond with valid JSON in this exact format:
 - If there are any critical or high severity issues, verdict MUST be "rejected"
 - issues array can be empty if verdict is "accepted"
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
-- confidence is a float 0.0–1.0: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified, 0.0 = speculative); omit or set to 1.0 if certain
+- confidence is a float in (0.0, 1.0]: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified); omit when certain or when you can't assess
 - Output ONLY the JSON object, no other text`
 }
 

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -126,10 +126,20 @@ type PromptOptions struct {
 	// paths are inlined under it (capped at testScopeHintsCap entries).
 	TestScopeHints []string
 
-	// CrossServicePackages names the top-level packages this PR touches. When
-	// it has at least two entries, the cross-service contract-sweep clause is
-	// appended.
+	// CrossServicePackages names all top-level packages this PR touches. When
+	// it has at least two entries and ChangedPackages is empty, the generic
+	// cross-service contract-sweep clause is appended.
 	CrossServicePackages []string
+
+	// ChangedPackages names the top-level packages directly modified by this
+	// diff (v2+ scope hints). When non-empty, the cross-service clause uses
+	// explicit caller/callee framing instead of the generic multi-package list.
+	ChangedPackages []string
+
+	// DependencyPackages names packages that import or are imported by the
+	// changed packages (v2+ scope hints). Used alongside ChangedPackages in
+	// the explicit caller/callee framing.
+	DependencyPackages []string
 
 	// SkipTestExecution discourages the agent from spawning bazel/go test/etc.
 	SkipTestExecution bool
@@ -294,15 +304,30 @@ Co-located test files to read (in addition to anything in the diff):
 ` + strings.Join(displayed, "\n") + suffix
 }
 
-// crossServiceClause returns the cross-service contract-sweep clause naming
-// the touched packages. The caller must guarantee len(packages) >= 2.
+// crossServiceClause returns the cross-service contract-sweep clause.
+//
+// When changedPkgs is non-empty, the clause uses explicit caller/callee
+// framing: it names the directly modified packages and tells the reviewer
+// which packages are the callers/dependencies to check. When changedPkgs is
+// empty (v1 hints or no split available), it falls back to the generic
+// multi-package framing using allPkgs.
 //
 // The four numbered items track the issue body's draft (#175). An earlier
 // version added a fifth item naming specific shapes (FastAPI path-parameter
 // ordering, ORM mixins, OpenAPI tag collisions) drawn from kernel-2998; it
 // was removed for the same anti-overfitting reason as testQualityClause.
 // New items should describe failure modes, not specific framework bugs.
-func crossServiceClause(packages []string) string {
+func crossServiceClause(allPkgs, changedPkgs, depPkgs []string) string {
+	if len(changedPkgs) > 0 {
+		return crossServiceClauseCallerCallee(changedPkgs, depPkgs)
+	}
+	return crossServiceClauseGeneric(allPkgs)
+}
+
+// crossServiceClauseGeneric is the v1 fallback: a flat list of touched
+// packages with no caller/callee distinction. The caller must guarantee
+// len(packages) >= 2.
+func crossServiceClauseGeneric(packages []string) string {
 	packages = filterPromptHints(packages)
 	if len(packages) < 2 {
 		// Sanitization filtered the list below the >=2 threshold the
@@ -338,6 +363,59 @@ When citing an issue, name both sides (file:line) and explain the desync
 explicitly. If both sides agree, do not flag the surface.`
 }
 
+// crossServiceClauseCallerCallee is the v2 explicit framing: it names which
+// packages were changed and which are the callers/dependencies to check.
+func crossServiceClauseCallerCallee(changedPkgs, depPkgs []string) string {
+	changedPkgs = filterPromptHints(changedPkgs)
+	depPkgs = filterPromptHints(depPkgs)
+	if len(changedPkgs) == 0 {
+		return ""
+	}
+
+	changedSuffix := ""
+	if len(changedPkgs) > crossServicePackagesCap {
+		extra := len(changedPkgs) - crossServicePackagesCap
+		changedPkgs = changedPkgs[:crossServicePackagesCap]
+		changedSuffix = fmt.Sprintf(" (and %d more)", extra)
+	}
+	changedLine := strings.Join(changedPkgs, ", ") + changedSuffix
+
+	depSection := ""
+	if len(depPkgs) > 0 {
+		depSuffix := ""
+		if len(depPkgs) > crossServicePackagesCap {
+			extra := len(depPkgs) - crossServicePackagesCap
+			depPkgs = depPkgs[:crossServicePackagesCap]
+			depSuffix = fmt.Sprintf(" (and %d more)", extra)
+		}
+		depLine := strings.Join(depPkgs, ", ") + depSuffix
+		depSection = `
+The following packages are callers or dependencies — check whether the interface
+contract (HTTP request shape, event schema, error codes, async message format)
+changed on the modified side without a matching update on these sides: ` + depLine + `.`
+	}
+
+	return `
+
+## Cross-service contract sweep
+The diff primarily modifies: ` + changedLine + `.` + depSection + `
+Trace every public API/handler/exported symbol modified in the changed packages
+to its consumers. Read both sides of each surface and flag:
+1. Signature or shape changes that don't match consumer expectations
+   (request/response field names, types, optionality, enum values).
+2. Async state updates that desync between producer and consumer
+   (optimistic UI updates that diverge from refetched server state,
+   stale-while-revalidate paths returning prior values).
+3. Error or loading paths whose handling differs across packages
+   (one side throws, the other silently falls back; one side surfaces a
+   typed error, the other treats it as success).
+4. Silent fallbacks that swallow values from another service (default
+   values masking missing fields, empty arrays masking failed lookups).
+
+When citing an issue, name both sides (file:line) and explain the desync
+explicitly. If both sides agree, do not flag the surface.`
+}
+
 // buildScopeSuffix concatenates the optional clauses dictated by opts. Each
 // clause is gated purely by data presence so callers without scope info pay
 // no cost — the returned string is empty when neither clause applies, which
@@ -347,8 +425,10 @@ func buildScopeSuffix(opts PromptOptions) string {
 	if len(opts.TestScopeHints) > 0 {
 		s += testQualityClause(opts.TestScopeHints)
 	}
-	if len(opts.CrossServicePackages) >= 2 {
-		s += crossServiceClause(opts.CrossServicePackages)
+	// v2: use explicit caller/callee framing when ChangedPackages is set.
+	// v1 fallback: generic framing when only CrossServicePackages is set.
+	if len(opts.ChangedPackages) >= 1 || len(opts.CrossServicePackages) >= 2 {
+		s += crossServiceClause(opts.CrossServicePackages, opts.ChangedPackages, opts.DependencyPackages)
 	}
 	return s
 }
@@ -403,7 +483,8 @@ You MUST respond with valid JSON in this exact format:
       "file": "path/to/file.go",
       "line": 42,
       "message": "Description of the issue",
-      "suggestion": "How to fix it"
+      "suggestion": "How to fix it",
+      "confidence": 0.9
     }
   ]
 }
@@ -419,6 +500,7 @@ You MUST respond with valid JSON in this exact format:
 - If there are any critical or high severity issues, verdict MUST be "rejected"
 - issues array can be empty if verdict is "accepted"
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
+- confidence is a float 0.0–1.0: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified, 0.0 = speculative); omit or set to 1.0 if certain
 - Output ONLY the JSON object, no other text`
 }
 

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -749,6 +749,27 @@ func TestBuildJSONPromptWithScope_GenericFallbackWhenNoChangedPackages(t *testin
 	}
 }
 
+func TestBuildJSONPromptWithScope_GenericFallbackWhenChangedPackagesAllSanitized(t *testing.T) {
+	// Direct callers that bypass LoadScopeHints can pass ChangedPackages
+	// entries that SanitizePromptHint rejects (e.g. leading '#'). The
+	// caller/callee clause then comes back empty — but if CrossServicePackages
+	// has >=2 entries the prompt must still get the generic cross-service
+	// guidance instead of dropping the section entirely.
+	out := BuildJSONPromptWithScope("g", PromptOptions{
+		ChangedPackages:      []string{"#bogus", "-also-bogus"},
+		CrossServicePackages: []string{"svc/a/", "svc/b/"},
+	})
+	if !strings.Contains(out, crossServiceMarker) {
+		t.Errorf("expected generic cross-service clause when ChangedPackages all sanitized out")
+	}
+	if strings.Contains(out, "primarily modifies") {
+		t.Errorf("caller/callee framing must not appear when ChangedPackages was all sanitized out")
+	}
+	if !strings.Contains(out, "touches multiple top-level packages") {
+		t.Errorf("expected generic framing fallback")
+	}
+}
+
 // TestLegacyJSONPromptGolden pins today's BuildJSONPrompt output byte-for-
 // byte. Drift is most likely to creep in when someone edits the base prompt
 // or the JSON output rules without realizing yoloswe/swe.go and any

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -716,7 +716,7 @@ func TestBuildJSONPromptWithScope_CallerCalleeFraming(t *testing.T) {
 	}
 }
 
-func TestBuildJSONPromptWithScope_CallerCalleeFallsBackToGenericWhenNoDeps(t *testing.T) {
+func TestBuildJSONPromptWithScope_CallerCalleeOmitsDepLineWhenNoDeps(t *testing.T) {
 	// ChangedPackages set but no DependencyPackages: clause still emits
 	// with the primary-modifies line but no callers/dependencies line.
 	out := BuildJSONPromptWithScope("g", PromptOptions{

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -691,6 +691,64 @@ func TestBuildPromptWithScope_NoOptionsMatchesLegacy(t *testing.T) {
 	}
 }
 
+func TestBuildJSONPromptWithScope_CallerCalleeFraming(t *testing.T) {
+	// When ChangedPackages is set, the prompt uses explicit caller/callee
+	// framing instead of the generic flat-list framing.
+	out := BuildJSONPromptWithScope("g", PromptOptions{
+		CrossServicePackages: []string{"svc/a/", "svc/b/"},
+		ChangedPackages:      []string{"svc/a/"},
+		DependencyPackages:   []string{"svc/b/"},
+	})
+	if !strings.Contains(out, crossServiceMarker) {
+		t.Errorf("expected cross-service clause with ChangedPackages set")
+	}
+	if !strings.Contains(out, "primarily modifies") {
+		t.Errorf("expected caller/callee framing with 'primarily modifies'")
+	}
+	if !strings.Contains(out, "svc/a/") {
+		t.Errorf("changed package svc/a/ missing from output")
+	}
+	if !strings.Contains(out, "callers or dependencies") {
+		t.Errorf("expected 'callers or dependencies' framing in output")
+	}
+	if !strings.Contains(out, "svc/b/") {
+		t.Errorf("dependency package svc/b/ missing from output")
+	}
+}
+
+func TestBuildJSONPromptWithScope_CallerCalleeFallsBackToGenericWhenNoDeps(t *testing.T) {
+	// ChangedPackages set but no DependencyPackages: clause still emits
+	// with the primary-modifies line but no callers/dependencies line.
+	out := BuildJSONPromptWithScope("g", PromptOptions{
+		ChangedPackages: []string{"svc/a/"},
+	})
+	if !strings.Contains(out, crossServiceMarker) {
+		t.Errorf("expected cross-service clause with ChangedPackages set")
+	}
+	if !strings.Contains(out, "primarily modifies") {
+		t.Errorf("expected 'primarily modifies' framing")
+	}
+	if strings.Contains(out, "callers or dependencies") {
+		t.Errorf("expected no callers/dependencies line when DependencyPackages is empty")
+	}
+}
+
+func TestBuildJSONPromptWithScope_GenericFallbackWhenNoChangedPackages(t *testing.T) {
+	// Without ChangedPackages the generic framing should be used (v1 compat).
+	out := BuildJSONPromptWithScope("g", PromptOptions{
+		CrossServicePackages: []string{"svc/a/", "svc/b/"},
+	})
+	if !strings.Contains(out, crossServiceMarker) {
+		t.Errorf("expected cross-service clause")
+	}
+	if strings.Contains(out, "primarily modifies") {
+		t.Errorf("generic framing must not use 'primarily modifies'")
+	}
+	if !strings.Contains(out, "touches multiple top-level packages") {
+		t.Errorf("expected generic 'touches multiple top-level packages' framing")
+	}
+}
+
 // TestLegacyJSONPromptGolden pins today's BuildJSONPrompt output byte-for-
 // byte. Drift is most likely to creep in when someone edits the base prompt
 // or the JSON output rules without realizing yoloswe/swe.go and any

--- a/yoloswe/reviewer/scope_hints.go
+++ b/yoloswe/reviewer/scope_hints.go
@@ -11,14 +11,19 @@ import (
 )
 
 // ScopeHintsSchemaVersion is the wire-format version of the scope-hints
-// JSON file consumed by `bramble code-review --scope-hints-file`. A version
-// bump only happens on a breaking shape change; new optional fields can be
-// added without a bump.
+// JSON file consumed by `bramble code-review --scope-hints-file`. Bump
+// when the loader needs to distinguish shapes — i.e. when a new field
+// changes the prompt-building path on the reviewer side, so old producers
+// shouldn't accidentally activate it. Pure additions that don't reroute
+// existing inputs (a new optional field that no clause reads) can land
+// without a bump.
 //
-// v1: original shape (cross_service_packages only)
-// v2: adds changed_packages and dependency_packages; cross_service_packages
+// v1: original shape (cross_service_packages only).
+// v2: adds changed_packages and dependency_packages, which select the
 //
-//	is kept for backwards compat (union of both new fields).
+//	caller/callee framing in buildScopeSuffix. cross_service_packages is
+//	still accepted (union of both new fields) so v1 producers keep
+//	working through a rolling upgrade.
 const ScopeHintsSchemaVersion = 2
 
 // scopeHintsMaxBytes caps the size of a scope-hints file LoadScopeHints will

--- a/yoloswe/reviewer/scope_hints.go
+++ b/yoloswe/reviewer/scope_hints.go
@@ -50,8 +50,9 @@ type ScopeHints struct {
 	CrossServicePackages []string `json:"cross_service_packages"`
 
 	// ChangedPackages names the top-level packages directly modified by
-	// this diff (v2+). When non-empty alongside DependencyPackages, the
-	// cross-service clause uses explicit caller/callee framing.
+	// this diff (v2+). When non-empty, the cross-service clause uses
+	// explicit caller/callee framing — DependencyPackages is optional and
+	// gates only the "callers or dependencies" sentence.
 	ChangedPackages []string `json:"changed_packages,omitempty"`
 
 	// DependencyPackages names packages that import or are imported by the
@@ -60,10 +61,12 @@ type ScopeHints struct {
 	// each interface.
 	DependencyPackages []string `json:"dependency_packages,omitempty"`
 
-	// SchemaVersion must equal ScopeHintsSchemaVersion. LoadScopeHints
-	// accepts v1 (no split fields) and v2 (split fields present) to
-	// allow a rolling upgrade: old scope_gate.py output keeps working
-	// while callers adopt the new shape.
+	// SchemaVersion must be 1 or ScopeHintsSchemaVersion (currently 2).
+	// LoadScopeHints accepts both to allow a rolling upgrade: old
+	// scope_gate.py output (v1, no split fields) keeps working while
+	// callers adopt the v2 shape (split fields present). Anything else
+	// is rejected loudly so a future breaking change is caught rather
+	// than silently producing a degenerate prompt.
 	SchemaVersion int `json:"schema_version"`
 }
 

--- a/yoloswe/reviewer/scope_hints.go
+++ b/yoloswe/reviewer/scope_hints.go
@@ -192,10 +192,14 @@ func sanitizedFSError(op, tag string, err error) error {
 // reject at the prompt-builder boundary. The clauses inline these strings
 // line-by-line under fixed Markdown headings, so a hint containing a
 // newline could close "## Test quality" early, and a leading Markdown
-// control character (#, -, *, >, _, =) could open a new section or list
-// at line start. scope_gate.py emits filesystem paths and package buckets,
-// neither of which exhibits these shapes — so this is a defense against a
-// buggy or hostile producer, not a normal input.
+// control character (#, -, *, +, >, =) or an ordered-list marker (e.g.
+// "1." / "12)") could open a new section or list at line start.
+// Underscore is intentionally allowed — TS/JS __tests__/ paths and
+// Python _helper.py paths are legitimate scope-hint inputs (see the
+// SanitizePromptHint godoc for the rationale). scope_gate.py emits
+// filesystem paths and package buckets, neither of which exhibits the
+// rejected shapes — so this is a defense against a buggy or hostile
+// producer, not a normal input.
 //
 // Failing here gives the operator a clear CLI warning ("test_paths[3]
 // starts with Markdown control char '#'") that points straight at the

--- a/yoloswe/reviewer/scope_hints.go
+++ b/yoloswe/reviewer/scope_hints.go
@@ -14,7 +14,12 @@ import (
 // JSON file consumed by `bramble code-review --scope-hints-file`. A version
 // bump only happens on a breaking shape change; new optional fields can be
 // added without a bump.
-const ScopeHintsSchemaVersion = 1
+//
+// v1: original shape (cross_service_packages only)
+// v2: adds changed_packages and dependency_packages; cross_service_packages
+//
+//	is kept for backwards compat (union of both new fields).
+const ScopeHintsSchemaVersion = 2
 
 // scopeHintsMaxBytes caps the size of a scope-hints file LoadScopeHints will
 // read. The expected on-disk shape is small (test_paths capped at 50 entries
@@ -38,14 +43,27 @@ type ScopeHints struct {
 	// clause is appended to the prompt.
 	TestPaths []string `json:"test_paths"`
 
-	// CrossServicePackages names the top-level packages the PR touches.
-	// When it has at least two entries, the cross-service contract-sweep
-	// clause is appended.
+	// CrossServicePackages names all top-level packages the PR touches
+	// (union of ChangedPackages and DependencyPackages). Kept for
+	// backwards compatibility with v1 consumers; v2 files populate this
+	// alongside the split fields.
 	CrossServicePackages []string `json:"cross_service_packages"`
 
+	// ChangedPackages names the top-level packages directly modified by
+	// this diff (v2+). When non-empty alongside DependencyPackages, the
+	// cross-service clause uses explicit caller/callee framing.
+	ChangedPackages []string `json:"changed_packages,omitempty"`
+
+	// DependencyPackages names packages that import or are imported by the
+	// changed packages — the callers/callees to check for contract drift
+	// (v2+). The cross-service clause flags these as the "other side" of
+	// each interface.
+	DependencyPackages []string `json:"dependency_packages,omitempty"`
+
 	// SchemaVersion must equal ScopeHintsSchemaVersion. LoadScopeHints
-	// rejects any other value to make incompatible upgrades fail loudly
-	// instead of silently producing a degenerate prompt.
+	// accepts v1 (no split fields) and v2 (split fields present) to
+	// allow a rolling upgrade: old scope_gate.py output keeps working
+	// while callers adopt the new shape.
 	SchemaVersion int `json:"schema_version"`
 }
 
@@ -113,7 +131,11 @@ func LoadScopeHints(path string) (*ScopeHints, error) {
 	if err := json.Unmarshal(data, &h); err != nil {
 		return nil, fmt.Errorf("parse scope-hints file %s: %w", tag, err)
 	}
-	if h.SchemaVersion != ScopeHintsSchemaVersion {
+	// Accept v1 (original shape) and v2 (adds changed_packages /
+	// dependency_packages). Reject anything else loudly so a future
+	// breaking change is caught rather than silently producing a
+	// degenerate prompt.
+	if h.SchemaVersion != 1 && h.SchemaVersion != ScopeHintsSchemaVersion {
 		return nil, fmt.Errorf(
 			"scope-hints file %s: schema_version=%d, want %d",
 			tag, h.SchemaVersion, ScopeHintsSchemaVersion,
@@ -123,6 +145,12 @@ func LoadScopeHints(path string) (*ScopeHints, error) {
 		return nil, err
 	}
 	if err := validateHintStrings(tag, h.CrossServicePackages, "cross_service_packages"); err != nil {
+		return nil, err
+	}
+	if err := validateHintStrings(tag, h.ChangedPackages, "changed_packages"); err != nil {
+		return nil, err
+	}
+	if err := validateHintStrings(tag, h.DependencyPackages, "dependency_packages"); err != nil {
 		return nil, err
 	}
 	return &h, nil
@@ -206,5 +234,7 @@ func (h *ScopeHints) ToPromptOptions(skipTestExecution bool) PromptOptions {
 	}
 	opts.TestScopeHints = h.TestPaths
 	opts.CrossServicePackages = h.CrossServicePackages
+	opts.ChangedPackages = h.ChangedPackages
+	opts.DependencyPackages = h.DependencyPackages
 	return opts
 }

--- a/yoloswe/reviewer/scope_hints.go
+++ b/yoloswe/reviewer/scope_hints.go
@@ -137,7 +137,7 @@ func LoadScopeHints(path string) (*ScopeHints, error) {
 	// degenerate prompt.
 	if h.SchemaVersion != 1 && h.SchemaVersion != ScopeHintsSchemaVersion {
 		return nil, fmt.Errorf(
-			"scope-hints file %s: schema_version=%d, want %d",
+			"scope-hints file %s: schema_version=%d, want 1 or %d",
 			tag, h.SchemaVersion, ScopeHintsSchemaVersion,
 		)
 	}

--- a/yoloswe/reviewer/scope_hints_test.go
+++ b/yoloswe/reviewer/scope_hints_test.go
@@ -185,8 +185,8 @@ func TestLoadScopeHints_SchemaVersionMismatch(t *testing.T) {
 	if !strings.Contains(err.Error(), "schema_version=3") {
 		t.Errorf("error should include observed version: %v", err)
 	}
-	if !strings.Contains(err.Error(), "want 2") {
-		t.Errorf("error should include expected version: %v", err)
+	if !strings.Contains(err.Error(), "want 1 or 2") {
+		t.Errorf("error should include accepted versions: %v", err)
 	}
 }
 

--- a/yoloswe/reviewer/scope_hints_test.go
+++ b/yoloswe/reviewer/scope_hints_test.go
@@ -27,7 +27,8 @@ func writeHintsFile(t *testing.T, contents string) string {
 	return path
 }
 
-func TestLoadScopeHints_Valid(t *testing.T) {
+func TestLoadScopeHints_ValidV1(t *testing.T) {
+	// v1 files (schema_version=1) must still load for backwards compat.
 	path := writeHintsFile(t, `{
 		"schema_version": 1,
 		"test_paths": ["a/test_x.py", "b/test_y.go"],
@@ -45,6 +46,30 @@ func TestLoadScopeHints_Valid(t *testing.T) {
 	}
 	if len(h.CrossServicePackages) != 2 || h.CrossServicePackages[1] != "svc/b/" {
 		t.Errorf("CrossServicePackages = %v", h.CrossServicePackages)
+	}
+}
+
+func TestLoadScopeHints_ValidV2(t *testing.T) {
+	// v2 files include changed_packages and dependency_packages.
+	path := writeHintsFile(t, `{
+		"schema_version": 2,
+		"test_paths": ["a/test_x.py"],
+		"cross_service_packages": ["svc/a/", "svc/b/"],
+		"changed_packages": ["svc/a/"],
+		"dependency_packages": ["svc/b/"]
+	}`)
+	h, err := LoadScopeHints(path)
+	if err != nil {
+		t.Fatalf("unexpected error for v2 file: %v", err)
+	}
+	if h.SchemaVersion != 2 {
+		t.Errorf("SchemaVersion = %d, want 2", h.SchemaVersion)
+	}
+	if len(h.ChangedPackages) != 1 || h.ChangedPackages[0] != "svc/a/" {
+		t.Errorf("ChangedPackages = %v, want [svc/a/]", h.ChangedPackages)
+	}
+	if len(h.DependencyPackages) != 1 || h.DependencyPackages[0] != "svc/b/" {
+		t.Errorf("DependencyPackages = %v, want [svc/b/]", h.DependencyPackages)
 	}
 }
 
@@ -149,19 +174,18 @@ func TestLoadScopeHints_MalformedJSON(t *testing.T) {
 }
 
 func TestLoadScopeHints_SchemaVersionMismatch(t *testing.T) {
-	// A future caller writing schema_version=2 must fail loudly here, not
-	// silently succeed with a degenerate prompt. The CLI layer treats this
-	// as a "log warning, fall back to narrow review" — the reviewer never
-	// reads a future-shape file.
-	path := writeHintsFile(t, `{"schema_version": 2, "test_paths": [], "cross_service_packages": []}`)
+	// A future caller writing schema_version=3 must fail loudly — the
+	// reviewer never reads a future-shape file it doesn't understand.
+	// schema_version=1 and schema_version=2 are both accepted.
+	path := writeHintsFile(t, `{"schema_version": 3, "test_paths": [], "cross_service_packages": []}`)
 	_, err := LoadScopeHints(path)
 	if err == nil {
-		t.Fatal("expected error for schema_version=2")
+		t.Fatal("expected error for schema_version=3")
 	}
-	if !strings.Contains(err.Error(), "schema_version=2") {
+	if !strings.Contains(err.Error(), "schema_version=3") {
 		t.Errorf("error should include observed version: %v", err)
 	}
-	if !strings.Contains(err.Error(), "want 1") {
+	if !strings.Contains(err.Error(), "want 2") {
 		t.Errorf("error should include expected version: %v", err)
 	}
 }
@@ -372,6 +396,25 @@ func TestLoadScopeHints_RejectsEmptyString(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty") {
 		t.Errorf("error should mention empty: %v", err)
+	}
+}
+
+func TestScopeHints_ToPromptOptions_V2Fields(t *testing.T) {
+	// v2 hints must pass ChangedPackages and DependencyPackages through to
+	// PromptOptions so the prompt builder can use caller/callee framing.
+	h := &ScopeHints{
+		SchemaVersion:        2,
+		TestPaths:            []string{"a/test_x.py"},
+		CrossServicePackages: []string{"svc/a/", "svc/b/"},
+		ChangedPackages:      []string{"svc/a/"},
+		DependencyPackages:   []string{"svc/b/"},
+	}
+	opts := h.ToPromptOptions(false)
+	if len(opts.ChangedPackages) != 1 || opts.ChangedPackages[0] != "svc/a/" {
+		t.Errorf("ChangedPackages = %v, want [svc/a/]", opts.ChangedPackages)
+	}
+	if len(opts.DependencyPackages) != 1 || opts.DependencyPackages[0] != "svc/b/" {
+		t.Errorf("DependencyPackages = %v, want [svc/b/]", opts.DependencyPackages)
 	}
 }
 

--- a/yoloswe/reviewer/testdata/legacy_json_prompt.txt
+++ b/yoloswe/reviewer/testdata/legacy_json_prompt.txt
@@ -41,5 +41,5 @@ You MUST respond with valid JSON in this exact format:
 - If there are any critical or high severity issues, verdict MUST be "rejected"
 - issues array can be empty if verdict is "accepted"
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
-- confidence is a float in (0.0, 1.0]: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified); omit when certain or when you can't assess
+- confidence is an optional float in (0.0, 1.0]: 1.0 = certain, 0.5 = plausible but unverified; omit only when you cannot assess (the field is treated as "no signal", not as a default value)
 - Output ONLY the JSON object, no other text

--- a/yoloswe/reviewer/testdata/legacy_json_prompt.txt
+++ b/yoloswe/reviewer/testdata/legacy_json_prompt.txt
@@ -24,7 +24,8 @@ You MUST respond with valid JSON in this exact format:
       "file": "path/to/file.go",
       "line": 42,
       "message": "Description of the issue",
-      "suggestion": "How to fix it"
+      "suggestion": "How to fix it",
+      "confidence": 0.9
     }
   ]
 }
@@ -40,4 +41,5 @@ You MUST respond with valid JSON in this exact format:
 - If there are any critical or high severity issues, verdict MUST be "rejected"
 - issues array can be empty if verdict is "accepted"
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
+- confidence is a float 0.0–1.0: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified, 0.0 = speculative); omit or set to 1.0 if certain
 - Output ONLY the JSON object, no other text

--- a/yoloswe/reviewer/testdata/legacy_json_prompt.txt
+++ b/yoloswe/reviewer/testdata/legacy_json_prompt.txt
@@ -41,5 +41,5 @@ You MUST respond with valid JSON in this exact format:
 - If there are any critical or high severity issues, verdict MUST be "rejected"
 - issues array can be empty if verdict is "accepted"
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
-- confidence is a float 0.0–1.0: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified, 0.0 = speculative); omit or set to 1.0 if certain
+- confidence is a float in (0.0, 1.0]: reviewer's confidence in this finding (1.0 = certain, 0.5 = plausible but unverified); omit when certain or when you can't assess
 - Output ONLY the JSON object, no other text

--- a/yoloswe/swe.go
+++ b/yoloswe/swe.go
@@ -126,12 +126,18 @@ type Stats struct {
 }
 
 // ReviewIssue represents a single issue found during review.
+//
+// Confidence mirrors reviewer.ReviewIssue.Confidence: an optional value in
+// (0.0, 1.0] the reviewer assigns when it can; nil means "no signal". Kept
+// in sync so the JSON the reviewer emits doesn't get silently truncated on
+// the builder-feedback path.
 type ReviewIssue struct {
-	Severity   string `json:"severity"`
-	File       string `json:"file"`
-	Message    string `json:"message"`
-	Suggestion string `json:"suggestion,omitempty"`
-	Line       int    `json:"line,omitempty"`
+	Confidence *float64 `json:"confidence,omitempty"`
+	Severity   string   `json:"severity"`
+	File       string   `json:"file"`
+	Message    string   `json:"message"`
+	Suggestion string   `json:"suggestion,omitempty"`
+	Line       int      `json:"line,omitempty"`
 }
 
 // ReviewVerdictJSON is the JSON structure returned by the reviewer.
@@ -577,6 +583,9 @@ func formatFeedback(result ReviewVerdictJSON) string {
 			if issue.Line > 0 {
 				sb.WriteString(fmt.Sprintf(":%d", issue.Line))
 			}
+		}
+		if issue.Confidence != nil {
+			sb.WriteString(fmt.Sprintf("\n   Confidence: %.2f", *issue.Confidence))
 		}
 		if issue.Suggestion != "" {
 			sb.WriteString(fmt.Sprintf("\n   Suggestion: %s", issue.Suggestion))

--- a/yoloswe/swe.go
+++ b/yoloswe/swe.go
@@ -419,6 +419,14 @@ func (s *SWEWrapper) parseVerdict(text string) *ReviewVerdict {
 		}
 	}
 
+	// Note: parseVerdict is deliberately lenient — its job is best-effort
+	// extraction of a verdict + feedback for the builder, even when the JSON
+	// is missing fields the strict envelope schema requires (line numbers,
+	// confidence range, etc.). reviewer.ValidateReviewJSON is available for
+	// callers that need strict semantics. Tightening this path would reject
+	// imperfect-but-actionable reviewer output and starve the builder of
+	// guidance, so the trade-off is intentional.
+
 	// Trim whitespace from verdict for robust comparison
 	verdict := strings.TrimSpace(result.Verdict)
 	accepted := strings.EqualFold(verdict, "accepted")

--- a/yoloswe/swe_test.go
+++ b/yoloswe/swe_test.go
@@ -217,6 +217,39 @@ func TestParseVerdict(t *testing.T) {
 	}
 }
 
+func TestParseVerdict_PreservesConfidence(t *testing.T) {
+	// Guard against the confidence field being silently stripped on the
+	// SWE feedback path: parseVerdict → ReviewVerdictJSON.Issues should
+	// preserve the *float64 confidence end-to-end.
+	swe := New(Config{})
+	text := `{"verdict": "rejected", "summary": "found one", "issues": [{"severity":"high","file":"a.go","line":1,"message":"bug","confidence":0.85}]}`
+	verdict := swe.parseVerdict(text)
+	if len(verdict.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(verdict.Issues))
+	}
+	if verdict.Issues[0].Confidence == nil {
+		t.Fatal("Confidence was dropped during parse")
+	}
+	if got := *verdict.Issues[0].Confidence; got != 0.85 {
+		t.Errorf("Confidence = %v, want 0.85", got)
+	}
+}
+
+func TestParseVerdict_ConfidenceOmittedStaysNil(t *testing.T) {
+	// An issue without a confidence field should keep Confidence as nil
+	// (no synthetic default) so callers can distinguish "no signal" from
+	// "low confidence".
+	swe := New(Config{})
+	text := `{"verdict": "rejected", "summary": "found one", "issues": [{"severity":"high","file":"a.go","line":1,"message":"bug"}]}`
+	verdict := swe.parseVerdict(text)
+	if len(verdict.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(verdict.Issues))
+	}
+	if verdict.Issues[0].Confidence != nil {
+		t.Errorf("Confidence = %v, want nil for omitted field", *verdict.Issues[0].Confidence)
+	}
+}
+
 func TestExtractJSON(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/yoloswe/swe_test.go
+++ b/yoloswe/swe_test.go
@@ -341,6 +341,26 @@ func TestFormatFeedback(t *testing.T) {
 			},
 			shouldMatch: []string{"Multiple issues", "[CRITICAL]", "SQL injection", "[MEDIUM]", "Unused variable"},
 		},
+		{
+			name: "issue with confidence",
+			verdict: ReviewVerdictJSON{
+				Summary: "Maybe an issue",
+				Issues: []ReviewIssue{
+					{Severity: "low", File: "x.go", Line: 1, Message: "perhaps", Confidence: floatPtr(0.7)},
+				},
+			},
+			shouldMatch: []string{"perhaps", "Confidence: 0.70"},
+		},
+		{
+			name: "issue without confidence (omitted)",
+			verdict: ReviewVerdictJSON{
+				Summary: "Sure thing",
+				Issues: []ReviewIssue{
+					{Severity: "low", File: "x.go", Line: 1, Message: "definitely"},
+				},
+			},
+			shouldMatch: []string{"definitely"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1001,3 +1021,5 @@ func TestFormatFeedbackEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func floatPtr(f float64) *float64 { return &f }


### PR DESCRIPTION
## Summary

Two prompt system improvements to the bramble code-review reviewer:

**Task 1 — Per-issue confidence field**
- `ReviewIssue` gets a `Confidence float64` (`json:"confidence,omitempty"`) field; omitted = 1.0 for backwards compat with existing envelopes
- JSON schema in `BuildJSONPromptWithScope` updated with example and rule: `1.0 = certain, 0.5 = plausible but unverified, 0.0 = speculative`
- Golden file updated; `compare-r1-r2.py` shows `conf=X.XX` in match label when confidence < 1.0

**Task 2 — Caller/callee anchor for cross-service clause**
- `ScopeHintsSchemaVersion` bumped to 2; `LoadScopeHints` accepts both v1 (old) and v2 (new split fields)
- `ScopeHints` gains `ChangedPackages` + `DependencyPackages` (both `omitempty`); `cross_service_packages` kept for backwards compat
- `PromptOptions` gains the same two fields; `ToPromptOptions` passes them through
- `crossServiceClause` dispatches to explicit caller/callee framing when `ChangedPackages` is set, falls back to generic flat-list for v1 hints:
  ```
  The diff primarily modifies: {changed_packages}.
  The following packages are callers or dependencies — check whether the interface
  contract ... changed on the modified side without a matching update on these sides: {dep_packages}.
  ```
- `scope_gate.py`: bumps `SCHEMA_VERSION` to 2, adds `split_changed_dependency_packages()` (dominant-file-count heuristic to classify changed vs dependency buckets), emits `changed_packages` + `dependency_packages` alongside `cross_service_packages`

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `bazel test //yoloswe/reviewer/... --test_timeout=60` — all pass
- [x] New tests: `TestLoadScopeHints_ValidV1` (v1 backwards compat), `TestLoadScopeHints_ValidV2`, `TestScopeHints_ToPromptOptions_V2Fields`, `TestBuildJSONPromptWithScope_CallerCalleeFraming`, `TestBuildJSONPromptWithScope_CallerCalleeFallsBackToGenericWhenNoDeps`, `TestBuildJSONPromptWithScope_GenericFallbackWhenNoChangedPackages`
- [x] `python3 -m py_compile` passes on `scope_gate.py` and `compare-r1-r2.py`
- [x] `ScopeHintsSchemaVersion` mismatch test updated: v3 still fails loudly, v2 now accepted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reviewer JSON/prompt contract and adds new schema validation, which could break downstream consumers that assume the older shape or don’t tolerate stricter validation. Scope-hints schema v2 is backward-compatible (v1 still accepted), but prompt text/routing changes may affect automation expectations.
> 
> **Overview**
> Adds an optional per-issue `confidence` field to the reviewer JSON contract (prompt example + parsing), preserves it through `BuildEnvelope`/`yoloswe` feedback, and enforces it via schema validation (finite, in (0.0, 1.0]); omitted stays nil). Also exports `ValidateReviewJSON` so non-envelope callers can apply the same strict schema checks.
> 
> Updates scope-hints to schema v2 by adding `changed_packages` and `dependency_packages`, wiring them through `ScopeHints`→`PromptOptions`, and switching the cross-service prompt clause to a more explicit caller/callee framing (with fallback to the legacy flat list for v1/invalid-sanitized inputs). Tests and the legacy prompt golden are updated accordingly, including an end-to-end CLI seam test for v2 hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5fefe993d54d77b8616c91c3fa67684213f5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->