### PR TITLE
[codex] Share display text truncation helpers

### DIFF
--- a/agent-cli-wrapper/claude/render/BUILD.bazel
+++ b/agent-cli-wrapper/claude/render/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     ],
     importpath = "github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render",
     visibility = ["//visibility:public"],
+    deps = ["//agent-cli-wrapper/displaytext"],
 )
 
 go_test(

--- a/agent-cli-wrapper/claude/render/format.go
+++ b/agent-cli-wrapper/claude/render/format.go
@@ -10,6 +10,9 @@ import (
 
 // FormatToolInput formats tool input for inline display after the tool name bracket.
 // Returns an empty string for tools that should be handled specially.
+// This renderer uses terminal-oriented widths and omits the tool name because
+// ToolStart prints it separately; sessionmodel.FormatToolContent uses different
+// widths and prefixes for persisted structured output.
 func FormatToolInput(name string, input map[string]interface{}) string {
 	switch name {
 	case "Read":

--- a/agent-cli-wrapper/claude/render/format.go
+++ b/agent-cli-wrapper/claude/render/format.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/displaytext"
 )
 
 // FormatToolInput formats tool input for inline display after the tool name bracket.
@@ -12,15 +14,15 @@ func FormatToolInput(name string, input map[string]interface{}) string {
 	switch name {
 	case "Read":
 		if path, ok := input["file_path"].(string); ok {
-			return TruncatePath(path, 80)
+			return displaytext.TruncatePath(path, 80)
 		}
 	case "Write", "Edit":
 		if path, ok := input["file_path"].(string); ok {
-			return fmt.Sprintf("→ %s", TruncatePath(path, 70))
+			return fmt.Sprintf("→ %s", displaytext.TruncatePath(path, 70))
 		}
 	case "Bash":
 		if cmd, ok := input["command"].(string); ok {
-			return TruncateForDisplay(cmd, 80)
+			return displaytext.Truncate(cmd, 80)
 		}
 	case "Glob":
 		if pattern, ok := input["pattern"].(string); ok {
@@ -28,7 +30,7 @@ func FormatToolInput(name string, input map[string]interface{}) string {
 		}
 	case "Grep":
 		if pattern, ok := input["pattern"].(string); ok {
-			return TruncateForDisplay(pattern, 60)
+			return displaytext.Truncate(pattern, 60)
 		}
 	case "Task":
 		if desc, ok := input["description"].(string); ok {
@@ -39,7 +41,7 @@ func FormatToolInput(name string, input map[string]interface{}) string {
 	default:
 		if len(input) > 0 {
 			data, _ := json.Marshal(input)
-			return TruncateForDisplay(string(data), 100)
+			return displaytext.Truncate(string(data), 100)
 		}
 	}
 	return ""
@@ -64,55 +66,4 @@ func formatContent(content interface{}) string {
 		data, _ := json.Marshal(content)
 		return string(data)
 	}
-}
-
-// TruncateForDisplay truncates s to at most max Unicode code points,
-// appending "..." if truncation occurred (the suffix counts toward max).
-// Rune-based indexing avoids splitting multi-byte UTF-8 sequences.
-func TruncateForDisplay(s string, max int) string {
-	// Fast path: byte length ≤ max implies rune length ≤ max.
-	if len(s) <= max {
-		return s
-	}
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
-	}
-	if max <= 3 {
-		return string(runes[:max])
-	}
-	return string(runes[:max-3]) + "..."
-}
-
-// TruncatePath truncates a file path, keeping the end visible.
-// For paths longer than max, shows ".../" plus the last two path components.
-func TruncatePath(path string, max int) string {
-	// Fast path: byte length ≤ max implies rune length ≤ max.
-	if len(path) <= max {
-		return path
-	}
-	runes := []rune(path)
-	if len(runes) <= max {
-		return path
-	}
-	// Try to keep the last two components (e.g. "foo/bar.go").
-	parts := strings.Split(path, "/")
-	if len(parts) >= 2 {
-		suffix := strings.Join(parts[len(parts)-2:], "/")
-		prefixed := ".../" + suffix
-		if len(prefixed) <= max { // ASCII-safe: ".../" + path segments
-			return prefixed
-		}
-	}
-	// Fall back to keeping just the filename.
-	if lastSlash := strings.LastIndexByte(path, '/'); lastSlash > 0 {
-		suffix := path[lastSlash:]
-		if len(suffix) <= max-3 { // ASCII-safe: path components
-			return "..." + suffix
-		}
-	}
-	if max <= 3 {
-		return string(runes[:max])
-	}
-	return string(runes[:max-3]) + "..."
 }

--- a/agent-cli-wrapper/claude/render/render.go
+++ b/agent-cli-wrapper/claude/render/render.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"strings"
 	"sync"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/displaytext"
 )
 
 // ANSI color codes — kept exported for backward compatibility.
@@ -411,11 +413,11 @@ func (r *Renderer) CommandEnd(callID string, exitCode int, durationMs int64) {
 
 	if exitCode == 0 {
 		fmt.Fprintf(r.out, "%s[%s]%s %s✓%s%s\n",
-			r.color(ColorCyan), TruncateForDisplay(command, 60), r.color(ColorReset),
+			r.color(ColorCyan), displaytext.Truncate(command, 60), r.color(ColorReset),
 			r.color(ColorGreen), durationStr, r.color(ColorReset))
 	} else {
 		fmt.Fprintf(r.out, "%s[%s]%s %s✗ exit %d%s%s\n",
-			r.color(ColorCyan), TruncateForDisplay(command, 60), r.color(ColorReset),
+			r.color(ColorCyan), displaytext.Truncate(command, 60), r.color(ColorReset),
 			r.color(ColorRed), exitCode, durationStr, r.color(ColorReset))
 	}
 }
@@ -649,12 +651,12 @@ func (r *Renderer) tagged(minV Verbosity, colorCode, label, msg string) {
 
 // TaskStarted prints a task/sub-agent start notification.
 func (r *Renderer) TaskStarted(taskID, description string) {
-	r.tagged(VerbosityVerbose, ColorBlue, "Task "+taskID, TruncateForDisplay(description, 80))
+	r.tagged(VerbosityVerbose, ColorBlue, "Task "+taskID, displaytext.Truncate(description, 80))
 }
 
 // TaskProgress prints a task progress update.
 func (r *Renderer) TaskProgress(taskID, description string) {
-	r.tagged(VerbosityVerbose, ColorGray, "Task "+taskID, TruncateForDisplay(description, 80))
+	r.tagged(VerbosityVerbose, ColorGray, "Task "+taskID, displaytext.Truncate(description, 80))
 }
 
 // TaskNotification prints a task completion notification.
@@ -679,7 +681,7 @@ func (r *Renderer) TaskNotification(taskID, status, summary string) {
 
 	fmt.Fprintf(r.out, "%s%s [Task %s] %s%s %s\n",
 		r.color(colorCode), icon, taskID, status, r.color(ColorReset),
-		TruncateForDisplay(summary, 70))
+		displaytext.Truncate(summary, 70))
 }
 
 // HookLifecycle prints a hook execution event.

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -133,6 +133,38 @@ func TestToolComplete_Normal(t *testing.T) {
 	}
 }
 
+func TestToolComplete_TruncatesLongSummaries(t *testing.T) {
+	assertSummary := func(t *testing.T, name string, input map[string]interface{}, maxRunes int, wantPart string, wantEllip bool) {
+		t.Helper()
+		summary := FormatToolInput(name, input)
+		if maxRunes > 0 && len([]rune(summary)) > maxRunes {
+			t.Fatalf("summary length = %d, want <= %d: %q", len([]rune(summary)), maxRunes, summary)
+		}
+		if !strings.Contains(summary, wantPart) {
+			t.Fatalf("summary %q does not contain %q", summary, wantPart)
+		}
+		if strings.HasSuffix(summary, "...") != wantEllip {
+			t.Fatalf("summary ellipsis suffix = %v, want %v: %q", strings.HasSuffix(summary, "..."), wantEllip, summary)
+		}
+	}
+
+	t.Run("Read", func(t *testing.T) {
+		assertSummary(t, "Read", map[string]interface{}{
+			"file_path": "/really/long/prefix/that/exceeds/eighty/chars/with/many/segments/deeply/nested/file.go",
+		}, 80, ".../nested/file.go", false)
+	})
+	t.Run("Bash", func(t *testing.T) {
+		assertSummary(t, "Bash", map[string]interface{}{
+			"command": strings.Repeat("echo very-long-command ", 8),
+		}, 80, "...", true)
+	})
+	t.Run("Task", func(t *testing.T) {
+		assertSummary(t, "Task", map[string]interface{}{
+			"description": "summarize " + strings.Repeat("details ", 20),
+		}, 0, "summarize details details", false)
+	})
+}
+
 func TestToolComplete_InteractiveTool_EventHandler(t *testing.T) {
 	r, _ := newTestRenderer(VerbosityNormal)
 	var startedName, completedName string

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -158,11 +158,6 @@ func TestToolComplete_TruncatesLongSummaries(t *testing.T) {
 			"command": strings.Repeat("echo very-long-command ", 8),
 		}, 80, "...", true)
 	})
-	t.Run("Task", func(t *testing.T) {
-		assertSummary(t, "Task", map[string]interface{}{
-			"description": "summarize " + strings.Repeat("details ", 20),
-		}, 0, "summarize details details", false)
-	})
 }
 
 func TestToolComplete_InteractiveTool_EventHandler(t *testing.T) {
@@ -498,6 +493,17 @@ func TestResetClosesOpenToolOutput(t *testing.T) {
 	}
 }
 
