### PR TITLE
Use protocol content block types in Claude events

### DIFF
--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/agentstream"
@@ -73,6 +74,9 @@ const (
 	// EventTypeSystemMessage fires for any CLI system message not surfaced
 	// via a dedicated typed event. Subtype identifies the kind.
 	EventTypeSystemMessage
+	// EventTypeUnknownMessage fires when the CLI emits an unrecognized
+	// top-level message type.
+	EventTypeUnknownMessage
 )
 
 // HookPhase identifies which hook lifecycle stage a HookLifecycleEvent represents.
@@ -441,7 +445,7 @@ func (e LocalCommandOutputEvent) Type() EventType { return EventTypeLocalCommand
 type AssistantMessageEvent struct {
 	ParentToolUse *string
 	Model         string
-	Blocks        []ContentBlock
+	Blocks        protocol.ContentBlocks
 	TurnNumber    int
 }
 
@@ -452,12 +456,22 @@ func (e AssistantMessageEvent) Type() EventType { return EventTypeAssistantMessa
 // frames). Not coalesced.
 type UserMessageEvent struct {
 	ParentToolUse *string
-	Blocks        []ContentBlock
+	Blocks        protocol.ContentBlocks
 	TurnNumber    int
 }
 
 // Type returns the event type.
 func (e UserMessageEvent) Type() EventType { return EventTypeUserMessage }
+
+// UnknownMessageEvent fires when the CLI emits a message whose top-level type
+// discriminator is not recognized.
+type UnknownMessageEvent struct {
+	MessageType protocol.MessageType
+	Raw         json.RawMessage
+}
+
+// Type returns the event type.
+func (e UnknownMessageEvent) Type() EventType { return EventTypeUnknownMessage }
 
 // ResultMessageEvent fires once per CLI ResultMessage. Unlike
 // TurnCompleteEvent it is never coalesced across bg-continuation turns.

--- a/agent-cli-wrapper/claude/integration/content_blocks_test.go
+++ b/agent-cli-wrapper/claude/integration/content_blocks_test.go
@@ -50,33 +50,34 @@ func TestSession_ContentBlocks(t *testing.T) {
 	var hasToolResult bool
 
 	for _, block := range result.ContentBlocks {
-		switch block.Type {
-		case claude.ContentBlockTypeText:
+		switch b := block.(type) {
+		case claude.TextBlock:
 			hasText = true
-			if block.Text == "" {
+			if b.Text == "" {
 				t.Error("text block has empty text")
 			}
-			t.Logf("Text block: %q", block.Text[:min(50, len(block.Text))])
+			t.Logf("Text block: %q", b.Text[:min(50, len(b.Text))])
 
-		case claude.ContentBlockTypeThinking:
-			t.Logf("Thinking block: %q", block.Thinking[:min(50, len(block.Thinking))])
+		case claude.ThinkingBlock:
+			t.Logf("Thinking block: %q", b.Thinking[:min(50, len(b.Thinking))])
 
-		case claude.ContentBlockTypeToolUse:
+		case claude.ToolUseBlock:
 			hasToolUse = true
-			if block.ToolUseID == "" {
+			if b.ID == "" {
 				t.Error("tool_use block has empty tool_use_id")
 			}
-			if block.ToolName == "" {
+			if b.Name == "" {
 				t.Error("tool_use block has empty tool_name")
 			}
-			t.Logf("Tool use block: name=%s, id=%s", block.ToolName, block.ToolUseID)
+			t.Logf("Tool use block: name=%s, id=%s", b.Name, b.ID)
 
-		case claude.ContentBlockTypeToolResult:
+		case claude.ToolResultBlock:
 			hasToolResult = true
-			if block.ToolUseID == "" {
+			if b.ToolUseID == "" {
 				t.Error("tool_result block has empty tool_use_id")
 			}
-			t.Logf("Tool result block: id=%s, is_error=%v", block.ToolUseID, block.IsError)
+			isError := b.IsError != nil && *b.IsError
+			t.Logf("Tool result block: id=%s, is_error=%v", b.ToolUseID, isError)
 		}
 	}
 

--- a/agent-cli-wrapper/claude/integration/stream_bg_test.go
+++ b/agent-cli-wrapper/claude/integration/stream_bg_test.go
@@ -386,7 +386,7 @@ func TestStreamBg_I11_ScheduleWakeupContinuation(t *testing.T) {
 	usedWakeup := false
 	for _, am := range state.AssistantMsgs {
 		for _, b := range am.Blocks {
-			if b.Type == claude.ContentBlockTypeToolUse && b.ToolName == "ScheduleWakeup" {
+			if tu, ok := b.(claude.ToolUseBlock); ok && tu.Name == "ScheduleWakeup" {
 				usedWakeup = true
 			}
 		}

--- a/agent-cli-wrapper/claude/message.go
+++ b/agent-cli-wrapper/claude/message.go
@@ -1,23 +1,17 @@
 package claude
 
-// ContentBlockType identifies the kind of content block.
-type ContentBlockType string
+import "github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 
 const (
-	ContentBlockTypeText       ContentBlockType = "text"
-	ContentBlockTypeThinking   ContentBlockType = "thinking"
-	ContentBlockTypeToolUse    ContentBlockType = "tool_use"
-	ContentBlockTypeToolResult ContentBlockType = "tool_result"
+	ContentBlockTypeText       = protocol.ContentBlockTypeText
+	ContentBlockTypeThinking   = protocol.ContentBlockTypeThinking
+	ContentBlockTypeToolUse    = protocol.ContentBlockTypeToolUse
+	ContentBlockTypeToolResult = protocol.ContentBlockTypeToolResult
 )
 
-// ContentBlock is a structured content block from a Claude response.
-type ContentBlock struct {
-	ToolResult interface{}            `json:"tool_result,omitempty"`
-	ToolInput  map[string]interface{} `json:"tool_input,omitempty"`
-	Type       ContentBlockType       `json:"type"`
-	Text       string                 `json:"text,omitempty"`
-	Thinking   string                 `json:"thinking,omitempty"`
-	ToolUseID  string                 `json:"tool_use_id,omitempty"`
-	ToolName   string                 `json:"tool_name,omitempty"`
-	IsError    bool                   `json:"is_error,omitempty"`
-}
+type ContentBlock = protocol.ContentBlock
+type ContentBlocks = protocol.ContentBlocks
+type TextBlock = protocol.TextBlock
+type ThinkingBlock = protocol.ThinkingBlock
+type ToolUseBlock = protocol.ToolUseBlock
+type ToolResultBlock = protocol.ToolResultBlock

--- a/agent-cli-wrapper/claude/message.go
+++ b/agent-cli-wrapper/claude/message.go
@@ -15,3 +15,4 @@ type TextBlock = protocol.TextBlock
 type ThinkingBlock = protocol.ThinkingBlock
 type ToolUseBlock = protocol.ToolUseBlock
 type ToolResultBlock = protocol.ToolResultBlock
+type UnknownContentBlock = protocol.UnknownContentBlock

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -30,9 +30,6 @@ type wakeupSuppressionState struct {
 	timerFired             bool        // set by the safety timer
 }
 
-// TODO: Re-introduce activeTaskIDs and wire it to bg-task suppression once
-// Bramble has a deterministic task_started/task_notification consumer.
-
 // reset clears wakeup suppression state and stops any pending timer.
 func (w *wakeupSuppressionState) reset() {
 	w.active = false
@@ -990,12 +987,14 @@ func (s *Session) handleAssistant(msg protocol.AssistantMessage) {
 	}
 
 	// Accumulate structured content blocks
+	accumulated := make(protocol.ContentBlocks, 0, len(blocks))
 	for _, block := range blocks {
-		switch block.(type) {
-		case protocol.TextBlock, protocol.ThinkingBlock, protocol.ToolUseBlock:
-			s.turnManager.AppendContentBlock(block)
+		switch block.BlockType() {
+		case protocol.ContentBlockTypeText, protocol.ContentBlockTypeThinking, protocol.ContentBlockTypeToolUse:
+			accumulated = append(accumulated, block)
 		}
 	}
+	s.turnManager.AppendContentBlocks(accumulated)
 }
 
 func (s *Session) handleUser(msg protocol.UserMessage) {
@@ -1044,11 +1043,13 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 	}
 
 	// Accumulate tool result content blocks
+	accumulated := make(protocol.ContentBlocks, 0, len(blocks))
 	for _, block := range blocks {
-		if _, ok := block.(protocol.ToolResultBlock); ok {
-			s.turnManager.AppendContentBlock(block)
+		if block.BlockType() == protocol.ContentBlockTypeToolResult {
+			accumulated = append(accumulated, block)
 		}
 	}
+	s.turnManager.AppendContentBlocks(accumulated)
 }
 
 func (s *Session) handleResult(msg protocol.ResultMessage) {

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -707,7 +707,7 @@ func (s *Session) handleLine(line []byte) {
 			raw = raw[:4096]
 		}
 		s.emit(UnknownMessageEvent{MessageType: m.Type, Raw: raw})
-		slog.Warn("unknown top-level message type", "type", m.Type)
+		slog.Warn("unknown top-level message type", "type", m.Type, "raw", string(raw))
 	}
 }
 

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -702,12 +702,12 @@ func (s *Session) handleLine(line []byte) {
 	case protocol.UpdateEnvironmentVariablesMessage:
 		slog.Warn("unexpected update_environment_variables from CLI (SDK->CLI only)")
 	case protocol.UnknownMessage:
-		raw := m.Raw
-		if len(raw) > 4096 {
-			raw = raw[:4096]
+		logRaw := m.Raw
+		if len(logRaw) > 4096 {
+			logRaw = logRaw[:4096]
 		}
-		s.emit(UnknownMessageEvent{MessageType: m.Type, Raw: raw})
-		slog.Warn("unknown top-level message type", "type", m.Type, "raw", string(raw))
+		s.emit(UnknownMessageEvent{MessageType: m.Type, Raw: m.Raw})
+		slog.Warn("unknown top-level message type", "type", m.Type, "raw", string(logRaw))
 	}
 }
 
@@ -1053,6 +1053,9 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 }
 
 func (s *Session) handleResult(msg protocol.ResultMessage) {
+	resultErr := resultMessageError(msg)
+	resultIsError := resultErr != nil
+
 	// Emit one raw ResultMessageEvent per CLI ResultMessage, before any
 	// wrapper-level suppression. This is the ground truth policy layers
 	// (e.g. logicalTurnState) read.
@@ -1070,8 +1073,8 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		DurationMs:    msg.DurationMs,
 		DurationAPIMs: msg.DurationAPIMs,
 		TotalCostUSD:  msg.TotalCostUSD,
-		IsError:       msg.IsError,
-		Error:         resultMessageError(msg),
+		IsError:       resultIsError,
+		Error:         resultErr,
 	})
 
 	// Cancel any pending wakeup-suppression safety timer.
@@ -1130,7 +1133,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 
 	result := TurnResult{
 		TurnNumber: resultTurnNumber,
-		Success:    !msg.IsError,
+		Success:    !resultIsError,
 		DurationMs: durationMs,
 		Usage: TurnUsage{
 			InputTokens:         msg.Usage.InputTokens + accUsage.InputTokens,
@@ -1156,7 +1159,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		result.ContentBlocks = turn.ContentBlocks
 	}
 
-	result.Error = resultMessageError(msg)
+	result.Error = resultErr
 
 	// Check if the turn ends with a NEW ScheduleWakeup tool call. When present,
 	// the CLI will auto-inject a continuation user message after the specified

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -928,7 +928,14 @@ func (s *Session) handleAssistant(msg protocol.AssistantMessage) {
 	// Get content blocks (if available)
 	blocks, ok := msg.Message.Content.AsBlocks()
 	if !ok {
-		return
+		text, ok := msg.Message.Content.AsString()
+		if !ok || text == "" {
+			return
+		}
+		blocks = protocol.ContentBlocks{protocol.TextBlock{
+			Type: protocol.ContentBlockTypeText,
+			Text: text,
+		}}
 	}
 
 	s.emit(AssistantMessageEvent{
@@ -1182,7 +1189,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 	// priorSuppressedWakeupToolID was snapshotted under mu above. If it matches
 	// latestWakeupID, the continuation appended no new ScheduleWakeup — the stale
 	// original block is the only one present, so we release rather than re-suppress.
-	shouldSuppressWakeup := !msg.IsError && !maxTurnsReached && latestWakeupID != "" &&
+	shouldSuppressWakeup := !resultIsError && !maxTurnsReached && latestWakeupID != "" &&
 		!(wakeupSuppressed && latestWakeupID == priorSuppressedWakeupToolID)
 	if shouldSuppressWakeup {
 		s.mu.Lock()

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -715,8 +715,13 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 	if msg.Subtype == string(protocol.SystemSubtypeInit) {
 		p, ok := msg.AsInit()
 		if !ok {
-			slog.Warn("failed to decode init payload")
-			return
+			// Fall back to lenient field-by-field decode so a single malformed
+			// optional field (e.g. unexpected tools/agents shape) does not
+			// strand the session waiting for Ready forever. Mirrors the parser
+			// and analysis paths in bramble/sessionmodel and bramble/sessionanalysis.
+			slog.Warn("init payload strict decode failed; using lenient fallback")
+			loose := msg.InitPayloadLenient()
+			p = &loose
 		}
 		s.mu.Lock()
 		s.info = &SessionInfo{

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -719,8 +719,18 @@ func (s *Session) handleSystem(msg protocol.SystemMessage) {
 			// optional field (e.g. unexpected tools/agents shape) does not
 			// strand the session waiting for Ready forever. Mirrors the parser
 			// and analysis paths in bramble/sessionmodel and bramble/sessionanalysis.
-			slog.Warn("init payload strict decode failed; using lenient fallback")
 			loose := msg.InitPayloadLenient()
+			// Require the mandatory fields: without session_id/model/cwd the
+			// session would come up with empty metadata, which is worse than
+			// failing closed and surfacing a protocol regression in logs.
+			if loose.SessionID == "" || loose.Model == "" || loose.CWD == "" {
+				slog.Error("init payload decode failed and lenient fallback missing required fields; not transitioning to Ready",
+					"have_session_id", loose.SessionID != "",
+					"have_model", loose.Model != "",
+					"have_cwd", loose.CWD != "")
+				return
+			}
+			slog.Warn("init payload strict decode failed; using lenient fallback")
 			p = &loose
 		}
 		s.mu.Lock()

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -994,14 +994,7 @@ func (s *Session) handleAssistant(msg protocol.AssistantMessage) {
 	}
 
 	// Accumulate structured content blocks
-	accumulated := make(protocol.ContentBlocks, 0, len(blocks))
-	for _, block := range blocks {
-		switch block.BlockType() {
-		case protocol.ContentBlockTypeText, protocol.ContentBlockTypeThinking, protocol.ContentBlockTypeToolUse:
-			accumulated = append(accumulated, block)
-		}
-	}
-	s.turnManager.AppendContentBlocks(accumulated)
+	s.turnManager.AppendContentBlocks(blocks)
 }
 
 func (s *Session) handleUser(msg protocol.UserMessage) {
@@ -1050,18 +1043,12 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 	}
 
 	// Accumulate tool result content blocks
-	accumulated := make(protocol.ContentBlocks, 0, len(blocks))
-	for _, block := range blocks {
-		if block.BlockType() == protocol.ContentBlockTypeToolResult {
-			accumulated = append(accumulated, block)
-		}
-	}
-	s.turnManager.AppendContentBlocks(accumulated)
+	s.turnManager.AppendContentBlocks(blocks)
 }
 
 func (s *Session) handleResult(msg protocol.ResultMessage) {
 	resultErr := resultMessageError(msg)
-	resultIsError := resultErr != nil
+	resultIsError := msg.IsFailure()
 
 	// Emit one raw ResultMessageEvent per CLI ResultMessage, before any
 	// wrapper-level suppression. This is the ground truth policy layers

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -30,6 +30,9 @@ type wakeupSuppressionState struct {
 	timerFired             bool        // set by the safety timer
 }
 
+// TODO: Re-introduce activeTaskIDs and wire it to bg-task suppression once
+// Bramble has a deterministic task_started/task_notification consumer.
+
 // reset clears wakeup suppression state and stops any pending timer.
 func (w *wakeupSuppressionState) reset() {
 	w.active = false
@@ -702,35 +705,41 @@ func (s *Session) handleLine(line []byte) {
 	case protocol.UpdateEnvironmentVariablesMessage:
 		slog.Warn("unexpected update_environment_variables from CLI (SDK->CLI only)")
 	case protocol.UnknownMessage:
-		rawStr := string(m.Raw)
-		if len(rawStr) > 200 {
-			rawStr = rawStr[:200]
+		raw := m.Raw
+		if len(raw) > 4096 {
+			raw = raw[:4096]
 		}
-		slog.Warn("unknown top-level message type", "type", m.Type, "raw", rawStr)
+		s.emit(UnknownMessageEvent{MessageType: m.Type, Raw: raw})
+		slog.Warn("unknown top-level message type", "type", m.Type)
 	}
 }
 
 func (s *Session) handleSystem(msg protocol.SystemMessage) {
-	if msg.Subtype == "init" {
+	if msg.Subtype == string(protocol.SystemSubtypeInit) {
+		p, ok := msg.AsInit()
+		if !ok {
+			slog.Warn("failed to decode init payload")
+			return
+		}
 		s.mu.Lock()
 		s.info = &SessionInfo{
-			SessionID:      msg.SessionID,
-			Model:          msg.Model,
-			WorkDir:        msg.CWD,
-			Tools:          msg.Tools,
-			PermissionMode: PermissionMode(msg.PermissionMode),
+			SessionID:      p.SessionID,
+			Model:          p.Model,
+			WorkDir:        p.CWD,
+			Tools:          p.Tools,
+			PermissionMode: PermissionMode(p.PermissionMode),
 		}
 		s.mu.Unlock()
 
 		// Initialize recorder with session info
 		if s.recorder != nil {
 			s.recorder.Initialize(RecordingMetadata{
-				SessionID:         msg.SessionID,
-				Model:             msg.Model,
-				WorkDir:           msg.CWD,
-				Tools:             msg.Tools,
-				ClaudeCodeVersion: msg.ClaudeCodeVersion,
-				PermissionMode:    msg.PermissionMode,
+				SessionID:         p.SessionID,
+				Model:             p.Model,
+				WorkDir:           p.CWD,
+				Tools:             p.Tools,
+				ClaudeCodeVersion: p.ClaudeCodeVersion,
+				PermissionMode:    p.PermissionMode,
 			})
 		}
 
@@ -927,7 +936,7 @@ func (s *Session) handleAssistant(msg protocol.AssistantMessage) {
 
 	s.emit(AssistantMessageEvent{
 		Model:         msg.Message.Model,
-		Blocks:        protocolBlocksToContentBlocks(blocks),
+		Blocks:        blocks,
 		ParentToolUse: msg.ParentToolUseID,
 		TurnNumber:    s.turnManager.CurrentTurnNumber(),
 	})
@@ -982,24 +991,9 @@ func (s *Session) handleAssistant(msg protocol.AssistantMessage) {
 
 	// Accumulate structured content blocks
 	for _, block := range blocks {
-		switch b := block.(type) {
-		case protocol.TextBlock:
-			s.turnManager.AppendContentBlock(ContentBlock{
-				Type: ContentBlockTypeText,
-				Text: b.Text,
-			})
-		case protocol.ThinkingBlock:
-			s.turnManager.AppendContentBlock(ContentBlock{
-				Type:     ContentBlockTypeThinking,
-				Thinking: b.Thinking,
-			})
-		case protocol.ToolUseBlock:
-			s.turnManager.AppendContentBlock(ContentBlock{
-				Type:      ContentBlockTypeToolUse,
-				ToolUseID: b.ID,
-				ToolName:  b.Name,
-				ToolInput: b.Input,
-			})
+		switch block.(type) {
+		case protocol.TextBlock, protocol.ThinkingBlock, protocol.ToolUseBlock:
+			s.turnManager.AppendContentBlock(block)
 		}
 	}
 }
@@ -1018,7 +1012,7 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 	}
 
 	s.emit(UserMessageEvent{
-		Blocks:        protocolBlocksToContentBlocks(blocks),
+		Blocks:        blocks,
 		ParentToolUse: msg.ParentToolUseID,
 		TurnNumber:    s.turnManager.CurrentTurnNumber(),
 	})
@@ -1051,17 +1045,8 @@ func (s *Session) handleUser(msg protocol.UserMessage) {
 
 	// Accumulate tool result content blocks
 	for _, block := range blocks {
-		if resultBlock, ok := block.(protocol.ToolResultBlock); ok {
-			isError := false
-			if resultBlock.IsError != nil {
-				isError = *resultBlock.IsError
-			}
-			s.turnManager.AppendContentBlock(ContentBlock{
-				Type:       ContentBlockTypeToolResult,
-				ToolUseID:  resultBlock.ToolUseID,
-				ToolResult: resultBlock.Content,
-				IsError:    isError,
-			})
+		if _, ok := block.(protocol.ToolResultBlock); ok {
+			s.turnManager.AppendContentBlock(block)
 		}
 	}
 }
@@ -1725,57 +1710,25 @@ func (s *Session) handleElicitationControl(ctx context.Context, requestID string
 	s.sendControlSuccess(requestID, resp)
 }
 
-// protocolBlocksToContentBlocks converts parsed protocol blocks into the
-// shared ContentBlock representation used across SDK events. Unknown block
-// types are dropped (they are already logged elsewhere).
-func protocolBlocksToContentBlocks(blocks protocol.ContentBlocks) []ContentBlock {
-	out := make([]ContentBlock, 0, len(blocks))
-	for _, block := range blocks {
-		switch b := block.(type) {
-		case protocol.TextBlock:
-			out = append(out, ContentBlock{Type: ContentBlockTypeText, Text: b.Text})
-		case protocol.ThinkingBlock:
-			out = append(out, ContentBlock{Type: ContentBlockTypeThinking, Thinking: b.Thinking})
-		case protocol.ToolUseBlock:
-			out = append(out, ContentBlock{
-				Type:      ContentBlockTypeToolUse,
-				ToolUseID: b.ID,
-				ToolName:  b.Name,
-				ToolInput: b.Input,
-			})
-		case protocol.ToolResultBlock:
-			isError := false
-			if b.IsError != nil {
-				isError = *b.IsError
-			}
-			out = append(out, ContentBlock{
-				Type:       ContentBlockTypeToolResult,
-				ToolUseID:  b.ToolUseID,
-				ToolResult: b.Content,
-				IsError:    isError,
-			})
-		}
-	}
-	return out
-}
-
 // resultMessageError extracts the non-nil error value from a ResultMessage
 // when the CLI reports a failed turn. Mirrors handleResult's error
 // construction but does not depend on accumulated suppression state, so the
 // raw ResultMessageEvent can surface error detail before the coalescing
-// branches run. Returns nil when msg.IsError is false.
+// branches run.
 func resultMessageError(msg protocol.ResultMessage) error {
-	if !msg.IsError {
+	switch o := msg.Outcome().(type) {
+	case protocol.ResultSuccess:
 		return nil
+	case protocol.ResultError:
+		if len(o.Errors) > 0 {
+			return fmt.Errorf("%s", strings.Join(o.Errors, "; "))
+		}
+		if o.Text != "" {
+			return fmt.Errorf("%s", o.Text)
+		}
+		return fmt.Errorf("turn failed: %s", o.Subtype)
 	}
-	switch {
-	case len(msg.Errors) > 0:
-		return fmt.Errorf("%s", strings.Join(msg.Errors, "; "))
-	case msg.Result != "":
-		return fmt.Errorf("%s", msg.Result)
-	default:
-		return fmt.Errorf("turn failed: %s", msg.Subtype)
-	}
+	return nil
 }
 
 // generateRequestID generates a unique request ID.

--- a/agent-cli-wrapper/claude/session_dispatch_test.go
+++ b/agent-cli-wrapper/claude/session_dispatch_test.go
@@ -352,13 +352,19 @@ func TestSessionDispatchUnknownMessage(t *testing.T) {
 	t.Parallel()
 	s := newTestSession(t)
 	// Completely unknown top-level type. ParseMessage returns UnknownMessage;
-	// handleLine logs a warning and emits nothing.
+	// handleLine logs a warning and emits an UnknownMessageEvent.
 	injectLine(t, s, map[string]interface{}{
 		"type":       "future_unknown_type_xyz",
 		"session_id": "s",
 		"uuid":       "u",
 	})
-	expectNoEvent(t, s, 100*time.Millisecond)
+	ev := waitForEvent(t, s, func(ev Event) bool {
+		return ev.Type() == EventTypeUnknownMessage
+	}, time.Second)
+	unknown, ok := ev.(UnknownMessageEvent)
+	require.True(t, ok, "got %T", ev)
+	require.Equal(t, protocol.MessageType("future_unknown_type_xyz"), unknown.MessageType)
+	require.Contains(t, string(unknown.Raw), "future_unknown_type_xyz")
 }
 
 // buildControlRequestLine frames an inner control-request payload inside a

--- a/agent-cli-wrapper/claude/session_dispatch_test.go
+++ b/agent-cli-wrapper/claude/session_dispatch_test.go
@@ -615,6 +615,24 @@ func TestSessionControlRequestMalformed_RepliesWithDeny(t *testing.T) {
 	require.Equal(t, "req-bad-1", resp["request_id"])
 }
 
+// TestSessionDispatchInit_NoFallbackWhenMandatoryFieldsMissing verifies that
+// the lenient fallback only fires when the mandatory metadata (session_id,
+// model, cwd) is recoverable. A frame missing model/cwd should leave the
+// session unready so a protocol regression surfaces in logs instead of
+// silently coming up with empty SessionInfo.
+func TestSessionDispatchInit_NoFallbackWhenMandatoryFieldsMissing(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	// Malformed `tools` triggers strict-decode failure. With model/cwd absent,
+	// lenient decode also can't recover the mandatory fields, so handleSystem
+	// must NOT emit ReadyEvent.
+	line := mkSystem(t, "init", map[string]interface{}{
+		"tools": "this-should-be-an-array",
+	})
+	s.handleLine(line)
+	expectNoEvent(t, s, 100*time.Millisecond)
+}
+
 // TestSessionDispatchInit_LenientFallbackOnMalformedField verifies that
 // a system/init frame with one malformed optional field (e.g. wrong-typed
 // `tools`) still drives the session to ready: ReadyEvent fires and SessionInfo

--- a/agent-cli-wrapper/claude/session_dispatch_test.go
+++ b/agent-cli-wrapper/claude/session_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -365,6 +366,26 @@ func TestSessionDispatchUnknownMessage(t *testing.T) {
 	require.True(t, ok, "got %T", ev)
 	require.Equal(t, protocol.MessageType("future_unknown_type_xyz"), unknown.MessageType)
 	require.Contains(t, string(unknown.Raw), "future_unknown_type_xyz")
+}
+
+func TestSessionDispatchUnknownMessageKeepsFullRaw(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	payload := strings.Repeat("x", 5000)
+
+	injectLine(t, s, map[string]interface{}{
+		"type":       "future_unknown_type_xyz",
+		"session_id": "s",
+		"uuid":       "u",
+		"payload":    payload,
+	})
+
+	ev := waitForEvent(t, s, func(ev Event) bool {
+		return ev.Type() == EventTypeUnknownMessage
+	}, time.Second)
+	unknown, ok := ev.(UnknownMessageEvent)
+	require.True(t, ok, "got %T", ev)
+	require.Contains(t, string(unknown.Raw), payload)
 }
 
 // buildControlRequestLine frames an inner control-request payload inside a

--- a/agent-cli-wrapper/claude/session_dispatch_test.go
+++ b/agent-cli-wrapper/claude/session_dispatch_test.go
@@ -614,3 +614,34 @@ func TestSessionControlRequestMalformed_RepliesWithDeny(t *testing.T) {
 	require.True(t, ok, "expected response object, got %v", msg)
 	require.Equal(t, "req-bad-1", resp["request_id"])
 }
+
+// TestSessionDispatchInit_LenientFallbackOnMalformedField verifies that
+// a system/init frame with one malformed optional field (e.g. wrong-typed
+// `tools`) still drives the session to ready: ReadyEvent fires and SessionInfo
+// is populated from fields that decoded cleanly. Strict AsInit() returns false
+// on the bad field, but handleSystem now falls back to InitPayloadLenient()
+// instead of stranding callers waiting on a session that never becomes ready.
+func TestSessionDispatchInit_LenientFallbackOnMalformedField(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	// `tools` is documented as []string; sending a string here makes strict
+	// AsInit() fail while leaving model/cwd/session_id decodable per-field.
+	line := mkSystem(t, "init", map[string]interface{}{
+		"model":               "claude-sonnet-4-7",
+		"cwd":                 "/tmp/demo",
+		"claude_code_version": "9.9.9",
+		"permissionMode":      "default",
+		"tools":               "this-should-be-an-array",
+	})
+	s.handleLine(line)
+
+	ev := waitForEvent(t, s, func(e Event) bool {
+		_, ok := e.(ReadyEvent)
+		return ok
+	}, time.Second)
+	ready, ok := ev.(ReadyEvent)
+	require.True(t, ok)
+	require.Equal(t, "claude-sonnet-4-7", ready.Info.Model)
+	require.Equal(t, "/tmp/demo", ready.Info.WorkDir)
+	require.Equal(t, "sess-1", ready.Info.SessionID)
+}

--- a/agent-cli-wrapper/claude/stream_replay_test.go
+++ b/agent-cli-wrapper/claude/stream_replay_test.go
@@ -528,7 +528,10 @@ func TestStream_Replay_R16_CancelledBgTool(t *testing.T) {
 	}
 	require.NotNil(t, cancelledUserMsg)
 	require.Len(t, cancelledUserMsg.Blocks, 1)
-	require.True(t, cancelledUserMsg.Blocks[0].IsError, "tool_result is_error surfaced raw")
+	resultBlock, ok := cancelledUserMsg.Blocks[0].(ToolResultBlock)
+	require.True(t, ok, "got %T", cancelledUserMsg.Blocks[0])
+	require.NotNil(t, resultBlock.IsError)
+	require.True(t, *resultBlock.IsError, "tool_result is_error surfaced raw")
 	require.Equal(t, 1, countEvents[TaskNotificationEvent](events),
 		"terminal task_notification also fires for cancelled bg tool")
 }

--- a/agent-cli-wrapper/claude/stream_replay_test.go
+++ b/agent-cli-wrapper/claude/stream_replay_test.go
@@ -93,10 +93,10 @@ func TestStream_Replay_AccumulatesStructuredContentBlocks(t *testing.T) {
 	s := newTestSession(t)
 	s.turnManager.StartTurn("hello")
 
-	assistantLine := []byte(`{"type":"assistant","message":{"model":"claude-opus-4-7","role":"assistant","content":[{"type":"text","text":"hi"},{"type":"thinking","thinking":"plan","signature":"sig"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"}}]},"session_id":"s1","uuid":"u1"}`)
+	assistantLine := []byte(`{"type":"assistant","message":{"model":"claude-opus-4-7","role":"assistant","content":[{"type":"text","text":"hi"},{"type":"thinking","thinking":"plan","signature":"sig"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"}},{"type":"server_tool_use","id":"srv_1","name":"future"}]},"session_id":"s1","uuid":"u1"}`)
 	s.handleLine(assistantLine)
 
-	userLine := []byte(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok","is_error":false}]},"session_id":"s1","uuid":"u2"}`)
+	userLine := []byte(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok","is_error":false},{"type":"future_user_block","value":"kept"}]},"session_id":"s1","uuid":"u2"}`)
 	s.handleLine(userLine)
 
 	resultLine := []byte(`{"type":"result","subtype":"success","session_id":"s1","uuid":"u3","result":"hi","num_turns":1,"duration_ms":10,"duration_api_ms":5,"total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
@@ -104,11 +104,13 @@ func TestStream_Replay_AccumulatesStructuredContentBlocks(t *testing.T) {
 
 	result := s.turnManager.GetCompletedResult(1)
 	require.NotNil(t, result, "turn should complete")
-	require.Len(t, result.ContentBlocks, 4)
+	require.Len(t, result.ContentBlocks, 6)
 	require.IsType(t, TextBlock{}, result.ContentBlocks[0])
 	require.IsType(t, ThinkingBlock{}, result.ContentBlocks[1])
 	require.IsType(t, ToolUseBlock{}, result.ContentBlocks[2])
-	require.IsType(t, ToolResultBlock{}, result.ContentBlocks[3])
+	require.IsType(t, UnknownContentBlock{}, result.ContentBlocks[3])
+	require.IsType(t, ToolResultBlock{}, result.ContentBlocks[4])
+	require.IsType(t, UnknownContentBlock{}, result.ContentBlocks[5])
 }
 
 func TestStream_Replay_AssistantStringContent(t *testing.T) {

--- a/agent-cli-wrapper/claude/stream_replay_test.go
+++ b/agent-cli-wrapper/claude/stream_replay_test.go
@@ -89,6 +89,28 @@ func TestStream_Replay_RawEventsAlwaysEmitted(t *testing.T) {
 	}, seen, "raw envelopes preserve protocol order")
 }
 
+func TestStream_Replay_AccumulatesStructuredContentBlocks(t *testing.T) {
+	s := newTestSession(t)
+	s.turnManager.StartTurn("hello")
+
+	assistantLine := []byte(`{"type":"assistant","message":{"model":"claude-opus-4-7","role":"assistant","content":[{"type":"text","text":"hi"},{"type":"thinking","thinking":"plan","signature":"sig"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"}}]},"session_id":"s1","uuid":"u1"}`)
+	s.handleLine(assistantLine)
+
+	userLine := []byte(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok","is_error":false}]},"session_id":"s1","uuid":"u2"}`)
+	s.handleLine(userLine)
+
+	resultLine := []byte(`{"type":"result","subtype":"success","session_id":"s1","uuid":"u3","result":"hi","num_turns":1,"duration_ms":10,"duration_api_ms":5,"total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
+	s.handleLine(resultLine)
+
+	result := s.turnManager.GetCompletedResult(1)
+	require.NotNil(t, result, "turn should complete")
+	require.Len(t, result.ContentBlocks, 4)
+	require.IsType(t, TextBlock{}, result.ContentBlocks[0])
+	require.IsType(t, ThinkingBlock{}, result.ContentBlocks[1])
+	require.IsType(t, ToolUseBlock{}, result.ContentBlocks[2])
+	require.IsType(t, ToolResultBlock{}, result.ContentBlocks[3])
+}
+
 // TestStream_Replay_ResultMessageEvent_Subtype asserts ResultMessageEvent
 // carries subtype and IsError faithfully. Consumers use these to
 // distinguish success vs error vs max-turns-exceeded vs bg-auto-continued

--- a/agent-cli-wrapper/claude/stream_replay_test.go
+++ b/agent-cli-wrapper/claude/stream_replay_test.go
@@ -139,6 +139,31 @@ func TestStream_Replay_ResultMessageEvent_Subtype(t *testing.T) {
 	require.InDelta(t, 0.05, rm.TotalCostUSD, 1e-9)
 }
 
+func TestStream_Replay_ResultMessageEvent_ErrorSubtypeSetsIsError(t *testing.T) {
+	s := newTestSession(t)
+	s.turnManager.StartTurn("prompt")
+
+	resultLine := []byte(`{"type":"result","subtype":"error_max_turns","session_id":"s1","uuid":"u_err","errors":["max turns exceeded"],"num_turns":3,"duration_ms":1000,"duration_api_ms":800,"total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
+	s.handleLine(resultLine)
+
+	events := drainEvents(t, s)
+	var rm *ResultMessageEvent
+	for _, e := range events {
+		if got, ok := e.(ResultMessageEvent); ok {
+			rm = &got
+			break
+		}
+	}
+	require.NotNil(t, rm, "ResultMessageEvent must fire for error subtype turns")
+	require.True(t, rm.IsError)
+	require.Error(t, rm.Error)
+
+	result := s.turnManager.GetCompletedResult(1)
+	require.NotNil(t, result, "turn should complete")
+	require.False(t, result.Success)
+	require.Error(t, result.Error)
+}
+
 // replaySessionFromLines feeds each raw line through handleLine and returns
 // the events emitted. Newlines are trimmed before injection.
 func replaySessionFromLines(t *testing.T, lines [][]byte) []Event {

--- a/agent-cli-wrapper/claude/stream_replay_test.go
+++ b/agent-cli-wrapper/claude/stream_replay_test.go
@@ -111,6 +111,27 @@ func TestStream_Replay_AccumulatesStructuredContentBlocks(t *testing.T) {
 	require.IsType(t, ToolResultBlock{}, result.ContentBlocks[3])
 }
 
+func TestStream_Replay_AssistantStringContent(t *testing.T) {
+	s := newTestSession(t)
+	s.turnManager.StartTurn("hello")
+
+	assistantLine := []byte(`{"type":"assistant","message":{"model":"claude-opus-4-7","role":"assistant","content":"plain text"},"session_id":"s1","uuid":"u1"}`)
+	s.handleLine(assistantLine)
+
+	resultLine := []byte(`{"type":"result","subtype":"success","session_id":"s1","uuid":"u2","result":"plain text","num_turns":1,"duration_ms":10,"duration_api_ms":5,"total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
+	s.handleLine(resultLine)
+
+	events := drainEvents(t, s)
+	require.Equal(t, 1, countEvents[AssistantMessageEvent](events))
+	require.Equal(t, 1, countEvents[TextEvent](events))
+
+	result := s.turnManager.GetCompletedResult(1)
+	require.NotNil(t, result, "turn should complete")
+	require.Equal(t, "plain text", result.Text)
+	require.Len(t, result.ContentBlocks, 1)
+	require.IsType(t, TextBlock{}, result.ContentBlocks[0])
+}
+
 // TestStream_Replay_ResultMessageEvent_Subtype asserts ResultMessageEvent
 // carries subtype and IsError faithfully. Consumers use these to
 // distinguish success vs error vs max-turns-exceeded vs bg-auto-continued
@@ -160,6 +181,22 @@ func TestStream_Replay_ResultMessageEvent_ErrorSubtypeSetsIsError(t *testing.T) 
 
 	result := s.turnManager.GetCompletedResult(1)
 	require.NotNil(t, result, "turn should complete")
+	require.False(t, result.Success)
+	require.Error(t, result.Error)
+}
+
+func TestStream_Replay_ErrorSubtypeDoesNotSuppressWakeup(t *testing.T) {
+	s := newTestSession(t)
+	s.turnManager.StartTurn("prompt")
+
+	assistantLine := []byte(`{"type":"assistant","message":{"model":"claude-opus-4-7","role":"assistant","content":[{"type":"tool_use","id":"toolu_wakeup","name":"ScheduleWakeup","input":{"delay_seconds":1}}]},"session_id":"s1","uuid":"u1"}`)
+	s.handleLine(assistantLine)
+
+	resultLine := []byte(`{"type":"result","subtype":"error_max_turns","session_id":"s1","uuid":"u_err","errors":["max turns exceeded"],"num_turns":1,"duration_ms":1000,"duration_api_ms":800,"total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
+	s.handleLine(resultLine)
+
+	result := s.turnManager.GetCompletedResult(1)
+	require.NotNil(t, result, "error result should complete immediately even with ScheduleWakeup")
 	require.False(t, result.Success)
 	require.Error(t, result.Error)
 }

--- a/agent-cli-wrapper/claude/testdata/retry/edit_error_then_recovered.json
+++ b/agent-cli-wrapper/claude/testdata/retry/edit_error_then_recovered.json
@@ -1,9 +1,9 @@
 [
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_edit_1",
-    "tool_name": "Edit",
-    "tool_input": {
+    "id": "toolu_edit_1",
+    "name": "Edit",
+    "input": {
       "file_path": "/repo/foo.go",
       "old_string": "old",
       "new_string": "new"
@@ -12,28 +12,28 @@
   {
     "type": "tool_result",
     "tool_use_id": "toolu_edit_1",
-    "tool_result": "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+    "content": "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
     "is_error": true
   },
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_read_1",
-    "tool_name": "Read",
-    "tool_input": {
+    "id": "toolu_read_1",
+    "name": "Read",
+    "input": {
       "file_path": "/repo/foo.go"
     }
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_read_1",
-    "tool_result": "package foo\n\nfunc Old() {}\n",
+    "content": "package foo\n\nfunc Old() {}\n",
     "is_error": false
   },
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_edit_2",
-    "tool_name": "Edit",
-    "tool_input": {
+    "id": "toolu_edit_2",
+    "name": "Edit",
+    "input": {
       "file_path": "/repo/foo.go",
       "old_string": "old",
       "new_string": "new"
@@ -42,7 +42,7 @@
   {
     "type": "tool_result",
     "tool_use_id": "toolu_edit_2",
-    "tool_result": "Successfully edited /repo/foo.go",
+    "content": "Successfully edited /repo/foo.go",
     "is_error": false
   }
 ]

--- a/agent-cli-wrapper/claude/testdata/retry/nonzero_exit_bash.json
+++ b/agent-cli-wrapper/claude/testdata/retry/nonzero_exit_bash.json
@@ -1,16 +1,16 @@
 [
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_017E3NKRaj3dZEWn8jStZhjR",
-    "tool_name": "Bash",
-    "tool_input": {
+    "id": "toolu_017E3NKRaj3dZEWn8jStZhjR",
+    "name": "Bash",
+    "input": {
       "command": "gh pr checks 2286"
     }
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_017E3NKRaj3dZEWn8jStZhjR",
-    "tool_result": "Exit code 8\nForge Visual Tests\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/1\t\nPython Tests\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/2\t\nSecurity Scan\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/3\t\nDocker Compose Smoke\tskipping\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/4\t\nDetect Changes\tpass\t6s\thttps://github.com/example-org/example-repo/actions/runs/1/job/5\t\nLint & Type Check\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/6\t",
+    "content": "Exit code 8\nForge Visual Tests\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/1\t\nPython Tests\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/2\t\nSecurity Scan\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/3\t\nDocker Compose Smoke\tskipping\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/4\t\nDetect Changes\tpass\t6s\thttps://github.com/example-org/example-repo/actions/runs/1/job/5\t\nLint & Type Check\tpending\t0\thttps://github.com/example-org/example-repo/actions/runs/1/job/6\t",
     "is_error": true
   }
 ]

--- a/agent-cli-wrapper/claude/testdata/retry/parked_with_skill_error.json
+++ b/agent-cli-wrapper/claude/testdata/retry/parked_with_skill_error.json
@@ -1,46 +1,46 @@
 [
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_bash_bg_1",
-    "tool_name": "Bash",
-    "tool_input": {
+    "id": "toolu_bash_bg_1",
+    "name": "Bash",
+    "input": {
       "command": "sleep 120",
       "run_in_background": true
     }
   },
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_bash_bg_2",
-    "tool_name": "Bash",
-    "tool_input": {
+    "id": "toolu_bash_bg_2",
+    "name": "Bash",
+    "input": {
       "command": "until gh api repos/example-org/example-repo/pulls/1/reviews | jq -e '.[0]'; do sleep 10; done",
       "run_in_background": true
     }
   },
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_skill_1",
-    "tool_name": "Skill",
-    "tool_input": {
+    "id": "toolu_skill_1",
+    "name": "Skill",
+    "input": {
       "skill": "example:pr-polish"
     }
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_bash_bg_1",
-    "tool_result": "command started in background",
+    "content": "command started in background",
     "is_error": false
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_bash_bg_2",
-    "tool_result": "command started in background",
+    "content": "command started in background",
     "is_error": false
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_skill_1",
-    "tool_result": "<tool_use_error>Skill example:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+    "content": "<tool_use_error>Skill example:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
     "is_error": true
   }
 ]

--- a/agent-cli-wrapper/claude/testdata/retry/real_tool_use_error.json
+++ b/agent-cli-wrapper/claude/testdata/retry/real_tool_use_error.json
@@ -1,30 +1,30 @@
 [
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_ruff",
-    "tool_name": "Bash",
-    "tool_input": {
+    "id": "toolu_ruff",
+    "name": "Bash",
+    "input": {
       "command": "uv run ruff check services/python/api-gateway"
     }
   },
   {
     "type": "tool_use",
-    "tool_use_id": "toolu_pytest",
-    "tool_name": "Bash",
-    "tool_input": {
+    "id": "toolu_pytest",
+    "name": "Bash",
+    "input": {
       "command": "uv run pytest services/python/api-gateway"
     }
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_ruff",
-    "tool_result": "Exit code 1\nservices/python/api-gateway/app.py:1:1: TC003 Move standard library import into TYPE_CHECKING block",
+    "content": "Exit code 1\nservices/python/api-gateway/app.py:1:1: TC003 Move standard library import into TYPE_CHECKING block",
     "is_error": true
   },
   {
     "type": "tool_result",
     "tool_use_id": "toolu_pytest",
-    "tool_result": "<tool_use_error>Cancelled: parallel tool call Bash(uv run ruff check services/python/api-ga…) errored</tool_use_error>",
+    "content": "<tool_use_error>Cancelled: parallel tool call Bash(uv run ruff check services/python/api-ga…) errored</tool_use_error>",
     "is_error": true
   }
 ]

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 )
 
 // toolUseErrorMarker is the sentinel the Claude CLI wraps around tool
@@ -93,7 +95,7 @@ func excerptRunes(s string, max int) string {
 // On parallel batches where the errored group is the final group, the
 // cancelled sibling (carrying the marker) is still the last tool_result
 // in forward order, so it remains detectable.
-func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
+func FinalTurnToolError(blocks protocol.ContentBlocks) (toolName, excerpt string, ok bool) {
 	toolName, _, excerpt, ok = FinalTurnToolErrorDetails(blocks)
 	return toolName, excerpt, ok
 }
@@ -101,24 +103,25 @@ func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok boo
 // FinalTurnToolErrorDetails reports the same final tool_use_error as
 // FinalTurnToolError, returning both the full tool result content for policy
 // decisions and a bounded excerpt for display.
-func FinalTurnToolErrorDetails(blocks []ContentBlock) (toolName, content, excerpt string, ok bool) {
+func FinalTurnToolErrorDetails(blocks protocol.ContentBlocks) (toolName, content, excerpt string, ok bool) {
 	for i := len(blocks) - 1; i >= 0; i-- {
-		block := blocks[i]
-		if block.Type != ContentBlockTypeToolResult {
+		block, ok := blocks[i].(protocol.ToolResultBlock)
+		if !ok {
 			continue
 		}
-		if !block.IsError {
+		if block.IsError == nil || !*block.IsError {
 			return "", "", "", false
 		}
-		content := stringifyToolResult(block.ToolResult)
+		content := stringifyToolResult(block.Content)
 		if !strings.Contains(content, toolUseErrorMarker) {
 			return "", "", "", false
 		}
 		// Build tool name map only on the error path (uncommon case).
 		toolNames := make(map[string]string)
 		for _, b := range blocks {
-			if b.Type == ContentBlockTypeToolUse && b.ToolUseID != "" {
-				toolNames[b.ToolUseID] = b.ToolName
+			toolUse, ok := b.(protocol.ToolUseBlock)
+			if ok && toolUse.ID != "" {
+				toolNames[toolUse.ID] = toolUse.Name
 			}
 		}
 		name := toolNames[block.ToolUseID]
@@ -162,7 +165,7 @@ type TurnResult struct {
 	Error         error
 	Text          string
 	Thinking      string
-	ContentBlocks []ContentBlock
+	ContentBlocks protocol.ContentBlocks
 	Usage         TurnUsage
 	TurnNumber    int
 	DurationMs    int64
@@ -179,14 +182,14 @@ const scheduleWakeupToolName = "ScheduleWakeup"
 // latestScheduleWakeup returns the last ScheduleWakeup tool_use block in the
 // turn (in arrival order), or nil if none. For chained wakeups a continuation
 // appends a new block; the safety timer should read from the newest.
-func (turn *turnState) latestScheduleWakeup() *ContentBlock {
+func (turn *turnState) latestScheduleWakeup() *protocol.ToolUseBlock {
 	if turn == nil {
 		return nil
 	}
 	for i := len(turn.ContentBlocks) - 1; i >= 0; i-- {
-		block := &turn.ContentBlocks[i]
-		if block.Type == ContentBlockTypeToolUse && block.ToolName == scheduleWakeupToolName {
-			return block
+		block, ok := turn.ContentBlocks[i].(protocol.ToolUseBlock)
+		if ok && block.Name == scheduleWakeupToolName {
+			return &block
 		}
 	}
 	return nil
@@ -194,7 +197,7 @@ func (turn *turnState) latestScheduleWakeup() *ContentBlock {
 
 func (turn *turnState) latestScheduleWakeupToolID() string {
 	if b := turn.latestScheduleWakeup(); b != nil {
-		return b.ToolUseID
+		return b.ID
 	}
 	return ""
 }
@@ -204,7 +207,7 @@ func (turn *turnState) latestScheduleWakeupDelaySeconds() float64 {
 	if b == nil {
 		return 0
 	}
-	switch v := b.ToolInput["delaySeconds"].(type) {
+	switch v := b.Input["delaySeconds"].(type) {
 	case float64:
 		return v
 	case int:
@@ -222,7 +225,7 @@ type turnState struct {
 	Tools         map[string]*toolState
 	FullText      string
 	FullThinking  string
-	ContentBlocks []ContentBlock
+	ContentBlocks protocol.ContentBlocks
 	Number        int
 }
 
@@ -414,7 +417,7 @@ func (tm *turnManager) GetTurnHistory() []*turnState {
 }
 
 // AppendContentBlock appends a content block to the current turn.
-func (tm *turnManager) AppendContentBlock(block ContentBlock) {
+func (tm *turnManager) AppendContentBlock(block protocol.ContentBlock) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil {

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -418,12 +418,20 @@ func (tm *turnManager) GetTurnHistory() []*turnState {
 
 // AppendContentBlock appends a content block to the current turn.
 func (tm *turnManager) AppendContentBlock(block protocol.ContentBlock) {
+	tm.AppendContentBlocks(protocol.ContentBlocks{block})
+}
+
+// AppendContentBlocks appends content blocks to the current turn.
+func (tm *turnManager) AppendContentBlocks(blocks protocol.ContentBlocks) {
+	if len(blocks) == 0 {
+		return
+	}
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.currentTurn == nil {
 		return
 	}
-	tm.currentTurn.ContentBlocks = append(tm.currentTurn.ContentBlocks, block)
+	tm.currentTurn.ContentBlocks = append(tm.currentTurn.ContentBlocks, blocks...)
 }
 
 // GetTurnByNumber returns a turn by its number.

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -8,17 +8,19 @@ import (
 	"testing"
 )
 
+func boolPtr(v bool) *bool { return &v }
+
 // TestFinalTurnToolError_IsErrorPlusMarker: both IsError and the marker
 // are required. The canonical positive case.
 func TestFinalTurnToolError_IsErrorPlusMarker(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Skill"},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "t1",
-			ToolResult: "<tool_use_error>Skill example:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
-			IsError:    true,
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Skill"},
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "t1",
+			Content:   "<tool_use_error>Skill example:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
 	}
 	name, excerpt, ok := FinalTurnToolError(blocks)
@@ -39,13 +41,13 @@ func TestFinalTurnToolError_IsErrorPlusMarker(t *testing.T) {
 // evidence log 2 false positive.
 func TestFinalTurnToolError_NonzeroExitBash(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "t1",
-			ToolResult: "Exit code 8\nForge Visual Tests\tpending\nPython Tests\tpending",
-			IsError:    true,
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "t1",
+			Content:   "Exit code 8\nForge Visual Tests\tpending\nPython Tests\tpending",
+			IsError:   boolPtr(true),
 		},
 	}
 	if _, _, ok := FinalTurnToolError(blocks); ok {
@@ -57,13 +59,13 @@ func TestFinalTurnToolError_NonzeroExitBash(t *testing.T) {
 // from evidence log 2. The CLI emits the wrapper, so retry fires.
 func TestFinalTurnToolError_WriteNotReadYet(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Write"},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "t1",
-			ToolResult: "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
-			IsError:    true,
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Write"},
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "t1",
+			Content:   "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
 	}
 	if _, _, ok := FinalTurnToolError(blocks); !ok {
@@ -76,13 +78,13 @@ func TestFinalTurnToolError_WriteNotReadYet(t *testing.T) {
 // is false. Must not fire — the AND rule requires both.
 func TestFinalTurnToolError_SubstringWithoutIsError(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "t1",
-			ToolResult: "log line mentions <tool_use_error> in text",
-			IsError:    false,
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "t1",
+			Content:   "log line mentions <tool_use_error> in text",
+			IsError:   boolPtr(false),
 		},
 	}
 	if _, _, ok := FinalTurnToolError(blocks); ok {
@@ -98,20 +100,20 @@ func TestFinalTurnToolError_SubstringWithoutIsError(t *testing.T) {
 // the model sees the full history in context.
 func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "ruff", ToolName: "Bash", ToolInput: map[string]interface{}{"command": "ruff check"}},
-		{Type: ContentBlockTypeToolUse, ToolUseID: "pytest", ToolName: "Bash", ToolInput: map[string]interface{}{"command": "pytest"}},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "ruff",
-			ToolResult: "Exit code 1\nTC003 stdlib import in runtime",
-			IsError:    true,
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "ruff", Name: "Bash", Input: map[string]interface{}{"command": "ruff check"}},
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "pytest", Name: "Bash", Input: map[string]interface{}{"command": "pytest"}},
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "ruff",
+			Content:   "Exit code 1\nTC003 stdlib import in runtime",
+			IsError:   boolPtr(true),
 		},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "pytest",
-			ToolResult: "<tool_use_error>Cancelled: parallel tool call Bash(ruff check) errored</tool_use_error>",
-			IsError:    true,
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "pytest",
+			Content:   "<tool_use_error>Cancelled: parallel tool call Bash(ruff check) errored</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
 	}
 	name, excerpt, ok := FinalTurnToolError(blocks)
@@ -128,9 +130,9 @@ func TestFinalTurnToolError_ParallelCancelled(t *testing.T) {
 
 func TestFinalTurnToolError_Clean(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Read"},
-		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "file contents", IsError: false},
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Read"},
+		ToolResultBlock{Type: ContentBlockTypeToolResult, ToolUseID: "t1", Content: "file contents", IsError: boolPtr(false)},
 	}
 	if _, _, ok := FinalTurnToolError(blocks); ok {
 		t.Fatal("expected ok=false for clean turn")
@@ -139,8 +141,8 @@ func TestFinalTurnToolError_Clean(t *testing.T) {
 
 func TestFinalTurnToolError_NoToolUse(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeText, Text: "hello"},
+	blocks := ContentBlocks{
+		TextBlock{Type: ContentBlockTypeText, Text: "hello"},
 	}
 	if _, _, ok := FinalTurnToolError(blocks); ok {
 		t.Fatal("expected ok=false for text-only turn")
@@ -160,9 +162,9 @@ func TestFinalTurnToolError_BlockShape(t *testing.T) {
 			"text": "<tool_use_error>Cancelled</tool_use_error>",
 		},
 	}
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: wireShape, IsError: true},
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		ToolResultBlock{Type: ContentBlockTypeToolResult, ToolUseID: "t1", Content: wireShape, IsError: boolPtr(true)},
 	}
 	_, excerpt, ok := FinalTurnToolError(blocks)
 	if !ok {
@@ -176,9 +178,9 @@ func TestFinalTurnToolError_BlockShape(t *testing.T) {
 func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
 	t.Parallel()
 	long := "<tool_use_error>" + strings.Repeat("x", 500) + "</tool_use_error>"
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: long, IsError: true},
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		ToolResultBlock{Type: ContentBlockTypeToolResult, ToolUseID: "t1", Content: long, IsError: boolPtr(true)},
 	}
 	_, excerpt, ok := FinalTurnToolError(blocks)
 	if !ok {
@@ -213,12 +215,12 @@ func TestFinalTurnToolErrorDetails_ReturnsFullContent(t *testing.T) {
 
 func TestFinalTurnToolError_UnknownTool(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "orphan",
-			ToolResult: "<tool_use_error>err</tool_use_error>",
-			IsError:    true,
+	blocks := ContentBlocks{
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "orphan",
+			Content:   "<tool_use_error>err</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
 	}
 	name, _, ok := FinalTurnToolError(blocks)
@@ -292,15 +294,15 @@ func TestFinalTurnToolError_Fixture_EditErrorThenRecovered(t *testing.T) {
 // must still fire.
 func TestFinalTurnToolError_ErrorIsLastToolResult(t *testing.T) {
 	t.Parallel()
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Read"},
-		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: "file contents", IsError: false},
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t2", ToolName: "Edit"},
-		{
-			Type:       ContentBlockTypeToolResult,
-			ToolUseID:  "t2",
-			ToolResult: "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
-			IsError:    true,
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Read"},
+		ToolResultBlock{Type: ContentBlockTypeToolResult, ToolUseID: "t1", Content: "file contents", IsError: boolPtr(false)},
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t2", Name: "Edit"},
+		ToolResultBlock{
+			Type:      ContentBlockTypeToolResult,
+			ToolUseID: "t2",
+			Content:   "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
 	}
 	name, excerpt, ok := FinalTurnToolError(blocks)
@@ -315,17 +317,17 @@ func TestFinalTurnToolError_ErrorIsLastToolResult(t *testing.T) {
 	}
 }
 
-// loadRetryFixture reads a JSON snapshot of []ContentBlock from
+// loadRetryFixture reads a JSON snapshot of ContentBlocks from
 // testdata/retry/. Fixtures are hand-extracted from real Claude CLI
 // session JSONL files to guard the detector against regressions.
-func loadRetryFixture(t *testing.T, name string) []ContentBlock {
+func loadRetryFixture(t *testing.T, name string) ContentBlocks {
 	t.Helper()
 	path := filepath.Join("testdata", "retry", name)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read fixture %s: %v", name, err)
 	}
-	var blocks []ContentBlock
+	var blocks ContentBlocks
 	if err := json.Unmarshal(data, &blocks); err != nil {
 		t.Fatalf("unmarshal fixture %s: %v", name, err)
 	}

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -194,9 +194,9 @@ func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
 func TestFinalTurnToolErrorDetails_ReturnsFullContent(t *testing.T) {
 	t.Parallel()
 	long := "<tool_use_error>" + strings.Repeat("x", 500) + " disable-model-invocation</tool_use_error>"
-	blocks := []ContentBlock{
-		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: long, IsError: true},
+	blocks := ContentBlocks{
+		ToolUseBlock{Type: ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		ToolResultBlock{Type: ContentBlockTypeToolResult, ToolUseID: "t1", Content: long, IsError: boolPtr(true)},
 	}
 	name, content, excerpt, ok := FinalTurnToolErrorDetails(blocks)
 	if !ok {

--- a/agent-cli-wrapper/claude/turn_test.go
+++ b/agent-cli-wrapper/claude/turn_test.go
@@ -412,17 +412,17 @@ func TestTurnManager_AppendContentBlock(t *testing.T) {
 	tm.StartTurn("Test")
 
 	// Append a text block
-	tm.AppendContentBlock(ContentBlock{
+	tm.AppendContentBlock(TextBlock{
 		Type: ContentBlockTypeText,
 		Text: "Hello world",
 	})
 
 	// Append a tool use block
-	tm.AppendContentBlock(ContentBlock{
-		Type:      ContentBlockTypeToolUse,
-		ToolUseID: "tool-1",
-		ToolName:  "Read",
-		ToolInput: map[string]interface{}{"file_path": "/test"},
+	tm.AppendContentBlock(ToolUseBlock{
+		Type:  ContentBlockTypeToolUse,
+		ID:    "tool-1",
+		Name:  "Read",
+		Input: map[string]interface{}{"file_path": "/test"},
 	})
 
 	// Verify blocks are stored
@@ -432,19 +432,21 @@ func TestTurnManager_AppendContentBlock(t *testing.T) {
 	}
 
 	// Check text block
-	if turn.ContentBlocks[0].Type != ContentBlockTypeText {
-		t.Errorf("expected text block type, got %v", turn.ContentBlocks[0].Type)
+	textBlock, ok := turn.ContentBlocks[0].(TextBlock)
+	if !ok {
+		t.Fatalf("expected text block type, got %T", turn.ContentBlocks[0])
 	}
-	if turn.ContentBlocks[0].Text != "Hello world" {
-		t.Errorf("expected text 'Hello world', got %q", turn.ContentBlocks[0].Text)
+	if textBlock.Text != "Hello world" {
+		t.Errorf("expected text 'Hello world', got %q", textBlock.Text)
 	}
 
 	// Check tool use block
-	if turn.ContentBlocks[1].Type != ContentBlockTypeToolUse {
-		t.Errorf("expected tool_use block type, got %v", turn.ContentBlocks[1].Type)
+	toolBlock, ok := turn.ContentBlocks[1].(ToolUseBlock)
+	if !ok {
+		t.Fatalf("expected tool_use block type, got %T", turn.ContentBlocks[1])
 	}
-	if turn.ContentBlocks[1].ToolName != "Read" {
-		t.Errorf("expected tool name 'Read', got %q", turn.ContentBlocks[1].ToolName)
+	if toolBlock.Name != "Read" {
+		t.Errorf("expected tool name 'Read', got %q", toolBlock.Name)
 	}
 }
 
@@ -452,7 +454,7 @@ func TestTurnManager_AppendContentBlock_NoTurn(t *testing.T) {
 	tm := newTurnManager()
 
 	// AppendContentBlock with no turn should not panic
-	tm.AppendContentBlock(ContentBlock{
+	tm.AppendContentBlock(TextBlock{
 		Type: ContentBlockTypeText,
 		Text: "test",
 	})
@@ -534,16 +536,20 @@ func TestTurnResult_ContentBlocks(t *testing.T) {
 	result := TurnResult{
 		TurnNumber: 1,
 		Success:    true,
-		ContentBlocks: []ContentBlock{
-			{Type: ContentBlockTypeText, Text: "Hello"},
-			{Type: ContentBlockTypeThinking, Thinking: "Analyzing..."},
+		ContentBlocks: ContentBlocks{
+			TextBlock{Type: ContentBlockTypeText, Text: "Hello"},
+			ThinkingBlock{Type: ContentBlockTypeThinking, Thinking: "Analyzing..."},
 		},
 	}
 
 	if len(result.ContentBlocks) != 2 {
 		t.Errorf("expected 2 content blocks, got %d", len(result.ContentBlocks))
 	}
-	if result.ContentBlocks[0].Text != "Hello" {
-		t.Errorf("expected text 'Hello', got %q", result.ContentBlocks[0].Text)
+	textBlock, ok := result.ContentBlocks[0].(TextBlock)
+	if !ok {
+		t.Fatalf("expected text block type, got %T", result.ContentBlocks[0])
+	}
+	if textBlock.Text != "Hello" {
+		t.Errorf("expected text 'Hello', got %q", textBlock.Text)
 	}
 }

--- a/agent-cli-wrapper/cursor/protocol.go
+++ b/agent-cli-wrapper/cursor/protocol.go
@@ -100,6 +100,14 @@ type ResultMessage struct {
 	IsError       bool   `json:"is_error"`
 }
 
+// IsFailure reports whether the result frame represents a failed turn. A turn
+// is failed when is_error is true OR the subtype is anything other than
+// "success" — error-subtyped frames sometimes leave is_error=false while
+// signalling failure via the subtype, mirroring the Claude CLI contract.
+func (m ResultMessage) IsFailure() bool {
+	return m.IsError || (m.Subtype != "" && m.Subtype != "success")
+}
+
 // Message is the union type returned by ParseMessage.
 type Message interface {
 	messageType() string

--- a/agent-cli-wrapper/cursor/protocol_test.go
+++ b/agent-cli-wrapper/cursor/protocol_test.go
@@ -151,3 +151,22 @@ func TestParseToolCallDetail_NilMessage(t *testing.T) {
 	_, err := ParseToolCallDetail(nil)
 	require.Error(t, err)
 }
+
+func TestResultMessage_IsFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  ResultMessage
+		want bool
+	}{
+		{"success_subtype_no_error", ResultMessage{Subtype: "success", IsError: false}, false},
+		{"empty_subtype_no_error", ResultMessage{Subtype: "", IsError: false}, false},
+		{"success_subtype_with_error", ResultMessage{Subtype: "success", IsError: true}, true},
+		{"error_subtype_no_iserror", ResultMessage{Subtype: "error_max_turns", IsError: false}, true},
+		{"error_subtype_with_iserror", ResultMessage{Subtype: "error", IsError: true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.msg.IsFailure())
+		})
+	}
+}

--- a/agent-cli-wrapper/cursor/session.go
+++ b/agent-cli-wrapper/cursor/session.go
@@ -264,13 +264,14 @@ func (s *Session) handleToolCall(msg *ToolCallMessage) {
 }
 
 func (s *Session) handleResult(msg *ResultMessage) {
+	failed := msg.IsFailure()
 	var resultErr error
-	if msg.IsError {
+	if failed {
 		resultErr = fmt.Errorf("%s", msg.Result)
 	}
 
 	s.emit(TurnCompleteEvent{
-		Success:       !msg.IsError,
+		Success:       !failed,
 		DurationMs:    msg.DurationMs,
 		DurationAPIMs: msg.DurationAPIMs,
 		Error:         resultErr,

--- a/agent-cli-wrapper/protocol/content.go
+++ b/agent-cli-wrapper/protocol/content.go
@@ -71,6 +71,33 @@ type ToolUseBlock struct {
 // BlockType returns the content block type.
 func (t ToolUseBlock) BlockType() ContentBlockType { return ContentBlockTypeToolUse }
 
+// UnmarshalJSON implements json.Unmarshaler. Older recordings used
+// tool_use_id/tool_name/tool_input field names; accept them when the current
+// id/name/input fields are absent.
+func (t *ToolUseBlock) UnmarshalJSON(data []byte) error {
+	type toolUseBlock ToolUseBlock
+	var raw struct {
+		*toolUseBlock
+		LegacyInput map[string]interface{} `json:"tool_input"`
+		LegacyID    string                 `json:"tool_use_id"`
+		LegacyName  string                 `json:"tool_name"`
+	}
+	raw.toolUseBlock = (*toolUseBlock)(t)
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if t.ID == "" {
+		t.ID = raw.LegacyID
+	}
+	if t.Name == "" {
+		t.Name = raw.LegacyName
+	}
+	if t.Input == nil {
+		t.Input = raw.LegacyInput
+	}
+	return nil
+}
+
 // ToolResultBlock contains tool execution results.
 type ToolResultBlock struct {
 	Content   interface{}      `json:"content"`

--- a/agent-cli-wrapper/protocol/content.go
+++ b/agent-cli-wrapper/protocol/content.go
@@ -21,6 +21,26 @@ type ContentBlock interface {
 	BlockType() ContentBlockType
 }
 
+// UnknownContentBlock preserves content blocks whose type is not known by this
+// package yet.
+type UnknownContentBlock struct {
+	Type ContentBlockType
+	Raw  json.RawMessage
+}
+
+// BlockType returns the content block type.
+func (u UnknownContentBlock) BlockType() ContentBlockType { return u.Type }
+
+// MarshalJSON implements json.Marshaler.
+func (u UnknownContentBlock) MarshalJSON() ([]byte, error) {
+	if len(u.Raw) == 0 {
+		return json.Marshal(struct {
+			Type ContentBlockType `json:"type"`
+		}{Type: u.Type})
+	}
+	return u.Raw, nil
+}
+
 // TextBlock contains text content.
 type TextBlock struct {
 	Type ContentBlockType `json:"type"`
@@ -62,6 +82,24 @@ type ToolResultBlock struct {
 // BlockType returns the content block type.
 func (t ToolResultBlock) BlockType() ContentBlockType { return ContentBlockTypeToolResult }
 
+// UnmarshalJSON implements json.Unmarshaler. Older recordings used
+// "tool_result" for the payload field; accept it when "content" is absent.
+func (t *ToolResultBlock) UnmarshalJSON(data []byte) error {
+	type toolResultBlock ToolResultBlock
+	var raw struct {
+		*toolResultBlock
+		LegacyContent json.RawMessage `json:"tool_result"`
+	}
+	raw.toolResultBlock = (*toolResultBlock)(t)
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if t.Content != nil || len(raw.LegacyContent) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw.LegacyContent, &t.Content)
+}
+
 // ContentBlocks is a slice of ContentBlock that handles JSON unmarshaling.
 type ContentBlocks []ContentBlock
 
@@ -77,9 +115,6 @@ func (c *ContentBlocks) UnmarshalJSON(data []byte) error {
 		block, err := UnmarshalContentBlock(raw)
 		if err != nil {
 			return err
-		}
-		if block == nil {
-			continue // skip unknown block types
 		}
 		*c = append(*c, block)
 	}
@@ -121,7 +156,9 @@ func UnmarshalContentBlock(data json.RawMessage) (ContentBlock, error) {
 		}
 		return block, nil
 	default:
-		slog.Warn("skipping unknown content block type", "type", base.Type)
-		return nil, nil
+		slog.Warn("preserving unknown content block type", "type", base.Type)
+		raw := make(json.RawMessage, len(data))
+		copy(raw, data)
+		return UnknownContentBlock{Type: base.Type, Raw: raw}, nil
 	}
 }

--- a/agent-cli-wrapper/protocol/content.go
+++ b/agent-cli-wrapper/protocol/content.go
@@ -3,6 +3,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 )
 
@@ -39,6 +40,16 @@ func (u UnknownContentBlock) MarshalJSON() ([]byte, error) {
 		}{Type: u.Type})
 	}
 	return u.Raw, nil
+}
+
+// DisplayString returns a human-readable representation of an unknown content
+// block for transcript surfaces (sessionmodel parser, sessionanalysis turn
+// aggregation, etc.) so the formatting stays consistent across consumers.
+func (u UnknownContentBlock) DisplayString() string {
+	if len(u.Raw) == 0 {
+		return fmt.Sprintf("[unknown content block: %s]", u.Type)
+	}
+	return fmt.Sprintf("[unknown content block: %s] %s", u.Type, string(u.Raw))
 }
 
 // TextBlock contains text content.

--- a/agent-cli-wrapper/protocol/content_test.go
+++ b/agent-cli-wrapper/protocol/content_test.go
@@ -83,3 +83,21 @@ func TestToolResultBlock_UnmarshalLegacyToolResultField(t *testing.T) {
 		t.Fatalf("content: %#v", block.Content)
 	}
 }
+
+func TestToolUseBlock_UnmarshalLegacyToolUseFields(t *testing.T) {
+	var block ToolUseBlock
+	raw := []byte(`{"type":"tool_use","tool_use_id":"toolu_1","tool_name":"Bash","tool_input":{"command":"pwd"}}`)
+
+	if err := json.Unmarshal(raw, &block); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if block.ID != "toolu_1" {
+		t.Fatalf("id: %q", block.ID)
+	}
+	if block.Name != "Bash" {
+		t.Fatalf("name: %q", block.Name)
+	}
+	if block.Input["command"] != "pwd" {
+		t.Fatalf("input: %#v", block.Input)
+	}
+}

--- a/agent-cli-wrapper/protocol/content_test.go
+++ b/agent-cli-wrapper/protocol/content_test.go
@@ -12,12 +12,19 @@ func TestUnmarshalContentBlock_UnknownType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error for unknown type, got: %v", err)
 	}
-	if block != nil {
-		t.Fatalf("expected nil block for unknown type, got: %v", block)
+	unknown, ok := block.(UnknownContentBlock)
+	if !ok {
+		t.Fatalf("expected UnknownContentBlock for unknown type, got: %T", block)
+	}
+	if unknown.BlockType() != ContentBlockType("server_tool_use") {
+		t.Fatalf("type: %q", unknown.BlockType())
+	}
+	if string(unknown.Raw) != string(raw) {
+		t.Fatalf("raw: %s", unknown.Raw)
 	}
 }
 
-func TestContentBlocks_SkipsUnknownTypes(t *testing.T) {
+func TestContentBlocks_PreservesUnknownTypes(t *testing.T) {
 	// Mix of known and unknown block types
 	raw := `[
 		{"type":"text","text":"hello"},
@@ -31,16 +38,21 @@ func TestContentBlocks_SkipsUnknownTypes(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	// Should only have the two known blocks (text + tool_use)
-	if len(blocks) != 2 {
-		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	if len(blocks) != 4 {
+		t.Fatalf("expected 4 blocks, got %d", len(blocks))
 	}
 
 	if blocks[0].BlockType() != ContentBlockTypeText {
 		t.Errorf("expected first block to be text, got %s", blocks[0].BlockType())
 	}
-	if blocks[1].BlockType() != ContentBlockTypeToolUse {
-		t.Errorf("expected second block to be tool_use, got %s", blocks[1].BlockType())
+	if blocks[1].BlockType() != ContentBlockType("server_tool_use") {
+		t.Errorf("expected second block to be server_tool_use, got %s", blocks[1].BlockType())
+	}
+	if blocks[2].BlockType() != ContentBlockTypeToolUse {
+		t.Errorf("expected third block to be tool_use, got %s", blocks[2].BlockType())
+	}
+	if blocks[3].BlockType() != ContentBlockType("image") {
+		t.Errorf("expected fourth block to be image, got %s", blocks[3].BlockType())
 	}
 
 	// Verify text content preserved
@@ -50,5 +62,24 @@ func TestContentBlocks_SkipsUnknownTypes(t *testing.T) {
 	}
 	if textBlock.Text != "hello" {
 		t.Errorf("expected text 'hello', got %q", textBlock.Text)
+	}
+}
+
+func TestToolResultBlock_UnmarshalLegacyToolResultField(t *testing.T) {
+	var block ToolResultBlock
+	raw := []byte(`{"type":"tool_result","tool_use_id":"toolu_1","tool_result":[{"type":"text","text":"legacy"}],"is_error":true}`)
+
+	if err := json.Unmarshal(raw, &block); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if block.ToolUseID != "toolu_1" {
+		t.Fatalf("tool_use_id: %q", block.ToolUseID)
+	}
+	if block.IsError == nil || !*block.IsError {
+		t.Fatalf("is_error: %v", block.IsError)
+	}
+	items, ok := block.Content.([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("content: %#v", block.Content)
 	}
 }

--- a/agent-cli-wrapper/protocol/content_test.go
+++ b/agent-cli-wrapper/protocol/content_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +22,24 @@ func TestUnmarshalContentBlock_UnknownType(t *testing.T) {
 	}
 	if string(unknown.Raw) != string(raw) {
 		t.Fatalf("raw: %s", unknown.Raw)
+	}
+}
+
+func TestUnknownContentBlock_DisplayString(t *testing.T) {
+	// Type-only block (no raw payload).
+	typeOnly := UnknownContentBlock{Type: ContentBlockType("server_tool_use")}
+	want := "[unknown content block: server_tool_use]"
+	if got := typeOnly.DisplayString(); got != want {
+		t.Errorf("type-only: got %q, want %q", got, want)
+	}
+	// Block with raw payload — must include both the type and the raw bytes.
+	withRaw := UnknownContentBlock{
+		Type: ContentBlockType("image"),
+		Raw:  json.RawMessage(`{"type":"image","source":"x"}`),
+	}
+	got := withRaw.DisplayString()
+	if !strings.Contains(got, "image") || !strings.Contains(got, `"source":"x"`) {
+		t.Errorf("with-raw: got %q, expected to contain 'image' and raw payload", got)
 	}
 }
 

--- a/agent-cli-wrapper/protocol/control.go
+++ b/agent-cli-wrapper/protocol/control.go
@@ -302,8 +302,8 @@ type MCPStatusResponse struct {
 }
 
 // GetContextUsageResponse is the response to a get_context_usage request.
-// TODO: shape is complex (categories, gridRows, memoryFiles, mcpTools,
-// messageBreakdown, apiUsage, etc). Kept as raw map until we need to consume.
+// XXX: type this when the first in-tree consumer lands; the upstream shape is
+// broad and speculative typing has low ROI until we know which fields matter.
 type GetContextUsageResponse map[string]json.RawMessage
 
 // RewindFilesResponse is the response to a rewind_files request.

--- a/agent-cli-wrapper/protocol/messages.go
+++ b/agent-cli-wrapper/protocol/messages.go
@@ -315,9 +315,13 @@ func (ResultError) isResultOutcome() {}
 
 // Outcome returns a sealed variant describing whether the turn succeeded or
 // failed, so callers can switch on the concrete type instead of inspecting
-// Subtype strings directly.
+// Subtype strings directly. A frame with is_error=false is treated as success
+// when the subtype is either the explicit "success" marker or empty —
+// partial/legacy NDJSON without a subtype field should not be reported as a
+// failure if no error signal is present, matching the pre-protocol-refactor
+// !is_error behavior consumers relied on.
 func (m ResultMessage) Outcome() ResultOutcome {
-	if !m.IsError && ResultSubtype(m.Subtype) == ResultSubtypeSuccess {
+	if !m.IsError && (m.Subtype == "" || ResultSubtype(m.Subtype) == ResultSubtypeSuccess) {
 		return ResultSuccess{Text: m.Result}
 	}
 	return ResultError{

--- a/agent-cli-wrapper/protocol/messages.go
+++ b/agent-cli-wrapper/protocol/messages.go
@@ -109,6 +109,16 @@ func (m *SystemMessage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON returns the original system envelope when this message came from
+// the wire, preserving subtype-specific fields not declared on SystemMessage.
+func (m SystemMessage) MarshalJSON() ([]byte, error) {
+	if len(m.raw) > 0 {
+		return m.raw, nil
+	}
+	type systemMessageAlias SystemMessage
+	return json.Marshal(systemMessageAlias(m))
+}
+
 // MsgType returns the message type.
 func (m SystemMessage) MsgType() MessageType { return MessageTypeSystem }
 

--- a/agent-cli-wrapper/protocol/messages.go
+++ b/agent-cli-wrapper/protocol/messages.go
@@ -327,6 +327,12 @@ func (m ResultMessage) Outcome() ResultOutcome {
 	}
 }
 
+// IsFailure reports whether the result frame represents a failed turn.
+func (m ResultMessage) IsFailure() bool {
+	_, ok := m.Outcome().(ResultError)
+	return ok
+}
+
 // MsgType returns the message type.
 func (m ResultMessage) MsgType() MessageType { return MessageTypeResult }
 

--- a/agent-cli-wrapper/protocol/messages.go
+++ b/agent-cli-wrapper/protocol/messages.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 )
 
 // MessageType discriminates between message kinds.
@@ -184,6 +185,9 @@ func (fc FlexibleContent) AsBlocks() (ContentBlocks, bool) {
 	}
 	var blocks ContentBlocks
 	if err := json.Unmarshal(fc.raw, &blocks); err != nil {
+		if fc.raw[0] == '[' {
+			slog.Warn("failed to decode content blocks", "error", err)
+		}
 		return nil, false
 	}
 	return blocks, true

--- a/agent-cli-wrapper/protocol/messages.go
+++ b/agent-cli-wrapper/protocol/messages.go
@@ -246,7 +246,7 @@ type ModelUsage struct {
 
 // ResultMessage contains turn completion metrics.
 //
-// result is populated only when Subtype == ResultSubtypeSuccess. For any of
+// Result is populated only when Subtype == ResultSubtypeSuccess. For any of
 // the error subtypes the Errors slice is populated instead with one or more
 // human-readable error strings. Callers should prefer Outcome() to get a
 // sealed variant that forces handling of the error case.
@@ -255,35 +255,21 @@ type ResultMessage struct {
 	SessionID         string                `json:"session_id"`
 	Subtype           string                `json:"subtype"`
 	UUID              string                `json:"uuid"`
+	Result            string                `json:"result,omitempty"`
 	Type              MessageType           `json:"type"`
-	result            string
-	Errors            []string      `json:"errors,omitempty"`
-	PermissionDenials []interface{} `json:"permission_denials,omitempty"`
-	Usage             UsageDetails  `json:"usage"`
-	TotalCostUSD      float64       `json:"total_cost_usd"`
-	NumTurns          int           `json:"num_turns"`
-	DurationAPIMs     int64         `json:"duration_api_ms"`
-	DurationMs        int64         `json:"duration_ms"`
-	IsError           bool          `json:"is_error"`
+	Errors            []string              `json:"errors,omitempty"`
+	PermissionDenials []interface{}         `json:"permission_denials,omitempty"`
+	Usage             UsageDetails          `json:"usage"`
+	TotalCostUSD      float64               `json:"total_cost_usd"`
+	NumTurns          int                   `json:"num_turns"`
+	DurationAPIMs     int64                 `json:"duration_api_ms"`
+	DurationMs        int64                 `json:"duration_ms"`
+	IsError           bool                  `json:"is_error"`
 }
 
-// UnmarshalJSON decodes the wire result field into the unexported storage used
-// by Outcome().
-func (m *ResultMessage) UnmarshalJSON(data []byte) error {
-	type resultMessageAlias ResultMessage
-	var alias resultMessageAlias
-	if err := json.Unmarshal(data, &alias); err != nil {
-		return err
-	}
-	*m = ResultMessage(alias)
-	var resultField struct {
-		Result string `json:"result"`
-	}
-	if err := json.Unmarshal(data, &resultField); err != nil {
-		return err
-	}
-	m.result = resultField.Result
-	return nil
+// ResultText returns the raw result text carried by successful result frames.
+func (m ResultMessage) ResultText() string {
+	return m.Result
 }
 
 // ResultOutcome is a sealed interface describing the outcome of a turn.
@@ -318,12 +304,12 @@ func (ResultError) isResultOutcome() {}
 // Subtype strings directly.
 func (m ResultMessage) Outcome() ResultOutcome {
 	if !m.IsError && ResultSubtype(m.Subtype) == ResultSubtypeSuccess {
-		return ResultSuccess{Text: m.result}
+		return ResultSuccess{Text: m.Result}
 	}
 	return ResultError{
 		Subtype: ResultSubtype(m.Subtype),
 		Errors:  m.Errors,
-		Text:    m.result,
+		Text:    m.Result,
 	}
 }
 

--- a/agent-cli-wrapper/protocol/messages.go
+++ b/agent-cli-wrapper/protocol/messages.go
@@ -85,27 +85,10 @@ type Plugin struct {
 
 // SystemMessage represents session initialization and system events.
 type SystemMessage struct {
-	ExitCode          *int        `json:"exit_code,omitempty"`
-	UUID              string      `json:"uuid"`
-	PermissionMode    string      `json:"permissionMode,omitempty"`
-	ClaudeCodeVersion string      `json:"claude_code_version,omitempty"`
-	CWD               string      `json:"cwd,omitempty"`
-	Type              MessageType `json:"type"`
-	Subtype           string      `json:"subtype"`
-	Model             string      `json:"model,omitempty"`
-	SessionID         string      `json:"session_id"`
-	Stderr            string      `json:"stderr,omitempty"`
-	Stdout            string      `json:"stdout,omitempty"`
-	HookEvent         string      `json:"hook_event,omitempty"`
-	HookName          string      `json:"hook_name,omitempty"`
-	APIKeySource      string      `json:"apiKeySource,omitempty"`
-	OutputStyle       string      `json:"output_style,omitempty"`
-	Tools             []string    `json:"tools,omitempty"`
-	Plugins           []Plugin    `json:"plugins,omitempty"`
-	Skills            []string    `json:"skills,omitempty"`
-	Agents            []string    `json:"agents,omitempty"`
-	SlashCommands     []string    `json:"slash_commands,omitempty"`
-	MCPServers        []MCPServer `json:"mcp_servers,omitempty"`
+	Type      MessageType `json:"type"`
+	Subtype   string      `json:"subtype"`
+	UUID      string      `json:"uuid"`
+	SessionID string      `json:"session_id"`
 	// raw preserves the on-wire JSON so DecodePayload() can decode
 	// subtype-specific fields not declared on this flat envelope.
 	raw json.RawMessage `json:"-"`
@@ -263,7 +246,7 @@ type ModelUsage struct {
 
 // ResultMessage contains turn completion metrics.
 //
-// Result is populated only when Subtype == ResultSubtypeSuccess. For any of
+// result is populated only when Subtype == ResultSubtypeSuccess. For any of
 // the error subtypes the Errors slice is populated instead with one or more
 // human-readable error strings. Callers should prefer Outcome() to get a
 // sealed variant that forces handling of the error case.
@@ -273,15 +256,34 @@ type ResultMessage struct {
 	Subtype           string                `json:"subtype"`
 	UUID              string                `json:"uuid"`
 	Type              MessageType           `json:"type"`
-	Result            string                `json:"result"`
-	Errors            []string              `json:"errors,omitempty"`
-	PermissionDenials []interface{}         `json:"permission_denials,omitempty"`
-	Usage             UsageDetails          `json:"usage"`
-	TotalCostUSD      float64               `json:"total_cost_usd"`
-	NumTurns          int                   `json:"num_turns"`
-	DurationAPIMs     int64                 `json:"duration_api_ms"`
-	DurationMs        int64                 `json:"duration_ms"`
-	IsError           bool                  `json:"is_error"`
+	result            string
+	Errors            []string      `json:"errors,omitempty"`
+	PermissionDenials []interface{} `json:"permission_denials,omitempty"`
+	Usage             UsageDetails  `json:"usage"`
+	TotalCostUSD      float64       `json:"total_cost_usd"`
+	NumTurns          int           `json:"num_turns"`
+	DurationAPIMs     int64         `json:"duration_api_ms"`
+	DurationMs        int64         `json:"duration_ms"`
+	IsError           bool          `json:"is_error"`
+}
+
+// UnmarshalJSON decodes the wire result field into the unexported storage used
+// by Outcome().
+func (m *ResultMessage) UnmarshalJSON(data []byte) error {
+	type resultMessageAlias ResultMessage
+	var alias resultMessageAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*m = ResultMessage(alias)
+	var resultField struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(data, &resultField); err != nil {
+		return err
+	}
+	m.result = resultField.Result
+	return nil
 }
 
 // ResultOutcome is a sealed interface describing the outcome of a turn.
@@ -316,12 +318,12 @@ func (ResultError) isResultOutcome() {}
 // Subtype strings directly.
 func (m ResultMessage) Outcome() ResultOutcome {
 	if !m.IsError && ResultSubtype(m.Subtype) == ResultSubtypeSuccess {
-		return ResultSuccess{Text: m.Result}
+		return ResultSuccess{Text: m.result}
 	}
 	return ResultError{
 		Subtype: ResultSubtype(m.Subtype),
 		Errors:  m.Errors,
-		Text:    m.Result,
+		Text:    m.result,
 	}
 }
 

--- a/agent-cli-wrapper/protocol/messages_test.go
+++ b/agent-cli-wrapper/protocol/messages_test.go
@@ -172,7 +172,7 @@ func TestParseMessage_UpdateEnvironmentVariables(t *testing.T) {
 }
 
 func TestResultMessage_Outcome_Success(t *testing.T) {
-	m := ResultMessage{Subtype: "success", Result: "hello"}
+	m := parseResultMessage(t, `{"type":"result","subtype":"success","result":"hello","is_error":false}`)
 	out := m.Outcome()
 	s, ok := out.(ResultSuccess)
 	if !ok {
@@ -215,7 +215,7 @@ func TestResultMessage_Outcome_Errors(t *testing.T) {
 // is_error is true but the subtype string still says "success" — Outcome must
 // classify the turn as failed and preserve the diagnostic text from Result.
 func TestResultMessage_Outcome_IsErrorWithSuccessSubtype(t *testing.T) {
-	m := ResultMessage{Subtype: "success", IsError: true, Result: "boom"}
+	m := parseResultMessage(t, `{"type":"result","subtype":"success","result":"boom","is_error":true}`)
 	out := m.Outcome()
 	e, ok := out.(ResultError)
 	if !ok {
@@ -224,4 +224,17 @@ func TestResultMessage_Outcome_IsErrorWithSuccessSubtype(t *testing.T) {
 	if e.Text != "boom" {
 		t.Errorf("text: %q", e.Text)
 	}
+}
+
+func parseResultMessage(t *testing.T, raw string) ResultMessage {
+	t.Helper()
+	msg, err := ParseMessage([]byte(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	result, ok := msg.(ResultMessage)
+	if !ok {
+		t.Fatalf("expected ResultMessage, got %T", msg)
+	}
+	return result
 }

--- a/agent-cli-wrapper/protocol/messages_test.go
+++ b/agent-cli-wrapper/protocol/messages_test.go
@@ -262,6 +262,13 @@ func TestResultMessage_Outcome_IsErrorWithSuccessSubtype(t *testing.T) {
 	}
 }
 
+func TestResultMessage_IsFailure_ErrorSubtypeWithoutIsError(t *testing.T) {
+	m := parseResultMessage(t, `{"type":"result","subtype":"error_max_turns","errors":["boom"]}`)
+	if !m.IsFailure() {
+		t.Fatal("expected error subtype to indicate failure")
+	}
+}
+
 func parseResultMessage(t *testing.T, raw string) ResultMessage {
 	t.Helper()
 	msg, err := ParseMessage([]byte(raw))

--- a/agent-cli-wrapper/protocol/messages_test.go
+++ b/agent-cli-wrapper/protocol/messages_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -180,6 +181,26 @@ func TestResultMessage_Outcome_Success(t *testing.T) {
 	}
 	if s.Text != "hello" {
 		t.Errorf("text: %q", s.Text)
+	}
+	if m.ResultText() != "hello" {
+		t.Errorf("result text: %q", m.ResultText())
+	}
+}
+
+func TestResultMessage_MarshalJSON_PreservesResult(t *testing.T) {
+	m := parseResultMessage(t, `{"type":"result","subtype":"success","result":"hello","is_error":false}`)
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal marshaled result: %v", err)
+	}
+	if wire.Result != "hello" {
+		t.Errorf("result: %q", wire.Result)
 	}
 }
 

--- a/agent-cli-wrapper/protocol/messages_test.go
+++ b/agent-cli-wrapper/protocol/messages_test.go
@@ -269,6 +269,21 @@ func TestResultMessage_IsFailure_ErrorSubtypeWithoutIsError(t *testing.T) {
 	}
 }
 
+// TestResultMessage_Outcome_EmptySubtypeIsSuccess covers partial/legacy NDJSON
+// where the result frame has is_error=false but no subtype. Pre-refactor
+// callers derived success from !is_error, so these frames must remain
+// non-failures to avoid silently flipping turns from success to error.
+func TestResultMessage_Outcome_EmptySubtypeIsSuccess(t *testing.T) {
+	m := parseResultMessage(t, `{"type":"result","result":"hello","is_error":false}`)
+	out := m.Outcome()
+	if _, ok := out.(ResultSuccess); !ok {
+		t.Fatalf("expected ResultSuccess for empty subtype with is_error=false, got %T", out)
+	}
+	if m.IsFailure() {
+		t.Fatal("IsFailure must be false for empty subtype with is_error=false")
+	}
+}
+
 func parseResultMessage(t *testing.T, raw string) ResultMessage {
 	t.Helper()
 	msg, err := ParseMessage([]byte(raw))

--- a/agent-cli-wrapper/protocol/messages_test.go
+++ b/agent-cli-wrapper/protocol/messages_test.go
@@ -97,6 +97,21 @@ func TestParseMessage_RateLimitEvent(t *testing.T) {
 	}
 }
 
+func TestSystemMessage_MarshalJSON_PreservesRawEnvelope(t *testing.T) {
+	raw := `{"type":"system","subtype":"init","session_id":"s1","uuid":"u1","cwd":"/tmp","model":"claude-opus-4-6","tools":["Bash"],"permissionMode":"default"}`
+	msg, err := ParseMessage([]byte(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	marshaled, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(marshaled) != raw {
+		t.Fatalf("marshaled: %s", marshaled)
+	}
+}
+
 func TestParseMessage_PromptSuggestion(t *testing.T) {
 	raw := `{"type":"prompt_suggestion","suggestion":"maybe try this","session_id":"s1","uuid":"u1"}`
 	msg, err := ParseMessage([]byte(raw))

--- a/agent-cli-wrapper/protocol/parse_test.go
+++ b/agent-cli-wrapper/protocol/parse_test.go
@@ -55,17 +55,21 @@ func TestParseMessage_SystemInit(t *testing.T) {
 	if sysMsg.SessionID != "c4e0fdb8-ea8e-4900-a07b-a7977627afb2" {
 		t.Errorf("unexpected session_id: %q", sysMsg.SessionID)
 	}
-	if sysMsg.Model != "claude-haiku-4-5-20251001" {
-		t.Errorf("unexpected model: %q", sysMsg.Model)
+	initPayload, ok := sysMsg.AsInit()
+	if !ok {
+		t.Fatal("AsInit failed")
 	}
-	if sysMsg.PermissionMode != "bypassPermissions" {
-		t.Errorf("unexpected permissionMode: %q", sysMsg.PermissionMode)
+	if initPayload.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("unexpected model: %q", initPayload.Model)
 	}
-	if len(sysMsg.Tools) != 5 {
-		t.Errorf("expected 5 tools, got %d", len(sysMsg.Tools))
+	if initPayload.PermissionMode != "bypassPermissions" {
+		t.Errorf("unexpected permissionMode: %q", initPayload.PermissionMode)
 	}
-	if sysMsg.ClaudeCodeVersion != "2.1.12" {
-		t.Errorf("unexpected claude_code_version: %q", sysMsg.ClaudeCodeVersion)
+	if len(initPayload.Tools) != 5 {
+		t.Errorf("expected 5 tools, got %d", len(initPayload.Tools))
+	}
+	if initPayload.ClaudeCodeVersion != "2.1.12" {
+		t.Errorf("unexpected claude_code_version: %q", initPayload.ClaudeCodeVersion)
 	}
 }
 
@@ -83,14 +87,18 @@ func TestParseMessage_SystemHookResponse(t *testing.T) {
 	if sysMsg.Subtype != "hook_response" {
 		t.Errorf("expected subtype 'hook_response', got %q", sysMsg.Subtype)
 	}
-	if sysMsg.HookName != "SessionStart:startup" {
-		t.Errorf("unexpected hook_name: %q", sysMsg.HookName)
+	hookPayload, ok := sysMsg.AsHookResponse()
+	if !ok {
+		t.Fatal("AsHookResponse failed")
 	}
-	if sysMsg.HookEvent != "SessionStart" {
-		t.Errorf("unexpected hook_event: %q", sysMsg.HookEvent)
+	if hookPayload.HookName != "SessionStart:startup" {
+		t.Errorf("unexpected hook_name: %q", hookPayload.HookName)
 	}
-	if sysMsg.ExitCode == nil || *sysMsg.ExitCode != 0 {
-		t.Errorf("unexpected exit_code: %v", sysMsg.ExitCode)
+	if hookPayload.HookEvent != "SessionStart" {
+		t.Errorf("unexpected hook_event: %q", hookPayload.HookEvent)
+	}
+	if hookPayload.ExitCode == nil || *hookPayload.ExitCode != 0 {
+		t.Errorf("unexpected exit_code: %v", hookPayload.ExitCode)
 	}
 }
 

--- a/agent-cli-wrapper/protocol/system.go
+++ b/agent-cli-wrapper/protocol/system.go
@@ -347,112 +347,91 @@ func (m SystemMessage) DecodePayload() (any, error) {
 
 // AsInit returns the init payload if m.Subtype is "init".
 func (m SystemMessage) AsInit() (*SystemInitPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*SystemInitPayload)
-	return v, ok
+	return systemPayloadAs[*SystemInitPayload](m)
 }
 
 // AsStatus returns the status payload if m.Subtype is "status".
 func (m SystemMessage) AsStatus() (*SystemStatusPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*SystemStatusPayload)
-	return v, ok
+	return systemPayloadAs[*SystemStatusPayload](m)
 }
 
 // AsCompactBoundary returns the compact_boundary payload.
 func (m SystemMessage) AsCompactBoundary() (*CompactBoundaryPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*CompactBoundaryPayload)
-	return v, ok
+	return systemPayloadAs[*CompactBoundaryPayload](m)
 }
 
 // AsPostTurnSummary returns the post_turn_summary payload.
 func (m SystemMessage) AsPostTurnSummary() (*PostTurnSummaryPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*PostTurnSummaryPayload)
-	return v, ok
+	return systemPayloadAs[*PostTurnSummaryPayload](m)
 }
 
 // AsAPIRetry returns the api_retry payload.
 func (m SystemMessage) AsAPIRetry() (*APIRetryPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*APIRetryPayload)
-	return v, ok
+	return systemPayloadAs[*APIRetryPayload](m)
 }
 
 // AsLocalCommandOutput returns the local_command_output payload.
 func (m SystemMessage) AsLocalCommandOutput() (*LocalCommandOutputPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*LocalCommandOutputPayload)
-	return v, ok
+	return systemPayloadAs[*LocalCommandOutputPayload](m)
 }
 
 // AsHookStarted returns the hook_started payload.
 func (m SystemMessage) AsHookStarted() (*HookStartedPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*HookStartedPayload)
-	return v, ok
+	return systemPayloadAs[*HookStartedPayload](m)
 }
 
 // AsHookProgress returns the hook_progress payload.
 func (m SystemMessage) AsHookProgress() (*HookProgressPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*HookProgressPayload)
-	return v, ok
+	return systemPayloadAs[*HookProgressPayload](m)
 }
 
 // AsHookResponse returns the hook_response payload.
 func (m SystemMessage) AsHookResponse() (*HookResponsePayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*HookResponsePayload)
-	return v, ok
+	return systemPayloadAs[*HookResponsePayload](m)
 }
 
 // AsTaskNotification returns the task_notification payload.
 func (m SystemMessage) AsTaskNotification() (*TaskNotificationPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*TaskNotificationPayload)
-	return v, ok
+	return systemPayloadAs[*TaskNotificationPayload](m)
 }
 
 // AsTaskStarted returns the task_started payload.
 func (m SystemMessage) AsTaskStarted() (*TaskStartedPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*TaskStartedPayload)
-	return v, ok
+	return systemPayloadAs[*TaskStartedPayload](m)
 }
 
 // AsTaskProgress returns the task_progress payload.
 func (m SystemMessage) AsTaskProgress() (*TaskProgressPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*TaskProgressPayload)
-	return v, ok
+	return systemPayloadAs[*TaskProgressPayload](m)
 }
 
 // AsTaskUpdated returns the task_updated payload.
 func (m SystemMessage) AsTaskUpdated() (*TaskUpdatedPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*TaskUpdatedPayload)
-	return v, ok
+	return systemPayloadAs[*TaskUpdatedPayload](m)
 }
 
 // AsSessionStateChanged returns the session_state_changed payload.
 func (m SystemMessage) AsSessionStateChanged() (*SessionStateChangedPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*SessionStateChangedPayload)
-	return v, ok
+	return systemPayloadAs[*SessionStateChangedPayload](m)
 }
 
 // AsFilesPersisted returns the files_persisted payload.
 func (m SystemMessage) AsFilesPersisted() (*FilesPersistedPayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*FilesPersistedPayload)
-	return v, ok
+	return systemPayloadAs[*FilesPersistedPayload](m)
 }
 
 // AsElicitationComplete returns the elicitation_complete payload.
 func (m SystemMessage) AsElicitationComplete() (*ElicitationCompletePayload, bool) {
-	p, _ := m.DecodePayload()
-	v, ok := p.(*ElicitationCompletePayload)
+	return systemPayloadAs[*ElicitationCompletePayload](m)
+}
+
+func systemPayloadAs[T any](m SystemMessage) (T, bool) {
+	var zero T
+	p, err := m.DecodePayload()
+	if err != nil {
+		slog.Warn("failed to decode system payload", "subtype", m.Subtype, "error", err)
+		return zero, false
+	}
+	v, ok := p.(T)
 	return v, ok
 }

--- a/agent-cli-wrapper/protocol/system.go
+++ b/agent-cli-wrapper/protocol/system.go
@@ -350,6 +350,46 @@ func (m SystemMessage) AsInit() (*SystemInitPayload, bool) {
 	return systemPayloadAs[*SystemInitPayload](m)
 }
 
+// InitPayloadLenient decodes only init metadata fields needed by offline
+// parsers. Each field is decoded independently so one malformed optional field
+// does not discard model/cwd/session metadata.
+func (m SystemMessage) InitPayloadLenient() SystemInitPayload {
+	payload := SystemInitPayload{
+		SessionID: m.SessionID,
+		UUID:      m.UUID,
+	}
+	var fields map[string]json.RawMessage
+	if len(m.raw) == 0 {
+		data, err := json.Marshal(m)
+		if err != nil {
+			return payload
+		}
+		_ = json.Unmarshal(data, &fields)
+	} else {
+		_ = json.Unmarshal(m.raw, &fields)
+	}
+	decodeInitField(fields, "session_id", &payload.SessionID)
+	decodeInitField(fields, "uuid", &payload.UUID)
+	decodeInitField(fields, "model", &payload.Model)
+	decodeInitField(fields, "cwd", &payload.CWD)
+	decodeInitField(fields, "claude_code_version", &payload.ClaudeCodeVersion)
+	decodeInitField(fields, "permissionMode", &payload.PermissionMode)
+	decodeInitField(fields, "tools", &payload.Tools)
+	decodeInitField(fields, "agents", &payload.Agents)
+	decodeInitField(fields, "skills", &payload.Skills)
+	return payload
+}
+
+func decodeInitField[T any](fields map[string]json.RawMessage, name string, dst *T) {
+	raw, ok := fields[name]
+	if !ok {
+		return
+	}
+	if err := json.Unmarshal(raw, dst); err != nil {
+		slog.Warn("failed to decode system init field", "field", name, "error", err)
+	}
+}
+
 // AsStatus returns the status payload if m.Subtype is "status".
 func (m SystemMessage) AsStatus() (*SystemStatusPayload, bool) {
 	return systemPayloadAs[*SystemStatusPayload](m)

--- a/agent-cli-wrapper/protocol/system.go
+++ b/agent-cli-wrapper/protocol/system.go
@@ -374,9 +374,16 @@ func (m SystemMessage) InitPayloadLenient() SystemInitPayload {
 	decodeInitField(fields, "cwd", &payload.CWD)
 	decodeInitField(fields, "claude_code_version", &payload.ClaudeCodeVersion)
 	decodeInitField(fields, "permissionMode", &payload.PermissionMode)
+	decodeInitField(fields, "apiKeySource", &payload.APIKeySource)
+	decodeInitField(fields, "output_style", &payload.OutputStyle)
 	decodeInitField(fields, "tools", &payload.Tools)
 	decodeInitField(fields, "agents", &payload.Agents)
 	decodeInitField(fields, "skills", &payload.Skills)
+	decodeInitField(fields, "betas", &payload.Betas)
+	decodeInitField(fields, "plugins", &payload.Plugins)
+	decodeInitField(fields, "slash_commands", &payload.SlashCommands)
+	decodeInitField(fields, "mcp_servers", &payload.MCPServers)
+	decodeInitField(fields, "fast_mode_state", &payload.FastModeState)
 	return payload
 }
 

--- a/agent-cli-wrapper/protocol/system_test.go
+++ b/agent-cli-wrapper/protocol/system_test.go
@@ -398,3 +398,24 @@ func TestSystemDecodePayload_UnknownReturnsNil(t *testing.T) {
 		t.Errorf("expected nil payload for unknown subtype, got %T", v)
 	}
 }
+
+func TestSystemMessage_InitPayloadLenient(t *testing.T) {
+	m := parseSystem(t, `{"type":"system","subtype":"init","session_id":"s1","uuid":"u1","cwd":"/tmp","model":"claude-opus-4-6","tools":"malformed","permissionMode":"default"}`)
+	if _, ok := m.AsInit(); ok {
+		t.Fatal("expected strict init decode to fail")
+	}
+
+	payload := m.InitPayloadLenient()
+	if payload.SessionID != "s1" {
+		t.Errorf("session_id: %q", payload.SessionID)
+	}
+	if payload.Model != "claude-opus-4-6" {
+		t.Errorf("model: %q", payload.Model)
+	}
+	if payload.CWD != "/tmp" {
+		t.Errorf("cwd: %q", payload.CWD)
+	}
+	if payload.PermissionMode != "default" {
+		t.Errorf("permissionMode: %q", payload.PermissionMode)
+	}
+}

--- a/agent-cli-wrapper/protocol/system_test.go
+++ b/agent-cli-wrapper/protocol/system_test.go
@@ -38,6 +38,43 @@ func TestSystemSubtype_Init(t *testing.T) {
 	}
 }
 
+func TestInitPayloadLenient_PreservesOptionalFields(t *testing.T) {
+	// Strict AsInit() will fail on the malformed `tools` field. The lenient
+	// fallback should still recover model/cwd plus the other optional fields
+	// codex-bot flagged as silently dropped (apiKeySource, output_style,
+	// betas, plugins, slash_commands, mcp_servers).
+	raw := `{"type":"system","subtype":"init","session_id":"s1","uuid":"u1","cwd":"/tmp","model":"claude-opus-4-6","tools":"malformed","permissionMode":"default","apiKeySource":"managed","output_style":"compact","betas":["beta-a"],"plugins":[{"name":"Plugin","path":"/usr/lib/p1"}],"slash_commands":["/help"],"mcp_servers":[{"name":"mcp1","status":"connected"}]}`
+	m := parseSystem(t, raw)
+	if _, ok := m.AsInit(); ok {
+		t.Fatal("expected strict AsInit() to fail on malformed tools field")
+	}
+	p := m.InitPayloadLenient()
+	if p.Model != "claude-opus-4-6" {
+		t.Errorf("model: %q", p.Model)
+	}
+	if p.CWD != "/tmp" {
+		t.Errorf("cwd: %q", p.CWD)
+	}
+	if p.APIKeySource != "managed" {
+		t.Errorf("apiKeySource: %q", p.APIKeySource)
+	}
+	if p.OutputStyle != "compact" {
+		t.Errorf("output_style: %q", p.OutputStyle)
+	}
+	if len(p.Betas) != 1 || p.Betas[0] != "beta-a" {
+		t.Errorf("betas: %v", p.Betas)
+	}
+	if len(p.Plugins) != 1 || p.Plugins[0].Name != "Plugin" {
+		t.Errorf("plugins: %v", p.Plugins)
+	}
+	if len(p.SlashCommands) != 1 || p.SlashCommands[0] != "/help" {
+		t.Errorf("slash_commands: %v", p.SlashCommands)
+	}
+	if len(p.MCPServers) != 1 || p.MCPServers[0].Name != "mcp1" {
+		t.Errorf("mcp_servers: %v", p.MCPServers)
+	}
+}
+
 func TestSystemSubtype_Status(t *testing.T) {
 	raw := `{"type":"system","subtype":"status","session_id":"s1","uuid":"u1","status":"compacting","permissionMode":"default"}`
 	m := parseSystem(t, raw)

--- a/agent-cli-wrapper/protocol/system_test.go
+++ b/agent-cli-wrapper/protocol/system_test.go
@@ -43,7 +43,7 @@ func TestInitPayloadLenient_PreservesOptionalFields(t *testing.T) {
 	// fallback should still recover model/cwd plus the other optional fields
 	// codex-bot flagged as silently dropped (apiKeySource, output_style,
 	// betas, plugins, slash_commands, mcp_servers).
-	raw := `{"type":"system","subtype":"init","session_id":"s1","uuid":"u1","cwd":"/tmp","model":"claude-opus-4-6","tools":"malformed","permissionMode":"default","apiKeySource":"managed","output_style":"compact","betas":["beta-a"],"plugins":[{"name":"Plugin","path":"/usr/lib/p1"}],"slash_commands":["/help"],"mcp_servers":[{"name":"mcp1","status":"connected"}]}`
+	raw := `{"type":"system","subtype":"init","session_id":"s1","uuid":"u1","cwd":"/tmp","model":"claude-opus-4-6","tools":"malformed","permissionMode":"default","apiKeySource":"managed","output_style":"compact","betas":["beta-a"],"plugins":[{"name":"Plugin","path":"/usr/lib/p1"}],"slash_commands":["/help"],"mcp_servers":[{"name":"mcp1","status":"connected"}],"agents":["agent-a"],"skills":["skill-a"]}`
 	m := parseSystem(t, raw)
 	if _, ok := m.AsInit(); ok {
 		t.Fatal("expected strict AsInit() to fail on malformed tools field")
@@ -72,6 +72,12 @@ func TestInitPayloadLenient_PreservesOptionalFields(t *testing.T) {
 	}
 	if len(p.MCPServers) != 1 || p.MCPServers[0].Name != "mcp1" {
 		t.Errorf("mcp_servers: %v", p.MCPServers)
+	}
+	if len(p.Agents) != 1 || p.Agents[0] != "agent-a" {
+		t.Errorf("agents: %v", p.Agents)
+	}
+	if len(p.Skills) != 1 || p.Skills[0] != "skill-a" {
+		t.Errorf("skills: %v", p.Skills)
 	}
 }
 

--- a/agent-cli-wrapper/protocol/trace_test.go
+++ b/agent-cli-wrapper/protocol/trace_test.go
@@ -53,7 +53,9 @@ func TestParseTraceFromCLI(t *testing.T) {
 		case SystemMessage:
 			systemMsgs++
 			if m.Subtype == "init" {
-				t.Logf("Session init: model=%s, session_id=%s", m.Model, m.SessionID)
+				if p, ok := m.AsInit(); ok {
+					t.Logf("Session init: model=%s, session_id=%s", p.Model, p.SessionID)
+				}
 			}
 		case AssistantMessage:
 			assistantMsgs++

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -314,7 +314,7 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 				if meta != nil && !meta.Timestamp.IsZero() {
 					currentTurn.EndTime = meta.Timestamp
 				}
-				if m.IsError {
+				if resultMessageIsError(m) {
 					currentTurn.Errors = append(currentTurn.Errors, "Turn ended with error")
 				}
 			}
@@ -339,6 +339,11 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 	}
 
 	return sess, nil
+}
+
+func resultMessageIsError(msg protocol.ResultMessage) bool {
+	_, ok := msg.Outcome().(protocol.ResultError)
+	return ok
 }
 
 // ParseProject parses all JSONL files in a project directory, returning

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -300,6 +300,13 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 						}
 						currentTurn.Response += b.Text
 					}
+				case protocol.ThinkingBlock:
+					if b.Thinking != "" {
+						if currentTurn.Response != "" {
+							currentTurn.Response += "\n"
+						}
+						currentTurn.Response += b.Thinking
+					}
 				case protocol.ToolUseBlock:
 					currentTurn.ToolCalls = append(currentTurn.ToolCalls, ToolCall{
 						Name:  b.Name,
@@ -307,6 +314,15 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 						Input: b.Input,
 						State: "running",
 					})
+				case protocol.UnknownContentBlock:
+					// Preserve unknown blocks in the response transcript so
+					// analysis output stays in sync with the wire protocol.
+					if len(b.Raw) > 0 {
+						if currentTurn.Response != "" {
+							currentTurn.Response += "\n"
+						}
+						currentTurn.Response += fmt.Sprintf("[unknown content block: %s] %s", b.Type, string(b.Raw))
+					}
 				}
 			}
 

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -317,12 +317,12 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 				case protocol.UnknownContentBlock:
 					// Preserve unknown blocks in the response transcript so
 					// analysis output stays in sync with the wire protocol.
-					if len(b.Raw) > 0 {
-						if currentTurn.Response != "" {
-							currentTurn.Response += "\n"
-						}
-						currentTurn.Response += fmt.Sprintf("[unknown content block: %s] %s", b.Type, string(b.Raw))
+					// Always emit (matching sessionmodel parser behavior) so a
+					// type-only block isn't dropped silently.
+					if currentTurn.Response != "" {
+						currentTurn.Response += "\n"
 					}
+					currentTurn.Response += b.DisplayString()
 				}
 			}
 

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -272,7 +272,18 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 				}
 			}
 			// Block content with tool_result updates current turn's tool states.
-			if blocks, ok := m.Message.Content.AsBlocks(); ok && currentTurn != nil {
+			// If a block-first user message arrives before any string opener,
+			// open an anonymous turn so unknown blocks and tool_result echoes
+			// are not silently dropped — matches sessionmodel's parser path,
+			// which has no turn concept and always processes the blocks.
+			if blocks, ok := m.Message.Content.AsBlocks(); ok {
+				if currentTurn == nil {
+					turnNum++
+					currentTurn = &Turn{
+						Number:    turnNum,
+						StartTime: meta.Timestamp,
+					}
+				}
 				for _, block := range blocks {
 					switch b := block.(type) {
 					case protocol.ToolResultBlock:

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -245,10 +245,13 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 		switch m := msg.(type) {
 		case protocol.SystemMessage:
 			if m.Subtype == string(protocol.SystemSubtypeInit) {
-				if payload, ok := m.AsInit(); ok {
-					sess.Model = payload.Model
-					sess.CWD = payload.CWD
+				payload, ok := m.AsInit()
+				if !ok {
+					loose := m.InitPayloadLenient()
+					payload = &loose
 				}
+				sess.Model = payload.Model
+				sess.CWD = payload.CWD
 			}
 
 		case protocol.UserMessage:
@@ -314,7 +317,7 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 				if meta != nil && !meta.Timestamp.IsZero() {
 					currentTurn.EndTime = meta.Timestamp
 				}
-				if resultMessageIsError(m) {
+				if m.IsFailure() {
 					currentTurn.Errors = append(currentTurn.Errors, "Turn ended with error")
 				}
 			}
@@ -339,11 +342,6 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 	}
 
 	return sess, nil
-}
-
-func resultMessageIsError(msg protocol.ResultMessage) bool {
-	_, ok := msg.Outcome().(protocol.ResultError)
-	return ok
 }
 
 // ParseProject parses all JSONL files in a project directory, returning

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -248,6 +248,13 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 				payload, ok := m.AsInit()
 				if !ok {
 					loose := m.InitPayloadLenient()
+					// Match the live wrapper and sessionmodel parser: skip
+					// applying init metadata if mandatory fields are missing
+					// after lenient decode, so analysis output stays aligned
+					// with the live session contract.
+					if loose.SessionID == "" || loose.Model == "" || loose.CWD == "" {
+						break
+					}
 					payload = &loose
 				}
 				sess.Model = payload.Model

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -274,8 +274,17 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 			// Block content with tool_result updates current turn's tool states.
 			if blocks, ok := m.Message.Content.AsBlocks(); ok && currentTurn != nil {
 				for _, block := range blocks {
-					if tr, ok := block.(protocol.ToolResultBlock); ok {
-						updateToolResult(currentTurn, tr)
+					switch b := block.(type) {
+					case protocol.ToolResultBlock:
+						updateToolResult(currentTurn, b)
+					case protocol.UnknownContentBlock:
+						// Mirror assistant handling: keep unknown user-side
+						// blocks visible in the response transcript so the
+						// wire protocol stays observable through analysis.
+						if currentTurn.Response != "" {
+							currentTurn.Response += "\n"
+						}
+						currentTurn.Response += b.DisplayString()
 					}
 				}
 			}

--- a/bramble/sessionanalysis/analysis.go
+++ b/bramble/sessionanalysis/analysis.go
@@ -244,9 +244,11 @@ func ParseSessionWithConfig(path string, cfg Config) (*Session, error) {
 
 		switch m := msg.(type) {
 		case protocol.SystemMessage:
-			if m.Subtype == "init" {
-				sess.Model = m.Model
-				sess.CWD = m.CWD
+			if m.Subtype == string(protocol.SystemSubtypeInit) {
+				if payload, ok := m.AsInit(); ok {
+					sess.Model = payload.Model
+					sess.CWD = payload.CWD
+				}
 			}
 
 		case protocol.UserMessage:

--- a/bramble/sessionanalysis/analysis_test.go
+++ b/bramble/sessionanalysis/analysis_test.go
@@ -69,6 +69,20 @@ func TestParseSession_NonexistentFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseSession_UserPreservesUnknownBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := []byte(
+		`{"type":"user","timestamp":"2026-05-05T00:00:00Z","message":{"role":"user","content":"hi"}}` + "\n" +
+			`{"type":"user","timestamp":"2026-05-05T00:00:01Z","message":{"role":"user","content":[{"type":"future_user_block","payload":"opaque"}]}}` + "\n" +
+			`{"type":"result","timestamp":"2026-05-05T00:00:02Z","message":{"subtype":"success","session_id":"s1","uuid":"u1","num_turns":1,"duration_ms":100,"duration_api_ms":50,"total_cost_usd":0.01,"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}` + "\n")
+	require.NoError(t, os.WriteFile(path, lines, 0o600))
+
+	sess, err := ParseSession(path)
+	require.NoError(t, err)
+	require.Len(t, sess.Turns, 1)
+	assert.Contains(t, sess.Turns[0].Response, "future_user_block")
+}
+
 func TestParseSession_AssistantPreservesUnknownAndThinkingBlocks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	lines := []byte(

--- a/bramble/sessionanalysis/analysis_test.go
+++ b/bramble/sessionanalysis/analysis_test.go
@@ -83,6 +83,23 @@ func TestParseSession_UserPreservesUnknownBlock(t *testing.T) {
 	assert.Contains(t, sess.Turns[0].Response, "future_user_block")
 }
 
+// TestParseSession_BlockFirstUserOpensAnonymousTurn covers the path where the
+// first user frame is block-only (no string opener). Analysis should open an
+// anonymous turn so unknown blocks and tool_result echoes are still captured.
+func TestParseSession_BlockFirstUserOpensAnonymousTurn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := []byte(
+		`{"type":"user","timestamp":"2026-05-05T00:00:00Z","message":{"role":"user","content":[{"type":"future_user_block","payload":"opaque"}]}}` + "\n" +
+			`{"type":"result","timestamp":"2026-05-05T00:00:01Z","message":{"subtype":"success","session_id":"s1","uuid":"u1","num_turns":1,"duration_ms":100,"duration_api_ms":50,"total_cost_usd":0.01,"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}` + "\n")
+	require.NoError(t, os.WriteFile(path, lines, 0o600))
+
+	sess, err := ParseSession(path)
+	require.NoError(t, err)
+	require.Len(t, sess.Turns, 1, "expected an anonymous turn to be opened for the block-first user frame")
+	assert.Empty(t, sess.Turns[0].UserInput)
+	assert.Contains(t, sess.Turns[0].Response, "future_user_block")
+}
+
 func TestParseSession_AssistantPreservesUnknownAndThinkingBlocks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	lines := []byte(

--- a/bramble/sessionanalysis/analysis_test.go
+++ b/bramble/sessionanalysis/analysis_test.go
@@ -69,6 +69,22 @@ func TestParseSession_NonexistentFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseSession_AssistantPreservesUnknownAndThinkingBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := []byte(
+		`{"type":"user","timestamp":"2026-05-05T00:00:00Z","message":{"role":"user","content":"hi"}}` + "\n" +
+			`{"type":"assistant","timestamp":"2026-05-05T00:00:01Z","message":{"model":"claude","id":"m1","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"reasoning"},{"type":"text","text":"answer"},{"type":"future_block_xyz","payload":"opaque"}],"stop_reason":"end_turn"}}` + "\n")
+	require.NoError(t, os.WriteFile(path, lines, 0o600))
+
+	sess, err := ParseSession(path)
+	require.NoError(t, err)
+	require.Len(t, sess.Turns, 1)
+	resp := sess.Turns[0].Response
+	assert.Contains(t, resp, "reasoning")
+	assert.Contains(t, resp, "answer")
+	assert.Contains(t, resp, "future_block_xyz")
+}
+
 func TestParseSession_ResultErrorSubtypeRecordsError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	lines := []byte(

--- a/bramble/sessionanalysis/analysis_test.go
+++ b/bramble/sessionanalysis/analysis_test.go
@@ -69,6 +69,19 @@ func TestParseSession_NonexistentFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseSession_ResultErrorSubtypeRecordsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := []byte(
+		`{"type":"user","timestamp":"2026-05-05T00:00:00Z","message":{"role":"user","content":"hello"}}` + "\n" +
+			`{"type":"result","timestamp":"2026-05-05T00:00:01Z","message":{"subtype":"error_max_turns","session_id":"s1","uuid":"u1","errors":["max turns exceeded"],"num_turns":1,"duration_ms":1000,"duration_api_ms":800,"total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}` + "\n")
+	require.NoError(t, os.WriteFile(path, lines, 0o600))
+
+	sess, err := ParseSession(path)
+	require.NoError(t, err)
+	require.Len(t, sess.Turns, 1)
+	require.NotEmpty(t, sess.Turns[0].Errors)
+}
+
 func TestCleanUserInput_TaskNotification(t *testing.T) {
 	input := `<task-notification><task-id>abc123</task-id><summary>Background command completed</summary></task-notification>`
 	meta := &sessionmodel.RawEnvelopeMeta{IsMeta: true}

--- a/bramble/sessionmodel/model_test.go
+++ b/bramble/sessionmodel/model_test.go
@@ -170,6 +170,21 @@ func TestMessageParser_ResultErrorSubtypeMarksFailed(t *testing.T) {
 	assert.Equal(t, StatusFailed, m.Meta().Status)
 }
 
+func TestMessageParser_AssistantPreservesUnknownBlock(t *testing.T) {
+	m := NewSessionModel(0)
+	p := NewMessageParser(m)
+
+	msg, err := FromLiveNDJSON([]byte(`{"type":"assistant","session_id":"s1","uuid":"u1","message":{"id":"m1","type":"message","role":"assistant","model":"claude","stop_reason":null,"content":[{"type":"future_block_xyz","payload":"opaque"}]}}`))
+	require.NoError(t, err)
+	p.HandleMessage(msg)
+
+	output := m.Output()
+	require.Len(t, output, 1)
+	assert.Equal(t, OutputTypeText, output[0].Type)
+	assert.Contains(t, output[0].Content, "future_block_xyz")
+	assert.Contains(t, output[0].Content, "opaque")
+}
+
 func TestMessageParser_InitLenientFallback(t *testing.T) {
 	m := NewSessionModel(0)
 	p := NewMessageParser(m)

--- a/bramble/sessionmodel/model_test.go
+++ b/bramble/sessionmodel/model_test.go
@@ -155,6 +155,21 @@ func TestSessionModel_StatusAllowsNonTerminal(t *testing.T) {
 	assert.Equal(t, StatusCompleted, m.Meta().Status)
 }
 
+func TestMessageParser_ResultErrorSubtypeMarksFailed(t *testing.T) {
+	m := NewSessionModel(0)
+	m.SetMeta(SessionMeta{Status: StatusRunning})
+	p := NewMessageParser(m)
+
+	msg, err := FromLiveNDJSON([]byte(`{"type":"result","subtype":"error_max_turns","session_id":"s1","uuid":"u1","errors":["max turns exceeded"],"num_turns":1,"duration_ms":1000,"duration_api_ms":800,"total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`))
+	require.NoError(t, err)
+	p.HandleMessage(msg)
+
+	output := m.Output()
+	require.Len(t, output, 1)
+	assert.True(t, output[0].IsError)
+	assert.Equal(t, StatusFailed, m.Meta().Status)
+}
+
 func TestSessionModel_ConcurrentAccess(t *testing.T) {
 	m := NewSessionModel(100)
 	m.SetMeta(SessionMeta{Status: StatusRunning})

--- a/bramble/sessionmodel/model_test.go
+++ b/bramble/sessionmodel/model_test.go
@@ -170,6 +170,22 @@ func TestMessageParser_ResultErrorSubtypeMarksFailed(t *testing.T) {
 	assert.Equal(t, StatusFailed, m.Meta().Status)
 }
 
+func TestMessageParser_InitLenientFallback(t *testing.T) {
+	m := NewSessionModel(0)
+	p := NewMessageParser(m)
+
+	msg, err := FromLiveNDJSON([]byte(`{"type":"system","subtype":"init","session_id":"s1","uuid":"u1","cwd":"/tmp","model":"claude-opus-4-6","tools":"malformed","permissionMode":"default"}`))
+	require.NoError(t, err)
+	p.HandleMessage(msg)
+
+	meta := m.Meta()
+	assert.Equal(t, "s1", meta.SessionID)
+	assert.Equal(t, "claude-opus-4-6", meta.Model)
+	assert.Equal(t, "/tmp", meta.CWD)
+	assert.Equal(t, "default", meta.PermissionMode)
+	assert.Equal(t, StatusRunning, meta.Status)
+}
+
 func TestSessionModel_ConcurrentAccess(t *testing.T) {
 	m := NewSessionModel(100)
 	m.SetMeta(SessionMeta{Status: StatusRunning})

--- a/bramble/sessionmodel/model_test.go
+++ b/bramble/sessionmodel/model_test.go
@@ -200,6 +200,22 @@ func TestMessageParser_AssistantPreservesUnknownBlock(t *testing.T) {
 	assert.Contains(t, output[0].Content, "opaque")
 }
 
+func TestMessageParser_InitSkipsWhenMandatoryFieldsMissing(t *testing.T) {
+	m := NewSessionModel(0)
+	p := NewMessageParser(m)
+
+	// Init frame missing model and cwd. Strict AsInit() succeeds (these are
+	// strings that default to ""), so this exercises the lenient guard via
+	// the malformed `tools` field which forces strict decode to fail.
+	msg, err := FromLiveNDJSON([]byte(`{"type":"system","subtype":"init","session_id":"","uuid":"","tools":"malformed"}`))
+	require.NoError(t, err)
+	p.HandleMessage(msg)
+
+	// SetMeta must not have been called: status defaults to "" rather than
+	// StatusRunning, because handleSystem refused the partial init payload.
+	assert.NotEqual(t, StatusRunning, m.Meta().Status)
+}
+
 func TestMessageParser_InitLenientFallback(t *testing.T) {
 	m := NewSessionModel(0)
 	p := NewMessageParser(m)

--- a/bramble/sessionmodel/model_test.go
+++ b/bramble/sessionmodel/model_test.go
@@ -170,6 +170,21 @@ func TestMessageParser_ResultErrorSubtypeMarksFailed(t *testing.T) {
 	assert.Equal(t, StatusFailed, m.Meta().Status)
 }
 
+func TestMessageParser_UserPreservesUnknownBlock(t *testing.T) {
+	m := NewSessionModel(0)
+	p := NewMessageParser(m)
+
+	msg, err := FromLiveNDJSON([]byte(`{"type":"user","session_id":"s1","uuid":"u1","message":{"role":"user","content":[{"type":"future_user_block","payload":"opaque"}]}}`))
+	require.NoError(t, err)
+	p.HandleMessage(msg)
+
+	output := m.Output()
+	require.Len(t, output, 1)
+	assert.Equal(t, OutputTypeText, output[0].Type)
+	assert.Contains(t, output[0].Content, "future_user_block")
+	assert.Contains(t, output[0].Content, "opaque")
+}
+
 func TestMessageParser_AssistantPreservesUnknownBlock(t *testing.T) {
 	m := NewSessionModel(0)
 	p := NewMessageParser(m)

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -133,7 +133,7 @@ func (p *MessageParser) handleAssistant(msg protocol.AssistantMessage) {
 			p.model.AppendOutput(OutputLine{
 				Timestamp: time.Now(),
 				Type:      OutputTypeText,
-				Content:   fmt.Sprintf("[unknown content block: %s] %s", b.Type, string(b.Raw)),
+				Content:   b.DisplayString(),
 			})
 		}
 	}

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -126,6 +126,15 @@ func (p *MessageParser) handleAssistant(msg protocol.AssistantMessage) {
 				ToolState: ToolStateRunning,
 				StartTime: now,
 			})
+		case protocol.UnknownContentBlock:
+			// Surface unknown blocks rather than dropping them so the
+			// transcript stays in sync with the wire protocol. The raw JSON
+			// payload is preserved by the protocol decoder.
+			p.model.AppendOutput(OutputLine{
+				Timestamp: time.Now(),
+				Type:      OutputTypeText,
+				Content:   fmt.Sprintf("[unknown content block: %s] %s", b.Type, string(b.Raw)),
+			})
 		}
 	}
 }

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -63,7 +63,8 @@ func (p *MessageParser) handleSystem(msg protocol.SystemMessage) {
 	if msg.Subtype == string(protocol.SystemSubtypeInit) {
 		payload, ok := msg.AsInit()
 		if !ok {
-			return
+			loose := msg.InitPayloadLenient()
+			payload = &loose
 		}
 		p.model.SetMeta(SessionMeta{
 			SessionID:         payload.SessionID,
@@ -200,21 +201,16 @@ func (p *MessageParser) handleResult(msg protocol.ResultMessage) {
 		TurnNumber: msg.NumTurns,
 		CostUSD:    msg.TotalCostUSD,
 		DurationMs: msg.DurationMs,
-		IsError:    resultMessageIsError(msg),
+		IsError:    msg.IsFailure(),
 	})
 
 	// Transition the session to a terminal status now that the result is known.
 	// These transitions are from StatusRunning so the guard should never fire.
-	if resultMessageIsError(msg) {
+	if msg.IsFailure() {
 		_ = p.model.UpdateStatus(StatusFailed)
 	} else {
 		_ = p.model.UpdateStatus(StatusCompleted)
 	}
-}
-
-func resultMessageIsError(msg protocol.ResultMessage) bool {
-	_, ok := msg.Outcome().(protocol.ResultError)
-	return ok
 }
 
 // --- stream_event (live streaming deltas) -----------------------------------

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -163,11 +163,12 @@ func (p *MessageParser) handleUser(msg protocol.UserMessage) {
 	}
 
 	for _, block := range blocks {
-		if tr, ok := block.(protocol.ToolResultBlock); ok {
-			isError := tr.IsError != nil && *tr.IsError
+		switch b := block.(type) {
+		case protocol.ToolResultBlock:
+			isError := b.IsError != nil && *b.IsError
 			now := time.Now()
-			p.model.UpdateTool(tr.ToolUseID, func(line *OutputLine) {
-				line.ToolResult = tr.Content
+			p.model.UpdateTool(b.ToolUseID, func(line *OutputLine) {
+				line.ToolResult = b.Content
 				line.IsError = isError
 				if isError {
 					line.ToolState = ToolStateError
@@ -185,6 +186,14 @@ func (p *MessageParser) handleUser(msg protocol.UserMessage) {
 				prog.CurrentPhase = ""
 				prog.LastActivity = time.Now()
 				prog.RecentOutput = recent
+			})
+		case protocol.UnknownContentBlock:
+			// Mirror handleAssistant: surface unknown user-side blocks so the
+			// transcript stays in sync with the wire protocol.
+			p.model.AppendOutput(OutputLine{
+				Timestamp: time.Now(),
+				Type:      OutputTypeText,
+				Content:   b.DisplayString(),
 			})
 		}
 	}

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -200,16 +200,21 @@ func (p *MessageParser) handleResult(msg protocol.ResultMessage) {
 		TurnNumber: msg.NumTurns,
 		CostUSD:    msg.TotalCostUSD,
 		DurationMs: msg.DurationMs,
-		IsError:    msg.IsError,
+		IsError:    resultMessageIsError(msg),
 	})
 
 	// Transition the session to a terminal status now that the result is known.
 	// These transitions are from StatusRunning so the guard should never fire.
-	if msg.IsError {
+	if resultMessageIsError(msg) {
 		_ = p.model.UpdateStatus(StatusFailed)
 	} else {
 		_ = p.model.UpdateStatus(StatusCompleted)
 	}
+}
+
+func resultMessageIsError(msg protocol.ResultMessage) bool {
+	_, ok := msg.Outcome().(protocol.ResultError)
+	return ok
 }
 
 // --- stream_event (live streaming deltas) -----------------------------------

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -60,16 +60,20 @@ func (p *MessageParser) HandleMessage(msg protocol.Message) {
 // --- system -----------------------------------------------------------------
 
 func (p *MessageParser) handleSystem(msg protocol.SystemMessage) {
-	if msg.Subtype == "init" {
+	if msg.Subtype == string(protocol.SystemSubtypeInit) {
+		payload, ok := msg.AsInit()
+		if !ok {
+			return
+		}
 		p.model.SetMeta(SessionMeta{
-			SessionID:         msg.SessionID,
-			Model:             msg.Model,
-			CWD:               msg.CWD,
-			ClaudeCodeVersion: msg.ClaudeCodeVersion,
-			PermissionMode:    msg.PermissionMode,
-			Tools:             msg.Tools,
-			Agents:            msg.Agents,
-			Skills:            msg.Skills,
+			SessionID:         payload.SessionID,
+			Model:             payload.Model,
+			CWD:               payload.CWD,
+			ClaudeCodeVersion: payload.ClaudeCodeVersion,
+			PermissionMode:    payload.PermissionMode,
+			Tools:             payload.Tools,
+			Agents:            payload.Agents,
+			Skills:            payload.Skills,
 			Status:            StatusRunning,
 		})
 	}

--- a/bramble/sessionmodel/parser.go
+++ b/bramble/sessionmodel/parser.go
@@ -64,6 +64,14 @@ func (p *MessageParser) handleSystem(msg protocol.SystemMessage) {
 		payload, ok := msg.AsInit()
 		if !ok {
 			loose := msg.InitPayloadLenient()
+			// Match the live wrapper (claude/session.go handleSystem): if
+			// neither strict nor lenient decode recovers the mandatory init
+			// fields, skip the StatusRunning transition so a corrupt frame
+			// surfaces as no-init rather than empty-meta-running, keeping
+			// offline parsing in sync with the live session contract.
+			if loose.SessionID == "" || loose.Model == "" || loose.CWD == "" {
+				return
+			}
 			payload = &loose
 		}
 		p.model.SetMeta(SessionMeta{

--- a/multiagent/agent/BUILD.bazel
+++ b/multiagent/agent/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/codex",
         "//agent-cli-wrapper/cursor",
+        "//agent-cli-wrapper/protocol",
         "//wt",
     ],
 )

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/agentstream"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 	"github.com/bazelment/yoloswe/wt"
 )
 
@@ -410,11 +411,12 @@ func ClaudeResultToAgentResult(r *claude.TurnResult) *AgentResult {
 		return nil
 	}
 	return &AgentResult{
-		Text:       r.Text,
-		Thinking:   r.Thinking,
-		Success:    r.Success,
-		Error:      r.Error,
-		DurationMs: r.DurationMs,
+		Text:          r.Text,
+		Thinking:      r.Thinking,
+		Success:       r.Success,
+		Error:         r.Error,
+		DurationMs:    r.DurationMs,
+		ContentBlocks: claudeBlocksToAgentBlocks(r.ContentBlocks),
 		Usage: AgentUsage{
 			InputTokens:     r.Usage.InputTokens,
 			OutputTokens:    r.Usage.OutputTokens,
@@ -422,4 +424,48 @@ func ClaudeResultToAgentResult(r *claude.TurnResult) *AgentResult {
 			CostUSD:         r.Usage.CostUSD,
 		},
 	}
+}
+
+// claudeBlocksToAgentBlocks maps protocol content blocks to the
+// provider-agnostic AgentContentBlock representation. Unknown block types are
+// preserved with their declared type and a textual rendering so downstream
+// consumers don't silently drop content the protocol layer kept.
+func claudeBlocksToAgentBlocks(blocks protocol.ContentBlocks) []AgentContentBlock {
+	if len(blocks) == 0 {
+		return nil
+	}
+	out := make([]AgentContentBlock, 0, len(blocks))
+	for _, block := range blocks {
+		switch b := block.(type) {
+		case protocol.TextBlock:
+			out = append(out, AgentContentBlock{
+				Type: string(protocol.ContentBlockTypeText),
+				Text: b.Text,
+			})
+		case protocol.ThinkingBlock:
+			out = append(out, AgentContentBlock{
+				Type: string(protocol.ContentBlockTypeThinking),
+				Text: b.Thinking,
+			})
+		case protocol.ToolUseBlock:
+			out = append(out, AgentContentBlock{
+				Type:      string(protocol.ContentBlockTypeToolUse),
+				ToolName:  b.Name,
+				ToolInput: b.Input,
+			})
+		case protocol.ToolResultBlock:
+			isError := b.IsError != nil && *b.IsError
+			out = append(out, AgentContentBlock{
+				Type:       string(protocol.ContentBlockTypeToolResult),
+				ToolResult: b.Content,
+				IsError:    isError,
+			})
+		case protocol.UnknownContentBlock:
+			out = append(out, AgentContentBlock{
+				Type: string(b.Type),
+				Text: b.DisplayString(),
+			})
+		}
+	}
+	return out
 }

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -465,6 +465,14 @@ func claudeBlocksToAgentBlocks(blocks protocol.ContentBlocks) []AgentContentBloc
 				Type: string(b.Type),
 				Text: b.DisplayString(),
 			})
+		default:
+			// A future protocol.ContentBlock implementation that this switch
+			// hasn't been updated for. Preserve at least the declared type
+			// so downstream consumers can see something landed rather than
+			// silently dropping the block.
+			out = append(out, AgentContentBlock{
+				Type: string(block.BlockType()),
+			})
 		}
 	}
 	return out

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -84,37 +84,37 @@ func (s *cancelAfterFirstAskSession) Ask(ctx context.Context, content string) (*
 // realToolUseErrorBlocks is the minimal set of ContentBlocks that
 // FinalTurnToolError will flag as retry-worthy: IsError true and the
 // <tool_use_error> wrapper present.
-func realToolUseErrorBlocks(excerpt string) []claude.ContentBlock {
-	return []claude.ContentBlock{
-		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{
-			Type:       claude.ContentBlockTypeToolResult,
-			ToolUseID:  "t1",
-			ToolResult: "<tool_use_error>" + excerpt + "</tool_use_error>",
-			IsError:    true,
+func realToolUseErrorBlocks(excerpt string) claude.ContentBlocks {
+	return claude.ContentBlocks{
+		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		claude.ToolResultBlock{
+			Type:      claude.ContentBlockTypeToolResult,
+			ToolUseID: "t1",
+			Content:   "<tool_use_error>" + excerpt + "</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
 	}
 }
 
 // nonzeroExitBashBlocks mimics a `gh pr checks` exit-8 shape: IsError
 // true but no <tool_use_error> wrapper. Must not trigger retry.
-func nonzeroExitBashBlocks() []claude.ContentBlock {
-	return []claude.ContentBlock{
-		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
-		{
-			Type:       claude.ContentBlockTypeToolResult,
-			ToolUseID:  "t1",
-			ToolResult: "Exit code 8\nForge Visual Tests\tpending",
-			IsError:    true,
+func nonzeroExitBashBlocks() claude.ContentBlocks {
+	return claude.ContentBlocks{
+		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
+		claude.ToolResultBlock{
+			Type:      claude.ContentBlockTypeToolResult,
+			ToolUseID: "t1",
+			Content:   "Exit code 8\nForge Visual Tests\tpending",
+			IsError:   boolPtr(true),
 		},
 	}
 }
 
-func cleanBlocks() []claude.ContentBlock {
-	return []claude.ContentBlock{{Type: claude.ContentBlockTypeText, Text: "done"}}
+func cleanBlocks() claude.ContentBlocks {
+	return claude.ContentBlocks{claude.TextBlock{Type: claude.ContentBlockTypeText, Text: "done"}}
 }
 
-func turnResult(text string, blocks []claude.ContentBlock) *claude.TurnResult {
+func turnResult(text string, blocks claude.ContentBlocks) *claude.TurnResult {
 	return &claude.TurnResult{
 		Text:          text,
 		ContentBlocks: blocks,
@@ -554,19 +554,19 @@ func TestRunRetryLoop_RetriesCleanlyOnRealToolUseError(t *testing.T) {
 // recoveredErrorBlocks returns a block sequence where an early Edit
 // tool_use_error is followed by a successful Read + Edit, mirroring the
 // 2026-04-18 production failure (fc29ffb6 session, line 132 → 156).
-func recoveredErrorBlocks() []claude.ContentBlock {
-	return []claude.ContentBlock{
-		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "edit1", ToolName: "Edit"},
-		{
-			Type:       claude.ContentBlockTypeToolResult,
-			ToolUseID:  "edit1",
-			ToolResult: "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
-			IsError:    true,
+func recoveredErrorBlocks() claude.ContentBlocks {
+	return claude.ContentBlocks{
+		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "edit1", Name: "Edit"},
+		claude.ToolResultBlock{
+			Type:      claude.ContentBlockTypeToolResult,
+			ToolUseID: "edit1",
+			Content:   "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+			IsError:   boolPtr(true),
 		},
-		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "read1", ToolName: "Read"},
-		{Type: claude.ContentBlockTypeToolResult, ToolUseID: "read1", ToolResult: "file contents", IsError: false},
-		{Type: claude.ContentBlockTypeToolUse, ToolUseID: "edit2", ToolName: "Edit"},
-		{Type: claude.ContentBlockTypeToolResult, ToolUseID: "edit2", ToolResult: "edit applied", IsError: false},
+		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "read1", Name: "Read"},
+		claude.ToolResultBlock{Type: claude.ContentBlockTypeToolResult, ToolUseID: "read1", Content: "file contents", IsError: boolPtr(false)},
+		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "edit2", Name: "Edit"},
+		claude.ToolResultBlock{Type: claude.ContentBlockTypeToolResult, ToolUseID: "edit2", Content: "edit applied", IsError: boolPtr(false)},
 	}
 }
 

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -592,6 +592,45 @@ func TestRunRetryLoop_SkipsWhenAgentRecovered(t *testing.T) {
 	}
 }
 
+// TestClaudeResultToAgentResult_MapsContentBlocksIncludingUnknown verifies
+// that the converter populates AgentResult.ContentBlocks from the claude
+// turn's blocks, including UnknownContentBlock — so downstream consumers
+// don't silently drop content the protocol layer preserves.
+func TestClaudeResultToAgentResult_MapsContentBlocksIncludingUnknown(t *testing.T) {
+	t.Parallel()
+	tr := &claude.TurnResult{
+		Text: "hello",
+		ContentBlocks: claude.ContentBlocks{
+			claude.TextBlock{Type: claude.ContentBlockTypeText, Text: "hello"},
+			claude.ThinkingBlock{Type: claude.ContentBlockTypeThinking, Thinking: "reasoning"},
+			claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "t1", Name: "Bash", Input: map[string]interface{}{"command": "ls"}},
+			claude.UnknownContentBlock{Type: "future_block_xyz", Raw: []byte(`{"type":"future_block_xyz","payload":"opaque"}`)},
+		},
+	}
+	got := ClaudeResultToAgentResult(tr)
+	if got == nil {
+		t.Fatal("nil result")
+	}
+	if len(got.ContentBlocks) != 4 {
+		t.Fatalf("blocks: got %d, want 4", len(got.ContentBlocks))
+	}
+	if got.ContentBlocks[0].Type != "text" || got.ContentBlocks[0].Text != "hello" {
+		t.Errorf("text block: %+v", got.ContentBlocks[0])
+	}
+	if got.ContentBlocks[1].Type != "thinking" || got.ContentBlocks[1].Text != "reasoning" {
+		t.Errorf("thinking block: %+v", got.ContentBlocks[1])
+	}
+	if got.ContentBlocks[2].Type != "tool_use" || got.ContentBlocks[2].ToolName != "Bash" {
+		t.Errorf("tool_use block: %+v", got.ContentBlocks[2])
+	}
+	if got.ContentBlocks[3].Type != "future_block_xyz" {
+		t.Errorf("unknown block type: %q", got.ContentBlocks[3].Type)
+	}
+	if !strings.Contains(got.ContentBlocks[3].Text, "future_block_xyz") {
+		t.Errorf("unknown block text missing type: %q", got.ContentBlocks[3].Text)
+	}
+}
+
 // TestRunRetryLoop_PropagatesAskError ensures an Ask transport error
 // aborts the loop cleanly without masking.
 func TestRunRetryLoop_PropagatesAskError(t *testing.T) {

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -86,13 +86,8 @@ func (s *cancelAfterFirstAskSession) Ask(ctx context.Context, content string) (*
 // <tool_use_error> wrapper present.
 func realToolUseErrorBlocks(excerpt string) claude.ContentBlocks {
 	return claude.ContentBlocks{
-		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
-		claude.ToolResultBlock{
-			Type:      claude.ContentBlockTypeToolResult,
-			ToolUseID: "t1",
-			Content:   "<tool_use_error>" + excerpt + "</tool_use_error>",
-			IsError:   boolPtr(true),
-		},
+		toolUseBlock("t1", "Bash", nil),
+		toolResultContent("t1", "<tool_use_error>"+excerpt+"</tool_use_error>", true),
 	}
 }
 
@@ -100,18 +95,22 @@ func realToolUseErrorBlocks(excerpt string) claude.ContentBlocks {
 // true but no <tool_use_error> wrapper. Must not trigger retry.
 func nonzeroExitBashBlocks() claude.ContentBlocks {
 	return claude.ContentBlocks{
-		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "t1", Name: "Bash"},
-		claude.ToolResultBlock{
-			Type:      claude.ContentBlockTypeToolResult,
-			ToolUseID: "t1",
-			Content:   "Exit code 8\nForge Visual Tests\tpending",
-			IsError:   boolPtr(true),
-		},
+		toolUseBlock("t1", "Bash", nil),
+		toolResultContent("t1", "Exit code 8\nForge Visual Tests\tpending", true),
 	}
 }
 
 func cleanBlocks() claude.ContentBlocks {
-	return claude.ContentBlocks{claude.TextBlock{Type: claude.ContentBlockTypeText, Text: "done"}}
+	return claude.ContentBlocks{asstTextBlock("done")}
+}
+
+func toolResultContent(id string, content interface{}, isError bool) claude.ContentBlock {
+	return claude.ToolResultBlock{
+		Type:      claude.ContentBlockTypeToolResult,
+		ToolUseID: id,
+		Content:   content,
+		IsError:   boolPtr(isError),
+	}
 }
 
 func turnResult(text string, blocks claude.ContentBlocks) *claude.TurnResult {
@@ -556,17 +555,12 @@ func TestRunRetryLoop_RetriesCleanlyOnRealToolUseError(t *testing.T) {
 // 2026-04-18 production failure (fc29ffb6 session, line 132 → 156).
 func recoveredErrorBlocks() claude.ContentBlocks {
 	return claude.ContentBlocks{
-		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "edit1", Name: "Edit"},
-		claude.ToolResultBlock{
-			Type:      claude.ContentBlockTypeToolResult,
-			ToolUseID: "edit1",
-			Content:   "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
-			IsError:   boolPtr(true),
-		},
-		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "read1", Name: "Read"},
-		claude.ToolResultBlock{Type: claude.ContentBlockTypeToolResult, ToolUseID: "read1", Content: "file contents", IsError: boolPtr(false)},
-		claude.ToolUseBlock{Type: claude.ContentBlockTypeToolUse, ID: "edit2", Name: "Edit"},
-		claude.ToolResultBlock{Type: claude.ContentBlockTypeToolResult, ToolUseID: "edit2", Content: "edit applied", IsError: boolPtr(false)},
+		toolUseBlock("edit1", "Edit", nil),
+		toolResultContent("edit1", "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>", true),
+		toolUseBlock("read1", "Read", nil),
+		toolResultContent("read1", "file contents", false),
+		toolUseBlock("edit2", "Edit", nil),
+		toolResultContent("edit2", "edit applied", false),
 	}
 }
 

--- a/multiagent/agent/turn_state.go
+++ b/multiagent/agent/turn_state.go
@@ -22,7 +22,7 @@ type logicalTurnState struct {
 	completedBgToolUseIDs map[string]struct{}
 	taskToToolUse         map[string]string
 
-	blocks []claude.ContentBlock
+	blocks claude.ContentBlocks
 
 	sessionID string
 	text      strings.Builder
@@ -56,19 +56,20 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 		s.turnNumber = e.TurnNumber
 		for _, block := range e.Blocks {
 			s.blocks = append(s.blocks, block)
-			switch block.Type {
-			case claude.ContentBlockTypeText:
-				s.text.WriteString(block.Text)
-			case claude.ContentBlockTypeThinking:
-				s.thinking.WriteString(block.Thinking)
+			switch b := block.(type) {
+			case claude.TextBlock:
+				s.text.WriteString(b.Text)
+			case claude.ThinkingBlock:
+				s.thinking.WriteString(b.Thinking)
 			}
 		}
 
 	case claude.UserMessageEvent:
 		for _, block := range e.Blocks {
 			s.blocks = append(s.blocks, block)
-			if block.Type == claude.ContentBlockTypeToolResult && block.IsError {
-				s.cancelledToolUseIDs[block.ToolUseID] = struct{}{}
+			result, ok := block.(claude.ToolResultBlock)
+			if ok && result.IsError != nil && *result.IsError {
+				s.cancelledToolUseIDs[result.ToolUseID] = struct{}{}
 			}
 		}
 
@@ -188,13 +189,14 @@ func (s *logicalTurnState) invalidateForContinuation() {
 
 func (s *logicalTurnState) hasUncancelledBgToolUse() bool {
 	for _, block := range s.blocks {
-		if block.Type != claude.ContentBlockTypeToolUse || !isBackgroundToolUse(block) {
+		toolUse, ok := block.(claude.ToolUseBlock)
+		if !ok || !isBackgroundToolUse(toolUse) {
 			continue
 		}
-		if _, cancelled := s.cancelledToolUseIDs[block.ToolUseID]; cancelled {
+		if _, cancelled := s.cancelledToolUseIDs[toolUse.ID]; cancelled {
 			continue
 		}
-		if _, done := s.completedBgToolUseIDs[block.ToolUseID]; done {
+		if _, done := s.completedBgToolUseIDs[toolUse.ID]; done {
 			continue
 		}
 		return true
@@ -202,13 +204,13 @@ func (s *logicalTurnState) hasUncancelledBgToolUse() bool {
 	return false
 }
 
-func (s *logicalTurnState) Text() string                         { return s.text.String() }
-func (s *logicalTurnState) Thinking() string                     { return s.thinking.String() }
-func (s *logicalTurnState) ContentBlocks() []claude.ContentBlock { return s.blocks }
-func (s *logicalTurnState) Usage() claude.TurnUsage              { return s.usage }
-func (s *logicalTurnState) SessionID() string                    { return s.sessionID }
-func (s *logicalTurnState) Err() error                           { return s.err }
-func (s *logicalTurnState) TurnNumber() int                      { return s.turnNumber }
+func (s *logicalTurnState) Text() string                        { return s.text.String() }
+func (s *logicalTurnState) Thinking() string                    { return s.thinking.String() }
+func (s *logicalTurnState) ContentBlocks() claude.ContentBlocks { return s.blocks }
+func (s *logicalTurnState) Usage() claude.TurnUsage             { return s.usage }
+func (s *logicalTurnState) SessionID() string                   { return s.sessionID }
+func (s *logicalTurnState) Err() error                          { return s.err }
+func (s *logicalTurnState) TurnNumber() int                     { return s.turnNumber }
 
 func (s *logicalTurnState) Success() bool {
 	return s.lastResult != nil && !s.lastResult.IsError
@@ -240,12 +242,9 @@ var backgroundToolNames = map[string]bool{
 	"Monitor": true,
 }
 
-func isBackgroundToolUse(block claude.ContentBlock) bool {
-	if block.Type != claude.ContentBlockTypeToolUse {
-		return false
-	}
-	if isBg, _ := block.ToolInput["run_in_background"].(bool); isBg {
+func isBackgroundToolUse(block claude.ToolUseBlock) bool {
+	if isBg, _ := block.Input["run_in_background"].(bool); isBg {
 		return true
 	}
-	return backgroundToolNames[block.ToolName]
+	return backgroundToolNames[block.Name]
 }

--- a/multiagent/agent/turn_state_test.go
+++ b/multiagent/agent/turn_state_test.go
@@ -13,16 +13,18 @@ import (
 
 func strPtr(s string) *string { return &s }
 
+func boolPtr(v bool) *bool { return &v }
+
 func asstTextBlock(text string) claude.ContentBlock {
-	return claude.ContentBlock{Type: claude.ContentBlockTypeText, Text: text}
+	return claude.TextBlock{Type: claude.ContentBlockTypeText, Text: text}
 }
 
 func toolUseBlock(id, name string, input map[string]interface{}) claude.ContentBlock {
-	return claude.ContentBlock{
-		Type:      claude.ContentBlockTypeToolUse,
-		ToolUseID: id,
-		ToolName:  name,
-		ToolInput: input,
+	return claude.ToolUseBlock{
+		Type:  claude.ContentBlockTypeToolUse,
+		ID:    id,
+		Name:  name,
+		Input: input,
 	}
 }
 
@@ -40,10 +42,10 @@ func bgBashToolUse(id string) claude.ContentBlock {
 }
 
 func toolResult(id string, isError bool) claude.ContentBlock {
-	return claude.ContentBlock{
+	return claude.ToolResultBlock{
 		Type:      claude.ContentBlockTypeToolResult,
 		ToolUseID: id,
-		IsError:   isError,
+		IsError:   boolPtr(isError),
 	}
 }
 
@@ -87,7 +89,7 @@ func TestTurnState_C1_PureBgMonitorTurn(t *testing.T) {
 	// Turn 1: assistant launches Monitor; CLI fires ResultMessage immediately.
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg1")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID:     "task1",
@@ -147,7 +149,7 @@ func TestTurnState_C2_MixedSyncBgTurn(t *testing.T) {
 	// Assistant turn with sync Read + bg Monitor in one message.
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks: []claude.ContentBlock{
+		Blocks: claude.ContentBlocks{
 			toolUseBlock("toolu_sync1", "Read", map[string]interface{}{"file_path": "/tmp/x"}),
 			monitorToolUse("toolu_bg1"),
 		},
@@ -155,7 +157,7 @@ func TestTurnState_C2_MixedSyncBgTurn(t *testing.T) {
 	// Sync tool result arrives as user message.
 	s.Apply(claude.UserMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{toolResult("toolu_sync1", false)},
+		Blocks:     claude.ContentBlocks{toolResult("toolu_sync1", false)},
 	})
 	// Bg Monitor registers as a task.
 	s.Apply(claude.TaskStartedEvent{
@@ -186,7 +188,7 @@ func TestTurnState_C3_TwoParallelMonitorsOneFailsFast(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks: []claude.ContentBlock{
+		Blocks: claude.ContentBlocks{
 			monitorToolUse("toolu_bg_fast"),
 			monitorToolUse("toolu_bg_slow"),
 		},
@@ -228,7 +230,7 @@ func TestTurnState_C4_PureBgBashRunInBackground(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{bgBashToolUse("toolu_bg_bash")},
+		Blocks:     claude.ContentBlocks{bgBashToolUse("toolu_bg_bash")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID:    "task_bash",
@@ -253,7 +255,7 @@ func TestTurnState_C5_MixedMonitorAndBgBash(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks: []claude.ContentBlock{
+		Blocks: claude.ContentBlocks{
 			monitorToolUse("toolu_mon"),
 			bgBashToolUse("toolu_bash"),
 		},
@@ -291,7 +293,7 @@ func TestTurnState_C6_TaskNotificationMissingToolUseID(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID:    "task1",
@@ -320,7 +322,7 @@ func TestTurnState_C7_ReorderedTaskStartedAfterNotification(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	// TaskNotification arrives before TaskStarted (reordered).
 	s.Apply(claude.TaskNotificationEvent{
@@ -352,7 +354,7 @@ func TestTurnState_C8_BudgetExceededMidBg(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg"),
@@ -374,7 +376,7 @@ func TestTurnState_C9_BgMonitorToolError(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg"),
@@ -397,7 +399,7 @@ func TestTurnState_C10_MonitorTimeoutMs(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg"),
@@ -419,7 +421,7 @@ func TestTurnState_C11_PlainSyncTurn(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{asstTextBlock("hello world")},
+		Blocks:     claude.ContentBlocks{asstTextBlock("hello world")},
 	})
 	require.False(t, s.LogicalTurnDone(), "no result message yet")
 	endOfCLITurn(s, false)
@@ -435,7 +437,7 @@ func TestTurnState_C12_CloseWhileBgLive(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg"),
@@ -455,7 +457,7 @@ func TestTurnState_C13_ToolErrorRetryAfterBgSettles(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg"),
@@ -484,12 +486,12 @@ func TestTurnState_CancelledBgToolDoesNotBlock(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
 	})
 	// tool_result carries IsError — caller cancelled.
 	s.Apply(claude.UserMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{toolResult("toolu_bg", true)},
+		Blocks:     claude.ContentBlocks{toolResult("toolu_bg", true)},
 	})
 	endOfCLITurn(s, false)
 	require.True(t, s.LogicalTurnDone(),
@@ -555,7 +557,7 @@ func TestTurnState_TerminalBgDrainAfterResultRequiresContinuation(t *testing.T) 
 	// immediately because it has nothing else to say.
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg1")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg1"),
@@ -593,7 +595,7 @@ func TestTurnState_TerminalTaskUpdatedAfterResultRequiresContinuation(t *testing
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg1")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
 	})
 	s.Apply(claude.TaskStartedEvent{
 		TaskID: "task1", ToolUseID: strPtr("toolu_bg1"),
@@ -618,7 +620,7 @@ func TestTurnState_TerminalBeforeTaskStartedStillCompletes(t *testing.T) {
 
 	s.Apply(claude.AssistantMessageEvent{
 		TurnNumber: 1,
-		Blocks:     []claude.ContentBlock{monitorToolUse("toolu_bg1")},
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
 	})
 	// Terminal first.
 	s.Apply(claude.TaskNotificationEvent{

--- a/yoloswe/reviewer/BUILD.bazel
+++ b/yoloswe/reviewer/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     deps = [
         "//agent-cli-wrapper/acp",
         "//agent-cli-wrapper/agentstream",
+        "//agent-cli-wrapper/claude/render",
         "//agent-cli-wrapper/codex",
     ],
 )

--- a/yoloswe/sessionplayer/BUILD.bazel
+++ b/yoloswe/sessionplayer/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/claude/render",
         "//agent-cli-wrapper/codex",
+        "//agent-cli-wrapper/protocol",
     ],
 )

--- a/yoloswe/sessionplayer/player.go
+++ b/yoloswe/sessionplayer/player.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 )
 
 // Player plays back recorded session messages (Claude or Codex format).
@@ -255,18 +256,13 @@ func (p *Player) renderUserMessage(raw json.RawMessage) {
 
 // renderResultMessage renders a result/completion message.
 func (p *Player) renderResultMessage(raw json.RawMessage) {
-	var msg struct {
-		Subtype      string  `json:"subtype"`
-		IsError      bool    `json:"is_error"`
-		DurationMs   int64   `json:"duration_ms"`
-		NumTurns     int     `json:"num_turns"`
-		TotalCostUSD float64 `json:"total_cost_usd"`
-	}
+	var msg protocol.ResultMessage
 	if err := json.Unmarshal(raw, &msg); err != nil {
 		return
 	}
-
-	if msg.Subtype == "success" || msg.Subtype == "error_max_turns" {
-		p.renderer.TurnSummary(msg.NumTurns, !msg.IsError, msg.DurationMs, msg.TotalCostUSD)
-	}
+	// Render any terminal frame (success or any error_* subtype). Success is
+	// derived from protocol.IsFailure so error-subtyped frames with
+	// is_error=false are still classified as failures, matching the live
+	// session contract.
+	p.renderer.TurnSummary(msg.NumTurns, !msg.IsFailure(), msg.DurationMs, msg.TotalCostUSD)
 }


### PR DESCRIPTION
## Summary

- Make `agent-cli-wrapper/protocol` the canonical content-block representation and re-export those block types from the Claude wrapper so assistant/user events, turn results, and multiagent turn state carry protocol `ContentBlocks` end to end.
- Preserve protocol fidelity for edge cases: unknown content blocks are retained, unknown top-level messages emit an SDK event with the full raw payload, system envelopes marshal back to their original wire JSON, and legacy `tool_use` / `tool_result` field shapes still decode.
- Decode system init metadata through subtype-specific payloads, with a lenient fallback for offline parsers so model, cwd, tools, agents, skills, and permission metadata survive malformed optional fields.
- Centralize result failure detection on `protocol.ResultMessage.Outcome()` / `IsFailure()`, preserve successful result text, and apply the derived failure state consistently across Claude events, wakeup suppression, Bramble sessionmodel parsing, and session analysis.
- Update retry/background-turn fixtures and expand coverage for protocol content/messages/system parsing, structured content accumulation, string assistant content fallback, unknown message handling, result classification, and Bramble metadata/error parsing.

## Impact

This removes a duplicated Claude content-block model while keeping SDK events, replay fixtures, retry detection, sessionmodel parsing, session analysis, and multiagent turn tracking aligned with the protocol package. It also makes the parsers more forward-compatible with new Claude CLI block/message shapes and more tolerant of older recorded fixture formats.

## Validation

- `scripts/lint.sh`
- `bazel build //...`
- `bazel test --test_timeout=60 //...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message/turn parsing and result classification across Claude wrapper, offline analysis, and multiagent turn-state, which could change how turns are marked successful and how transcripts are accumulated. Added fallbacks and tests reduce risk, but protocol-shape differences (unknown blocks/messages, legacy fields) can still affect downstream consumers.
> 
> **Overview**
> Claude wrapper events and turn results now carry `protocol.ContentBlocks` end-to-end (re-exported via `claude`), and turn accumulation was updated to append raw blocks directly (including assistant string-content fallback).
> 
> Protocol parsing is made more forward- and backward-compatible by **preserving unknown content blocks**, emitting a new `UnknownMessageEvent` for unknown top-level message types (with full raw payload), and accepting legacy `tool_use`/`tool_result` field names during JSON unmarshal.
> 
> Result handling is centralized on `ResultMessage.Outcome()`/`IsFailure()` (treating error subtypes as failures even when `is_error` is unset), and system `init` decoding now uses typed payloads with a **lenient fallback** that only transitions to ready when mandatory fields are recoverable; offline `sessionmodel`/`sessionanalysis`, cursor session handling, session replay, and multiagent turn-state/tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7e0627c46eb600e12cde53f3d509811cf82b69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->