### PR TITLE
Stop retrying permanent tool errors

### DIFF
--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -94,17 +94,25 @@ func excerptRunes(s string, max int) string {
 // cancelled sibling (carrying the marker) is still the last tool_result
 // in forward order, so it remains detectable.
 func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok bool) {
+	toolName, _, excerpt, ok = FinalTurnToolErrorDetails(blocks)
+	return toolName, excerpt, ok
+}
+
+// FinalTurnToolErrorDetails reports the same final tool_use_error as
+// FinalTurnToolError, returning both the full tool result content for policy
+// decisions and a bounded excerpt for display.
+func FinalTurnToolErrorDetails(blocks []ContentBlock) (toolName, content, excerpt string, ok bool) {
 	for i := len(blocks) - 1; i >= 0; i-- {
 		block := blocks[i]
 		if block.Type != ContentBlockTypeToolResult {
 			continue
 		}
 		if !block.IsError {
-			return "", "", false
+			return "", "", "", false
 		}
 		content := stringifyToolResult(block.ToolResult)
 		if !strings.Contains(content, toolUseErrorMarker) {
-			return "", "", false
+			return "", "", "", false
 		}
 		// Build tool name map only on the error path (uncommon case).
 		toolNames := make(map[string]string)
@@ -117,9 +125,9 @@ func FinalTurnToolError(blocks []ContentBlock) (toolName, excerpt string, ok boo
 		if name == "" {
 			name = "unknown"
 		}
-		return name, excerptRunes(content, toolErrorExcerptMaxRunes), true
+		return name, content, excerptRunes(content, toolErrorExcerptMaxRunes), true
 	}
-	return "", "", false
+	return "", "", "", false
 }
 
 // TurnUsage contains token usage for a turn.

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -18,29 +18,6 @@ const toolUseErrorMarker = "<tool_use_error>"
 
 const toolErrorExcerptMaxRunes = 200
 
-// permanentToolErrorMarkers are substrings that, when present in a
-// tool_use_error excerpt, indicate the failure cannot be recovered by retrying
-// within the same session. The canonical case is disable-model-invocation
-// config errors: the CLI will refuse the same tool the same way every turn.
-// Keep this list tight: each entry must correspond to a CLI error class that
-// is definitionally unrecoverable.
-var permanentToolErrorMarkers = []string{
-	"disable-model-invocation",
-	"cannot be used with",
-}
-
-// IsPermanentToolError reports whether the excerpt matches a permanent-class
-// CLI error that should not be retried. Designed to be called by the retry
-// loop after FinalTurnToolError returns ok=true.
-func IsPermanentToolError(excerpt string) bool {
-	for _, marker := range permanentToolErrorMarkers {
-		if strings.Contains(excerpt, marker) {
-			return true
-		}
-	}
-	return false
-}
-
 func stringifyToolResult(result interface{}) string {
 	if result == nil {
 		return ""

--- a/agent-cli-wrapper/claude/turn.go
+++ b/agent-cli-wrapper/claude/turn.go
@@ -18,6 +18,29 @@ const toolUseErrorMarker = "<tool_use_error>"
 
 const toolErrorExcerptMaxRunes = 200
 
+// permanentToolErrorMarkers are substrings that, when present in a
+// tool_use_error excerpt, indicate the failure cannot be recovered by retrying
+// within the same session. The canonical case is disable-model-invocation
+// config errors: the CLI will refuse the same tool the same way every turn.
+// Keep this list tight: each entry must correspond to a CLI error class that
+// is definitionally unrecoverable.
+var permanentToolErrorMarkers = []string{
+	"disable-model-invocation",
+	"cannot be used with",
+}
+
+// IsPermanentToolError reports whether the excerpt matches a permanent-class
+// CLI error that should not be retried. Designed to be called by the retry
+// loop after FinalTurnToolError returns ok=true.
+func IsPermanentToolError(excerpt string) bool {
+	for _, marker := range permanentToolErrorMarkers {
+		if strings.Contains(excerpt, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 func stringifyToolResult(result interface{}) string {
 	if result == nil {
 		return ""

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -189,6 +189,28 @@ func TestFinalTurnToolError_ExcerptLength(t *testing.T) {
 	}
 }
 
+func TestFinalTurnToolErrorDetails_ReturnsFullContent(t *testing.T) {
+	t.Parallel()
+	long := "<tool_use_error>" + strings.Repeat("x", 500) + " disable-model-invocation</tool_use_error>"
+	blocks := []ContentBlock{
+		{Type: ContentBlockTypeToolUse, ToolUseID: "t1", ToolName: "Bash"},
+		{Type: ContentBlockTypeToolResult, ToolUseID: "t1", ToolResult: long, IsError: true},
+	}
+	name, content, excerpt, ok := FinalTurnToolErrorDetails(blocks)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if name != "Bash" {
+		t.Errorf("expected name=Bash, got %q", name)
+	}
+	if content != long {
+		t.Error("expected full content to be preserved")
+	}
+	if strings.Contains(excerpt, "disable-model-invocation") {
+		t.Errorf("expected display excerpt to be truncated before marker, got %q", excerpt)
+	}
+}
+
 func TestFinalTurnToolError_UnknownTool(t *testing.T) {
 	t.Parallel()
 	blocks := []ContentBlock{

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -33,45 +33,6 @@ func TestFinalTurnToolError_IsErrorPlusMarker(t *testing.T) {
 	}
 }
 
-func TestIsPermanentToolError(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name    string
-		excerpt string
-		want    bool
-	}{
-		{
-			name:    "disable model invocation",
-			excerpt: "<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
-			want:    true,
-		},
-		{
-			name:    "cannot be used with",
-			excerpt: "<tool_use_error>Skill pr-polish cannot be used with Skill tool</tool_use_error>",
-			want:    true,
-		},
-		{
-			name:    "non permanent marker error",
-			excerpt: "<tool_use_error>Cancelled: parallel tool call errored</tool_use_error>",
-			want:    false,
-		},
-		{
-			name:    "empty",
-			excerpt: "",
-			want:    false,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := IsPermanentToolError(tt.excerpt); got != tt.want {
-				t.Errorf("IsPermanentToolError() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // TestFinalTurnToolError_NonzeroExitBash: is_error without the marker is
 // a nonzero-exit Bash the agent ran to inspect output (gh pr checks,
 // grep, git diff). These must NOT trigger retry. Regression for the

--- a/agent-cli-wrapper/claude/turn_retry_test.go
+++ b/agent-cli-wrapper/claude/turn_retry_test.go
@@ -33,6 +33,45 @@ func TestFinalTurnToolError_IsErrorPlusMarker(t *testing.T) {
 	}
 }
 
+func TestIsPermanentToolError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		excerpt string
+		want    bool
+	}{
+		{
+			name:    "disable model invocation",
+			excerpt: "<tool_use_error>Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation</tool_use_error>",
+			want:    true,
+		},
+		{
+			name:    "cannot be used with",
+			excerpt: "<tool_use_error>Skill pr-polish cannot be used with Skill tool</tool_use_error>",
+			want:    true,
+		},
+		{
+			name:    "non permanent marker error",
+			excerpt: "<tool_use_error>Cancelled: parallel tool call errored</tool_use_error>",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			excerpt: "",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsPermanentToolError(tt.excerpt); got != tt.want {
+				t.Errorf("IsPermanentToolError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestFinalTurnToolError_NonzeroExitBash: is_error without the marker is
 // a nonzero-exit Bash the agent ran to inspect output (gh pr checks,
 // grep, git diff). These must NOT trigger retry. Regression for the

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -259,27 +259,33 @@ Also-ran approaches and why they lose:
 
 The field is a minimal, immutable, point-in-time snapshot.
 
-### G3 — Permanent-class error deny list (optional, lower priority)
+### G3 — Permanent-class error deny list (shipped 2026-05-05, PR #153)
 
-Add a package-private list of error substrings that should never
-trigger retry:
+G3 shipped as a retry-loop policy check, after fresh jiradozer logs still
+showed the disable-model-invocation pattern. It adds a package-private
+list of error substrings that should never trigger retry:
 
 ```
-permanentErrorMarkers = []string{
+permanentToolErrorMarkers = []string{
     "disable-model-invocation",
     "cannot be used with",  // covers "Skill X cannot be used with Skill tool"
 }
 ```
 
-`FinalTurnToolError` (or a new sibling `FinalTurnRetryableToolError`)
-returns `ok=false` when the excerpt matches any marker. Keep the list
-*tight* — each entry must correspond to a real CLI error class that
-is definitionally unrecoverable within the same session.
+`FinalTurnToolError` keeps its narrow contract: detect whether the final
+tool result is a CLI-reported `tool_use_error`. The retry loop calls the
+sibling helper `IsPermanentToolError(excerpt)` after
+`FinalTurnToolError` returns `ok=true`; when it matches, the loop stops
+with `RetryStopPermanent = "permanent"` without issuing another Ask.
+Keep the list *tight* — each entry must correspond to a real CLI error
+class that is definitionally unrecoverable within the same session.
 
-G3 is optional. G2 alone would have caught both evidence logs, because
-in both cases live bg work was present when the retry fired. Ship G1+G2
-first; add G3 only if a repro surfaces a permanent error *without*
-concurrent bg work.
+G2 alone would have caught both original evidence logs, because in both
+cases live bg work was present when the retry fired. In the current branch,
+the explicit G2 symbols are not present; that approach was superseded by
+`logicalTurnState`, as noted in this doc's status section. For future
+changes, ship G1+G2 first; add or expand G3 only if a concrete repro log
+surfaces a permanent error that still reaches the retry loop.
 
 ### Gate combination
 
@@ -289,7 +295,7 @@ Final retry decision in `ClaudeProvider.Execute`:
 fire retry iff:
   result.HasLiveBackgroundWork == false AND
   FinalTurnToolError(blocks) returns ok==true AND
-  (G3 optional) excerpt does not match permanentErrorMarkers AND
+  IsPermanentToolError(excerpt) == false AND
   // v1 guardrails unchanged:
   attempts < cfg.MaxToolErrorRetries AND
   time.Since(start) < budget AND
@@ -307,15 +313,21 @@ tell "we saw a tool error but chose not to retry" apart from "no tool
 error was seen at all." Without this signal the non-retry case is
 invisible in logs.
 
+When the gate blocks for permanent-error reasons, emit
+`RetryStopReason = "permanent"` via the existing unresolved-tool-error
+path and `OnRetryAbort`.
+
 ## File/line summary
 
 | File | Change |
 |---|---|
 | `agent-cli-wrapper/claude/turn.go:82-104` | `FinalTurnToolError` tightens to require `IsError && marker` |
+| `agent-cli-wrapper/claude/turn.go` | `permanentToolErrorMarkers` and `IsPermanentToolError` classify permanent retry-loop aborts |
 | `agent-cli-wrapper/claude/turn.go` (TurnResult struct ~L124) | New field `HasLiveBackgroundWork bool` |
 | `agent-cli-wrapper/claude/session.go:1116-1120` | Set `result.HasLiveBackgroundWork = turn.shouldSuppressForBgTasks()` before `CompleteTurn` |
 | `multiagent/agent/claude_provider.go:182-210` | Gate retry on `!result.HasLiveBackgroundWork` first; new abort reason `bg_work_live` |
 | `multiagent/agent/claude_provider.go` const block ~L22 | `RetryStopBgWorkLive = "bg_work_live"` |
+| `multiagent/agent/claude_provider.go` | `RetryStopPermanent = "permanent"` and deny-list short-circuit after `FinalTurnToolError` |
 | `agent-cli-wrapper/claude/turn_retry_test.go` | Update `SubstringOnly` (now negative); add new cases (see Test Plan) |
 | `agent-cli-wrapper/claude/testdata/` (new) | Wire-shape fixtures extracted from the two evidence logs |
 

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -379,24 +379,20 @@ Cases:
   single Ask, raw result returned, no marker, no
   `UnresolvedToolError`. Preserves today's behavior for jiradozer
   configs that did not opt in.
-- **`skips_when_bg_work_live`** — *G2 core test*. Fake returns one
-  `TurnResult` with `HasLiveBackgroundWork:true` AND the content
-  blocks of a real tool_use_error. Assert exactly 1 Ask, no retry,
-  `UnresolvedToolError.Reason=bg_work_live`, marker appended. This is
-  the regression test for evidence log 1.
 - **`skips_on_nonzero_exit_bash`** — *G1 core test*. Fake returns a
   `TurnResult` whose blocks have `IsError:true` but no
   `<tool_use_error>` marker. Assert exactly 1 Ask, no retry, no
   `UnresolvedToolError` (because `FinalTurnToolError` returned
   ok=false — nothing to mark unresolved). Regression test for
   evidence log 2.
+- **`skips_on_permanent_skill_error`** — *G3 core test*. Fake returns
+  one real tool_use_error whose excerpt matches the permanent Skill
+  compatibility deny list. Assert no retry,
+  `UnresolvedToolError.Reason=permanent`, marker appended, and
+  `OnRetryAbort("permanent", ...)` emitted.
 - `retries_cleanly_on_real_tool_use_error` — fake returns [real
-  tool_use_error with `HasLiveBackgroundWork:false`, clean]; assert 2
-  Asks, clean final. Ensures G1+G2 tightening did not break the
-  original PLA-212 fix path.
-- `skips_when_bg_work_live_and_cancelled_sibling` — evidence-shaped:
-  one tool_use_error, one cancelled sibling, `HasLiveBackgroundWork:
-  true`. Assert no retry (G2 dominates even when G1 would allow).
+  tool_use_error, clean]; assert 2 Asks, clean final. Ensures G1+G3
+  tightening did not break the original PLA-212 fix path.
 
 ### Fixture-driven testing
 

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -449,19 +449,10 @@ is the load-bearing regression coverage.
   code retried is a subset of what v2 retries plus strictly more cases
   it correctly skips. No config currently in the tree relies on the
   buggy retry behavior.
-- `HasLiveBackgroundWork` is a new field on the public `TurnResult`
-  struct. Monorepo style permits API changes; all in-tree callers are
-  exhaustively enumerated (provider, render, bramble via adapter).
-  Gazelle-regenerated BUILDs pick up the new field with no changes.
-- `RetryStopBgWorkLive` is a new abort reason string. Any log parser
-  that pattern-matches on reasons should be updated. (In tree:
-  jiradozer log consumers only; no external consumers.)
-- `OnRetryAbort` fires for `bg_work_live` even though no retry was
-  attempted. This is a semantic widening — "abort" now covers "gate
-  blocked from the start" as well as "we tried and ran out of budget."
-  `logEventHandler.OnRetryAbort` (jiradozer/agent.go) should log at
-  INFO, not WARN, when `reason == bg_work_live` since it's the
-  expected case.
+Historical note: this section originally proposed adding
+`HasLiveBackgroundWork` to `TurnResult`, `RetryStopBgWorkLive`, and
+`OnRetryAbort("bg_work_live", ...)`. That G2 approach was superseded
+before implementation; those names are not part of the shipped API.
 
 ## G4 — Error must be the final tool_result in the turn
 

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -267,19 +267,22 @@ classifier in `multiagent/agent` for errors that should never trigger
 retry:
 
 ```
-func isPermanentToolError(excerpt string) bool {
-    return strings.Contains(excerpt, "disable-model-invocation") ||
-        strings.Contains(excerpt, " cannot be used with Skill tool")
+func isPermanentToolError(toolResult string) bool {
+    return strings.Contains(toolResult, "disable-model-invocation") ||
+        strings.Contains(toolResult, " cannot be used with Skill tool")
 }
 ```
 
 `FinalTurnToolError` keeps its narrow contract: detect whether the final
-tool result is a CLI-reported `tool_use_error`. The retry loop applies
-`isPermanentToolError(excerpt)` after `FinalTurnToolError` returns
-`ok=true`; when it matches, the loop stops with `RetryStopPermanent =
-"permanent"` without issuing another Ask. Keep the classifier *tight*:
-each match must correspond to a real CLI error class that is
-definitionally unrecoverable within the same session.
+tool result is a CLI-reported `tool_use_error` and return a bounded
+display excerpt. Retry policy uses `FinalTurnToolErrorDetails` so
+`isPermanentToolError(toolResult)` sees the full tool result content,
+not the truncated excerpt. Cancellation and retry-budget guards take
+precedence; when the permanent classifier matches after those guards,
+the loop stops with `RetryStopPermanent = "permanent"` without issuing
+another Ask. Keep the classifier *tight*: each match must correspond to
+a real CLI error class that is definitionally unrecoverable within the
+same session.
 
 G2 alone would have caught both original evidence logs, because in both
 cases live bg work was present when the retry fired. In the current branch,

--- a/docs/design/jiradozer-tool-error-retry-v2.md
+++ b/docs/design/jiradozer-tool-error-retry-v2.md
@@ -263,22 +263,23 @@ The field is a minimal, immutable, point-in-time snapshot.
 
 G3 shipped as a retry-loop policy check, after fresh jiradozer logs still
 showed the disable-model-invocation pattern. It adds a package-private
-list of error substrings that should never trigger retry:
+classifier in `multiagent/agent` for errors that should never trigger
+retry:
 
 ```
-permanentToolErrorMarkers = []string{
-    "disable-model-invocation",
-    "cannot be used with",  // covers "Skill X cannot be used with Skill tool"
+func isPermanentToolError(excerpt string) bool {
+    return strings.Contains(excerpt, "disable-model-invocation") ||
+        strings.Contains(excerpt, " cannot be used with Skill tool")
 }
 ```
 
 `FinalTurnToolError` keeps its narrow contract: detect whether the final
-tool result is a CLI-reported `tool_use_error`. The retry loop calls the
-sibling helper `IsPermanentToolError(excerpt)` after
-`FinalTurnToolError` returns `ok=true`; when it matches, the loop stops
-with `RetryStopPermanent = "permanent"` without issuing another Ask.
-Keep the list *tight* — each entry must correspond to a real CLI error
-class that is definitionally unrecoverable within the same session.
+tool result is a CLI-reported `tool_use_error`. The retry loop applies
+`isPermanentToolError(excerpt)` after `FinalTurnToolError` returns
+`ok=true`; when it matches, the loop stops with `RetryStopPermanent =
+"permanent"` without issuing another Ask. Keep the classifier *tight*:
+each match must correspond to a real CLI error class that is
+definitionally unrecoverable within the same session.
 
 G2 alone would have caught both original evidence logs, because in both
 cases live bg work was present when the retry fired. In the current branch,
@@ -293,9 +294,8 @@ Final retry decision in `ClaudeProvider.Execute`:
 
 ```
 fire retry iff:
-  result.HasLiveBackgroundWork == false AND
   FinalTurnToolError(blocks) returns ok==true AND
-  IsPermanentToolError(excerpt) == false AND
+  isPermanentToolError(excerpt) == false AND
   // v1 guardrails unchanged:
   attempts < cfg.MaxToolErrorRetries AND
   time.Since(start) < budget AND
@@ -303,15 +303,10 @@ fire retry iff:
   ctx.Err() == nil
 ```
 
-Order matters: check `HasLiveBackgroundWork` *first*, before the content
-walk. It's the cheapest check and it's the most consequential — it
-blocks the destructive case where the retry orphans bg work.
-
-When the gate blocks for bg reasons, emit a distinct
-`RetryStopReason = "bg_work_live"` via `OnRetryAbort` so triage can
-tell "we saw a tool error but chose not to retry" apart from "no tool
-error was seen at all." Without this signal the non-retry case is
-invisible in logs.
+The background-work gate described earlier in this document is now handled
+by the raw event stream plus `logicalTurnState`: the provider waits for the
+logical turn to finish before it constructs the `TurnResult` consumed by
+the retry loop.
 
 When the gate blocks for permanent-error reasons, emit
 `RetryStopReason = "permanent"` via the existing unresolved-tool-error
@@ -322,14 +317,9 @@ path and `OnRetryAbort`.
 | File | Change |
 |---|---|
 | `agent-cli-wrapper/claude/turn.go:82-104` | `FinalTurnToolError` tightens to require `IsError && marker` |
-| `agent-cli-wrapper/claude/turn.go` | `permanentToolErrorMarkers` and `IsPermanentToolError` classify permanent retry-loop aborts |
-| `agent-cli-wrapper/claude/turn.go` (TurnResult struct ~L124) | New field `HasLiveBackgroundWork bool` |
-| `agent-cli-wrapper/claude/session.go:1116-1120` | Set `result.HasLiveBackgroundWork = turn.shouldSuppressForBgTasks()` before `CompleteTurn` |
-| `multiagent/agent/claude_provider.go:182-210` | Gate retry on `!result.HasLiveBackgroundWork` first; new abort reason `bg_work_live` |
-| `multiagent/agent/claude_provider.go` const block ~L22 | `RetryStopBgWorkLive = "bg_work_live"` |
-| `multiagent/agent/claude_provider.go` | `RetryStopPermanent = "permanent"` and deny-list short-circuit after `FinalTurnToolError` |
-| `agent-cli-wrapper/claude/turn_retry_test.go` | Update `SubstringOnly` (now negative); add new cases (see Test Plan) |
-| `agent-cli-wrapper/claude/testdata/` (new) | Wire-shape fixtures extracted from the two evidence logs |
+| `multiagent/agent/claude_provider.go` | `RetryStopPermanent = "permanent"` and `isPermanentToolError` short-circuit after `FinalTurnToolError` |
+| `multiagent/agent/provider.go` | `RetryHandler.OnRetryAbort` documents the permanent stop reason |
+| `multiagent/agent/claude_provider_retry_test.go` | Cover permanent abort and non-permanent retry behavior |
 
 ## Test plan
 

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -265,26 +265,9 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		return nil, err
 	}
 
-	agentResult := ClaudeResultToAgentResult(result)
+	agentResult := claudeResultToAgentResultWithRetryAbort(result, cfg, attempts, stopReason)
 	if info := session.Info(); info != nil {
 		agentResult.SessionID = info.SessionID
-	}
-	if cfg.MaxToolErrorRetries > 0 {
-		if toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks); ok {
-			unresolved := &UnresolvedToolError{
-				Tool:     toolName,
-				Excerpt:  excerpt,
-				Reason:   stopReason,
-				Attempts: attempts,
-				Max:      cfg.MaxToolErrorRetries,
-			}
-			agentResult.UnresolvedToolError = unresolved
-			agentResult.Text = AppendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
-			// Fire the abort callback once per loop execution that stopped
-			// with a tool error still present. Covers all four stop reasons:
-			// exhausted, no_progress, budget_exceeded, ctx_cancelled.
-			emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
-		}
 	}
 	return agentResult, nil
 }
@@ -360,6 +343,30 @@ func dispatchClaudeEvent(ev claude.Event, handler EventHandler, out chan<- Agent
 		return
 	}
 	dispatchStreamEvent(sev, handler, out)
+}
+
+func claudeResultToAgentResultWithRetryAbort(result *claude.TurnResult, cfg ExecuteConfig, attempts int, stopReason string) *AgentResult {
+	agentResult := ClaudeResultToAgentResult(result)
+	if agentResult == nil || cfg.MaxToolErrorRetries <= 0 {
+		return agentResult
+	}
+	toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
+	if !ok {
+		return agentResult
+	}
+	unresolved := &UnresolvedToolError{
+		Tool:     toolName,
+		Excerpt:  excerpt,
+		Reason:   stopReason,
+		Attempts: attempts,
+		Max:      cfg.MaxToolErrorRetries,
+	}
+	agentResult.UnresolvedToolError = unresolved
+	agentResult.Text = AppendUnresolvedToolErrorMarker(agentResult.Text, *unresolved)
+	// Fire the abort callback once per loop execution that stopped with a
+	// tool error still present, including permanent errors skipped pre-retry.
+	emitRetryAbort(cfg.EventHandler, stopReason, toolName, excerpt)
+	return agentResult
 }
 
 // claudeEffortLevel maps the neutral agent.EffortLevel to claude.EffortLevel.

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -25,6 +25,7 @@ const (
 	RetryStopNoProgress     = "no_progress"
 	RetryStopBudgetExceeded = "budget_exceeded"
 	RetryStopCtxCancelled   = "ctx_cancelled"
+	RetryStopPermanent      = "permanent"
 )
 
 // FormatUnresolvedToolErrorMarker returns the marker string used to surface
@@ -124,7 +125,7 @@ func (p *ClaudeProvider) Name() string { return "claude" }
 // runRetryLoop drives the retry-on-tool-error loop: re-issues the turn up to
 // cfg.MaxToolErrorRetries times while a tool_use_error is present. Returns
 // the final result, retry count, and the stop reason (exhausted, no_progress,
-// budget_exceeded, ctx_cancelled, or self-recovered).
+// budget_exceeded, ctx_cancelled, permanent, or self-recovered).
 func runRetryLoop(ctx context.Context, session retrySession, initial *claude.TurnResult, cfg ExecuteConfig) (*claude.TurnResult, int, string, error) {
 	result := initial
 	start := time.Now()
@@ -138,6 +139,10 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 	for attempts < cfg.MaxToolErrorRetries {
 		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
 		if !ok {
+			break
+		}
+		if claude.IsPermanentToolError(excerpt) {
+			stopReason = RetryStopPermanent
 			break
 		}
 		if ctx.Err() != nil {

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/agentstream"
@@ -63,6 +64,13 @@ func computeRetryTimeBudget(cfg ExecuteConfig) time.Duration {
 
 func buildRetryPrompt() string {
 	return retryPrompt
+}
+
+func isPermanentToolError(excerpt string) bool {
+	if strings.Contains(excerpt, "disable-model-invocation") {
+		return true
+	}
+	return strings.Contains(excerpt, " cannot be used with Skill tool")
 }
 
 // emitRetry fires the hook before each follow-up Ask so logs see the
@@ -141,7 +149,7 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 		if !ok {
 			break
 		}
-		if claude.IsPermanentToolError(excerpt) {
+		if isPermanentToolError(excerpt) {
 			stopReason = RetryStopPermanent
 			break
 		}

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -145,11 +145,11 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 		attempts    int
 	)
 	for attempts < cfg.MaxToolErrorRetries {
-		toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
+		toolName, toolResult, excerpt, ok := claude.FinalTurnToolErrorDetails(result.ContentBlocks)
 		if !ok {
 			break
 		}
-		if isPermanentToolError(excerpt) {
+		if isPermanentToolError(toolResult) {
 			stopReason = RetryStopPermanent
 			break
 		}
@@ -161,11 +161,11 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 			stopReason = RetryStopBudgetExceeded
 			break
 		}
-		if havePrev && excerpt == prevExcerpt {
+		if havePrev && toolResult == prevExcerpt {
 			stopReason = RetryStopNoProgress
 			break
 		}
-		prevExcerpt = excerpt
+		prevExcerpt = toolResult
 		havePrev = true
 		attempts++
 

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -66,11 +66,24 @@ func buildRetryPrompt() string {
 	return retryPrompt
 }
 
-func isPermanentToolError(excerpt string) bool {
-	if strings.Contains(excerpt, "disable-model-invocation") {
+func isPermanentToolError(toolResult string) bool {
+	if strings.Contains(toolResult, "disable-model-invocation") {
 		return true
 	}
-	return strings.Contains(excerpt, " cannot be used with Skill tool")
+	return strings.Contains(toolResult, " cannot be used with Skill tool")
+}
+
+func permanentToolErrorExcerpt(toolResult, excerpt string) string {
+	if isPermanentToolError(excerpt) {
+		return excerpt
+	}
+	if strings.Contains(toolResult, "disable-model-invocation") {
+		return "permanent tool error: disable-model-invocation"
+	}
+	if strings.Contains(toolResult, " cannot be used with Skill tool") {
+		return "permanent tool error: cannot be used with Skill tool"
+	}
+	return excerpt
 }
 
 // emitRetry fires the hook before each follow-up Ask so logs see the
@@ -140,17 +153,13 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 	budget := computeRetryTimeBudget(cfg)
 	stopReason := RetryStopExhausted
 	var (
-		prevExcerpt string
-		havePrev    bool
-		attempts    int
+		prevToolResult string
+		havePrev       bool
+		attempts       int
 	)
 	for attempts < cfg.MaxToolErrorRetries {
 		toolName, toolResult, excerpt, ok := claude.FinalTurnToolErrorDetails(result.ContentBlocks)
 		if !ok {
-			break
-		}
-		if isPermanentToolError(toolResult) {
-			stopReason = RetryStopPermanent
 			break
 		}
 		if ctx.Err() != nil {
@@ -161,11 +170,15 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 			stopReason = RetryStopBudgetExceeded
 			break
 		}
-		if havePrev && toolResult == prevExcerpt {
+		if isPermanentToolError(toolResult) {
+			stopReason = RetryStopPermanent
+			break
+		}
+		if havePrev && toolResult == prevToolResult {
 			stopReason = RetryStopNoProgress
 			break
 		}
-		prevExcerpt = toolResult
+		prevToolResult = toolResult
 		havePrev = true
 		attempts++
 
@@ -350,9 +363,12 @@ func claudeResultToAgentResultWithRetryAbort(result *claude.TurnResult, cfg Exec
 	if agentResult == nil || cfg.MaxToolErrorRetries <= 0 {
 		return agentResult
 	}
-	toolName, excerpt, ok := claude.FinalTurnToolError(result.ContentBlocks)
+	toolName, toolResult, excerpt, ok := claude.FinalTurnToolErrorDetails(result.ContentBlocks)
 	if !ok {
 		return agentResult
+	}
+	if stopReason == RetryStopPermanent {
+		excerpt = permanentToolErrorExcerpt(toolResult, excerpt)
 	}
 	unresolved := &UnresolvedToolError{
 		Tool:     toolName,

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -149,6 +149,11 @@ func TestIsPermanentToolError(t *testing.T) {
 			want:    true,
 		},
 		{
+			name:    "full tool result",
+			excerpt: "<tool_use_error>" + strings.Repeat("x", 220) + " disable-model-invocation</tool_use_error>",
+			want:    true,
+		},
+		{
 			name:    "skill tool compatibility",
 			excerpt: "Skill pr-polish cannot be used with Skill tool",
 			want:    true,
@@ -276,6 +281,27 @@ func TestRunRetryLoop_CtxCancelled(t *testing.T) {
 	}
 	if len(fake.asks) != 0 {
 		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if reason != RetryStopCtxCancelled {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopCtxCancelled, reason)
+	}
+}
+
+func TestRunRetryLoop_CtxCancelledTakesPrecedenceOverPermanent(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("blocked",
+		realToolUseErrorBlocks("Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	_, attempts, reason, err := runRetryLoop(ctx, fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no Asks before ctx check, got %d", attempts)
 	}
 	if reason != RetryStopCtxCancelled {
 		t.Errorf("expected stopReason=%s, got %s", RetryStopCtxCancelled, reason)
@@ -449,6 +475,34 @@ func TestClaudeResultToAgentResultWithRetryAbort_PermanentError(t *testing.T) {
 	}
 	if recorder.excerpt != wrappedExcerpt {
 		t.Errorf("expected abort excerpt %q, got %q", wrappedExcerpt, recorder.excerpt)
+	}
+}
+
+func TestClaudeResultToAgentResultWithRetryAbort_PermanentBeyondExcerpt(t *testing.T) {
+	t.Parallel()
+	const summary = "permanent tool error: disable-model-invocation"
+	recorder := &retryAbortRecorder{}
+	result := claudeResultToAgentResultWithRetryAbort(
+		turnResult("blocked", realToolUseErrorBlocks(strings.Repeat("x", 220)+" disable-model-invocation")),
+		ExecuteConfig{
+			MaxToolErrorRetries: 3,
+			EventHandler:        recorder,
+		},
+		0,
+		RetryStopPermanent,
+	)
+
+	if result.UnresolvedToolError == nil {
+		t.Fatal("expected unresolved tool error")
+	}
+	if result.UnresolvedToolError.Excerpt != summary {
+		t.Errorf("expected permanent summary excerpt %q, got %q", summary, result.UnresolvedToolError.Excerpt)
+	}
+	if recorder.excerpt != summary {
+		t.Errorf("expected abort excerpt %q, got %q", summary, recorder.excerpt)
+	}
+	if !strings.Contains(result.Text, summary) {
+		t.Errorf("expected marker text to include %q, got %q", summary, result.Text)
 	}
 }
 

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -224,6 +224,56 @@ func TestRunRetryLoop_SkipsOnNonzeroExitBash(t *testing.T) {
 	}
 }
 
+// TestRunRetryLoop_SkipsOnPermanentError covers the canonical
+// disable-model-invocation case: a marker-bearing tool_use_error whose excerpt
+// cannot be recovered by retry. Loop exits with RetryStopPermanent and no Ask
+// is issued.
+func TestRunRetryLoop_SkipsOnPermanentError(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("blocked",
+		realToolUseErrorBlocks("Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation"))
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	result, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries on permanent error, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if reason != RetryStopPermanent {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopPermanent, reason)
+	}
+	if result != initial {
+		t.Error("expected original result returned unchanged")
+	}
+}
+
+// TestRunRetryLoop_RetriesNonPermanentMarkerError is a negative regression: a
+// marker-bearing error whose excerpt does not match the deny list must still
+// retry as before.
+func TestRunRetryLoop_RetriesNonPermanentMarkerError(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("parallel",
+		realToolUseErrorBlocks("Cancelled: parallel tool call errored"))
+	fake := &scriptedSession{
+		responses: []*claude.TurnResult{turnResult("ok", cleanBlocks())},
+	}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 2}
+
+	_, attempts, _, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 retry Ask for non-permanent marker, got %d", attempts)
+	}
+}
+
 // TestRunRetryLoop_RetriesCleanlyOnRealToolUseError ensures the G1
 // tightening did not break the PLA-212 recover-on-retry path.
 func TestRunRetryLoop_RetriesCleanlyOnRealToolUseError(t *testing.T) {

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -104,6 +104,15 @@ func turnResult(text string, blocks []claude.ContentBlock) *claude.TurnResult {
 	}
 }
 
+func finalToolErrorExcerpt(t *testing.T, inner string) string {
+	t.Helper()
+	_, excerpt, ok := claude.FinalTurnToolError(realToolUseErrorBlocks(inner))
+	if !ok {
+		t.Fatal("expected realToolUseErrorBlocks to produce a final tool error")
+	}
+	return excerpt
+}
+
 func TestIsPermanentToolError(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -114,6 +123,11 @@ func TestIsPermanentToolError(t *testing.T) {
 		{
 			name:    "disable model invocation",
 			excerpt: "Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation",
+			want:    true,
+		},
+		{
+			name:    "exact final tool error excerpt",
+			excerpt: finalToolErrorExcerpt(t, "Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation"),
 			want:    true,
 		},
 		{

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -63,6 +63,24 @@ func (s *scriptedSession) Ask(ctx context.Context, content string) (*claude.Turn
 	return r, nil
 }
 
+type cancelAfterFirstAskSession struct {
+	cancel    context.CancelFunc
+	responses []*claude.TurnResult
+	asks      []string
+	cursor    int
+}
+
+func (s *cancelAfterFirstAskSession) Ask(ctx context.Context, content string) (*claude.TurnResult, error) {
+	s.asks = append(s.asks, content)
+	if s.cursor >= len(s.responses) {
+		return nil, errors.New("cancelAfterFirstAskSession: no more responses queued")
+	}
+	r := s.responses[s.cursor]
+	s.cursor++
+	s.cancel()
+	return r, nil
+}
+
 // realToolUseErrorBlocks is the minimal set of ContentBlocks that
 // FinalTurnToolError will flag as retry-worthy: IsError true and the
 // <tool_use_error> wrapper present.
@@ -264,6 +282,33 @@ func TestRunRetryLoop_CtxCancelled(t *testing.T) {
 	}
 }
 
+func TestRunRetryLoop_CtxCancelledBetweenRetries(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("err1", realToolUseErrorBlocks("first"))
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &cancelAfterFirstAskSession{
+		cancel: cancel,
+		responses: []*claude.TurnResult{
+			turnResult("err2", realToolUseErrorBlocks("second")),
+		},
+	}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	_, attempts, reason, err := runRetryLoop(ctx, fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected exactly 1 Ask before ctx cancellation, got %d", attempts)
+	}
+	if len(fake.asks) != 1 {
+		t.Errorf("expected 1 Ask call, got %d", len(fake.asks))
+	}
+	if reason != RetryStopCtxCancelled {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopCtxCancelled, reason)
+	}
+}
+
 func TestRunRetryLoop_DisabledByDefault(t *testing.T) {
 	t.Parallel()
 	initial := turnResult("err1", realToolUseErrorBlocks("first"))
@@ -326,6 +371,31 @@ func TestRunRetryLoop_SkipsOnPermanentError(t *testing.T) {
 	}
 	if attempts != 0 {
 		t.Errorf("expected no retries on permanent error, got %d", attempts)
+	}
+	if len(fake.asks) != 0 {
+		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))
+	}
+	if reason != RetryStopPermanent {
+		t.Errorf("expected stopReason=%s, got %s", RetryStopPermanent, reason)
+	}
+	if result != initial {
+		t.Error("expected original result returned unchanged")
+	}
+}
+
+func TestRunRetryLoop_SkipsOnPermanentErrorBeyondExcerpt(t *testing.T) {
+	t.Parallel()
+	initial := turnResult("blocked",
+		realToolUseErrorBlocks(strings.Repeat("x", 220)+" disable-model-invocation"))
+	fake := &scriptedSession{}
+	cfg := ExecuteConfig{MaxToolErrorRetries: 3}
+
+	result, attempts, reason, err := runRetryLoop(context.Background(), fake, initial, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("expected no retries on permanent error beyond excerpt, got %d", attempts)
 	}
 	if len(fake.asks) != 0 {
 		t.Errorf("expected 0 Ask calls, got %d", len(fake.asks))

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 )
 
+type retryAbortRecorder struct {
+	reason  string
+	tool    string
+	excerpt string
+}
+
+func (r *retryAbortRecorder) OnText(string) {}
+
+func (r *retryAbortRecorder) OnThinking(string) {}
+
+func (r *retryAbortRecorder) OnToolStart(string, string, map[string]interface{}) {}
+
+func (r *retryAbortRecorder) OnToolComplete(string, string, map[string]interface{}, interface{}, bool) {
+}
+
+func (r *retryAbortRecorder) OnTurnComplete(int, bool, int64, float64) {}
+
+func (r *retryAbortRecorder) OnError(error, string) {}
+
+func (r *retryAbortRecorder) OnRetry(int, int, string, string) {}
+
+func (r *retryAbortRecorder) OnRetryAbort(reason, tool, excerpt string) {
+	r.reason = reason
+	r.tool = tool
+	r.excerpt = excerpt
+}
+
 // scriptedSession drives runRetryLoop with a pre-scripted sequence of
 // TurnResults. The first result is returned by the caller of Execute
 // before runRetryLoop is invoked, so the slice held here represents
@@ -294,6 +321,50 @@ func TestRunRetryLoop_SkipsOnPermanentError(t *testing.T) {
 	}
 	if result != initial {
 		t.Error("expected original result returned unchanged")
+	}
+}
+
+func TestClaudeResultToAgentResultWithRetryAbort_PermanentError(t *testing.T) {
+	t.Parallel()
+	const excerpt = "Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation"
+	const wrappedExcerpt = "<tool_use_error>" + excerpt + "</tool_use_error>"
+	recorder := &retryAbortRecorder{}
+	result := claudeResultToAgentResultWithRetryAbort(
+		turnResult("blocked", realToolUseErrorBlocks(excerpt)),
+		ExecuteConfig{
+			MaxToolErrorRetries: 3,
+			EventHandler:        recorder,
+		},
+		0,
+		RetryStopPermanent,
+	)
+
+	if result.UnresolvedToolError == nil {
+		t.Fatal("expected unresolved tool error")
+	}
+	if result.UnresolvedToolError.Reason != RetryStopPermanent {
+		t.Errorf("expected reason=%s, got %s", RetryStopPermanent, result.UnresolvedToolError.Reason)
+	}
+	if result.UnresolvedToolError.Attempts != 0 {
+		t.Errorf("expected 0 attempts, got %d", result.UnresolvedToolError.Attempts)
+	}
+	if result.UnresolvedToolError.Max != 3 {
+		t.Errorf("expected max=3, got %d", result.UnresolvedToolError.Max)
+	}
+	if result.UnresolvedToolError.Tool != "Bash" {
+		t.Errorf("expected tool Bash, got %q", result.UnresolvedToolError.Tool)
+	}
+	if !strings.Contains(result.Text, UnresolvedToolErrorMarkerPrefix+RetryStopPermanent+")") {
+		t.Errorf("expected permanent unresolved marker in text, got %q", result.Text)
+	}
+	if recorder.reason != RetryStopPermanent {
+		t.Errorf("expected abort reason=%s, got %s", RetryStopPermanent, recorder.reason)
+	}
+	if recorder.tool != "Bash" {
+		t.Errorf("expected abort tool Bash, got %q", recorder.tool)
+	}
+	if recorder.excerpt != wrappedExcerpt {
+		t.Errorf("expected abort excerpt %q, got %q", wrappedExcerpt, recorder.excerpt)
 	}
 }
 

--- a/multiagent/agent/claude_provider_retry_test.go
+++ b/multiagent/agent/claude_provider_retry_test.go
@@ -77,6 +77,50 @@ func turnResult(text string, blocks []claude.ContentBlock) *claude.TurnResult {
 	}
 }
 
+func TestIsPermanentToolError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		excerpt string
+		want    bool
+	}{
+		{
+			name:    "disable model invocation",
+			excerpt: "Skill sy:pr-polish cannot be used with Skill tool due to disable-model-invocation",
+			want:    true,
+		},
+		{
+			name:    "skill tool compatibility",
+			excerpt: "Skill pr-polish cannot be used with Skill tool",
+			want:    true,
+		},
+		{
+			name:    "broad compatibility phrase outside skill tool",
+			excerpt: "command cannot be used with this terminal state",
+			want:    false,
+		},
+		{
+			name:    "non permanent marker error",
+			excerpt: "Cancelled: parallel tool call errored",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			excerpt: "",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isPermanentToolError(tt.excerpt); got != tt.want {
+				t.Errorf("isPermanentToolError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunRetryLoop_RetriesUntilClean(t *testing.T) {
 	t.Parallel()
 	initial := turnResult("err1", realToolUseErrorBlocks("first"))

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -25,7 +25,7 @@ type AgentResult struct {
 // AgentResult.Text, which may be replaced downstream (e.g. when a plan file
 // is read instead of the agent's text). Reason distinguishes why the loop
 // stopped — "exhausted" (count budget reached), "budget_exceeded",
-// "no_progress", or "ctx_cancelled".
+// "no_progress", "ctx_cancelled", or "permanent".
 type UnresolvedToolError struct {
 	Tool     string
 	Excerpt  string

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -147,9 +147,9 @@ type RetryHandler interface {
 	// OnRetryAbort fires once per retry-loop execution when the loop
 	// stops while a tool error is still present. reason is one of
 	// "exhausted" (count budget reached), "no_progress",
-	// "budget_exceeded", or "ctx_cancelled". The same reason is carried
-	// on UnresolvedToolError.Reason and in the appended marker, so
-	// handlers can correlate logs with downstream output.
+	// "budget_exceeded", "ctx_cancelled", or "permanent". The same
+	// reason is carried on UnresolvedToolError.Reason and in the appended
+	// marker, so handlers can correlate logs with downstream output.
 	OnRetryAbort(reason, tool, excerpt string)
 }
 


### PR DESCRIPTION
## Summary
- stop retrying permanent Claude tool-use failures such as `disable-model-invocation` and Skill-tool compatibility errors by returning `RetryStopPermanent` before another `Ask` is issued
- keep cancellation and retry-budget guards ahead of permanent-error classification, and preserve normal retry behavior for non-permanent marker errors
- add `FinalTurnToolErrorDetails` so retry policy can inspect the full tool result while display paths keep using bounded excerpts
- centralize unresolved tool-error marker and `OnRetryAbort` emission, including permanent-error summaries when the marker appears beyond the display excerpt
- document the new `permanent` stop reason in provider APIs and update the retry design note to match the shipped G3 behavior
- expand retry tests for permanent classification, full-content detection, permanent abort reporting, cancellation precedence, and non-permanent retry coverage

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`