### PR TITLE
Add jiradozer skip phases support

### DIFF
--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -41,7 +41,7 @@ func TestNewPromptData_StripsJiradozerLabels(t *testing.T) {
 		ID:         "id",
 		Identifier: "ENG-1",
 		Title:      "Test",
-		Labels:     []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done"},
+		Labels:     []string{"bug", "jiradozer-plan-inprogress", "feature", "jiradozer-build-done", "jiradozer-skip-plan"},
 	}
 
 	data := NewPromptData(issue, "main")

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -247,6 +247,11 @@ work_dir: .
 # Default base branch for PRs.
 base_branch: main
 
+# Optional phases to skip for every run. Skipped phases advance in-memory
+# workflow state and clear stale -inprogress labels, but do not write -done
+# labels; use tracker labels like jiradozer-plan-done for durable completion.
+#skip_phases: [plan]
+
 `
 
 // bootstrapTopLevelTail — top-level scalars that come after the step blocks.

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -250,6 +250,8 @@ base_branch: main
 # Optional phases to skip for every run. Skipped phases advance in-memory
 # workflow state and clear stale -inprogress labels, but do not write -done
 # labels; use tracker labels like jiradozer-plan-done for durable completion.
+# Tracker labels like jiradozer-skip-plan are also honored; label editors are
+# trusted to bypass the matching phase.
 #skip_phases: [plan]
 
 `

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -188,6 +188,7 @@ func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {
 		branchPrefix:  "hotfix",
 		dryRunSet:     true,
 		dryRun:        true,
+		skipPhases:    "plan, validate",
 	})
 	require.NoError(t, err)
 
@@ -197,6 +198,24 @@ func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {
 	require.Equal(t, 7, cfg.Source.MaxConcurrent)
 	require.Equal(t, "hotfix", cfg.Source.BranchPrefix)
 	require.True(t, cfg.Source.DryRun)
+	require.Equal(t, []string{"plan", "validate"}, cfg.SkipPhases)
+}
+
+func TestLoadRunConfigSkipPhasesCLIBeatsConfig(t *testing.T) {
+	cfgPath := writeRunConfig(t, "linear", t.TempDir())
+	content, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	content = append(content, []byte("\nskip_phases: [plan]\n")...)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0o600))
+
+	cfg, err := loadRunConfig(runArgs{
+		configPath:    cfgPath,
+		sourceFilters: []string{"team=ENG"},
+		skipPhases:    "validate",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"validate"}, cfg.SkipPhases)
 }
 
 func TestValidateReloadCompatibleRejectsTrackerChanges(t *testing.T) {
@@ -544,6 +563,7 @@ func TestBuildChildArgsOrdering(t *testing.T) {
 		thinkingLevel: "max",
 		maxBudget:     12.5,
 		autoApprove:   "all",
+		skipPhases:    "plan,validate",
 	}
 	got := buildChildArgs(app, args, "/tmp/jiradozer.yaml")
 
@@ -568,7 +588,7 @@ func TestBuildChildArgsOrdering(t *testing.T) {
 			"persistent flag %s must appear before `run` (got argv: %v)", flag, got)
 	}
 