+func TestCommandEnd_TruncatesLongCommand(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityVerbose)
+	r.CommandStart("call1", strings.Repeat("c", 80))
+	r.CommandEnd("call1", 0, 10)
+
+	want := "[" + strings.Repeat("c", 57) + "...]"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("CommandEnd output missing truncated command %q: %q", want, buf.String())
+	}
+}
+
 // --- Turn summaries ---
 
 func TestTurnSummary(t *testing.T) {
@@ -518,6 +524,25 @@ func TestTurnCompleteWithTokens(t *testing.T) {
 	}
 	if !strings.Contains(output, "1000") {
 		t.Errorf("Missing input tokens: %q", output)
+	}
+}
+
+func TestTaskLifecycle_TruncatesLongSummaries(t *testing.T) {
+	r, buf := newTestRenderer(VerbosityVerbose)
+
+	r.TaskStarted("1", strings.Repeat("s", 100))
+	r.TaskProgress("1", strings.Repeat("p", 100))
+	r.TaskNotification("1", "completed", strings.Repeat("n", 100))
+
+	output := buf.String()
+	for _, want := range []string{
+		strings.Repeat("s", 77) + "...",
+		strings.Repeat("p", 77) + "...",
+		strings.Repeat("n", 67) + "...",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("Task lifecycle output missing %q: %q", want, output)
+		}
 	}
 }
 

