### PR TITLE
jiradozer: honor --config in config commands

### DIFF
--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -27,6 +27,10 @@ bazel-bin/jiradozer/cmd/jiradozer/jiradozer \
 
 Create a `jiradozer.yaml` in your working directory:
 
+```bash
+jiradozer bootstrap
+```
+
 ```yaml
 tracker:
   kind: linear
@@ -63,6 +67,17 @@ states:
 ```
 
 The `states` section maps logical workflow states to your tracker's state names. Jiradozer uses these to transition the issue as it moves through the workflow.
+
+You can keep multiple configs in the same directory by selecting the path
+with `--config`. `bootstrap` writes to `--config` by default; `--output`
+is still supported when you want to write somewhere else.
+
+```bash
+jiradozer bootstrap --config jiradozer.linear.yaml
+jiradozer bootstrap --config jiradozer.github.yaml
+jiradozer validate-config --config jiradozer.linear.yaml
+jiradozer run --config jiradozer.github.yaml --issue owner/repo#42
+```
 
 ### Step configuration
 

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -18,15 +18,19 @@ type bootstrapArgs struct {
 	force  bool
 }
 
-func newBootstrapCommand(args *bootstrapArgs) *cobra.Command {
+func newBootstrapCommand(args *bootstrapArgs, configPath *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
-		Short: "Generate a starter jiradozer.yaml",
-		Long: `Write a jiradozer.yaml seeded with the canonical step prompts and
-comment templates. Edit the prompts to taste; the generated file is the
-source of truth for what the agent says.`,
+		Short: "Generate a starter config file",
+		Long: `Write a starter config file seeded with the canonical step prompts and
+comment templates. By default bootstrap writes to --config; use --output
+to write somewhere else. Edit the prompts to taste; the generated file is
+the source of truth for what the agent says.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			path := args.output
+			if path == "" {
+				path = *configPath
+			}
 			if path == "" {
 				path = "jiradozer.yaml"
 			}
@@ -47,7 +51,7 @@ source of truth for what the agent says.`,
 		},
 	}
 	cmd.SilenceUsage = true
-	cmd.Flags().StringVarP(&args.output, "output", "o", "jiradozer.yaml", "Path to write the starter config")
+	cmd.Flags().StringVarP(&args.output, "output", "o", "", "Path to write the starter config; overrides --config")
 	cmd.Flags().BoolVarP(&args.force, "force", "f", false, "Overwrite the output file if it already exists")
 	return cmd
 }

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -237,8 +237,8 @@ func TestBootstrapForceOverwrites(t *testing.T) {
 	assert.Contains(t, string(got), "jiradozer bootstrap")
 }
 
-// TestBootstrapDefaultPath verifies direct bootstrap invocation still writes
-// jiradozer.yaml when neither --config nor --output is set by a root command.
+// TestBootstrapDefaultPath verifies standalone bootstrap invocation writes to
+// the configured default path when no output override is supplied.
 func TestBootstrapDefaultPath(t *testing.T) {
 	t.Setenv("LINEAR_API_KEY", "test")
 

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -203,7 +203,8 @@ func TestBootstrapRefusesExistingFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("# pre-existing\n"), 0o644))
 
 	args := &bootstrapArgs{}
-	cmd := newBootstrapCommand(args)
+	configPath := "jiradozer.yaml"
+	cmd := newBootstrapCommand(args, &configPath)
 	cmd.SetArgs([]string{"--output", path})
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -225,12 +226,31 @@ func TestBootstrapForceOverwrites(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("# pre-existing\n"), 0o644))
 
 	args := &bootstrapArgs{}
-	cmd := newBootstrapCommand(args)
+	configPath := "jiradozer.yaml"
+	cmd := newBootstrapCommand(args, &configPath)
 	cmd.SetArgs([]string{"--output", path, "--force"})
 	require.NoError(t, cmd.Execute())
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.NotEqual(t, "# pre-existing\n", string(got))
+	assert.Contains(t, string(got), "jiradozer bootstrap")
+}
+
+// TestBootstrapDefaultPath verifies direct bootstrap invocation still writes
+// jiradozer.yaml when neither --config nor --output is set by a root command.
+func TestBootstrapDefaultPath(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "test")
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	args := &bootstrapArgs{}
+	configPath := "jiradozer.yaml"
+	cmd := newBootstrapCommand(args, &configPath)
+	require.NoError(t, cmd.Execute())
+
+	got, err := os.ReadFile(filepath.Join(dir, "jiradozer.yaml"))
+	require.NoError(t, err)
 	assert.Contains(t, string(got), "jiradozer bootstrap")
 }

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -47,7 +47,7 @@ func newRootCommand(opts *cliapp.Options) *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&rargs.configPath, "config", "jiradozer.yaml", "Path to config file")
 
 	runCmd := newRunCommand(&rargs)
