### PR TITLE
Forward Claude tool results to Bramble sessions

### DIFF
--- a/agent-cli-wrapper/claude/render/events.go
+++ b/agent-cli-wrapper/claude/render/events.go
@@ -23,6 +23,9 @@ type EventHandler interface {
 	// The result may be nil if not captured; isError indicates failure.
 	OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool)
 
+	// OnToolResult is called when a tool result is emitted after completion.
+	OnToolResult(content interface{}, isError bool)
+
 	// OnTurnComplete is called when a conversation turn finishes.
 	OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64)
 
@@ -41,6 +44,7 @@ func (NoOpEventHandler) OnText(string)                                          
 func (NoOpEventHandler) OnThinking(string)                                                {}
 func (NoOpEventHandler) OnToolStart(string, string, map[string]interface{})               {}
 func (NoOpEventHandler) OnToolComplete(string, string, map[string]interface{}, any, bool) {}
+func (NoOpEventHandler) OnToolResult(any, bool)                                           {}
 func (NoOpEventHandler) OnTurnComplete(int, bool, int64, float64)                         {}
 func (NoOpEventHandler) OnStatus(string)                                                  {}
 func (NoOpEventHandler) OnError(error, string)                                            {}

--- a/agent-cli-wrapper/claude/render/events.go
+++ b/agent-cli-wrapper/claude/render/events.go
@@ -24,7 +24,7 @@ type EventHandler interface {
 	OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool)
 
 	// OnToolResult is called when a tool result is emitted after completion.
-	OnToolResult(content interface{}, isError bool)
+	OnToolResult(name, id string, content interface{}, isError bool)
 
 	// OnTurnComplete is called when a conversation turn finishes.
 	OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64)
@@ -44,7 +44,7 @@ func (NoOpEventHandler) OnText(string)                                          
 func (NoOpEventHandler) OnThinking(string)                                                {}
 func (NoOpEventHandler) OnToolStart(string, string, map[string]interface{})               {}
 func (NoOpEventHandler) OnToolComplete(string, string, map[string]interface{}, any, bool) {}
-func (NoOpEventHandler) OnToolResult(any, bool)                                           {}
+func (NoOpEventHandler) OnToolResult(string, string, any, bool)                           {}
 func (NoOpEventHandler) OnTurnComplete(int, bool, int64, float64)                         {}
 func (NoOpEventHandler) OnStatus(string)                                                  {}
 func (NoOpEventHandler) OnError(error, string)                                            {}

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -278,16 +278,34 @@ func (r *Renderer) ToolComplete(name string, input map[string]interface{}) {
 	r.lastToolID = ""
 }
 