--- a/agent-cli-wrapper/claude/render/render_test.go
+++ b/agent-cli-wrapper/claude/render/render_test.go
@@ -575,29 +575,6 @@ func TestVerbosity_String(t *testing.T) {
 	}
 }
 
-// --- Format helpers ---
-
-func TestTruncateForDisplay(t *testing.T) {
-	if got := TruncateForDisplay("hello", 10); got != "hello" {
-		t.Errorf("short string: got %q", got)
-	}
-	if got := TruncateForDisplay("hello world", 8); got != "hello..." {
-		t.Errorf("truncated: got %q", got)
-	}
-}
-
-func TestTruncatePath(t *testing.T) {
-	short := "/tmp/test.go"
-	if got := TruncatePath(short, 50); got != short {
-		t.Errorf("short path: got %q", got)
-	}
-	long := "/very/long/path/to/some/deeply/nested/file.go"
-	got := TruncatePath(long, 25)
-	if got != ".../nested/file.go" {
-		t.Errorf("truncated path should keep last two components: got %q", got)
-	}
-}
-
 // --- Event handler ---
 
 func TestEventHandler_TextFlush(t *testing.T) {

--- a/agent-cli-wrapper/displaytext/BUILD.bazel
+++ b/agent-cli-wrapper/displaytext/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "displaytext",
+    srcs = ["displaytext.go"],
+    importpath = "github.com/bazelment/yoloswe/agent-cli-wrapper/displaytext",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "displaytext_test",
+    srcs = ["displaytext_test.go"],
+    deps = [":displaytext"],
+)

