### PR TITLE
Reset renderer state after sessions

### DIFF
--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -429,6 +429,7 @@ func (r *Renderer) Reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.closeToolOutput()
 	r.commands = make(map[string]string)
 	r.outputs = make(map[string]*strings.Builder)
 	r.textBuffer.Reset()

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -429,12 +429,8 @@ func (r *Renderer) Reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for k := range r.commands {
-		delete(r.commands, k)
-	}
-	for k := range r.outputs {
-		delete(r.outputs, k)
-	}
+	r.commands = make(map[string]string)
+	r.outputs = make(map[string]*strings.Builder)
 	r.lastToolName = ""
 	r.lastToolID = ""
 	r.lastCompletedToolName = ""

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -420,6 +420,29 @@ func (r *Renderer) CommandEnd(callID string, exitCode int, durationMs int64) {
 	}
 }
 
+// Reset clears any in-flight command state. Call this from session teardown
+// (context cancellation, session end, crash recovery) so commands that never
+// received a CommandEnd do not leak accumulated output.
+//
+// Reset does not flush text or write any output; it only drops state.
+func (r *Renderer) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for k := range r.commands {
+		delete(r.commands, k)
+	}
+	for k := range r.outputs {
+		delete(r.outputs, k)
+	}
+	r.lastToolName = ""
+	r.lastToolID = ""
+	r.lastCompletedToolName = ""
+	r.lastCompletedToolID = ""
+	r.inToolOutput = false
+	r.inReasoning = false
+}
+
 // ---------------------------------------------------------------------------
 // Questions
 // ---------------------------------------------------------------------------

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -420,9 +420,9 @@ func (r *Renderer) CommandEnd(callID string, exitCode int, durationMs int64) {
 	}
 }
 
-// Reset clears any in-flight command state. Call this from session teardown
+// Reset clears any in-flight render state. Call this from session teardown
 // (context cancellation, session end, crash recovery) so commands that never
-// received a CommandEnd do not leak accumulated output.
+// received a CommandEnd and partial text chunks do not leak into later sessions.
 //
 // Reset does not flush text or write any output; it only drops state.
 func (r *Renderer) Reset() {
@@ -431,6 +431,7 @@ func (r *Renderer) Reset() {
 
 	r.commands = make(map[string]string)
 	r.outputs = make(map[string]*strings.Builder)
+	r.textBuffer.Reset()
 	r.lastToolName = ""
 	r.lastToolID = ""
 	r.lastCompletedToolName = ""

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -420,9 +420,20 @@ func TestReset_ClearsInFlightCommands(t *testing.T) {
 }
 
 func TestReset_IsIdempotent(t *testing.T) {
-	r, _ := newTestRenderer(VerbosityVerbose)
+	r, buf := newTestRenderer(VerbosityVerbose)
+	r.CommandStart("call1", "sleep 9999")
+	r.CommandOutput("call1", "buffered output")
+	buf.Reset()
+
 	r.Reset()
 	r.Reset()
+
+	if r.HasOutput("call1") {
+		t.Error("Reset should keep in-flight output cleared after repeated calls")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("Reset should not produce output after repeated calls, got %q", buf.String())
+	}
 }
 
 func TestReset_DoesNotWriteOutput(t *testing.T) {

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -411,6 +411,12 @@ func TestReset_ClearsInFlightCommands(t *testing.T) {
 	}
 	// CommandEnd on a reset call should be a no-op.
 	r.CommandEnd("call1", 0, 50)
+
+	r.CommandStart("call2", "echo ok")
+	r.CommandOutput("call2", "ok")
+	if !r.HasOutput("call2") {
+		t.Fatal("renderer should accept new command output after Reset")
+	}
 }
 
 func TestReset_IsIdempotent(t *testing.T) {

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -449,6 +449,23 @@ func TestReset_DoesNotWriteOutput(t *testing.T) {
 	}
 }
 
+func TestResetClosesOpenToolOutput(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityNormal)
+	r.ToolStart("Read", "tool-1")
+
+	r.Reset()
+
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("Reset should close an open tool output line, got %q", buf.String())
+	}
+	buf.Reset()
+
+	r.Text("next")
+	if strings.HasPrefix(buf.String(), "\n") {
+		t.Errorf("next text should not close stale tool output, got %q", buf.String())
+	}
+}
+
 // --- Turn summaries ---
 
 func TestTurnSummary(t *testing.T) {

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -396,6 +396,42 @@ func TestCommandEnd_ZeroDuration(t *testing.T) {
 	}
 }
 