-	bootstrapCmd := newBootstrapCommand(&bargs)
+	bootstrapCmd := newBootstrapCommand(&bargs, &rargs.configPath)
 	validateConfigCmd := newValidateConfigCommand(&rargs.configPath)
 
 	rootCmd.AddCommand(runCmd, bootstrapCmd, validateConfigCmd)

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -255,5 +258,114 @@ func TestBuildChildArgsOrdering(t *testing.T) {
 		require.NotEqualf(t, -1, idx, "argv must contain run-only flag %s; got %v", flag, got)
 		assert.Greaterf(t, idx, runIdx,
 			"run-only flag %s must appear after `run` (got argv: %v)", flag, got)
+	}
+}
+
+func TestBootstrapUsesConfigPathFromRoot(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "test")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "config before bootstrap",
+			args: []string{"--config", "custom.yaml", "bootstrap"},
+		},
+		{
+			name: "config after bootstrap",
+			args: []string{"bootstrap", "--config", "custom.yaml"},
+		},
+		{
+			name: "output overrides config",
+			args: []string{"bootstrap", "--config", "config.yaml", "--output", "output.yaml"},
+		},
+		{
+			name: "output still works without config",
+			args: []string{"bootstrap", "--output", "output.yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			args := append([]string{}, tt.args...)
+			for i, arg := range args {
+				if filepath.Ext(arg) == ".yaml" {
+					args[i] = filepath.Join(dir, arg)
+				}
+			}
+
+			cmd := newRootCommand(&cliapp.Options{ToolName: "jiradozer"})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs(args)
+			require.NoError(t, cmd.Execute())
+
+			wantFile := "custom.yaml"
+			if containsArg(tt.args, "output.yaml") {
+				wantFile = "output.yaml"
+			}
+			got, err := os.ReadFile(filepath.Join(dir, wantFile))
+			require.NoError(t, err)
+			assert.Contains(t, string(got), "jiradozer bootstrap")
+
+			if wantFile == "output.yaml" {
+				_, err := os.Stat(filepath.Join(dir, "config.yaml"))
+				assert.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateConfigUsesConfigPathFromRoot(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "test")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "config before validate-config",
+			args: []string{"--config", "custom.yaml", "validate-config"},
+		},
+		{
+			name: "config after validate-config",
+			args: []string{"validate-config", "--config", "custom.yaml"},
+		},
+	}
+
+	content, err := bootstrapYAML()
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "custom.yaml")
+			require.NoError(t, os.WriteFile(configPath, content, 0o644))
+
+			args := append([]string{}, tt.args...)
+			for i, arg := range args {
+				if arg == "custom.yaml" {
+					args[i] = configPath
+				}
+			}
+
+			cmd := newRootCommand(&cliapp.Options{ToolName: "jiradozer"})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs(args)
+			require.NoError(t, cmd.Execute())
+			assert.Contains(t, out.String(), "ok: "+configPath)
+		})
 	}
 }

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -265,66 +264,53 @@ func TestBootstrapUsesConfigPathFromRoot(t *testing.T) {
 	t.Setenv("LINEAR_API_KEY", "test")
 
 	tests := []struct {
-		name string
-		args []string
+		name     string
+		wantFile string
+		args     []string
 	}{
 		{
-			name: "config before bootstrap",
-			args: []string{"--config", "custom.yaml", "bootstrap"},
+			name:     "config before bootstrap",
+			wantFile: "custom.yaml",
+			args:     []string{"--config", "custom.yaml", "bootstrap"},
 		},
 		{
-			name: "config after bootstrap",
-			args: []string{"bootstrap", "--config", "custom.yaml"},
+			name:     "config after bootstrap",
+			wantFile: "custom.yaml",
+			args:     []string{"bootstrap", "--config", "custom.yaml"},
 		},
 		{
-			name: "output overrides config",
-			args: []string{"bootstrap", "--config", "config.yaml", "--output", "output.yaml"},
+			name:     "output overrides config",
+			wantFile: "output.yaml",
+			args:     []string{"bootstrap", "--config", "config.yaml", "--output", "output.yaml"},
 		},
 		{
-			name: "output still works without config",
-			args: []string{"bootstrap", "--output", "output.yaml"},
+			name:     "output still works without config",
+			wantFile: "output.yaml",
+			args:     []string{"bootstrap", "--output", "output.yaml"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			args := append([]string{}, tt.args...)
-			for i, arg := range args {
-				if filepath.Ext(arg) == ".yaml" {
-					args[i] = filepath.Join(dir, arg)
-				}
-			}
+			t.Chdir(dir)
 
 			cmd := newRootCommand(&cliapp.Options{ToolName: "jiradozer"})
 			var out bytes.Buffer
 			cmd.SetOut(&out)
-			cmd.SetArgs(args)
+			cmd.SetArgs(tt.args)
 			require.NoError(t, cmd.Execute())
 
-			wantFile := "custom.yaml"
-			if containsArg(tt.args, "output.yaml") {
-				wantFile = "output.yaml"
-			}
-			got, err := os.ReadFile(filepath.Join(dir, wantFile))
+			got, err := os.ReadFile(tt.wantFile)
 			require.NoError(t, err)
 			assert.Contains(t, string(got), "jiradozer bootstrap")
 
-			if wantFile == "output.yaml" {
-				_, err := os.Stat(filepath.Join(dir, "config.yaml"))
+			if tt.wantFile == "output.yaml" {
+				_, err := os.Stat("config.yaml")
 				assert.ErrorIs(t, err, os.ErrNotExist)
 			}
 		})
 	}
-}
-
-func containsArg(args []string, want string) bool {
-	for _, arg := range args {
-		if arg == want {
-			return true
-		}
-	}
-	return false
 }
 
 func TestValidateConfigUsesConfigPathFromRoot(t *testing.T) {
@@ -350,22 +336,15 @@ func TestValidateConfigUsesConfigPathFromRoot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			configPath := filepath.Join(dir, "custom.yaml")
-			require.NoError(t, os.WriteFile(configPath, content, 0o644))
-
-			args := append([]string{}, tt.args...)
-			for i, arg := range args {
-				if arg == "custom.yaml" {
-					args[i] = configPath
-				}
-			}
+			t.Chdir(dir)
+			require.NoError(t, os.WriteFile("custom.yaml", content, 0o644))
 
 			cmd := newRootCommand(&cliapp.Options{ToolName: "jiradozer"})
 			var out bytes.Buffer
 			cmd.SetOut(&out)
-			cmd.SetArgs(args)
+			cmd.SetArgs(tt.args)
 			require.NoError(t, cmd.Execute())
-			assert.Contains(t, out.String(), "ok: "+configPath)
+			assert.Contains(t, out.String(), "ok: custom.yaml")
 		})
 	}
 }