-	runOnlyAfterRun := []string{"--model", "--thinking-level", "--max-budget", "--auto-approve"}
+	runOnlyAfterRun := []string{"--model", "--thinking-level", "--max-budget", "--auto-approve", "--skip-phases"}
 	for _, flag := range runOnlyAfterRun {
 		idx := indexOf(flag)
 		require.NotEqualf(t, -1, idx, "argv must contain run-only flag %s; got %v", flag, got)

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -89,7 +89,7 @@ func registerRunFlags(cmd *cobra.Command, args *runArgs) {
 	cmd.Flags().Float64Var(&args.maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	cmd.Flags().StringVar(&args.runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
 	cmd.Flags().StringVar(&args.autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
-	cmd.Flags().StringVar(&args.skipPhases, "skip-phases", "", "Skip workflow phases for this run (comma-separated: plan,build,validate,ship)")
+	cmd.Flags().StringVar(&args.skipPhases, "skip-phases", "", "Skip high-level workflow phases for this run (comma-separated: plan,build,validate,ship; create_pr is part of build)")
 	cmd.Flags().StringArrayVar(&args.sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo,Backlog)")
 	cmd.Flags().IntVar(&args.maxConcurrent, "max-concurrent", 0, "Max concurrent workflows (overrides config)")
 	cmd.Flags().StringVar(&args.branchPrefix, "branch-prefix", "", "Worktree branch prefix (overrides config)")

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -233,7 +233,7 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 		cfg.MaxBudgetUSD = args.maxBudget
 	}
 	if args.skipPhases != "" {
-		if err := cfg.ApplySkipPhases(parseCSV(args.skipPhases), "cli"); err != nil {
+		if err := cfg.ApplySkipPhases(tracker.SplitCSV(args.skipPhases), "cli"); err != nil {
 			return nil, fmt.Errorf("--skip-phases: %w", err)
 		}
 	}
@@ -598,18 +598,7 @@ func parseAutoApprove(value string) []string {
 	if strings.TrimSpace(value) == "all" {
 		return allSteps
 	}
-	return parseCSV(value)
-}
-
-func parseCSV(value string) []string {
-	parts := strings.Split(value, ",")
-	result := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if s := strings.TrimSpace(p); s != "" {
-			result = append(result, s)
-		}
-	}
-	return result
+	return tracker.SplitCSV(value)
 }
 
 func availableModels() string {

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -32,6 +32,7 @@ type runArgs struct {
 	thinkingLevel   string
 	runStep         string
 	autoApprove     string
+	skipPhases      string
 	branchPrefix    string
 	issueID         string
 	descriptionFile string
@@ -88,6 +89,7 @@ func registerRunFlags(cmd *cobra.Command, args *runArgs) {
 	cmd.Flags().Float64Var(&args.maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	cmd.Flags().StringVar(&args.runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
 	cmd.Flags().StringVar(&args.autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
+	cmd.Flags().StringVar(&args.skipPhases, "skip-phases", "", "Skip workflow phases for this run (comma-separated: plan,build,validate,ship)")
 	cmd.Flags().StringArrayVar(&args.sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo,Backlog)")
 	cmd.Flags().IntVar(&args.maxConcurrent, "max-concurrent", 0, "Max concurrent workflows (overrides config)")
 	cmd.Flags().StringVar(&args.branchPrefix, "branch-prefix", "", "Worktree branch prefix (overrides config)")
@@ -229,6 +231,11 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 	}
 	if args.maxBudget > 0 {
 		cfg.MaxBudgetUSD = args.maxBudget
+	}
+	if args.skipPhases != "" {
+		if err := cfg.ApplySkipPhases(parseCSV(args.skipPhases), "cli"); err != nil {
+			return nil, fmt.Errorf("--skip-phases: %w", err)
+		}
 	}
 
 	// Apply source overrides.
@@ -414,6 +421,9 @@ func buildChildArgs(app *cliapp.App, args runArgs, absConfigPath string) []strin
 	if args.autoApprove != "" {
 		out = append(out, "--auto-approve", args.autoApprove)
 	}
+	if args.skipPhases != "" {
+		out = append(out, "--skip-phases", args.skipPhases)
+	}
 	return out
 }
 
@@ -588,6 +598,10 @@ func parseAutoApprove(value string) []string {
 	if strings.TrimSpace(value) == "all" {
 		return allSteps
 	}
+	return parseCSV(value)
+}
+
+func parseCSV(value string) []string {
 	parts := strings.Split(value, ",")
 	result := make([]string, 0, len(parts))
 	for _, p := range parts {

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -17,7 +17,7 @@ import (
 
 // Config is the top-level configuration for jiradozer.
 //
-//nolint:govet // fieldalignment: keep YAML fields in config-file order; skipPhaseSources is internal metadata.
+//nolint:govet // fieldalignment: keep YAML fields in config-file order; skipPhaseSource is internal metadata.
 type Config struct {
 	Tracker      TrackerConfig `yaml:"tracker"`
 	Source       SourceConfig  `yaml:"source"`
@@ -34,8 +34,16 @@ type Config struct {
 	MaxBudgetUSD float64       `yaml:"max_budget_usd"`
 	PollInterval time.Duration `yaml:"poll_interval"`
 
-	skipPhaseSources map[string]string
+	skipPhaseSource skipPhaseSource
 }
+
+type skipPhaseSource string
+
+const (
+	skipPhaseSourceConfig skipPhaseSource = "config"
+	skipPhaseSourceCLI    skipPhaseSource = "cli"
+	skipPhaseSourceLabel  skipPhaseSource = "label"
+)
 
 // TrackerConfig specifies the issue tracker backend.
 type TrackerConfig struct {
@@ -205,13 +213,8 @@ func (c *Config) validate() error {
 	}
 	c.SkipPhases = skipPhases
 	if len(c.SkipPhases) > 0 {
-		if c.skipPhaseSources == nil {
-			c.skipPhaseSources = make(map[string]string)
-		}
-		for _, phase := range c.SkipPhases {
-			if c.skipPhaseSources[phase] == "" {
-				c.skipPhaseSources[phase] = "config"
-			}
+		if c.skipPhaseSource == "" {
+			c.skipPhaseSource = skipPhaseSourceConfig
 		}
 	}
 	namedSteps := []struct {
@@ -239,7 +242,7 @@ func NormalizeSkipPhases(phases []string) ([]string, error) {
 		if phase == "" {
 			continue
 		}
-		if !isUserPhase(phase) {
+		if startStepForPhase(phase) == StepInit {
 			return nil, fmt.Errorf("unknown phase %q (valid: %s)", phase, strings.Join(validUserPhases(), ", "))
 		}
 		if seen[phase] {
@@ -258,19 +261,34 @@ func (c *Config) ApplySkipPhases(phases []string, source string) error {
 	if err != nil {
 		return err
 	}
-	c.SkipPhases = normalized
-	c.skipPhaseSources = make(map[string]string)
-	for _, phase := range normalized {
-		c.skipPhaseSources[phase] = source
+	parsedSource, err := parseSkipPhaseSource(source)
+	if err != nil {
+		return err
 	}
+	c.SkipPhases = normalized
+	c.skipPhaseSource = parsedSource
 	return nil
 }
 
-func (c *Config) skipPhaseSource(phase string) string {
-	if c == nil || c.skipPhaseSources == nil {
-		return ""
+func (c *Config) skipSourceForPhase(phase string) skipPhaseSource {
+	if c == nil || c.skipPhaseSource == "" {
+		return skipPhaseSourceConfig
 	}
-	return c.skipPhaseSources[phase]
+	for _, skippedPhase := range c.SkipPhases {
+		if skippedPhase == phase {
+			return c.skipPhaseSource
+		}
+	}
+	return ""
+}
+
+func parseSkipPhaseSource(source string) (skipPhaseSource, error) {
+	switch skipPhaseSource(source) {
+	case skipPhaseSourceConfig, skipPhaseSourceCLI, skipPhaseSourceLabel:
+		return skipPhaseSource(source), nil
+	default:
+		return "", fmt.Errorf("unknown skip phase source %q", source)
+	}
 }
 
 func validUserPhases() []string {
@@ -279,15 +297,6 @@ func validUserPhases() []string {
 		out = append(out, p.name)
 	}
 	return out
-}
-
-func isUserPhase(phase string) bool {
-	for _, p := range phaseTable {
-		if p.name == phase {
-			return true
-		}
-	}
-	return false
 }
 
 // validateStep checks one named step.

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -43,6 +43,7 @@ const (
 	skipPhaseSourceConfig skipPhaseSource = "config"
 	skipPhaseSourceCLI    skipPhaseSource = "cli"
 	skipPhaseSourceLabel  skipPhaseSource = "label"
+	skipPhaseSourceDone   skipPhaseSource = "done"
 )
 
 // TrackerConfig specifies the issue tracker backend.
@@ -271,11 +272,14 @@ func (c *Config) ApplySkipPhases(phases []string, source string) error {
 }
 
 func (c *Config) skipSourceForPhase(phase string) skipPhaseSource {
-	if c == nil || c.skipPhaseSource == "" {
-		return skipPhaseSourceConfig
+	if c == nil {
+		return ""
 	}
 	for _, skippedPhase := range c.SkipPhases {
 		if skippedPhase == phase {
+			if c.skipPhaseSource == "" {
+				return skipPhaseSourceConfig
+			}
 			return c.skipPhaseSource
 		}
 	}

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -16,6 +16,8 @@ import (
 )
 
 // Config is the top-level configuration for jiradozer.
+//
+//nolint:govet // fieldalignment: keep YAML fields in config-file order; skipPhaseSources is internal metadata.
 type Config struct {
 	Tracker      TrackerConfig `yaml:"tracker"`
 	Source       SourceConfig  `yaml:"source"`
@@ -28,8 +30,11 @@ type Config struct {
 	CreatePR     StepConfig    `yaml:"create_pr"`
 	Validate     StepConfig    `yaml:"validate"`
 	Ship         StepConfig    `yaml:"ship"`
+	SkipPhases   []string      `yaml:"skip_phases"`
 	MaxBudgetUSD float64       `yaml:"max_budget_usd"`
 	PollInterval time.Duration `yaml:"poll_interval"`
+
+	skipPhaseSources map[string]string
 }
 
 // TrackerConfig specifies the issue tracker backend.
@@ -194,6 +199,21 @@ func (c *Config) validate() error {
 			return fmt.Errorf("agent.effort: %w", err)
 		}
 	}
+	skipPhases, err := NormalizeSkipPhases(c.SkipPhases)
+	if err != nil {
+		return fmt.Errorf("skip_phases: %w", err)
+	}
+	c.SkipPhases = skipPhases
+	if len(c.SkipPhases) > 0 {
+		if c.skipPhaseSources == nil {
+			c.skipPhaseSources = make(map[string]string)
+		}
+		for _, phase := range c.SkipPhases {
+			if c.skipPhaseSources[phase] == "" {
+				c.skipPhaseSources[phase] = "config"
+			}
+		}
+	}
 	namedSteps := []struct {
 		step *StepConfig
 		name string
@@ -207,6 +227,67 @@ func (c *Config) validate() error {
 		}
 	}
 	return nil
+}
+
+// NormalizeSkipPhases validates phase names, trims whitespace, removes
+// duplicates, and preserves first-seen order.
+func NormalizeSkipPhases(phases []string) ([]string, error) {
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(phases))
+	for _, phase := range phases {
+		phase = strings.TrimSpace(phase)
+		if phase == "" {
+			continue
+		}
+		if !isUserPhase(phase) {
+			return nil, fmt.Errorf("unknown phase %q (valid: %s)", phase, strings.Join(validUserPhases(), ", "))
+		}
+		if seen[phase] {
+			continue
+		}
+		seen[phase] = true
+		out = append(out, phase)
+	}
+	return out, nil
+}
+
+// ApplySkipPhases replaces the configured skip set and records its source for
+// workflow logs. This is used by CLI overrides after LoadConfig validation.
+func (c *Config) ApplySkipPhases(phases []string, source string) error {
+	normalized, err := NormalizeSkipPhases(phases)
+	if err != nil {
+		return err
+	}
+	c.SkipPhases = normalized
+	c.skipPhaseSources = make(map[string]string)
+	for _, phase := range normalized {
+		c.skipPhaseSources[phase] = source
+	}
+	return nil
+}
+
+func (c *Config) skipPhaseSource(phase string) string {
+	if c == nil || c.skipPhaseSources == nil {
+		return ""
+	}
+	return c.skipPhaseSources[phase]
+}
+
+func validUserPhases() []string {
+	out := make([]string, 0, len(phaseTable))
+	for _, p := range phaseTable {
+		out = append(out, p.name)
+	}
+	return out
+}
+
+func isUserPhase(phase string) bool {
+	for _, p := range phaseTable {
+		if p.name == phase {
+			return true
+		}
+	}
+	return false
 }
 
 // validateStep checks one named step.

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -163,6 +163,25 @@ poll_interval: 0s
 	assert.Equal(t, 15*time.Second, cfg.PollInterval)
 }
 
+func TestConfig_SkipPhases_ValidatesNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	yaml := `
+tracker:
+  kind: linear
+  api_key: test-key
+agent:
+  model: sonnet
+skip_phases: [plan, not_a_phase]
+` + minimalSteps()
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skip_phases")
+	assert.Contains(t, err.Error(), "not_a_phase")
+	assert.Contains(t, err.Error(), "plan, build, validate, ship")
+}
+
 // minimalSteps returns a YAML block populating the prompt and
 // comment_template fields jiradozer requires for every named step. Useful
 // for inline-YAML test cases that exercise something *other than* the

--- a/jiradozer/integration/e2e_workflow_test.go
+++ b/jiradozer/integration/e2e_workflow_test.go
@@ -193,6 +193,62 @@ func TestE2E_HappyPath_AllAutoApprove(t *testing.T) {
 	assert.GreaterOrEqual(t, len(ft.CallsFor("FetchComments")), 3, "auto-approved review gates should still check for late feedback")
 }
 
+func TestE2E_SkipPlanLabel_RunsBuildValidateShip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	workDir := t.TempDir()
+
+	issue := e2eIssue()
+	issue.Labels = []string{"jiradozer-skip-plan"}
+	ft := NewFakeTracker(e2eWorkflowStates())
+	ft.AddIssue(*issue)
+
+	cfg := e2eConfig(t, workDir)
+	wf := jiradozer.NewWorkflow(ft, issue, cfg, logger)
+
+	var transitions []jiradozer.WorkflowStep
+	var mu sync.Mutex
+	wf.OnTransition = func(step jiradozer.WorkflowStep) {
+		mu.Lock()
+		transitions = append(transitions, step)
+		mu.Unlock()
+		t.Logf("transition → %s", step)
+	}
+
+	err := wf.Run(ctx)
+	require.NoError(t, err, "workflow should complete successfully")
+
+	mu.Lock()
+	got := transitions
+	mu.Unlock()
+
+	expected := []jiradozer.WorkflowStep{
+		jiradozer.StepPlanning,
+		jiradozer.StepBuilding,
+		jiradozer.StepCreatingPR,
+		jiradozer.StepBuildReview,
+		jiradozer.StepValidating,
+		jiradozer.StepValidateReview,
+		jiradozer.StepShipping,
+		jiradozer.StepShipReview,
+		jiradozer.StepDone,
+	}
+	assert.Equal(t, expected, got, "skip-plan label should omit only plan execution and review")
+
+	postBodies := postCommentBodies(ft)
+	assert.Equal(t, 0, countBodies(postBodies, "## Plan Complete"))
+	assertBodyContains(t, postBodies, "## Build Complete")
+	assertBodyContains(t, postBodies, "## Create_pr Complete")
+	assertBodyContains(t, postBodies, "## Validate Complete")
+	assertBodyContains(t, postBodies, "## Ship Complete")
+}
+
 // TestE2E_PlanStep_Smoke is a fast smoke test that runs only the plan step
 // with real Claude execution. Verifies the agent setup works before running
 // the full 10-minute E2E test.

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -85,6 +85,11 @@ work_dir: .
 # Default base branch for PRs.
 base_branch: main
 
+# Optional phases to skip for every run. Skipped phases advance in-memory
+# workflow state and clear stale -inprogress labels, but do not write -done
+# labels; use tracker labels like jiradozer-plan-done for durable completion.
+#skip_phases: [plan]
+
 # ---- plan — write an implementation plan ----
 # Agent reads the issue and writes an approach. permission_mode is `plan` so
 # it cannot edit files. Output is posted to the issue and gated on a human

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -88,6 +88,8 @@ base_branch: main
 # Optional phases to skip for every run. Skipped phases advance in-memory
 # workflow state and clear stale -inprogress labels, but do not write -done
 # labels; use tracker labels like jiradozer-plan-done for durable completion.
+# Tracker labels like jiradozer-skip-plan are also honored; label editors are
+# trusted to bypass the matching phase.
 #skip_phases: [plan]
 
 # ---- plan — write an implementation plan ----

--- a/jiradozer/runtime_state.go
+++ b/jiradozer/runtime_state.go
@@ -75,6 +75,8 @@ func cloneConfig(cfg *Config) *Config {
 	}
 	cp := *cfg
 	cp.Source.Filters = cloneStringMap(cfg.Source.Filters)
+	cp.SkipPhases = append([]string(nil), cfg.SkipPhases...)
+	cp.skipPhaseSources = cloneStringMap(cfg.skipPhaseSources)
 	cp.Plan.Rounds = append([]RoundConfig(nil), cfg.Plan.Rounds...)
 	cp.Build.Rounds = append([]RoundConfig(nil), cfg.Build.Rounds...)
 	cp.CreatePR.Rounds = append([]RoundConfig(nil), cfg.CreatePR.Rounds...)

--- a/jiradozer/runtime_state.go
+++ b/jiradozer/runtime_state.go
@@ -76,7 +76,6 @@ func cloneConfig(cfg *Config) *Config {
 	cp := *cfg
 	cp.Source.Filters = cloneStringMap(cfg.Source.Filters)
 	cp.SkipPhases = append([]string(nil), cfg.SkipPhases...)
-	cp.skipPhaseSources = cloneStringMap(cfg.skipPhaseSources)
 	cp.Plan.Rounds = append([]RoundConfig(nil), cfg.Plan.Rounds...)
 	cp.Build.Rounds = append([]RoundConfig(nil), cfg.Build.Rounds...)
 	cp.CreatePR.Rounds = append([]RoundConfig(nil), cfg.CreatePR.Rounds...)

--- a/jiradozer/steplabels.go
+++ b/jiradozer/steplabels.go
@@ -61,15 +61,16 @@ func phaseAfter(phase string) string {
 
 func inProgressLabel(phase string) string { return "jiradozer-" + phase + "-inprogress" }
 func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done" }
+func skipLabel(phase string) string       { return "jiradozer-skip-" + phase }
 
 // isJiradozerLabel reports whether label is one of jiradozer's bookkeeping
 // phase labels. Callers strip these from user-facing prompts so agents see
 // only substantive labels. The check is an exact-match allowlist against
-// the eight phase × state labels so unrelated jiradozer-prefixed labels
-// (e.g. a team-owned jiradozer-backlog) are left visible to agents.
+// phase bookkeeping and skip-directive labels so unrelated jiradozer-prefixed
+// labels (e.g. a team-owned jiradozer-backlog) are left visible to agents.
 func isJiradozerLabel(label string) bool {
 	for _, p := range phaseTable {
-		if label == inProgressLabel(p.name) || label == doneLabel(p.name) {
+		if label == inProgressLabel(p.name) || label == doneLabel(p.name) || label == skipLabel(p.name) {
 			return true
 		}
 	}

--- a/jiradozer/steplabels.go
+++ b/jiradozer/steplabels.go
@@ -63,6 +63,15 @@ func inProgressLabel(phase string) string { return "jiradozer-" + phase + "-inpr
 func doneLabel(phase string) string       { return "jiradozer-" + phase + "-done" }
 func skipLabel(phase string) string       { return "jiradozer-skip-" + phase }
 
+func phaseForSkipLabel(label string) string {
+	for _, p := range phaseTable {
+		if label == skipLabel(p.name) {
+			return p.name
+		}
+	}
+	return ""
+}
+
 // isJiradozerLabel reports whether label is one of jiradozer's bookkeeping
 // phase labels. Callers strip these from user-facing prompts so agents see
 // only substantive labels. The check is an exact-match allowlist against
@@ -70,9 +79,9 @@ func skipLabel(phase string) string       { return "jiradozer-skip-" + phase }
 // labels (e.g. a team-owned jiradozer-backlog) are left visible to agents.
 func isJiradozerLabel(label string) bool {
 	for _, p := range phaseTable {
-		if label == inProgressLabel(p.name) || label == doneLabel(p.name) || label == skipLabel(p.name) {
+		if label == inProgressLabel(p.name) || label == doneLabel(p.name) {
 			return true
 		}
 	}
-	return false
+	return phaseForSkipLabel(label) != ""
 }

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -66,6 +66,8 @@ type Workflow struct {
 	stateIDs            map[string]string
 	redoCounts          map[WorkflowStep]int
 	phases              map[string]phaseState
+	skipPhases          map[string]bool
+	skipPhaseSources    map[string]string
 	OnTransition        func(step WorkflowStep)
 	OnRoundProgress     func(roundIndex, roundTotal int)
 	runStepAgent        func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error)
@@ -86,16 +88,25 @@ type Workflow struct {
 // refreshLabels) doesn't leak bookkeeping labels.
 func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logger *slog.Logger) *Workflow {
 	w := &Workflow{
-		tracker:      t,
-		state:        NewStateMachine(),
-		config:       cfg,
-		logger:       logger,
-		stateIDs:     make(map[string]string),
-		sessionIDs:   make(map[WorkflowStep]string),
-		redoCounts:   make(map[WorkflowStep]int),
-		phases:       make(map[string]phaseState),
-		maxRedos:     DefaultMaxRedos,
-		runStepAgent: RunStepAgent,
+		tracker:          t,
+		state:            NewStateMachine(),
+		config:           cfg,
+		logger:           logger,
+		stateIDs:         make(map[string]string),
+		sessionIDs:       make(map[WorkflowStep]string),
+		redoCounts:       make(map[WorkflowStep]int),
+		phases:           make(map[string]phaseState),
+		skipPhases:       make(map[string]bool),
+		skipPhaseSources: make(map[string]string),
+		maxRedos:         DefaultMaxRedos,
+		runStepAgent:     RunStepAgent,
+	}
+	for _, phase := range cfg.SkipPhases {
+		source := cfg.skipPhaseSource(phase)
+		if source == "" {
+			source = "config"
+		}
+		w.addSkipPhase(phase, source)
 	}
 	if issue != nil {
 		// Shallow-copy so Labels mutations on w.issue don't bleed back into
@@ -103,10 +114,41 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		// phase-skip decisions before the first tracker fetch.
 		issueCopy := *issue
 		w.lastLabels = slices.Clone(issue.Labels)
+		for _, label := range issue.Labels {
+			for _, p := range phaseTable {
+				if label == skipLabel(p.name) {
+					w.addSkipPhase(p.name, "label")
+				}
+			}
+		}
 		issueCopy.Labels = slices.DeleteFunc(slices.Clone(issue.Labels), isJiradozerLabel)
 		w.issue = &issueCopy
 	}
 	return w
+}
+
+func (w *Workflow) addSkipPhase(phase, source string) {
+	if !isUserPhase(phase) {
+		return
+	}
+	if prev := w.skipPhaseSources[phase]; prev != "" && skipPhasePriority(prev) > skipPhasePriority(source) {
+		return
+	}
+	w.skipPhases[phase] = true
+	w.skipPhaseSources[phase] = source
+}
+
+func skipPhasePriority(source string) int {
+	switch source {
+	case "cli":
+		return 3
+	case "label":
+		return 2
+	case "config":
+		return 1
+	default:
+		return 0
+	}
 }
 
 // SetRenderer sets the terminal renderer for streaming output.
@@ -130,6 +172,11 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		"work_dir", w.config.WorkDir,
 		"base_branch", w.config.BaseBranch,
 	)
+	for _, p := range phaseTable {
+		if w.skipPhases[p.name] {
+			w.logger.Info("phase configured to skip", "phase", p.name, "source", w.skipPhaseSources[p.name])
+		}
+	}
 	workflowStart := time.Now()
 	defer func() {
 		finalStep := w.state.Current().String()
@@ -611,6 +658,13 @@ func (w *Workflow) completePriorPhases(ctx context.Context, currentPhase string)
 // forceTransition. If all remaining phases are -done, jumps to StepDone.
 func (w *Workflow) skipDonePhases(ctx context.Context) {
 	labels := w.refreshLabels(ctx)
+	for _, label := range labels {
+		for _, p := range phaseTable {
+			if label == skipLabel(p.name) {
+				w.addSkipPhase(p.name, "label")
+			}
+		}
+	}
 
 	for {
 		cur := w.state.Current()
@@ -618,14 +672,15 @@ func (w *Workflow) skipDonePhases(ctx context.Context) {
 		if phase == "" {
 			return
 		}
-		if !slices.Contains(labels, doneLabel(phase)) {
+		hasDoneLabel := slices.Contains(labels, doneLabel(phase))
+		if !hasDoneLabel && !w.skipPhases[phase] {
 			return
 		}
 		// The -done label is authoritative, so clear any stale -inprogress
 		// label left over from a prior interrupted run or a user toggling
 		// phase state manually. Without this, the issue can end up tagged
 		// both -inprogress and -done for the same phase.
-		if slices.Contains(labels, inProgressLabel(phase)) {
+		if hasDoneLabel && slices.Contains(labels, inProgressLabel(phase)) {
 			if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 				w.logger.Warn("failed to clear stale in-progress label while skipping phase", "phase", phase, "error", err)
 			}
@@ -633,12 +688,16 @@ func (w *Workflow) skipDonePhases(ctx context.Context) {
 		w.phases[phase] = phaseDone
 		nextPhase := phaseAfter(phase)
 		if nextPhase == "" {
-			w.logger.Info("all phases already marked done; skipping to StepDone")
+			w.logger.Info("all phases already marked done or skipped; skipping to StepDone")
 			w.forceTransition(StepDone)
 			return
 		}
 		next := startStepForPhase(nextPhase)
-		w.logger.Info("skipping phase (label present)", "phase", phase, "next", next)
+		source := "label"
+		if !hasDoneLabel {
+			source = w.skipPhaseSources[phase]
+		}
+		w.logger.Info("skipping phase", "phase", phase, "source", source, "next", next)
 		w.forceTransition(next)
 		if phase == PhasePlan && w.plan == "" {
 			if content, err := LoadPersistedPlan(w.config.WorkDir); err != nil {

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -823,6 +823,9 @@ func (w *Workflow) tryRedo(ctx context.Context, redoTarget WorkflowStep) error {
 	}
 	w.reopenPhaseOnRedo(ctx, redoTarget)
 	w.skipCompletedOrConfiguredPhases(ctx)
+	if w.state.Current() != redoTarget {
+		w.feedback = ""
+	}
 	return nil
 }
 

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -66,8 +66,7 @@ type Workflow struct {
 	stateIDs            map[string]string
 	redoCounts          map[WorkflowStep]int
 	phases              map[string]phaseState
-	skipPhases          map[string]bool
-	skipPhaseSources    map[string]string
+	skipPhaseSources    map[string]skipPhaseSource
 	OnTransition        func(step WorkflowStep)
 	OnRoundProgress     func(roundIndex, roundTotal int)
 	runStepAgent        func(ctx context.Context, stepName string, data PromptData, cfg StepConfig, workDir string, feedback string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error)
@@ -96,17 +95,12 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		sessionIDs:       make(map[WorkflowStep]string),
 		redoCounts:       make(map[WorkflowStep]int),
 		phases:           make(map[string]phaseState),
-		skipPhases:       make(map[string]bool),
-		skipPhaseSources: make(map[string]string),
+		skipPhaseSources: make(map[string]skipPhaseSource),
 		maxRedos:         DefaultMaxRedos,
 		runStepAgent:     RunStepAgent,
 	}
 	for _, phase := range cfg.SkipPhases {
-		source := cfg.skipPhaseSource(phase)
-		if source == "" {
-			source = "config"
-		}
-		w.addSkipPhase(phase, source)
+		w.addSkipPhase(phase, cfg.skipSourceForPhase(phase))
 	}
 	if issue != nil {
 		// Shallow-copy so Labels mutations on w.issue don't bleed back into
@@ -114,37 +108,43 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 		// phase-skip decisions before the first tracker fetch.
 		issueCopy := *issue
 		w.lastLabels = slices.Clone(issue.Labels)
-		for _, label := range issue.Labels {
-			for _, p := range phaseTable {
-				if label == skipLabel(p.name) {
-					w.addSkipPhase(p.name, "label")
-				}
-			}
-		}
+		w.addSkipPhasesFromLabels(issue.Labels)
 		issueCopy.Labels = slices.DeleteFunc(slices.Clone(issue.Labels), isJiradozerLabel)
 		w.issue = &issueCopy
 	}
 	return w
 }
 
-func (w *Workflow) addSkipPhase(phase, source string) {
-	if !isUserPhase(phase) {
+func (w *Workflow) addSkipPhase(phase string, source skipPhaseSource) {
+	if startStepForPhase(phase) == StepInit || source == "" {
 		return
 	}
 	if prev := w.skipPhaseSources[phase]; prev != "" && skipPhasePriority(prev) > skipPhasePriority(source) {
 		return
 	}
-	w.skipPhases[phase] = true
 	w.skipPhaseSources[phase] = source
 }
 
-func skipPhasePriority(source string) int {
+func (w *Workflow) addSkipPhasesFromLabels(labels []string) {
+	for _, label := range labels {
+		if phase := phaseForSkipLabel(label); phase != "" {
+			w.addSkipPhase(phase, skipPhaseSourceLabel)
+		}
+	}
+}
+
+func (w *Workflow) isSkipPhase(phase string) bool {
+	_, ok := w.skipPhaseSources[phase]
+	return ok
+}
+
+func skipPhasePriority(source skipPhaseSource) int {
 	switch source {
-	case "cli":
+	case skipPhaseSourceCLI:
 		return 3
-	case "label":
+	case skipPhaseSourceLabel:
 		return 2
-	case "config":
+	case skipPhaseSourceConfig:
 		return 1
 	default:
 		return 0
@@ -173,7 +173,7 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		"base_branch", w.config.BaseBranch,
 	)
 	for _, p := range phaseTable {
-		if w.skipPhases[p.name] {
+		if w.isSkipPhase(p.name) {
 			w.logger.Info("phase configured to skip", "phase", p.name, "source", w.skipPhaseSources[p.name])
 		}
 	}
@@ -217,7 +217,7 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 	// Honor pre-existing -done labels by skipping completed phases. A fresh
 	// workflow run never re-does plan/build/validate/ship that the user has
 	// already marked done. Users clear the label manually to re-run a phase.
-	w.skipDonePhases(ctx)
+	w.skipCompletedOrConfiguredPhases(ctx)
 	if phase := phaseForStep(w.state.Current()); phase != "" {
 		w.enterPhase(ctx, phase)
 	}
@@ -599,7 +599,7 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 		// Final sweep: completePhase's -inprogress removal is best-effort, so
 		// a transient RemoveLabel failure can leave the issue with both
 		// -inprogress and -done for a completed phase. At StepDone there's no
-		// subsequent handlePhaseBoundary to reconcile via skipDonePhases, so
+		// subsequent handlePhaseBoundary to reconcile via skipCompletedOrConfiguredPhases, so
 		// do the cleanup here.
 		w.cleanupStalePhaseLabels(ctx)
 		return
@@ -609,7 +609,7 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 		w.completePriorPhases(ctx, curPhase)
 	}
 
-	w.skipDonePhases(ctx)
+	w.skipCompletedOrConfiguredPhases(ctx)
 
 	if phase := phaseForStep(w.state.Current()); phase != "" {
 		w.enterPhase(ctx, phase)
@@ -618,7 +618,7 @@ func (w *Workflow) handlePhaseBoundary(ctx context.Context) {
 
 // cleanupStalePhaseLabels removes any -inprogress label still present on
 // the issue for a phase that bookkeeping considers phaseDone. This is the
-// terminal counterpart to skipDonePhases' stale-label reconciliation —
+// terminal counterpart to skipCompletedOrConfiguredPhases' stale-label reconciliation —
 // without it, a transient RemoveLabel failure during completePhase would
 // leave the issue permanently tagged with both -inprogress and -done.
 func (w *Workflow) cleanupStalePhaseLabels(ctx context.Context) {
@@ -653,18 +653,13 @@ func (w *Workflow) completePriorPhases(ctx context.Context, currentPhase string)
 	}
 }
 
-// skipDonePhases refreshes labels from the tracker, then walks phases forward
-// from the current step, jumping past any phase already marked -done via
-// forceTransition. If all remaining phases are -done, jumps to StepDone.
-func (w *Workflow) skipDonePhases(ctx context.Context) {
+// skipCompletedOrConfiguredPhases refreshes labels from the tracker, then walks
+// phases forward from the current step, jumping past any phase marked -done or
+// configured to skip. If all remaining phases are complete or skipped, jumps to
+// StepDone.
+func (w *Workflow) skipCompletedOrConfiguredPhases(ctx context.Context) {
 	labels := w.refreshLabels(ctx)
-	for _, label := range labels {
-		for _, p := range phaseTable {
-			if label == skipLabel(p.name) {
-				w.addSkipPhase(p.name, "label")
-			}
-		}
-	}
+	w.addSkipPhasesFromLabels(labels)
 
 	for {
 		cur := w.state.Current()
@@ -673,7 +668,7 @@ func (w *Workflow) skipDonePhases(ctx context.Context) {
 			return
 		}
 		hasDoneLabel := slices.Contains(labels, doneLabel(phase))
-		if !hasDoneLabel && !w.skipPhases[phase] {
+		if !hasDoneLabel && !w.isSkipPhase(phase) {
 			return
 		}
 		// The -done label is authoritative, so clear any stale -inprogress
@@ -693,7 +688,7 @@ func (w *Workflow) skipDonePhases(ctx context.Context) {
 			return
 		}
 		next := startStepForPhase(nextPhase)
-		source := "label"
+		source := skipPhaseSourceLabel
 		if !hasDoneLabel {
 			source = w.skipPhaseSources[phase]
 		}
@@ -766,13 +761,13 @@ func (w *Workflow) enterPhase(ctx context.Context, phase string) {
 // completePhase flips internal bookkeeping to phaseDone only after the
 // tracker confirms the -done label write. Order matters: add -done first,
 // then remove -inprogress. A crash between these two calls leaves the
-// issue with both labels, which skipDonePhases reconciles on the next run.
+// issue with both labels, which skipCompletedOrConfiguredPhases reconciles on the next run.
 // The reverse order would leave the issue with NEITHER label on crash,
 // losing durable evidence that the phase completed and causing a resumed
 // run to redo an already-finished phase.
 //
 // The -inprogress removal is best-effort (a stale -inprogress will be
-// cleared on the next skipDonePhases), but the -done write is
+// cleared on the next skipCompletedOrConfiguredPhases), but the -done write is
 // authoritative: without it the phase stays "in progress" in memory and
 // the workflow will retry the transition rather than advance past a phase
 // the tracker didn't record.
@@ -850,7 +845,7 @@ func (w *Workflow) reopenPhaseOnRedo(ctx context.Context, redoTarget WorkflowSte
 				}
 			}
 			// Force a fresh -inprogress write even if prior was phaseInProgress,
-			// in case the previous -inprogress was removed by skipDonePhases or
+			// in case the previous -inprogress was removed by skipCompletedOrConfiguredPhases or
 			// a prior boundary.
 			w.phases[phase] = phaseNotStarted
 			w.enterPhase(ctx, phase)

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -697,7 +697,7 @@ func (w *Workflow) skipCompletedOrConfiguredPhases(ctx context.Context) {
 		// -inprogress label left over from a prior interrupted run or a user
 		// toggling phase state manually. Without this, the issue can show a
 		// phase as both current and already done/skipped.
-		if slices.Contains(labels, inProgressLabel(phase)) {
+		if slices.Contains(labels, inProgressLabel(phase)) || w.phases[phase] == phaseInProgress {
 			if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 				w.logger.Warn("failed to clear stale in-progress label while skipping phase", "phase", phase, "error", err)
 			}
@@ -822,6 +822,7 @@ func (w *Workflow) tryRedo(ctx context.Context, redoTarget WorkflowStep) error {
 		return err
 	}
 	w.reopenPhaseOnRedo(ctx, redoTarget)
+	w.skipCompletedOrConfiguredPhases(ctx)
 	return nil
 }
 

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -133,6 +133,28 @@ func (w *Workflow) addSkipPhasesFromLabels(labels []string) {
 	}
 }
 
+func (w *Workflow) reconcileSkipPhasesFromLabels(labels []string) {
+	labelPhases := make(map[string]bool)
+	for _, label := range labels {
+		if phase := phaseForSkipLabel(label); phase != "" {
+			labelPhases[phase] = true
+		}
+	}
+	for phase, source := range w.skipPhaseSources {
+		if source != skipPhaseSourceLabel || labelPhases[phase] {
+			continue
+		}
+		if configSource := w.config.skipSourceForPhase(phase); configSource != "" {
+			w.skipPhaseSources[phase] = configSource
+		} else {
+			delete(w.skipPhaseSources, phase)
+		}
+	}
+	for phase := range labelPhases {
+		w.addSkipPhase(phase, skipPhaseSourceLabel)
+	}
+}
+
 func (w *Workflow) isSkipPhase(phase string) bool {
 	_, ok := w.skipPhaseSources[phase]
 	return ok
@@ -659,7 +681,7 @@ func (w *Workflow) completePriorPhases(ctx context.Context, currentPhase string)
 // StepDone.
 func (w *Workflow) skipCompletedOrConfiguredPhases(ctx context.Context) {
 	labels := w.refreshLabels(ctx)
-	w.addSkipPhasesFromLabels(labels)
+	w.reconcileSkipPhasesFromLabels(labels)
 
 	for {
 		cur := w.state.Current()
@@ -688,7 +710,7 @@ func (w *Workflow) skipCompletedOrConfiguredPhases(ctx context.Context) {
 			return
 		}
 		next := startStepForPhase(nextPhase)
-		source := skipPhaseSourceLabel
+		source := skipPhaseSourceDone
 		if !hasDoneLabel {
 			source = w.skipPhaseSources[phase]
 		}

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -671,11 +671,11 @@ func (w *Workflow) skipCompletedOrConfiguredPhases(ctx context.Context) {
 		if !hasDoneLabel && !w.isSkipPhase(phase) {
 			return
 		}
-		// The -done label is authoritative, so clear any stale -inprogress
-		// label left over from a prior interrupted run or a user toggling
-		// phase state manually. Without this, the issue can end up tagged
-		// both -inprogress and -done for the same phase.
-		if hasDoneLabel && slices.Contains(labels, inProgressLabel(phase)) {
+		// The -done label or explicit skip is authoritative, so clear any stale
+		// -inprogress label left over from a prior interrupted run or a user
+		// toggling phase state manually. Without this, the issue can show a
+		// phase as both current and already done/skipped.
+		if slices.Contains(labels, inProgressLabel(phase)) {
 			if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
 				w.logger.Warn("failed to clear stale in-progress label while skipping phase", "phase", phase, "error", err)
 			}

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1623,6 +1623,21 @@ func TestWorkflow_SkipPhases_FromLabel(t *testing.T) {
 	assert.Empty(t, labelSequence(mt))
 }
 
+func TestWorkflow_SkipPhases_SourcePriority(t *testing.T) {
+	t.Parallel()
+
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
+
+	wf.addSkipPhase(PhaseBuild, skipPhaseSourceConfig)
+	wf.addSkipPhase(PhaseBuild, skipPhaseSourceLabel)
+	wf.addSkipPhase(PhaseBuild, skipPhaseSourceConfig)
+	assert.Equal(t, skipPhaseSourceLabel, wf.skipPhaseSources[PhaseBuild])
+
+	wf.addSkipPhase(PhaseBuild, skipPhaseSourceCLI)
+	wf.addSkipPhase(PhaseBuild, skipPhaseSourceLabel)
+	assert.Equal(t, skipPhaseSourceCLI, wf.skipPhaseSources[PhaseBuild])
+}
+
 func TestWorkflow_SkipPhases_AllSkipped(t *testing.T) {
 	cfg := testConfig()
 	require.NoError(t, cfg.ApplySkipPhases([]string{PhasePlan, PhaseBuild, PhaseValidate, PhaseShip}, "config"))
@@ -1686,6 +1701,31 @@ func TestWorkflow_SkipDonePhases_ClearsStaleInProgress(t *testing.T) {
 	assert.Equal(t, StepBuilding, wf.state.Current())
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
 	// The stale -inprogress should have been cleared.
+	assert.Equal(t,
+		[]string{"RemoveLabel:jiradozer-plan-inprogress"},
+		labelSequence(mt))
+}
+
+func TestWorkflow_SkipConfiguredPhase_ClearsStaleInProgress(t *testing.T) {
+	workDir := t.TempDir()
+	PersistPlan(workDir, "persisted plan", discardLogger())
+
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-plan-inprogress"}
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: issue.Labels},
+	}
+
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+	require.NoError(t, cfg.ApplySkipPhases([]string{PhasePlan}, "config"))
+	wf := NewWorkflow(mt, issue, cfg, discardLogger())
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.skipCompletedOrConfiguredPhases(context.Background())
+
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
 	assert.Equal(t,
 		[]string{"RemoveLabel:jiradozer-plan-inprogress"},
 		labelSequence(mt))

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1583,6 +1583,84 @@ func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
 	assert.Empty(t, labelSequence(mt))
 }
 
+func TestWorkflow_SkipPhases_FromConfig(t *testing.T) {
+	workDir := t.TempDir()
+	PersistPlan(workDir, "persisted plan", discardLogger())
+
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{"bug"}},
+	}
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+	require.NoError(t, cfg.ApplySkipPhases([]string{PhasePlan}, "config"))
+
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.skipDonePhases(context.Background())
+
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, "persisted plan", wf.plan)
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+	assert.Equal(t, "config", wf.skipPhaseSources[PhasePlan])
+	assert.Empty(t, labelSequence(mt))
+}
+
+func TestWorkflow_SkipPhases_FromLabel(t *testing.T) {
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-skip-validate"}
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: issue.Labels},
+	}
+	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
+	walkTo(t, wf.state, StepValidating)
+
+	wf.skipDonePhases(context.Background())
+
+	assert.Equal(t, StepShipping, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhaseValidate])
+	assert.Equal(t, "label", wf.skipPhaseSources[PhaseValidate])
+	assert.Empty(t, labelSequence(mt))
+}
+
+func TestWorkflow_SkipPhases_AllSkipped(t *testing.T) {
+	cfg := testConfig()
+	require.NoError(t, cfg.ApplySkipPhases([]string{PhasePlan, PhaseBuild, PhaseValidate, PhaseShip}, "config"))
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.skipDonePhases(context.Background())
+
+	assert.Equal(t, StepDone, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
+	assert.Equal(t, phaseDone, wf.phases[PhaseBuild])
+	assert.Equal(t, phaseDone, wf.phases[PhaseValidate])
+	assert.Equal(t, phaseDone, wf.phases[PhaseShip])
+}
+
+func TestWorkflow_SkipPlan_LoadsPersistedPlan(t *testing.T) {
+	workDir := t.TempDir()
+	PersistPlan(workDir, "persisted plan from new skip entry", discardLogger())
+
+	cfg := testConfig()
+	cfg.WorkDir = workDir
+	require.NoError(t, cfg.ApplySkipPhases([]string{PhasePlan}, "cli"))
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+
+	wf.skipDonePhases(context.Background())
+
+	assert.Equal(t, StepBuilding, wf.state.Current())
+	assert.Equal(t, "persisted plan from new skip entry", wf.plan)
+	assert.Equal(t, "cli", wf.skipPhaseSources[PhasePlan])
+}
+
 // TestWorkflow_SkipDonePhases_ClearsStaleInProgress verifies that when a phase
 // has both -inprogress and -done labels (e.g. from a prior interrupted run),
 // skipDonePhases removes the stale -inprogress label so the issue doesn't end

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -2028,11 +2028,13 @@ func TestWorkflow_Redo_SkipsReopenedPhase(t *testing.T) {
 	wf.phases[PhasePlan] = phaseDone
 	wf.phases[PhaseBuild] = phaseDone
 	wf.phases[PhaseValidate] = phaseInProgress
+	wf.feedback = "redo feedback for skipped build"
 
 	require.NoError(t, wf.tryRedo(context.Background(), StepBuilding))
 
 	assert.Equal(t, StepValidating, wf.state.Current())
 	assert.Equal(t, phaseDone, wf.phases[PhaseBuild])
+	assert.Empty(t, wf.feedback, "feedback for a skipped redo target must not leak into the next phase")
 	seq := labelSequence(mt)
 	assert.Contains(t, seq, "AddLabel:jiradozer-build-inprogress",
 		"redo first reopens the target phase")

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1623,6 +1623,22 @@ func TestWorkflow_SkipPhases_FromLabel(t *testing.T) {
 	assert.Empty(t, labelSequence(mt))
 }
 
+func TestWorkflow_SkipPhases_RemovedLabelStopsSkipping(t *testing.T) {
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-skip-validate"}
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{"bug"}},
+	}
+	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
+	walkTo(t, wf.state, StepValidating)
+
+	wf.skipCompletedOrConfiguredPhases(context.Background())
+
+	assert.Equal(t, StepValidating, wf.state.Current())
+	assert.NotEqual(t, phaseDone, wf.phases[PhaseValidate])
+	assert.NotContains(t, wf.skipPhaseSources, PhaseValidate)
+}
+
 func TestWorkflow_SkipPhases_SourcePriority(t *testing.T) {
 	t.Parallel()
 

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1639,6 +1639,24 @@ func TestWorkflow_SkipPhases_RemovedLabelStopsSkipping(t *testing.T) {
 	assert.NotContains(t, wf.skipPhaseSources, PhaseValidate)
 }
 
+func TestWorkflow_SkipPhases_RemovedLabelKeepsConfigSkip(t *testing.T) {
+	issue := testIssue()
+	issue.Labels = []string{"bug", "jiradozer-skip-validate"}
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{"bug"}},
+	}
+	cfg := testConfig()
+	require.NoError(t, cfg.ApplySkipPhases([]string{PhaseValidate}, "config"))
+	wf := NewWorkflow(mt, issue, cfg, discardLogger())
+	walkTo(t, wf.state, StepValidating)
+
+	wf.skipCompletedOrConfiguredPhases(context.Background())
+
+	assert.Equal(t, StepShipping, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhaseValidate])
+	assert.Equal(t, skipPhaseSourceConfig, wf.skipPhaseSources[PhaseValidate])
+}
+
 func TestWorkflow_SkipPhases_SourcePriority(t *testing.T) {
 	t.Parallel()
 
@@ -1996,6 +2014,30 @@ func TestWorkflow_Redo_ReopensCompletedPhase(t *testing.T) {
 		"the aborted later phase's -inprogress must be cleared")
 	assert.Contains(t, seq, "AddLabel:jiradozer-build-inprogress",
 		"the reopened phase gets a fresh -inprogress label")
+}
+
+func TestWorkflow_Redo_SkipsReopenedPhase(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		fetchIssueReply: &tracker.Issue{Labels: []string{}},
+	}
+	cfg := testConfig()
+	require.NoError(t, cfg.ApplySkipPhases([]string{PhaseBuild}, "config"))
+	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
+
+	walkTo(t, wf.state, StepValidateReview)
+	wf.phases[PhasePlan] = phaseDone
+	wf.phases[PhaseBuild] = phaseDone
+	wf.phases[PhaseValidate] = phaseInProgress
+
+	require.NoError(t, wf.tryRedo(context.Background(), StepBuilding))
+
+	assert.Equal(t, StepValidating, wf.state.Current())
+	assert.Equal(t, phaseDone, wf.phases[PhaseBuild])
+	seq := labelSequence(mt)
+	assert.Contains(t, seq, "AddLabel:jiradozer-build-inprogress",
+		"redo first reopens the target phase")
+	assert.Contains(t, seq, "RemoveLabel:jiradozer-build-inprogress",
+		"skip reconciliation immediately clears the reopened phase")
 }
 
 // TestWorkflow_Redo_SamePhase verifies that a redo inside the same phase

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -1418,7 +1418,7 @@ func TestWorkflow_CompletePhase_WritesDoneBeforeRemovingInProgress(t *testing.T)
 // that when -done succeeds but the subsequent -inprogress removal fails,
 // completePhase still advances the in-memory phase to phaseDone. The
 // tracker has the authoritative -done label; the stale -inprogress is a
-// cosmetic issue that skipDonePhases will reconcile on the next run.
+// cosmetic issue that skipCompletedOrConfiguredPhases will reconcile on the next run.
 func TestWorkflow_CompletePhase_RemoveInProgressFailureStillAdvances(t *testing.T) {
 	mt := &mockWorkflowTracker{
 		removeLabelErr: map[string]error{"jiradozer-plan-inprogress": errors.New("transient")},
@@ -1550,7 +1550,7 @@ func TestWorkflow_ApproveTransition_BuildToValidate(t *testing.T) {
 		labelSequence(mt))
 }
 
-// TestWorkflow_SkipDonePhases_FromInit verifies that skipDonePhases at workflow
+// TestWorkflow_SkipDonePhases_FromInit verifies that skipCompletedOrConfiguredPhases at workflow
 // start jumps over phases whose -done label is already present.
 func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
 	workDir := t.TempDir()
@@ -1570,7 +1570,7 @@ func TestWorkflow_SkipDonePhases_FromInit(t *testing.T) {
 
 	// Workflow starts at StepPlanning (the first step after init transition).
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	// Should have jumped forward past plan and build to validating.
 	assert.Equal(t, StepValidating, wf.state.Current())
@@ -1597,12 +1597,12 @@ func TestWorkflow_SkipPhases_FromConfig(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	assert.Equal(t, StepBuilding, wf.state.Current())
 	assert.Equal(t, "persisted plan", wf.plan)
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
-	assert.Equal(t, "config", wf.skipPhaseSources[PhasePlan])
+	assert.Equal(t, skipPhaseSourceConfig, wf.skipPhaseSources[PhasePlan])
 	assert.Empty(t, labelSequence(mt))
 }
 
@@ -1615,11 +1615,11 @@ func TestWorkflow_SkipPhases_FromLabel(t *testing.T) {
 	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
 	walkTo(t, wf.state, StepValidating)
 
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	assert.Equal(t, StepShipping, wf.state.Current())
 	assert.Equal(t, phaseDone, wf.phases[PhaseValidate])
-	assert.Equal(t, "label", wf.skipPhaseSources[PhaseValidate])
+	assert.Equal(t, skipPhaseSourceLabel, wf.skipPhaseSources[PhaseValidate])
 	assert.Empty(t, labelSequence(mt))
 }
 
@@ -1632,7 +1632,7 @@ func TestWorkflow_SkipPhases_AllSkipped(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	assert.Equal(t, StepDone, wf.state.Current())
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
@@ -1654,16 +1654,16 @@ func TestWorkflow_SkipPlan_LoadsPersistedPlan(t *testing.T) {
 	wf := NewWorkflow(mt, testIssue(), cfg, discardLogger())
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	assert.Equal(t, StepBuilding, wf.state.Current())
 	assert.Equal(t, "persisted plan from new skip entry", wf.plan)
-	assert.Equal(t, "cli", wf.skipPhaseSources[PhasePlan])
+	assert.Equal(t, skipPhaseSourceCLI, wf.skipPhaseSources[PhasePlan])
 }
 
 // TestWorkflow_SkipDonePhases_ClearsStaleInProgress verifies that when a phase
 // has both -inprogress and -done labels (e.g. from a prior interrupted run),
-// skipDonePhases removes the stale -inprogress label so the issue doesn't end
+// skipCompletedOrConfiguredPhases removes the stale -inprogress label so the issue doesn't end
 // up with contradictory phase labels.
 func TestWorkflow_SkipDonePhases_ClearsStaleInProgress(t *testing.T) {
 	workDir := t.TempDir()
@@ -1681,7 +1681,7 @@ func TestWorkflow_SkipDonePhases_ClearsStaleInProgress(t *testing.T) {
 	wf := NewWorkflow(mt, issue, cfg, discardLogger())
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	assert.Equal(t, StepBuilding, wf.state.Current())
 	assert.Equal(t, phaseDone, wf.phases[PhasePlan])
@@ -1708,7 +1708,7 @@ func TestWorkflow_SkipDonePhases_AllDone(t *testing.T) {
 	wf := NewWorkflow(mt, issue, testConfig(), discardLogger())
 	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
 
-	wf.skipDonePhases(context.Background())
+	wf.skipCompletedOrConfiguredPhases(context.Background())
 
 	assert.Equal(t, StepDone, wf.state.Current())
 }


### PR DESCRIPTION
## Summary
- Add first-class skip-phase support for `plan`, `build`, `validate`, and `ship` through `skip_phases` config, `--skip-phases` CLI overrides, and tracker labels like `jiradozer-skip-<phase>`.
- Teach workflow progression to fast-forward completed or skipped phases, clear stale `*-inprogress` labels, preserve persisted plans when skipping `plan`, and avoid leaking redo feedback when a skipped redo target is bypassed.
- Reconcile label-driven skips dynamically so removing a `jiradozer-skip-*` label stops skipping unless config/CLI still requires it; source priority is CLI > label > config.
- Filter skip bookkeeping labels out of agent-facing prompt data while leaving unrelated `jiradozer-*` labels visible.
- Carry skip-phase runtime state through cloned configs and propagate `--skip-phases` into child run invocations.
- Document skip-phase semantics in generated bootstrap config and `jiradozer.example.yaml`, including the trust model for label-driven skips and the distinction from durable `*-done` labels.
- Expand unit and integration coverage for config validation, CLI override precedence, child arg propagation, workflow skip behavior, stale label cleanup, redo behavior, prompt label filtering, and E2E `jiradozer-skip-plan` execution.

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workflow progression and tracker label reconciliation to allow skipping phases, which could alter step execution order and label state if misconfigured. Impact is mitigated by validation plus extensive unit/E2E coverage.
> 
> **Overview**
> Adds first-class **skip phase** support so runs can bypass `plan`/`build`/`validate`/`ship` via `skip_phases` in config, a `--skip-phases` CLI override (propagated to child processes), or tracker labels like `jiradozer-skip-<phase>`.
> 
> Updates the workflow’s phase-skip logic to treat configured skips similarly to `-done` labels (advancing in-memory state and clearing stale `-inprogress` labels without writing `-done`), records/logs the skip source with priority rules, and filters skip labels out of agent-facing issue labels. Adds config validation/normalization, safe cloning of `SkipPhases`, bootstrap/example YAML documentation, and broad test coverage including a new E2E case for `jiradozer-skip-plan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa06554693eab623e565aef495c4ce2ed4a55f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->