+func TestReset_ClearsInFlightCommands(t *testing.T) {
+	r, _ := newTestRenderer(VerbosityVerbose)
+	r.CommandStart("call1", "sleep 9999")
+	r.CommandOutput("call1", "buffered output...")
+	if !r.HasOutput("call1") {
+		t.Fatal("precondition: HasOutput should be true")
+	}
+
+	r.Reset()
+
+	if r.HasOutput("call1") {
+		t.Error("Reset should drop in-flight output")
+	}
+	// CommandEnd on a reset call should be a no-op.
+	r.CommandEnd("call1", 0, 50)
+}
+
+func TestReset_IsIdempotent(t *testing.T) {
+	r, _ := newTestRenderer(VerbosityVerbose)
+	r.Reset()
+	r.Reset()
+}
+
+func TestReset_DoesNotWriteOutput(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityVerbose)
+	r.CommandStart("call1", "ls")
+	r.CommandOutput("call1", "x")
+	buf.Reset()
+
+	r.Reset()
+
+	if buf.Len() != 0 {
+		t.Errorf("Reset should not produce output, got %q", buf.String())
+	}
+}
+
 // --- Turn summaries ---
 
 func TestTurnSummary(t *testing.T) {

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -586,6 +586,23 @@ func TestEventHandler_TextFlush(t *testing.T) {
 	}
 }
 