-// ToolResult prints the result of a tool execution.
+// ToolResult prints the result of the most recently completed tool execution.
 func (r *Renderer) ToolResult(content interface{}, isError bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.eventHandler != nil {
-		r.eventHandler.OnToolResult(r.lastCompletedToolName, r.lastCompletedToolID, content, isError)
-	}
+	r.emitToolResult(r.lastCompletedToolName, r.lastCompletedToolID, content, isError)
 	r.lastCompletedToolName = ""
 	r.lastCompletedToolID = ""
+}
+
+// ToolResultForTool prints the result of the specified tool execution.
+func (r *Renderer) ToolResultForTool(name, id string, content interface{}, isError bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.emitToolResult(name, id, content, isError)
+	if r.lastCompletedToolID == id {
+		r.lastCompletedToolName = ""
+		r.lastCompletedToolID = ""
+	}
+}
+
+// emitToolResult emits the semantic event and terminal output for a tool result.
+// Must be called with mutex held.
+func (r *Renderer) emitToolResult(name, id string, content interface{}, isError bool) {
+	if r.eventHandler != nil {
+		r.eventHandler.OnToolResult(name, id, content, isError)
+	}
 
 	// Errors always shown (even in Quiet); success results at Verbose+
 	if !isError && r.verbosity < VerbosityVerbose {

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -284,12 +284,10 @@ func (r *Renderer) ToolResult(content interface{}, isError bool) {
 	defer r.mu.Unlock()
 
 	if r.eventHandler != nil {
-		r.eventHandler.OnToolResult(content, isError)
+		r.eventHandler.OnToolResult(r.lastCompletedToolName, r.lastCompletedToolID, content, isError)
 	}
-	if r.lastCompletedToolName != "" || r.lastCompletedToolID != "" {
-		r.lastCompletedToolName = ""
-		r.lastCompletedToolID = ""
-	}
+	r.lastCompletedToolName = ""
+	r.lastCompletedToolID = ""
 
 	// Errors always shown (even in Quiet); success results at Verbose+
 	if !isError && r.verbosity < VerbosityVerbose {

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -29,18 +29,20 @@ const (
 
 // Renderer handles terminal output with ANSI colors and verbosity control.
 type Renderer struct {
-	out          io.Writer
-	eventHandler EventHandler
-	commands     map[string]string
-	outputs      map[string]*strings.Builder
-	lastToolName string
-	lastToolID   string
-	textBuffer   strings.Builder
-	mu           sync.Mutex
-	verbosity    Verbosity
-	palette      Palette
-	inToolOutput bool
-	inReasoning  bool
+	out                   io.Writer
+	eventHandler          EventHandler
+	commands              map[string]string
+	outputs               map[string]*strings.Builder
+	lastToolName          string
+	lastToolID            string
+	lastCompletedToolName string
+	lastCompletedToolID   string
+	textBuffer            strings.Builder
+	mu                    sync.Mutex
+	verbosity             Verbosity
+	palette               Palette
+	inToolOutput          bool
+	inReasoning           bool
 }
 
 // Option configures a Renderer.
@@ -246,6 +248,9 @@ func (r *Renderer) ToolComplete(name string, input map[string]interface{}) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.lastCompletedToolName = name
+	r.lastCompletedToolID = r.lastToolID
+
 	// Don't print for interactive tools, but still notify the event handler.
 	if name == "AskUserQuestion" || name == "ExitPlanMode" {
 		r.inToolOutput = false
@@ -277,6 +282,14 @@ func (r *Renderer) ToolComplete(name string, input map[string]interface{}) {
 func (r *Renderer) ToolResult(content interface{}, isError bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	if r.eventHandler != nil {
+		r.eventHandler.OnToolResult(content, isError)
+	}
+	if r.lastCompletedToolName != "" || r.lastCompletedToolID != "" {
+		r.lastCompletedToolName = ""
+		r.lastCompletedToolID = ""
+	}
 
 	// Errors always shown (even in Quiet); success results at Verbose+
 	if !isError && r.verbosity < VerbosityVerbose {

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -231,6 +231,7 @@ func TestToolResultForTool_UsesExplicitToolIdentity(t *testing.T) {
 	})
 
 	r.ToolStart("Bash", "tool-2")
+	r.ToolComplete("Bash", map[string]interface{}{"command": "echo hi"})
 	r.ToolResultForTool("Read", "tool-1", "file contents", false)
 
 	if gotName != "Read" || gotID != "tool-1" {
@@ -238,6 +239,15 @@ func TestToolResultForTool_UsesExplicitToolIdentity(t *testing.T) {
 	}
 	if gotContent != "file contents" || gotIsError {
 		t.Errorf("OnToolResult got (%v, %v), want (%q, false)", gotContent, gotIsError, "file contents")
+	}
+
+	r.ToolResult("bash output", false)
+
+	if gotName != "Bash" || gotID != "tool-2" {
+		t.Errorf("fallback OnToolResult got tool (%q, %q), want (%q, %q)", gotName, gotID, "Bash", "tool-2")
+	}
+	if gotContent != "bash output" || gotIsError {
+		t.Errorf("fallback OnToolResult got (%v, %v), want (%q, false)", gotContent, gotIsError, "bash output")
 	}
 }
 

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -181,11 +181,89 @@ func TestToolResult_Success_VerboseOnly(t *testing.T) {
 	}
 }
 
+func TestToolResult_Success_NotifiesEventHandlerAtNormalVerbosity(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityNormal)
+	var gotContent interface{}
+	var gotIsError bool
+	var called bool
+	r.SetEventHandler(&testEventHandler{
+		onToolResult: func(content interface{}, isError bool) {
+			called = true
+			gotContent = content
+			gotIsError = isError
+		},
+	})
+
+	r.ToolResult("success output", false)
+
+	if buf.Len() != 0 {
+		t.Errorf("Normal mode should still suppress successful tool result output, got %q", buf.String())
+	}
+	if !called {
+		t.Fatal("EventHandler should receive successful tool result at normal verbosity")
+	}
+	if gotContent != "success output" || gotIsError {
+		t.Errorf("OnToolResult got (%v, %v), want (%q, false)", gotContent, gotIsError, "success output")
+	}
+}
+
+func TestToolResult_Error_NotifiesEventHandlerAtQuietVerbosity(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityQuiet)
+	var gotContent interface{}
+	var gotIsError bool
+	var called bool
+	r.SetEventHandler(&testEventHandler{
+		onToolResult: func(content interface{}, isError bool) {
+			called = true
+			gotContent = content
+			gotIsError = isError
+		},
+	})
+
+	r.ToolResult("something failed", true)
+
+	if !strings.Contains(buf.String(), "something failed") {
+		t.Errorf("Quiet mode should show error tool result, got %q", buf.String())
+	}
+	if !called {
+		t.Fatal("EventHandler should receive error tool result at quiet verbosity")
+	}
+	if gotContent != "something failed" || !gotIsError {
+		t.Errorf("OnToolResult got (%v, %v), want (%q, true)", gotContent, gotIsError, "something failed")
+	}
+}
+
 func TestToolResult_SkipsInternalErrors(t *testing.T) {
 	r, buf := newTestRenderer(VerbosityNormal)
 	r.ToolResult("Answer questions?", true)
 	if buf.Len() != 0 {
 		t.Errorf("Internal AskUserQuestion errors should be skipped, got %q", buf.String())
+	}
+}
+
+func TestToolResult_InternalErrorFilteringIsTerminalOnly(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityNormal)
+	var gotContent interface{}
+	var gotIsError bool
+	var called bool
+	r.SetEventHandler(&testEventHandler{
+		onToolResult: func(content interface{}, isError bool) {
+			called = true
+			gotContent = content
+			gotIsError = isError
+		},
+	})
+
+	r.ToolResult("Answer questions?", true)
+
+	if buf.Len() != 0 {
+		t.Errorf("Internal AskUserQuestion errors should be skipped in terminal output, got %q", buf.String())
+	}
+	if !called {
+		t.Fatal("EventHandler should receive internal tool result")
+	}
+	if gotContent != "Answer questions?" || !gotIsError {
+		t.Errorf("OnToolResult got (%v, %v), want (%q, true)", gotContent, gotIsError, "Answer questions?")
 	}
 }
 
@@ -433,6 +511,7 @@ type testEventHandler struct {
 	onText         func(string)
 	onToolStart    func(name, id string, input map[string]interface{})
 	onToolComplete func(name, id string, input map[string]interface{}, result interface{}, isError bool)
+	onToolResult   func(content interface{}, isError bool)
 	onStatus       func(string)
 }
 
@@ -451,6 +530,12 @@ func (h *testEventHandler) OnToolStart(name, id string, input map[string]interfa
 func (h *testEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	if h.onToolComplete != nil {
 		h.onToolComplete(name, id, input, result, isError)
+	}
+}
+
+func (h *testEventHandler) OnToolResult(content interface{}, isError bool) {
+	if h.onToolResult != nil {
+		h.onToolResult(content, isError)
 	}
 }
 

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -185,15 +185,21 @@ func TestToolResult_Success_NotifiesEventHandlerAtNormalVerbosity(t *testing.T) 
 	r, buf := newTestRenderer(VerbosityNormal)
 	var gotContent interface{}
 	var gotIsError bool
+	var gotName, gotID string
 	var called bool
 	r.SetEventHandler(&testEventHandler{
 		onToolResult: func(name, id string, content interface{}, isError bool) {
 			called = true
+			gotName = name
+			gotID = id
 			gotContent = content
 			gotIsError = isError
 		},
 	})
 
+	r.ToolStart("Read", "tool-1")
+	r.ToolComplete("Read", map[string]interface{}{"file_path": "/tmp/test.go"})
+	buf.Reset()
 	r.ToolResult("success output", false)
 
 	if buf.Len() != 0 {
@@ -202,8 +208,36 @@ func TestToolResult_Success_NotifiesEventHandlerAtNormalVerbosity(t *testing.T) 
 	if !called {
 		t.Fatal("EventHandler should receive successful tool result at normal verbosity")
 	}
+	if gotName != "Read" || gotID != "tool-1" {
+		t.Errorf("OnToolResult got tool (%q, %q), want (%q, %q)", gotName, gotID, "Read", "tool-1")
+	}
 	if gotContent != "success output" || gotIsError {
 		t.Errorf("OnToolResult got (%v, %v), want (%q, false)", gotContent, gotIsError, "success output")
+	}
+}
+
+func TestToolResultForTool_UsesExplicitToolIdentity(t *testing.T) {
+	r, _ := newTestRenderer(VerbosityNormal)
+	var gotName, gotID string
+	var gotContent interface{}
+	var gotIsError bool
+	r.SetEventHandler(&testEventHandler{
+		onToolResult: func(name, id string, content interface{}, isError bool) {
+			gotName = name
+			gotID = id
+			gotContent = content
+			gotIsError = isError
+		},
+	})
+
+	r.ToolStart("Bash", "tool-2")
+	r.ToolResultForTool("Read", "tool-1", "file contents", false)
+
+	if gotName != "Read" || gotID != "tool-1" {
+		t.Errorf("OnToolResult got tool (%q, %q), want (%q, %q)", gotName, gotID, "Read", "tool-1")
+	}
+	if gotContent != "file contents" || gotIsError {
+		t.Errorf("OnToolResult got (%v, %v), want (%q, false)", gotContent, gotIsError, "file contents")
 	}
 }
 

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -187,7 +187,7 @@ func TestToolResult_Success_NotifiesEventHandlerAtNormalVerbosity(t *testing.T) 
 	var gotIsError bool
 	var called bool
 	r.SetEventHandler(&testEventHandler{
-		onToolResult: func(content interface{}, isError bool) {
+		onToolResult: func(name, id string, content interface{}, isError bool) {
 			called = true
 			gotContent = content
 			gotIsError = isError
@@ -209,17 +209,22 @@ func TestToolResult_Success_NotifiesEventHandlerAtNormalVerbosity(t *testing.T) 
 
 func TestToolResult_Error_NotifiesEventHandlerAtQuietVerbosity(t *testing.T) {
 	r, buf := newTestRenderer(VerbosityQuiet)
+	var gotName, gotID string
 	var gotContent interface{}
 	var gotIsError bool
 	var called bool
 	r.SetEventHandler(&testEventHandler{
-		onToolResult: func(content interface{}, isError bool) {
+		onToolResult: func(name, id string, content interface{}, isError bool) {
 			called = true
+			gotName = name
+			gotID = id
 			gotContent = content
 			gotIsError = isError
 		},
 	})
 
+	r.ToolStart("Read", "tool-1")
+	r.ToolComplete("Read", map[string]interface{}{"file_path": "/tmp/test.go"})
 	r.ToolResult("something failed", true)
 
 	if !strings.Contains(buf.String(), "something failed") {
@@ -227,6 +232,9 @@ func TestToolResult_Error_NotifiesEventHandlerAtQuietVerbosity(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("EventHandler should receive error tool result at quiet verbosity")
+	}
+	if gotName != "Read" || gotID != "tool-1" {
+		t.Errorf("OnToolResult got tool (%q, %q), want (%q, %q)", gotName, gotID, "Read", "tool-1")
 	}
 	if gotContent != "something failed" || !gotIsError {
 		t.Errorf("OnToolResult got (%v, %v), want (%q, true)", gotContent, gotIsError, "something failed")
@@ -247,7 +255,7 @@ func TestToolResult_InternalErrorFilteringIsTerminalOnly(t *testing.T) {
 	var gotIsError bool
 	var called bool
 	r.SetEventHandler(&testEventHandler{
-		onToolResult: func(content interface{}, isError bool) {
+		onToolResult: func(name, id string, content interface{}, isError bool) {
 			called = true
 			gotContent = content
 			gotIsError = isError
@@ -511,7 +519,7 @@ type testEventHandler struct {
 	onText         func(string)
 	onToolStart    func(name, id string, input map[string]interface{})
 	onToolComplete func(name, id string, input map[string]interface{}, result interface{}, isError bool)
-	onToolResult   func(content interface{}, isError bool)
+	onToolResult   func(name, id string, content interface{}, isError bool)
 	onStatus       func(string)
 }
 
@@ -533,9 +541,9 @@ func (h *testEventHandler) OnToolComplete(name, id string, input map[string]inte
 	}
 }
 
-func (h *testEventHandler) OnToolResult(content interface{}, isError bool) {
+func (h *testEventHandler) OnToolResult(name, id string, content interface{}, isError bool) {
 	if h.onToolResult != nil {
-		h.onToolResult(content, isError)
+		h.onToolResult(name, id, content, isError)
 	}
 }
 

--- a/bramble/cmd/delegator/delegator.go
+++ b/bramble/cmd/delegator/delegator.go
@@ -188,7 +188,7 @@ func runMockConversation(ctx context.Context, s *claude.Session, mock *session.M
 			case claude.ToolCompleteEvent:
 				r.ToolComplete(e.Name, e.Input)
 			case claude.CLIToolResultEvent:
-				r.ToolResult(e.Content, e.IsError)
+				r.ToolResultForTool(e.ToolName, e.ToolUseID, e.Content, e.IsError)
 			case claude.ToolExecutionProgressEvent:
 				r.ToolExecutionProgress(e.ToolName, e.ToolUseID, e.ElapsedTimeSeconds)
 			case claude.TaskStartedEvent:

--- a/bramble/session/delegator_runner.go
+++ b/bramble/session/delegator_runner.go
@@ -244,7 +244,7 @@ func (r *delegatorRunner) forwardEvents(ctx context.Context) {
 			case claude.ToolCompleteEvent:
 				r.eventHandler.OnToolComplete(e.Name, e.ID, e.Input, nil, false)
 			case claude.CLIToolResultEvent:
-				r.eventHandler.OnToolComplete(e.ToolName, e.ToolUseID, nil, e.Content, e.IsError)
+				r.eventHandler.OnToolResult(e.ToolName, e.ToolUseID, e.Content, e.IsError)
 			case claude.TurnCompleteEvent:
 				// TurnEnd is emitted synchronously by the manager after
 				// RunTurn returns, so we skip it here to avoid duplicates.

--- a/bramble/session/delegator_runner.go
+++ b/bramble/session/delegator_runner.go
@@ -234,24 +234,28 @@ func (r *delegatorRunner) forwardEvents(ctx context.Context) {
 			if !ok {
 				return
 			}
-			switch e := evt.(type) {
-			case claude.TextEvent:
-				r.eventHandler.OnText(e.Text)
-			case claude.ThinkingEvent:
-				r.eventHandler.OnThinking(e.Thinking)
-			case claude.ToolStartEvent:
-				r.eventHandler.OnToolStart(e.Name, e.ID, nil)
-			case claude.ToolCompleteEvent:
-				r.eventHandler.OnToolComplete(e.Name, e.ID, e.Input, nil, false)
-			case claude.CLIToolResultEvent:
-				r.eventHandler.OnToolResult(e.ToolName, e.ToolUseID, e.Content, e.IsError)
-			case claude.TurnCompleteEvent:
-				// TurnEnd is emitted synchronously by the manager after
-				// RunTurn returns, so we skip it here to avoid duplicates.
-				_ = e
-			case claude.ErrorEvent:
-				r.eventHandler.OnError(e.Error, "delegator")
-			}
+			r.forwardEvent(evt)
 		}
+	}
+}
+
+func (r *delegatorRunner) forwardEvent(evt claude.Event) {
+	switch e := evt.(type) {
+	case claude.TextEvent:
+		r.eventHandler.OnText(e.Text)
+	case claude.ThinkingEvent:
+		r.eventHandler.OnThinking(e.Thinking)
+	case claude.ToolStartEvent:
+		r.eventHandler.OnToolStart(e.Name, e.ID, nil)
+	case claude.ToolCompleteEvent:
+		r.eventHandler.OnToolComplete(e.Name, e.ID, e.Input, nil, false)
+	case claude.CLIToolResultEvent:
+		r.eventHandler.OnToolResult(e.ToolName, e.ToolUseID, e.Content, e.IsError)
+	case claude.TurnCompleteEvent:
+		// TurnEnd is emitted synchronously by the manager after RunTurn returns,
+		// so we skip it here to avoid duplicates.
+		_ = e
+	case claude.ErrorEvent:
+		r.eventHandler.OnError(e.Error, "delegator")
 	}
 }

--- a/bramble/session/delegator_runner_test.go
+++ b/bramble/session/delegator_runner_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 )
 
 func TestDelegatorRunnerConstruction(t *testing.T) {
@@ -73,6 +75,42 @@ func TestDelegatorToolRegistry(t *testing.T) {
 	assert.Contains(t, toolNames, "stop_session")
 	assert.Contains(t, toolNames, "get_session_progress")
 	assert.Contains(t, toolNames, "send_followup")
+}
+
+func TestDelegatorRunnerForwardEventForwardsCLIToolResult(t *testing.T) {
+	m := NewManagerWithConfig(ManagerConfig{SessionMode: SessionModeTUI})
+	defer m.Close()
+
+	sessionID := SessionID("test-session")
+	m.AddSession(&Session{
+		ID:       sessionID,
+		Status:   StatusRunning,
+		Progress: &SessionProgress{},
+	})
+	m.InitOutputBuffer(sessionID)
+
+	runner := &delegatorRunner{
+		eventHandler: newSessionEventHandler(m, sessionID),
+	}
+	runner.forwardEvent(claude.ToolStartEvent{Name: "Read", ID: "tool-1"})
+	runner.forwardEvent(claude.ToolCompleteEvent{
+		Name:  "Read",
+		ID:    "tool-1",
+		Input: map[string]interface{}{"file_path": "x"},
+	})
+	runner.forwardEvent(claude.CLIToolResultEvent{
+		ToolName:  "Read",
+		ToolUseID: "tool-1",
+		Content:   "file contents",
+		IsError:   false,
+	})
+
+	output := m.GetSessionOutput(sessionID)
+	require.Len(t, output, 1)
+	assert.Equal(t, "tool-1", output[0].ToolID)
+	assert.Equal(t, "Read", output[0].ToolName)
+	assert.Equal(t, "file contents", output[0].ToolResult)
+	assert.False(t, output[0].IsError)
 }
 
 func TestDelegatorSystemPromptWithModels(t *testing.T) {

--- a/bramble/session/event_handler.go
+++ b/bramble/session/event_handler.go
@@ -12,11 +12,9 @@ import (
 // It converts semantic events from the renderer into structured OutputLine
 // entries that the TUI can display.
 type sessionEventHandler struct {
-	manager             *Manager
-	sessionID           SessionID
-	currentToolID       string
-	lastCompletedToolID string
-	suppressTurnEnd     bool // true when manager emits TurnEnd synchronously after RunTurn
+	manager         *Manager
+	sessionID       SessionID
+	suppressTurnEnd bool // true when manager emits TurnEnd synchronously after RunTurn
 }
 
 // Ensure interface compliance at compile time
@@ -52,7 +50,6 @@ func (h *sessionEventHandler) OnThinking(thinking string) {
 }
 
 func (h *sessionEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
-	h.currentToolID = id
 	now := time.Now()
 	h.manager.addOutput(h.sessionID, OutputLine{
 		Timestamp: now,
@@ -76,12 +73,21 @@ func (h *sessionEventHandler) OnToolStart(name, id string, input map[string]inte
 }
 
 func (h *sessionEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
-	h.lastCompletedToolID = id
 	now := time.Now()
 
-	// Update the existing tool line in-place
+	h.updateToolLine(name, id, input, result, isError, now)
+	h.clearToolProgress()
+}
+
+func (h *sessionEventHandler) OnToolResult(name, id string, content interface{}, isError bool) {
+	if id == "" {
+		return
+	}
+	h.updateToolLine(name, id, nil, content, isError, time.Now())
+}
+
+func (h *sessionEventHandler) updateToolLine(name, id string, input map[string]interface{}, result interface{}, isError bool, now time.Time) {
 	h.manager.updateToolOutput(h.sessionID, id, func(line *OutputLine) {
-		// Update input and content (input is nil at OnToolStart, available now)
 		if input != nil {
 			line.ToolInput = input
 			line.Content = formatToolContent(name, input)
@@ -93,44 +99,13 @@ func (h *sessionEventHandler) OnToolComplete(name, id string, input map[string]i
 		} else {
 			line.ToolState = ToolStateComplete
 		}
-		// Calculate duration from StartTime
 		if !line.StartTime.IsZero() {
 			line.DurationMs = now.Sub(line.StartTime).Milliseconds()
 		}
-	})
-
-	recent := h.manager.RecentOutputLines(h.sessionID, sessionmodel.RecentOutputDisplayLines)
-	h.manager.updateSessionProgress(h.sessionID, func(p *SessionProgress) {
-		p.CurrentTool = ""
-		p.CurrentPhase = ""
-		p.LastActivity = time.Now()
-		p.RecentOutput = recent
 	})
 }
 
-func (h *sessionEventHandler) OnToolResult(content interface{}, isError bool) {
-	toolID := h.lastCompletedToolID
-	if toolID == "" {
-		toolID = h.currentToolID
-	}
-	if toolID == "" {
-		return
-	}
-	now := time.Now()
-
-	h.manager.updateToolOutput(h.sessionID, toolID, func(line *OutputLine) {
-		line.ToolResult = content
-		line.IsError = isError
-		if isError {
-			line.ToolState = ToolStateError
-		} else {
-			line.ToolState = ToolStateComplete
-		}
-		if !line.StartTime.IsZero() {
-			line.DurationMs = now.Sub(line.StartTime).Milliseconds()
-		}
-	})
-
+func (h *sessionEventHandler) clearToolProgress() {
 	recent := h.manager.RecentOutputLines(h.sessionID, sessionmodel.RecentOutputDisplayLines)
 	h.manager.updateSessionProgress(h.sessionID, func(p *SessionProgress) {
 		p.CurrentTool = ""
@@ -138,7 +113,6 @@ func (h *sessionEventHandler) OnToolResult(content interface{}, isError bool) {
 		p.LastActivity = time.Now()
 		p.RecentOutput = recent
 	})
-	h.lastCompletedToolID = ""
 }
 
 // formatToolContent creates a display-friendly content string for tool results.

--- a/bramble/session/event_handler.go
+++ b/bramble/session/event_handler.go
@@ -75,7 +75,7 @@ func (h *sessionEventHandler) OnToolStart(name, id string, input map[string]inte
 func (h *sessionEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	now := time.Now()
 
-	h.updateToolLine(name, id, input, result, isError, now)
+	h.updateToolLine(name, id, input, result, isError, now, false)
 	h.clearToolProgress()
 }
 
@@ -83,10 +83,11 @@ func (h *sessionEventHandler) OnToolResult(name, id string, content interface{},
 	if id == "" {
 		return
 	}
-	h.updateToolLine(name, id, nil, content, isError, time.Now())
+	h.updateToolLine(name, id, nil, content, isError, time.Now(), true)
+	h.refreshToolResultProgress()
 }
 
-func (h *sessionEventHandler) updateToolLine(name, id string, input map[string]interface{}, result interface{}, isError bool, now time.Time) {
+func (h *sessionEventHandler) updateToolLine(name, id string, input map[string]interface{}, result interface{}, isError bool, now time.Time, preserveDuration bool) {
 	h.manager.updateToolOutput(h.sessionID, id, func(line *OutputLine) {
 		if input != nil {
 			line.ToolInput = input
@@ -99,7 +100,7 @@ func (h *sessionEventHandler) updateToolLine(name, id string, input map[string]i
 		} else {
 			line.ToolState = ToolStateComplete
 		}
-		if !line.StartTime.IsZero() {
+		if !line.StartTime.IsZero() && (!preserveDuration || line.DurationMs == 0) {
 			line.DurationMs = now.Sub(line.StartTime).Milliseconds()
 		}
 	})
@@ -110,6 +111,14 @@ func (h *sessionEventHandler) clearToolProgress() {
 	h.manager.updateSessionProgress(h.sessionID, func(p *SessionProgress) {
 		p.CurrentTool = ""
 		p.CurrentPhase = ""
+		p.LastActivity = time.Now()
+		p.RecentOutput = recent
+	})
+}
+
+func (h *sessionEventHandler) refreshToolResultProgress() {
+	recent := h.manager.RecentOutputLines(h.sessionID, sessionmodel.RecentOutputDisplayLines)
+	h.manager.updateSessionProgress(h.sessionID, func(p *SessionProgress) {
 		p.LastActivity = time.Now()
 		p.RecentOutput = recent
 	})

--- a/bramble/session/event_handler.go
+++ b/bramble/session/event_handler.go
@@ -12,9 +12,11 @@ import (
 // It converts semantic events from the renderer into structured OutputLine
 // entries that the TUI can display.
 type sessionEventHandler struct {
-	manager         *Manager
-	sessionID       SessionID
-	suppressTurnEnd bool // true when manager emits TurnEnd synchronously after RunTurn
+	manager             *Manager
+	sessionID           SessionID
+	currentToolID       string
+	lastCompletedToolID string
+	suppressTurnEnd     bool // true when manager emits TurnEnd synchronously after RunTurn
 }
 
 // Ensure interface compliance at compile time
@@ -50,6 +52,7 @@ func (h *sessionEventHandler) OnThinking(thinking string) {
 }
 
 func (h *sessionEventHandler) OnToolStart(name, id string, input map[string]interface{}) {
+	h.currentToolID = id
 	now := time.Now()
 	h.manager.addOutput(h.sessionID, OutputLine{
 		Timestamp: now,
@@ -73,6 +76,7 @@ func (h *sessionEventHandler) OnToolStart(name, id string, input map[string]inte
 }
 
 func (h *sessionEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
+	h.lastCompletedToolID = id
 	now := time.Now()
 
 	// Update the existing tool line in-place
@@ -102,6 +106,39 @@ func (h *sessionEventHandler) OnToolComplete(name, id string, input map[string]i
 		p.LastActivity = time.Now()
 		p.RecentOutput = recent
 	})
+}
+
+func (h *sessionEventHandler) OnToolResult(content interface{}, isError bool) {
+	toolID := h.lastCompletedToolID
+	if toolID == "" {
+		toolID = h.currentToolID
+	}
+	if toolID == "" {
+		return
+	}
+	now := time.Now()
+
+	h.manager.updateToolOutput(h.sessionID, toolID, func(line *OutputLine) {
+		line.ToolResult = content
+		line.IsError = isError
+		if isError {
+			line.ToolState = ToolStateError
+		} else {
+			line.ToolState = ToolStateComplete
+		}
+		if !line.StartTime.IsZero() {
+			line.DurationMs = now.Sub(line.StartTime).Milliseconds()
+		}
+	})
+
+	recent := h.manager.RecentOutputLines(h.sessionID, sessionmodel.RecentOutputDisplayLines)
+	h.manager.updateSessionProgress(h.sessionID, func(p *SessionProgress) {
+		p.CurrentTool = ""
+		p.CurrentPhase = ""
+		p.LastActivity = time.Now()
+		p.RecentOutput = recent
+	})
+	h.lastCompletedToolID = ""
 }
 
 // formatToolContent creates a display-friendly content string for tool results.

--- a/bramble/session/event_handler_test.go
+++ b/bramble/session/event_handler_test.go
@@ -118,3 +118,24 @@ func TestSessionEventHandler_OnToolResultPreservesCompletedDuration(t *testing.T
 	assert.Equal(t, completedDuration, output[0].DurationMs)
 	assert.Equal(t, "file contents", output[0].ToolResult)
 }
+
+func TestSessionEventHandler_OnToolResultRefreshesProgress(t *testing.T) {
+	manager, handler, sessionID := newTestSessionEventHandler(t)
+
+	handler.OnText("prior assistant text")
+	handler.OnToolStart("Read", "tool-1", nil)
+	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
+	manager.updateSessionProgress(sessionID, func(p *SessionProgress) {
+		p.LastActivity = time.Time{}
+		p.RecentOutput = nil
+	})
+
+	handler.OnToolResult("Read", "tool-1", "file contents", false)
+
+	session, ok := manager.GetSession(sessionID)
+	require.True(t, ok)
+	progress := session.Progress
+	require.NotNil(t, progress)
+	assert.False(t, progress.LastActivity.IsZero())
+	assert.Equal(t, []string{"prior assistant text"}, progress.RecentOutput)
+}

--- a/bramble/session/event_handler_test.go
+++ b/bramble/session/event_handler_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,6 +72,13 @@ func TestSessionEventHandler_OnToolResultUsesExplicitToolID(t *testing.T) {
 	assert.Equal(t, ToolStateComplete, output[0].ToolState)
 	assert.Nil(t, output[1].ToolResult)
 	assert.Equal(t, ToolStateRunning, output[1].ToolState)
+
+	session, ok := manager.GetSession(sessionID)
+	require.True(t, ok)
+	progress := session.Progress
+	require.NotNil(t, progress)
+	assert.Equal(t, "Bash", progress.CurrentTool)
+	assert.Equal(t, "tool_execution", progress.CurrentPhase)
 }
 
 func TestSessionEventHandler_OnToolResultIgnoresMissingToolID(t *testing.T) {
@@ -83,4 +91,30 @@ func TestSessionEventHandler_OnToolResultIgnoresMissingToolID(t *testing.T) {
 	output := manager.GetSessionOutput(sessionID)
 	require.Len(t, output, 1)
 	assert.Nil(t, output[0].ToolResult)
+}
+
+func TestSessionEventHandler_OnToolResultPreservesCompletedDuration(t *testing.T) {
+	manager, handler, sessionID := newTestSessionEventHandler(t)
+
+	start := time.Now().Add(-time.Second)
+	handler.OnToolStart("Read", "tool-1", nil)
+	manager.updateToolOutput(sessionID, "tool-1", func(line *OutputLine) {
+		line.StartTime = start
+	})
+	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
+
+	output := manager.GetSessionOutput(sessionID)
+	require.Len(t, output, 1)
+	completedDuration := output[0].DurationMs
+	require.Positive(t, completedDuration)
+
+	manager.updateToolOutput(sessionID, "tool-1", func(line *OutputLine) {
+		line.StartTime = time.Now().Add(-time.Hour)
+	})
+	handler.OnToolResult("Read", "tool-1", "file contents", false)
+
+	output = manager.GetSessionOutput(sessionID)
+	require.Len(t, output, 1)
+	assert.Equal(t, completedDuration, output[0].DurationMs)
+	assert.Equal(t, "file contents", output[0].ToolResult)
 }

--- a/bramble/session/event_handler_test.go
+++ b/bramble/session/event_handler_test.go
@@ -29,7 +29,7 @@ func TestSessionEventHandler_OnToolResultUpdatesCompletedToolLine(t *testing.T) 
 
 	handler.OnToolStart("Read", "tool-1", nil)
 	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
-	handler.OnToolResult("file contents", false)
+	handler.OnToolResult("Read", "tool-1", "file contents", false)
 
 	output := manager.GetSessionOutput(sessionID)
 	require.Len(t, output, 1)
@@ -46,7 +46,7 @@ func TestSessionEventHandler_OnToolResultMarksError(t *testing.T) {
 
 	handler.OnToolStart("Read", "tool-1", nil)
 	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
-	handler.OnToolResult("failed", true)
+	handler.OnToolResult("Read", "tool-1", "failed", true)
 
 	output := manager.GetSessionOutput(sessionID)
 	require.Len(t, output, 1)
@@ -57,13 +57,13 @@ func TestSessionEventHandler_OnToolResultMarksError(t *testing.T) {
 	assert.True(t, line.IsError)
 }
 
-func TestSessionEventHandler_OnToolResultUsesLastCompletedTool(t *testing.T) {
+func TestSessionEventHandler_OnToolResultUsesExplicitToolID(t *testing.T) {
 	manager, handler, sessionID := newTestSessionEventHandler(t)
 
 	handler.OnToolStart("Read", "tool-1", nil)
 	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
 	handler.OnToolStart("Bash", "tool-2", nil)
-	handler.OnToolResult("file contents", false)
+	handler.OnToolResult("Read", "tool-1", "file contents", false)
 
 	output := manager.GetSessionOutput(sessionID)
 	require.Len(t, output, 2)
@@ -71,4 +71,16 @@ func TestSessionEventHandler_OnToolResultUsesLastCompletedTool(t *testing.T) {
 	assert.Equal(t, ToolStateComplete, output[0].ToolState)
 	assert.Nil(t, output[1].ToolResult)
 	assert.Equal(t, ToolStateRunning, output[1].ToolState)
+}
+
+func TestSessionEventHandler_OnToolResultIgnoresMissingToolID(t *testing.T) {
+	manager, handler, sessionID := newTestSessionEventHandler(t)
+
+	handler.OnToolStart("Read", "tool-1", nil)
+	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
+	handler.OnToolResult("Read", "", "file contents", false)
+
+	output := manager.GetSessionOutput(sessionID)
+	require.Len(t, output, 1)
+	assert.Nil(t, output[0].ToolResult)
 }

--- a/bramble/session/event_handler_test.go
+++ b/bramble/session/event_handler_test.go
@@ -1,0 +1,74 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSessionEventHandler(t *testing.T) (*Manager, *sessionEventHandler, SessionID) {
+	t.Helper()
+
+	manager := NewManager()
+	t.Cleanup(manager.Close)
+
+	sessionID := SessionID("test-session")
+	manager.AddSession(&Session{
+		ID:       sessionID,
+		Status:   StatusRunning,
+		Progress: &SessionProgress{},
+	})
+	manager.InitOutputBuffer(sessionID)
+
+	return manager, newSessionEventHandler(manager, sessionID), sessionID
+}
+
+func TestSessionEventHandler_OnToolResultUpdatesCompletedToolLine(t *testing.T) {
+	manager, handler, sessionID := newTestSessionEventHandler(t)
+
+	handler.OnToolStart("Read", "tool-1", nil)
+	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
+	handler.OnToolResult("file contents", false)
+
+	output := manager.GetSessionOutput(sessionID)
+	require.Len(t, output, 1)
+	line := output[0]
+	assert.Equal(t, "tool-1", line.ToolID)
+	assert.Equal(t, map[string]interface{}{"file_path": "x"}, line.ToolInput)
+	assert.Equal(t, "file contents", line.ToolResult)
+	assert.Equal(t, ToolStateComplete, line.ToolState)
+	assert.False(t, line.IsError)
+}
+
+func TestSessionEventHandler_OnToolResultMarksError(t *testing.T) {
+	manager, handler, sessionID := newTestSessionEventHandler(t)
+
+	handler.OnToolStart("Read", "tool-1", nil)
+	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
+	handler.OnToolResult("failed", true)
+
+	output := manager.GetSessionOutput(sessionID)
+	require.Len(t, output, 1)
+	line := output[0]
+	assert.Equal(t, "tool-1", line.ToolID)
+	assert.Equal(t, "failed", line.ToolResult)
+	assert.Equal(t, ToolStateError, line.ToolState)
+	assert.True(t, line.IsError)
+}
+
+func TestSessionEventHandler_OnToolResultUsesLastCompletedTool(t *testing.T) {
+	manager, handler, sessionID := newTestSessionEventHandler(t)
+
+	handler.OnToolStart("Read", "tool-1", nil)
+	handler.OnToolComplete("Read", "tool-1", map[string]interface{}{"file_path": "x"}, nil, false)
+	handler.OnToolStart("Bash", "tool-2", nil)
+	handler.OnToolResult("file contents", false)
+
+	output := manager.GetSessionOutput(sessionID)
+	require.Len(t, output, 2)
+	assert.Equal(t, "file contents", output[0].ToolResult)
+	assert.Equal(t, ToolStateComplete, output[0].ToolState)
+	assert.Nil(t, output[1].ToolResult)
+	assert.Equal(t, ToolStateRunning, output[1].ToolState)
+}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -264,7 +264,7 @@ func (h *rendererEventHandler) OnToolStart(name, id string, input map[string]int
 func (h *rendererEventHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	h.r.ToolComplete(name, input)
 	if result != nil || isError {
-		h.r.ToolResult(result, isError)
+		h.r.ToolResultForTool(name, id, result, isError)
 	}
 }
 

--- a/prdozer/agent.go
+++ b/prdozer/agent.go
@@ -229,7 +229,7 @@ func (h *rendererHandler) OnToolStart(name, id string, _ map[string]interface{})
 func (h *rendererHandler) OnToolComplete(name, id string, input map[string]interface{}, result interface{}, isError bool) {
 	h.r.ToolComplete(name, input)
 	if result != nil || isError {
-		h.r.ToolResult(result, isError)
+		h.r.ToolResultForTool(name, id, result, isError)
 	}
 }
 func (h *rendererHandler) OnTurnComplete(turn int, success bool, durationMs int64, costUSD float64) {

--- a/yoloswe/planner/planner.go
+++ b/yoloswe/planner/planner.go
@@ -447,7 +447,7 @@ func (p *PlannerWrapper) handleEvent(ctx context.Context, event claude.Event) (b
 		}
 
 	case claude.CLIToolResultEvent:
-		p.renderer.ToolResult(e.Content, e.IsError)
+		p.renderer.ToolResultForTool(e.ToolName, e.ToolUseID, e.Content, e.IsError)
 
 	case claude.TurnCompleteEvent:
 		p.renderer.TurnSummary(e)
@@ -927,7 +927,7 @@ func (p *PlannerWrapper) RunTurn(ctx context.Context, message string) (*claude.T
 				p.renderer.ToolComplete(e.Name, e.Input)
 
 			case claude.CLIToolResultEvent:
-				p.renderer.ToolResult(e.Content, e.IsError)
+				p.renderer.ToolResultForTool(e.ToolName, e.ToolUseID, e.Content, e.IsError)
 
 			case claude.TurnCompleteEvent:
 				p.renderer.TurnSummary(e)

--- a/yoloswe/session.go
+++ b/yoloswe/session.go
@@ -156,7 +156,7 @@ func (b *baseSession) RunTurn(ctx context.Context, message string) (*claude.Turn
 				b.renderer.ToolComplete(e.Name, e.Input)
 
 			case claude.CLIToolResultEvent:
-				b.renderer.ToolResult(e.Content, e.IsError)
+				b.renderer.ToolResultForTool(e.ToolName, e.ToolUseID, e.Content, e.IsError)
 
 			case claude.TurnCompleteEvent:
 				b.stats.TurnCount++


### PR DESCRIPTION
## Summary
- Add a first-class `render.EventHandler.OnToolResult` callback so Claude CLI tool results are emitted as semantic events even when terminal verbosity suppresses successful tool output.
- Teach `render.Renderer` to preserve completed tool identity and add `ToolResultForTool(name, id, ...)` for callers that receive explicit `ToolUseID` values from `CLIToolResultEvent`.
- Update Bramble session forwarding so `CLIToolResultEvent` updates the existing tool output line by ID instead of treating the result as another completion event.
- Attach tool result content and error state to Bramble `OutputLine`s while preserving completed tool duration and refreshing recent session progress.
- Update downstream renderer call sites in the delegator mock path, jiradozer, prdozer, and yoloswe planner/session flows to pass explicit tool identity for CLI tool results.
- Add renderer, session event handler, and delegator runner tests covering successful results, error results, explicit tool ID routing, terminal-only internal-error filtering, missing IDs, duration preservation, and progress refresh behavior.

## Impact
Bramble sessions now retain successful Claude tool results in structured session output even when those results stay hidden from normal terminal output. Tool results are associated by explicit tool ID where available, reducing the chance that delayed or interleaved result events attach to the wrong tool line while keeping existing terminal verbosity behavior intact.

The renderer event interface has a new `OnToolResult` method, and in-repo handlers/callers have been updated for the API change.

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `render.EventHandler` interface and rewires tool-result propagation, which could break downstream handlers or mis-associate results if tool IDs are missing/incorrect.
> 
> **Overview**
> Tool results are now emitted as a first-class semantic event (`OnToolResult`) separate from `OnToolComplete`, so structured consumers can capture results even when terminal verbosity hides successful output.
> 
> `Renderer` tracks the most recently completed tool and adds `ToolResultForTool(name,id,...)` to associate results with the correct tool call; all callers that handle `CLIToolResultEvent` were updated to use the explicit tool identity.
> 
> Bramble sessions now attach tool result content/error state to the corresponding `OutputLine` via `sessionEventHandler.OnToolResult`, with new unit tests covering success/error cases, explicit tool IDs, duration preservation, and "internal" error filtering being terminal-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5e3bd48ff715021f07f522b923e81013bd373b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->