--- a/jiradozer/cmd/jiradozer/validate_config.go
+++ b/jiradozer/cmd/jiradozer/validate_config.go
@@ -11,8 +11,8 @@ import (
 func newValidateConfigCommand(configPath *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate-config",
-		Short: "Validate a jiradozer.yaml file",
-		Long:  "Load and validate the config file (default: jiradozer.yaml). Exits 0 if valid, non-zero with the error otherwise.",
+		Short: "Validate the selected config file",
+		Long:  "Load and validate the config file selected by --config (default: jiradozer.yaml). Exits 0 if valid, non-zero with the error otherwise.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			path := *configPath
 			if _, err := jiradozer.LoadConfig(path); err != nil {


### PR DESCRIPTION
## Summary
- Make `jiradozer bootstrap` honor the root `--config` path by default, so starter configs are generated at the same path later used by `validate-config` and `run`.
- Keep `bootstrap --output` as an explicit override and document its precedence over `--config`.
- Update `bootstrap` and `validate-config` help text to describe selected config files instead of implying only `jiradozer.yaml`.
- Document multi-config workflows in `jiradozer/README.md`, including separate Linear/GitHub config examples.
- Add command-level tests for root `--config` placement before and after subcommands, `--output` precedence, standalone bootstrap defaults, and `validate-config --config` behavior.

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

Note: the first full test run observed a transient `//bramble/session:session_test` failure in `TestManager_PrefixModelRoutesToCorrectProvider/composer-v9`; rerunning that target passed, and the subsequent full suite passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CLI flag/wiring and help-text updates with added tests; main behavior change is where `bootstrap` writes when `--output` isn’t provided.
> 
> **Overview**
> `bootstrap` now writes its starter config to the path selected by the root `--config` flag by default, with `--output` becoming an explicit override instead of always defaulting to `jiradozer.yaml`.
> 
> `validate-config` help text was updated to clarify it validates the `--config`-selected file, and new tests/docs were added to cover `--config` placement (before/after subcommands) and multi-config workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974cc1a86c30e12928a9f8e7f04e46e751b36ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