+func TestResetDropsBufferedText(t *testing.T) {
+	r, _ := newTestRenderer(VerbosityNormal)
+	var received []string
+	handler := &testEventHandler{
+		onText: func(text string) { received = append(received, text) },
+	}
+	r.SetEventHandler(handler)
+
+	r.Text("partial")
+	r.Reset()
+	r.Text("fresh\n")
+
+	if len(received) != 1 || received[0] != "fresh\n" {
+		t.Errorf("Reset should discard partial text before next flush, got %v", received)
+	}
+}
+
 func TestEventHandler_StatusAlwaysEmitted(t *testing.T) {
 	r, _ := newTestRenderer(VerbosityQuiet)
 	var received string

--- a/bramble/cmd/delegator/delegator.go
+++ b/bramble/cmd/delegator/delegator.go
@@ -164,6 +164,8 @@ func runMock(ctx context.Context, renderer *render.Renderer, model, workDir, pro
 }
 
 func runMockConversation(ctx context.Context, s *claude.Session, mock *session.MockDelegatorToolHandler, r *render.Renderer, msg string, autoAdvance bool) {
+	defer r.Reset()
+
 	if _, err := s.SendMessage(ctx, msg); err != nil {
 		fmt.Fprintf(os.Stderr, "SendMessage error: %v\n", err)
 		return

--- a/bramble/cmd/delegator/delegator.go
+++ b/bramble/cmd/delegator/delegator.go
@@ -79,6 +79,7 @@ func runDelegator(cmd *cobra.Command, args []string) error {
 	defer stop()
 
 	renderer := render.NewRenderer(os.Stdout, verbose)
+	defer renderer.Reset()
 
 	switch mode {
 	case "mock":

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -378,6 +378,7 @@ func runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, work
 	logHandler := newLogEventHandler(logger, stepName)
 	var handler agent.EventHandler = logHandler
 	if renderer != nil {
+		defer renderer.Reset()
 		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, &rendererEventHandler{r: renderer}}}
 	}
 

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -101,6 +101,9 @@ func registerRunFlags(cmd *cobra.Command, args *runArgs) {
 func run(ctx context.Context, app *cliapp.App, args runArgs) error {
 	logger := app.Logger
 	renderer := app.Renderer
+	if renderer != nil {
+		defer renderer.Reset()
+	}
 
 	// Resolve --description-file into --description.
 	if args.descriptionFile != "" {

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -599,6 +599,8 @@ func (r *Reviewer) Review(ctx context.Context, prompt string) error {
 
 // ReviewWithResult sends a review prompt and returns the result with response text.
 func (r *Reviewer) ReviewWithResult(ctx context.Context, prompt string) (*ReviewResult, error) {
+	defer r.renderer.Reset()
+
 	model := r.config.Model
 	if model == "" {
 		model = "default"
@@ -623,6 +625,8 @@ func (r *Reviewer) ReviewWithResult(ctx context.Context, prompt string) (*Review
 
 // FollowUp sends a follow-up message to the existing backend session.
 func (r *Reviewer) FollowUp(ctx context.Context, prompt string) (*ReviewResult, error) {
+	defer r.renderer.Reset()
+
 	handler := r.newEventHandler()
 	result, err := r.backend.RunPrompt(ctx, prompt, handler)
 	if err != nil {

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -1,6 +1,7 @@
 package reviewer
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/codex"
 )
 
@@ -17,6 +19,17 @@ import (
 // is caught at CI time. Mirrors the UPDATE_FIXTURES pattern documented in
 // CLAUDE.md.
 func updateGoldens() bool { return os.Getenv("UPDATE_GOLDENS") == "1" }
+
+type danglingToolBackend struct{}
+
+func (danglingToolBackend) Start(context.Context) error { return nil }
+
+func (danglingToolBackend) Stop() error { return nil }
+
+func (danglingToolBackend) RunPrompt(_ context.Context, _ string, handler EventHandler) (*ReviewResult, error) {
+	handler.OnToolStart("Shell", "call-1", nil)
+	return &ReviewResult{Success: true}, nil
+}
 
 func TestBuildPrompt(t *testing.T) {
 	tests := []struct {
@@ -52,6 +65,44 @@ func TestBuildPrompt(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReviewWithResultResetsRendererState(t *testing.T) {
+	var buf bytes.Buffer
+	r := &Reviewer{
+		config:   Config{BackendType: BackendCodex, Model: "test-model"},
+		backend:  danglingToolBackend{},
+		renderer: render.NewRendererWithOptions(&buf, true, true),
+	}
+
+	if _, err := r.ReviewWithResult(context.Background(), "review"); err != nil {
+		t.Fatalf("ReviewWithResult returned error: %v", err)
+	}
+	buf.Reset()
+
+	r.renderer.CommandEnd("call-1", 0, 1)
+	if buf.Len() != 0 {
+		t.Errorf("ReviewWithResult should reset dangling renderer command state, got %q", buf.String())
+	}
+}
+
+func TestFollowUpResetsRendererState(t *testing.T) {
+	var buf bytes.Buffer
+	r := &Reviewer{
+		config:   Config{BackendType: BackendCodex, Model: "test-model"},
+		backend:  danglingToolBackend{},
+		renderer: render.NewRendererWithOptions(&buf, true, true),
+	}
+
+	if _, err := r.FollowUp(context.Background(), "again"); err != nil {
+		t.Fatalf("FollowUp returned error: %v", err)
+	}
+	buf.Reset()
+
+	r.renderer.CommandEnd("call-1", 0, 1)
+	if buf.Len() != 0 {
+		t.Errorf("FollowUp should reset dangling renderer command state, got %q", buf.String())
 	}
 }
 

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -3,6 +3,7 @@ package reviewer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,6 +30,26 @@ func (danglingToolBackend) Stop() error { return nil }
 func (danglingToolBackend) RunPrompt(_ context.Context, _ string, handler EventHandler) (*ReviewResult, error) {
 	handler.OnToolStart("Shell", "call-1", nil)
 	return &ReviewResult{Success: true}, nil
+}
+
+type partialTextErrorBackend struct{}
+
+func (partialTextErrorBackend) Start(context.Context) error { return nil }
+
+func (partialTextErrorBackend) Stop() error { return nil }
+
+func (partialTextErrorBackend) RunPrompt(_ context.Context, _ string, handler EventHandler) (*ReviewResult, error) {
+	handler.OnText("partial")
+	return nil, errors.New("backend failed")
+}
+
+type captureTextHandler struct {
+	render.NoOpEventHandler
+	texts []string
+}
+
+func (h *captureTextHandler) OnText(text string) {
+	h.texts = append(h.texts, text)
 }
 
 func TestBuildPrompt(t *testing.T) {
@@ -103,6 +124,46 @@ func TestFollowUpResetsRendererState(t *testing.T) {
 	r.renderer.CommandEnd("call-1", 0, 1)
 	if buf.Len() != 0 {
 		t.Errorf("FollowUp should reset dangling renderer command state, got %q", buf.String())
+	}
+}
+
+func TestReviewWithResultResetsPartialTextOnError(t *testing.T) {
+	var buf bytes.Buffer
+	texts := &captureTextHandler{}
+	r := &Reviewer{
+		config:   Config{BackendType: BackendCodex, Model: "test-model"},
+		backend:  partialTextErrorBackend{},
+		renderer: render.NewRendererWithOptions(&buf, false, true),
+	}
+	r.renderer.SetEventHandler(texts)
+
+	if _, err := r.ReviewWithResult(context.Background(), "review"); err == nil {
+		t.Fatal("ReviewWithResult returned nil error")
+	}
+	r.renderer.Status("next session")
+
+	if len(texts.texts) != 0 {
+		t.Errorf("ReviewWithResult should reset partial text after backend error, got %v", texts.texts)
+	}
+}
+
+func TestFollowUpResetsPartialTextOnError(t *testing.T) {
+	var buf bytes.Buffer
+	texts := &captureTextHandler{}
+	r := &Reviewer{
+		config:   Config{BackendType: BackendCodex, Model: "test-model"},
+		backend:  partialTextErrorBackend{},
+		renderer: render.NewRendererWithOptions(&buf, false, true),
+	}
+	r.renderer.SetEventHandler(texts)
+
+	if _, err := r.FollowUp(context.Background(), "again"); err == nil {
+		t.Fatal("FollowUp returned nil error")
+	}
+	r.renderer.Status("next session")
+
+	if len(texts.texts) != 0 {
+		t.Errorf("FollowUp should reset partial text after backend error, got %v", texts.texts)
 	}
 }
 

--- a/yoloswe/sessionplayer/codex.go
+++ b/yoloswe/sessionplayer/codex.go
@@ -79,7 +79,9 @@ func NewCodexPlayer(renderer *render.Renderer, verbose bool) *CodexPlayer {
 
 // PlayFile plays back a Codex session log file.
 func (p *CodexPlayer) PlayFile(path string) error {
-	defer p.renderer.Reset()
+	if p.renderer != nil {
+		defer p.renderer.Reset()
+	}
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/yoloswe/sessionplayer/codex.go
+++ b/yoloswe/sessionplayer/codex.go
@@ -79,6 +79,8 @@ func NewCodexPlayer(renderer *render.Renderer, verbose bool) *CodexPlayer {
 
 // PlayFile plays back a Codex session log file.
 func (p *CodexPlayer) PlayFile(path string) error {
+	defer p.renderer.Reset()
+
 	f, err := os.Open(path)
 	if err != nil {
 		return err

--- a/yoloswe/sessionplayer/player.go
+++ b/yoloswe/sessionplayer/player.go
@@ -68,6 +68,10 @@ func (p *Player) Play(path string) error {
 
 // playClaude plays back a Claude session recording directory.
 func (p *Player) playClaude(dirPath string) error {
+	if p.renderer != nil {
+		defer p.renderer.Reset()
+	}
+
 	// Load metadata (optional - continue without it if missing)
 	recording, metaErr := claude.LoadRecording(dirPath)
 	if metaErr == nil {


### PR DESCRIPTION
## Summary
- add `Renderer.Reset()` to clear in-flight command state, buffered command output, partial text, reasoning/tool tracking, and stale tool-output formatting state during session teardown
- reset shared renderers after delegator mock conversations, jiradozer agent/run lifecycles, reviewer review/follow-up sessions, and Claude/Codex session playback so interrupted sessions cannot leak output into the next run
- make reset behavior reusable and nil-safe where playback may not have a renderer
- expand regression coverage for dropped command output, idempotent/no-output resets, partial text cleanup, open tool-output closure, reviewer follow-up cleanup, and reviewer backend error paths

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes session teardown behavior across multiple CLIs, which could alter or suppress terminal output/formatting if reset is called too broadly or in unexpected lifecycles.
> 
> **Overview**
> Adds `Renderer.Reset()` to explicitly drop in-flight render state (dangling command/tool tracking, buffered command output, partial text, and tool-output formatting flags) so interrupted or incomplete sessions don’t leak output into subsequent runs.
> 
> Wires `Reset()` into teardown paths across delegator runs (including per mock conversation), jiradozer agent/run lifecycles, reviewer `ReviewWithResult`/`FollowUp`, and session playback (Claude/Codex), with nil-safe handling where a renderer may be absent.
> 
> Expands tests to cover reset semantics (clears in-flight commands, idempotent/no-output behavior, closes open tool output lines, and discards buffered partial text), plus reviewer regressions for dangling tool starts and backend error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197a790e0e0f56dbcc4df99ac4ac42f442c37f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->