--- a/agent-cli-wrapper/displaytext/displaytext.go
+++ b/agent-cli-wrapper/displaytext/displaytext.go
@@ -2,55 +2,92 @@ package displaytext
 
 import "strings"
 
-// Truncate truncates s to at most max Unicode code points, appending "..." if
-// truncation occurred (the suffix counts toward max). Rune-based indexing avoids
-// splitting multi-byte UTF-8 sequences. If max <= 3, returns max runes with no
-// suffix.
+// Truncate returns s shortened to at most max runes, appending "..." when the
+// suffix fits within max.
 func Truncate(s string, max int) string {
-	// Fast path: byte length <= max implies rune length <= max.
-	if len(s) <= max {
-		return s
+	if max <= 0 {
+		return ""
 	}
-	runes := []rune(s)
-	if len(runes) <= max {
+	if len(s) <= max || runeCountAtMost(s, max) {
 		return s
 	}
 	if max <= 3 {
-		return string(runes[:max])
+		return s[:byteIndexAfterRunes(s, max)]
 	}
-	return string(runes[:max-3]) + "..."
+	return s[:byteIndexAfterRunes(s, max-3)] + "..."
 }
 
-// TruncatePath truncates a file path, keeping the end visible. For paths longer
-// than max, prefers ".../" + last two path components; falls back to "..." +
-// filename, then to rune-truncation.
+// TruncatePath returns path shortened to at most max runes, preferring to keep
+// the last two path components visible.
 func TruncatePath(path string, max int) string {
-	// Fast path: byte length <= max implies rune length <= max.
-	if len(path) <= max {
+	return TruncatePathComponents(path, max, 2)
+}
+
+// TruncatePathComponents returns path shortened to at most max runes, preferring
+// to keep the requested number of trailing path components visible.
+func TruncatePathComponents(path string, max int, components int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(path) <= max || runeCountAtMost(path, max) {
 		return path
 	}
-	runes := []rune(path)
-	if len(runes) <= max {
-		return path
-	}
-	// Try to keep the last two components (e.g. "foo/bar.go").
-	parts := strings.Split(path, "/")
-	if len(parts) >= 2 {
-		suffix := strings.Join(parts[len(parts)-2:], "/")
-		prefixed := ".../" + suffix
-		if len(prefixed) <= max { // ASCII-safe: ".../" + path segments
-			return prefixed
+	if components > 0 {
+		if suffix := trailingPathComponents(path, components); suffix != "" {
+			if candidate := ".../" + suffix; runeCountAtMost(candidate, max) {
+				return candidate
+			}
 		}
 	}
-	// Fall back to keeping just the filename.
-	if lastSlash := strings.LastIndexByte(path, '/'); lastSlash > 0 {
-		suffix := path[lastSlash:]
-		if len(suffix) <= max-3 { // ASCII-safe: path components
-			return "..." + suffix
+	if suffix := trailingPathComponents(path, 1); suffix != "" {
+		if candidate := ".../" + suffix; runeCountAtMost(candidate, max) {
+			return candidate
 		}
 	}
-	if max <= 3 {
-		return string(runes[:max])
+	return Truncate(path, max)
+}
+
+func trailingPathComponents(path string, components int) string {
+	end := strings.TrimRight(path, "/")
+	if end == "" {
+		return ""
 	}
-	return string(runes[:max-3]) + "..."
+
+	start := len(end)
+	for i := 0; i < components; i++ {
+		slash := strings.LastIndexByte(end[:start], '/')
+		if slash < 0 {
+			return strings.TrimLeft(end, "/")
+		}
+		start = slash
+	}
+	return strings.TrimLeft(end[start:], "/")
+}
+
+func runeCountAtMost(s string, max int) bool {
+	if max < 0 {
+		return false
+	}
+	count := 0
+	for range s {
+		count++
+		if count > max {
+			return false
+		}
+	}
+	return true
+}
+
+func byteIndexAfterRunes(s string, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	count := 0
+	for i := range s {
+		if count == n {
+			return i
+		}
+		count++
+	}
+	return len(s)
 }

--- a/agent-cli-wrapper/displaytext/displaytext.go
+++ b/agent-cli-wrapper/displaytext/displaytext.go
@@ -1,0 +1,56 @@
+package displaytext
+
+import "strings"
+
+// Truncate truncates s to at most max Unicode code points, appending "..." if
+// truncation occurred (the suffix counts toward max). Rune-based indexing avoids
+// splitting multi-byte UTF-8 sequences. If max <= 3, returns max runes with no
+// suffix.
+func Truncate(s string, max int) string {
+	// Fast path: byte length <= max implies rune length <= max.
+	if len(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}
+
+// TruncatePath truncates a file path, keeping the end visible. For paths longer
+// than max, prefers ".../" + last two path components; falls back to "..." +
+// filename, then to rune-truncation.
+func TruncatePath(path string, max int) string {
+	// Fast path: byte length <= max implies rune length <= max.
+	if len(path) <= max {
+		return path
+	}
+	runes := []rune(path)
+	if len(runes) <= max {
+		return path
+	}
+	// Try to keep the last two components (e.g. "foo/bar.go").
+	parts := strings.Split(path, "/")
+	if len(parts) >= 2 {
+		suffix := strings.Join(parts[len(parts)-2:], "/")
+		prefixed := ".../" + suffix
+		if len(prefixed) <= max { // ASCII-safe: ".../" + path segments
+			return prefixed
+		}
+	}
+	// Fall back to keeping just the filename.
+	if lastSlash := strings.LastIndexByte(path, '/'); lastSlash > 0 {
+		suffix := path[lastSlash:]
+		if len(suffix) <= max-3 { // ASCII-safe: path components
+			return "..." + suffix
+		}
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}

--- a/agent-cli-wrapper/displaytext/displaytext_test.go
+++ b/agent-cli-wrapper/displaytext/displaytext_test.go
@@ -44,4 +44,14 @@ func TestTruncatePathComponents(t *testing.T) {
 	if got != ".../file.go" {
 		t.Errorf("unicode path should use rune-aware fallback: got %q", got)
 	}
+	nonASCIIFilename := "/really/long/path/世界.go"
+	got = displaytext.TruncatePathComponents(nonASCIIFilename, 10, 1)
+	if got != ".../世界.go" {
+		t.Errorf("non-ASCII filename should be preserved when it fits: got %q", got)
+	}
+	tooLongFilename := "/very/long/path/supercalifragilistic.go"
+	got = displaytext.TruncatePathComponents(tooLongFilename, 12, 1)
+	if got != "/very/lon..." {
+		t.Errorf("too-long filename should fall back to generic truncation: got %q", got)
+	}
 }

--- a/agent-cli-wrapper/displaytext/displaytext_test.go
+++ b/agent-cli-wrapper/displaytext/displaytext_test.go
@@ -1,0 +1,28 @@
+package displaytext_test
+
+import (
+	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/displaytext"
+)
+
+func TestTruncate(t *testing.T) {
+	if got := displaytext.Truncate("hello", 10); got != "hello" {
+		t.Errorf("short string: got %q", got)
+	}
+	if got := displaytext.Truncate("hello world", 8); got != "hello..." {
+		t.Errorf("truncated: got %q", got)
+	}
+}
+
+func TestTruncatePath(t *testing.T) {
+	short := "/tmp/test.go"
+	if got := displaytext.TruncatePath(short, 50); got != short {
+		t.Errorf("short path: got %q", got)
+	}
+	long := "/very/long/path/to/some/deeply/nested/file.go"
+	got := displaytext.TruncatePath(long, 25)
+	if got != ".../nested/file.go" {
+		t.Errorf("truncated path should keep last two components: got %q", got)
+	}
+}

--- a/agent-cli-wrapper/displaytext/displaytext_test.go
+++ b/agent-cli-wrapper/displaytext/displaytext_test.go
@@ -13,6 +13,12 @@ func TestTruncate(t *testing.T) {
 	if got := displaytext.Truncate("hello world", 8); got != "hello..." {
 		t.Errorf("truncated: got %q", got)
 	}
+	if got := displaytext.Truncate("hello 世界!", 8); got != "hello..." {
+		t.Errorf("unicode truncation: got %q", got)
+	}
+	if got := displaytext.Truncate("世界hello", 3); got != "世界h" {
+		t.Errorf("small max should not add suffix: got %q", got)
+	}
 }
 
 func TestTruncatePath(t *testing.T) {
@@ -24,5 +30,18 @@ func TestTruncatePath(t *testing.T) {
 	got := displaytext.TruncatePath(long, 25)
 	if got != ".../nested/file.go" {
 		t.Errorf("truncated path should keep last two components: got %q", got)
+	}
+}
+
+func TestTruncatePathComponents(t *testing.T) {
+	long := "/very/long/path/to/some/deeply/nested/file.go"
+	got := displaytext.TruncatePathComponents(long, 25, 1)
+	if got != ".../file.go" {
+		t.Errorf("truncated path should keep filename: got %q", got)
+	}
+	unicode := "/really/long/path/with/unicode/世界/file.go"
+	got = displaytext.TruncatePathComponents(unicode, 13, 2)
+	if got != ".../file.go" {
+		t.Errorf("unicode path should use rune-aware fallback: got %q", got)
 	}
 }

--- a/bramble/replay/BUILD.bazel
+++ b/bramble/replay/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//agent-cli-wrapper/codex",
+        "//agent-cli-wrapper/displaytext",
         "//bramble/session",
         "//bramble/sessionmodel",
     ],

--- a/bramble/replay/raw_jsonl.go
+++ b/bramble/replay/raw_jsonl.go
@@ -38,7 +38,6 @@ func extractPrompt(lines []session.OutputLine) string {
 		if line.Type != session.OutputTypeText || line.Content == "" {
 			continue
 		}
-		// Truncate to 203 so that displaytext.Truncate keeps 200 content runes + "...".
 		s := displaytext.Truncate(line.Content, 203)
 		if line.IsUserPrompt {
 			return s

--- a/bramble/replay/raw_jsonl.go
+++ b/bramble/replay/raw_jsonl.go
@@ -1,6 +1,7 @@
 package replay
 
 import (
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/displaytext"
 	"github.com/bazelment/yoloswe/bramble/session"
 	"github.com/bazelment/yoloswe/bramble/sessionmodel"
 )
@@ -37,8 +38,8 @@ func extractPrompt(lines []session.OutputLine) string {
 		if line.Type != session.OutputTypeText || line.Content == "" {
 			continue
 		}
-		// Truncate to 203 so that TruncateForDisplay keeps 200 content runes + "...".
-		s := sessionmodel.TruncateForDisplay(line.Content, 203)
+		// Truncate to 203 so that displaytext.Truncate keeps 200 content runes + "...".
+		s := displaytext.Truncate(line.Content, 203)
 		if line.IsUserPrompt {
 			return s
 		}

--- a/bramble/replay/replay_test.go
+++ b/bramble/replay/replay_test.go
@@ -75,6 +75,19 @@ func TestParse_AutoDetectsClaude(t *testing.T) {
 	assert.Equal(t, "hello claude", result.Prompt)
 }
 
+func TestExtractPromptTruncatesLongUserPrompt(t *testing.T) {
+	longPrompt := strings.Repeat("x", 240)
+
+	got := extractPrompt([]session.OutputLine{
+		{Type: session.OutputTypeText, Content: strings.Repeat("fallback", 40)},
+		{Type: session.OutputTypeText, Content: longPrompt, IsUserPrompt: true},
+	})
+
+	assert.Len(t, []rune(got), 203)
+	assert.True(t, strings.HasSuffix(got, "..."), "prompt should end with ellipsis: %q", got)
+	assert.Equal(t, strings.Repeat("x", 200)+"...", got)
+}
+
 // --- Codex parser tests (migrated from codexlogview) ---
 
 func TestCodexParser_TrimsPromptAndFollowUp(t *testing.T) {

--- a/bramble/sessionmodel/BUILD.bazel
+++ b/bramble/sessionmodel/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//agent-cli-wrapper/claude",
+        "//agent-cli-wrapper/displaytext",
         "//agent-cli-wrapper/protocol",
         "//multiagent/agent",
     ],
@@ -24,6 +25,7 @@ go_library(
 go_test(
     name = "sessionmodel_test",
     srcs = [
+        "format_test.go",
         "loader_test.go",
         "model_test.go",
     ],

--- a/bramble/sessionmodel/format.go
+++ b/bramble/sessionmodel/format.go
@@ -2,7 +2,8 @@ package sessionmodel
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/displaytext"
 )
 
 // FormatToolContent creates a display-friendly content string for a tool call.
@@ -15,15 +16,15 @@ func FormatToolContent(name string, input map[string]interface{}) string {
 	switch name {
 	case "Read":
 		if path, ok := input["file_path"].(string); ok {
-			return fmt.Sprintf("%s %s", name, truncatePathForDisplay(path))
+			return fmt.Sprintf("%s %s", name, displaytext.TruncatePath(path, 60))
 		}
 	case "Write", "Edit":
 		if path, ok := input["file_path"].(string); ok {
-			return fmt.Sprintf("%s → %s", name, truncatePathForDisplay(path))
+			return fmt.Sprintf("%s → %s", name, displaytext.TruncatePath(path, 60))
 		}
 	case "Bash":
 		if cmd, ok := input["command"].(string); ok {
-			return fmt.Sprintf("%s: %s", name, TruncateForDisplay(cmd, 50))
+			return fmt.Sprintf("%s: %s", name, displaytext.Truncate(cmd, 50))
 		}
 	case "Glob":
 		if pattern, ok := input["pattern"].(string); ok {
@@ -31,43 +32,12 @@ func FormatToolContent(name string, input map[string]interface{}) string {
 		}
 	case "Grep":
 		if pattern, ok := input["pattern"].(string); ok {
-			return fmt.Sprintf("%s %s", name, TruncateForDisplay(pattern, 40))
+			return fmt.Sprintf("%s %s", name, displaytext.Truncate(pattern, 40))
 		}
 	case "Task":
 		if desc, ok := input["description"].(string); ok {
-			return fmt.Sprintf("%s: %s", name, TruncateForDisplay(desc, 40))
+			return fmt.Sprintf("%s: %s", name, displaytext.Truncate(desc, 40))
 		}
 	}
 	return name
-}
-
-// truncatePathForDisplay keeps the filename visible when truncating paths.
-func truncatePathForDisplay(path string) string {
-	runes := []rune(path)
-	if len(runes) <= 60 {
-		return path
-	}
-	if lastSlash := strings.LastIndexByte(path, '/'); lastSlash > 0 {
-		suffix := path[lastSlash:]
-		if len([]rune(suffix)) <= 50 {
-			return "..." + suffix
-		}
-	}
-	return string(runes[:57]) + "..."
-}
-
-// TruncateForDisplay truncates s to at most max Unicode code points, appending
-// "..." if truncation occurred (the suffix counts toward max). Rune-based
-// indexing avoids splitting multi-byte UTF-8 sequences that byte-based slicing
-// would corrupt. If max is less than 3, the string is truncated to max runes
-// with no suffix.
-func TruncateForDisplay(s string, max int) string {
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
-	}
-	if max <= 3 {
-		return string(runes[:max])
-	}
-	return string(runes[:max-3]) + "..."
 }

--- a/bramble/sessionmodel/format.go
+++ b/bramble/sessionmodel/format.go
@@ -16,11 +16,11 @@ func FormatToolContent(name string, input map[string]interface{}) string {
 	switch name {
 	case "Read":
 		if path, ok := input["file_path"].(string); ok {
-			return fmt.Sprintf("%s %s", name, displaytext.TruncatePath(path, 60))
+			return fmt.Sprintf("%s %s", name, displaytext.TruncatePathComponents(path, 60, 1))
 		}
 	case "Write", "Edit":
 		if path, ok := input["file_path"].(string); ok {
-			return fmt.Sprintf("%s → %s", name, displaytext.TruncatePath(path, 60))
+			return fmt.Sprintf("%s → %s", name, displaytext.TruncatePathComponents(path, 60, 1))
 		}
 	case "Bash":
 		if cmd, ok := input["command"].(string); ok {

--- a/bramble/sessionmodel/format.go
+++ b/bramble/sessionmodel/format.go
@@ -8,6 +8,8 @@ import (
 
 // FormatToolContent creates a display-friendly content string for a tool call.
 // Ported from bramble/session/event_handler.go:formatToolContent.
+// This structured-output path includes the tool name and uses narrower persisted
+// display widths; render.FormatToolInput uses terminal-oriented inline widths.
 func FormatToolContent(name string, input map[string]interface{}) string {
 	if input == nil {
 		return name

--- a/bramble/sessionmodel/format_test.go
+++ b/bramble/sessionmodel/format_test.go
@@ -1,15 +1,41 @@
 package sessionmodel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormatToolContentTruncatesLongPathWithParent(t *testing.T) {
+func TestFormatToolContentReadTruncatesToTrailingFilename(t *testing.T) {
 	content := FormatToolContent("Read", map[string]interface{}{
 		"file_path": "/really/long/prefix/that/exceeds/sixty/chars/with/many/segments/deeply/nested/file.go",
 	})
 
 	assert.Equal(t, "Read .../file.go", content)
+}
+
+func TestFormatToolContentTruncatesNonReadBranches(t *testing.T) {
+	assertContent := func(t *testing.T, name string, input map[string]interface{}, maxRunes int, want string) {
+		t.Helper()
+		content := FormatToolContent(name, input)
+		assert.LessOrEqual(t, len([]rune(content)), maxRunes)
+		assert.Equal(t, want, content)
+	}
+
+	t.Run("Bash", func(t *testing.T) {
+		assertContent(t, "Bash", map[string]interface{}{
+			"command": strings.Repeat("printf unicode-λ ", 5),
+		}, 56, "Bash: printf unicode-λ printf unicode-λ printf unicod...")
+	})
+	t.Run("Grep", func(t *testing.T) {
+		assertContent(t, "Grep", map[string]interface{}{
+			"pattern": strings.Repeat("needle", 10),
+		}, 45, "Grep needleneedleneedleneedleneedleneedlen...")
+	})
+	t.Run("Task", func(t *testing.T) {
+		assertContent(t, "Task", map[string]interface{}{
+			"description": strings.Repeat("summarize ", 6),
+		}, 46, "Task: summarize summarize summarize summari...")
+	})
 }

--- a/bramble/sessionmodel/format_test.go
+++ b/bramble/sessionmodel/format_test.go
@@ -1,0 +1,15 @@
+package sessionmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatToolContentTruncatesLongPathWithParent(t *testing.T) {
+	content := FormatToolContent("Read", map[string]interface{}{
+		"file_path": "/really/long/prefix/that/exceeds/sixty/chars/with/many/segments/deeply/nested/file.go",
+	})
+
+	assert.Equal(t, "Read .../nested/file.go", content)
+}

--- a/bramble/sessionmodel/format_test.go
+++ b/bramble/sessionmodel/format_test.go
@@ -11,5 +11,5 @@ func TestFormatToolContentTruncatesLongPathWithParent(t *testing.T) {
 		"file_path": "/really/long/prefix/that/exceeds/sixty/chars/with/many/segments/deeply/nested/file.go",
 	})
 
-	assert.Equal(t, "Read .../nested/file.go", content)
+	assert.Equal(t, "Read .../file.go", content)
 }


### PR DESCRIPTION
## Summary

- Add a shared `agent-cli-wrapper/displaytext` package for rune-safe display truncation, including generic string truncation, path truncation that preserves trailing components, and configurable trailing-component retention.
- Replace duplicated truncation helpers in Claude terminal rendering, Bramble replay prompt extraction, and `bramble/sessionmodel` tool formatting with the shared helpers.
- Preserve the intended differences between formatter surfaces: terminal render output keeps inline, wider summaries while sessionmodel persisted output keeps tool names and narrower widths.
- Document the formatter-surface differences in code so future changes do not accidentally collapse the render and sessionmodel behaviors.
- Expand coverage across the new helper package, Claude renderer call sites, replay prompt extraction, and sessionmodel formatting, including Unicode and long-path cases.

## Validation

- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors duplicated truncation logic into a shared package and updates call sites; main impact is slightly different truncation behavior in CLI/session summaries, not core logic.
> 
> **Overview**
> Introduces a new shared `agent-cli-wrapper/displaytext` package providing rune-safe `Truncate` plus path truncation helpers that preserve trailing path components.
> 
> Replaces duplicated truncation implementations across Claude terminal rendering (`render`), `bramble/sessionmodel` tool content formatting, and `bramble/replay` prompt extraction to use the shared helpers, while documenting/keeping different width and prefix conventions between terminal vs persisted structured output.
> 
> Adds/updates tests to lock in truncation behavior for long/unicode strings, long paths, task/command summaries, and replay prompt extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2f23d13668d9a2759d1b539021fa76a50d08a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->