### PR TITLE
Add jiradozer PR feedback refinement

### DIFF
--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "orchestrator_logtail.go",
         "poller.go",
         "prompts.go",
+        "refine.go",
         "runtime_state.go",
         "state.go",
         "steplabels.go",
@@ -22,7 +23,9 @@ go_library(
     deps = [
         "//agent-cli-wrapper/claude/render",
         "//jiradozer/tracker",
+        "//jiradozer/tracker/github",
         "//multiagent/agent",
+        "//wt",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )
@@ -36,6 +39,7 @@ go_test(
         "orchestrator_logtail_test.go",
         "orchestrator_test.go",
         "poller_test.go",
+        "refine_test.go",
         "runtime_state_test.go",
         "state_test.go",
         "steplabels_test.go",

--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
     deps = [
         "//agent-cli-wrapper/claude/render",
         "//jiradozer/tracker",
+        "//wt",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -109,6 +109,10 @@ func resolvePromptForExecution(stepName, configPrompt string, data PromptData, f
 	if err != nil {
 		return "", err
 	}
+	if data.PRFeedback != "" && !strings.Contains(prompt, data.PRFeedback) {
+		prompt += "\n\nReviewer feedback on the PR:\n" + data.PRFeedback +
+			"\n\nPlease address each point. Update the PR by committing and pushing to the same branch."
+	}
 
 	// Fallback: no session to resume but have feedback — append it.
 	if feedback != "" {

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -29,6 +29,7 @@ type PromptData struct {
 	BaseBranch  string // e.g. "main"
 	Plan        string // plan output from the planning step
 	BuildOutput string // build output from the build step
+	PRFeedback  string // reviewer feedback injected during refine runs
 }
 
 func truncate(s string, maxLen int) string {

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -228,6 +229,23 @@ func TestResolvePromptForExecution_FeedbackWithoutSession(t *testing.T) {
 	assert.Contains(t, prompt, "ENG-1")
 	assert.Contains(t, prompt, "Previous feedback to incorporate")
 	assert.Contains(t, prompt, "Consider edge cases")
+}
+
+func TestResolvePromptForExecution_PRFeedbackWithoutTemplateBlock(t *testing.T) {
+	data := PromptData{Identifier: "ENG-1", Title: "Test", PRFeedback: `foo.go:7 by @alice: "tighten this"`}
+
+	prompt, err := resolvePromptForExecution("validate", "Issue {{.Identifier}}", data, "", "")
+	require.NoError(t, err)
+	assert.Contains(t, prompt, "Reviewer feedback on the PR:\nfoo.go:7 by @alice")
+	assert.Contains(t, prompt, "Update the PR by committing and pushing to the same branch")
+}
+
+func TestResolvePromptForExecution_PRFeedbackTemplateBlockNotDuplicated(t *testing.T) {
+	data := PromptData{Identifier: "ENG-1", Title: "Test", PRFeedback: "make timeout configurable"}
+
+	prompt, err := resolvePromptForExecution("validate", "Issue {{.Identifier}}\n{{.PRFeedback}}", data, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(prompt, "make timeout configurable"))
 }
 
 func TestResolvePromptForExecution_ResumeWithoutFeedback(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bootstrap.go",
         "main.go",
+        "refine.go",
         "run.go",
         "team_signals_other.go",
         "team_signals_unix.go",

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//cliapp",
         "//jiradozer",
         "//jiradozer/tracker",
+        "//jiradozer/tracker/local",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -33,6 +33,7 @@ func main() {
 func newRootCommand(opts *cliapp.Options) *cobra.Command {
 	var rargs runArgs
 	var bargs bootstrapArgs
+	var fargs refineArgs
 
 	rootCmd := &cobra.Command{
 		Use:   "jiradozer",
@@ -47,10 +48,11 @@ func newRootCommand(opts *cliapp.Options) *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&rargs.configPath, "config", "jiradozer.yaml", "Path to config file")
 
 	runCmd := newRunCommand(&rargs)
+	refineCmd := newRefineCommand(&fargs, &rargs.configPath)
 	bootstrapCmd := newBootstrapCommand(&bargs, &rargs.configPath)
 	validateConfigCmd := newValidateConfigCommand(&rargs.configPath)
 
-	rootCmd.AddCommand(runCmd, bootstrapCmd, validateConfigCmd)
+	rootCmd.AddCommand(runCmd, refineCmd, bootstrapCmd, validateConfigCmd)
 
 	// Back-compat: bare `jiradozer --issue X --description Y` (no
 	// subcommand) behaves like `jiradozer run --issue X --description Y`.

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bazelment/yoloswe/cliapp"
 	"github.com/bazelment/yoloswe/jiradozer"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
+	"github.com/bazelment/yoloswe/jiradozer/tracker/local"
 )
 
 func testMainLogger(_ testing.TB) *slog.Logger {
@@ -175,6 +176,26 @@ func TestResolveRepoName(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestFindExistingLocalIssueByDescription(t *testing.T) {
+	lt, err := local.NewTracker(t.TempDir())
+	require.NoError(t, err)
+	created, err := lt.CreateIssue("local task", "make timeout configurable\n")
+	require.NoError(t, err)
+
+	got, err := findExistingLocalIssueByDescription(context.Background(), lt, "make timeout configurable")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, created.Identifier, got.Identifier)
+}
+
+func TestFindExistingLocalIssueByDescriptionMissing(t *testing.T) {
+	lt, err := local.NewTracker(t.TempDir())
+	require.NoError(t, err)
+
+	_, err = findExistingLocalIssueByDescription(context.Background(), lt, "missing")
+	require.ErrorContains(t, err, "no existing local issue found")
 }
 
 func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/refine.go
+++ b/jiradozer/cmd/jiradozer/refine.go
@@ -89,10 +89,9 @@ func refine(ctx context.Context, app *cliapp.App, args refineArgs) error {
 		if !ok {
 			return fmt.Errorf("--description-file requires local tracker (got %T)", issueTracker)
 		}
-		title := jiradozer.GenerateTitle(args.description)
-		issue, err = lt.CreateIssue(title, args.description)
+		issue, err = findExistingLocalIssueByDescription(ctx, lt, args.description)
 		if err != nil {
-			return fmt.Errorf("create local issue: %w", err)
+			return err
 		}
 	} else {
 		app.Logger.Info("fetching issue", "identifier", args.issueID)
@@ -125,4 +124,21 @@ func refine(ctx context.Context, app *cliapp.App, args refineArgs) error {
 		NoPoll:   args.noPoll,
 	}
 	return jiradozer.RunRefine(ctx, wfOpts)
+}
+
+func findExistingLocalIssueByDescription(ctx context.Context, lt *local.Tracker, description string) (*tracker.Issue, error) {
+	issues, err := lt.ListIssues(ctx, tracker.IssueFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("list local issues: %w", err)
+	}
+	description = strings.TrimSpace(description)
+	for _, issue := range issues {
+		if issue.Description == nil {
+			continue
+		}
+		if strings.TrimSpace(*issue.Description) == description {
+			return issue, nil
+		}
+	}
+	return nil, fmt.Errorf("no existing local issue found for --description-file; run jiradozer run --description-file first or use --issue LOCAL-N")
 }

--- a/jiradozer/cmd/jiradozer/refine.go
+++ b/jiradozer/cmd/jiradozer/refine.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bazelment/yoloswe/cliapp"
+	"github.com/bazelment/yoloswe/jiradozer"
+	"github.com/bazelment/yoloswe/jiradozer/tracker"
+	"github.com/bazelment/yoloswe/jiradozer/tracker/local"
+)
+
+//nolint:govet // fieldalignment: keep embedded run args and refine-only flags grouped by purpose.
+type refineArgs struct {
+	runArgs
+	feedback     string
+	feedbackFile string
+	prRef        string
+	noPoll       bool
+}
+
+func newRefineCommand(args *refineArgs, configPath *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "refine",
+		Short: "Address review feedback on an existing PR",
+		Long:  "Re-enter a completed jiradozer workflow at validate, using explicit feedback or GitHub PR review comments, and update the existing branch/PR in place.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			args.dryRunSet = dryRunChanged(cmd)
+			args.configPath = *configPath
+			app := cliapp.FromContext(cmd.Context())
+			return refine(cmd.Context(), app, *args)
+		},
+	}
+	cmd.SilenceUsage = true
+	registerRunFlags(cmd, &args.runArgs)
+	cmd.Flags().StringVar(&args.feedback, "feedback", "", "Explicit refinement feedback; skips PR comment fetching")
+	cmd.Flags().StringVar(&args.feedbackFile, "feedback-file", "", "Read explicit refinement feedback from file (use - for stdin)")
+	cmd.Flags().StringVar(&args.prRef, "pr", "", "PR number or URL (overrides PR auto-discovery)")
+	cmd.Flags().BoolVar(&args.noPoll, "no-poll", false, "Run one validation pass and exit at the next review gate")
+	return cmd
+}
+
+func refine(ctx context.Context, app *cliapp.App, args refineArgs) error {
+	if args.feedback != "" && args.feedbackFile != "" {
+		return fmt.Errorf("--feedback and --feedback-file are mutually exclusive")
+	}
+	if args.feedbackFile != "" {
+		data, err := readFileOrStdin(args.feedbackFile)
+		if err != nil {
+			return fmt.Errorf("read feedback file: %w", err)
+		}
+		args.feedback = strings.TrimSpace(string(data))
+		if args.feedback == "" {
+			return fmt.Errorf("feedback file is empty")
+		}
+	}
+	if args.descriptionFile != "" {
+		if args.issueID != "" {
+			return fmt.Errorf("--issue and --description-file are mutually exclusive")
+		}
+		data, err := readFileOrStdin(args.descriptionFile)
+		if err != nil {
+			return fmt.Errorf("read description file: %w", err)
+		}
+		args.description = strings.TrimSpace(string(data))
+		if args.description == "" {
+			return fmt.Errorf("description file is empty")
+		}
+	}
+	if args.issueID == "" && args.description == "" {
+		return fmt.Errorf("refine requires --issue or --description-file")
+	}
+
+	cfg, err := loadRunConfig(args.runArgs)
+	if err != nil {
+		return err
+	}
+	issueTracker, err := createTracker(cfg, args.issueID)
+	if err != nil {
+		return err
+	}
+
+	var issue *tracker.Issue
+	if args.description != "" {
+		lt, ok := issueTracker.(*local.Tracker)
+		if !ok {
+			return fmt.Errorf("--description-file requires local tracker (got %T)", issueTracker)
+		}
+		title := jiradozer.GenerateTitle(args.description)
+		issue, err = lt.CreateIssue(title, args.description)
+		if err != nil {
+			return fmt.Errorf("create local issue: %w", err)
+		}
+	} else {
+		app.Logger.Info("fetching issue", "identifier", args.issueID)
+		issue, err = issueTracker.FetchIssue(ctx, args.issueID)
+		if err != nil {
+			return fmt.Errorf("fetch issue: %w", err)
+		}
+	}
+
+	if args.feedback == "" {
+		if issueFeedback, ok, err := jiradozer.RefineFeedbackFromIssueComment(ctx, issueTracker, issue.ID); err != nil {
+			app.Logger.Warn("failed to inspect issue comments for refine feedback", "error", err)
+		} else if ok {
+			args.feedback = issueFeedback
+		}
+	}
+
+	if app.Renderer != nil {
+		defer app.Renderer.Reset()
+	}
+	wfOpts := jiradozer.RefineOptions{
+		Issue:    issue,
+		Tracker:  issueTracker,
+		Config:   cfg,
+		Logger:   app.Logger,
+		Renderer: app.Renderer,
+		Feedback: args.feedback,
+		PRRef:    args.prRef,
+		WorkDir:  args.workDir,
+		NoPoll:   args.noPoll,
+	}
+	return jiradozer.RunRefine(ctx, wfOpts)
+}

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -332,6 +332,19 @@ func (a *wtAdapter) RemoveWorktree(ctx context.Context, nameOrBranch string, del
 	return a.mgr.Remove(ctx, nameOrBranch, deleteBranch, false)
 }
 
+func (a *wtAdapter) FindWorktree(ctx context.Context, branch string) (string, error) {
+	worktrees, err := a.mgr.List(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, w := range worktrees {
+		if w.Branch == branch && !w.IsGone {
+			return w.Path, nil
+		}
+	}
+	return "", wt.ErrWorktreeNotFound
+}
+
 // validateDryRunMode enforces that --dry-run is only used with team mode.
 // Single-issue and local description modes already give the caller an
 // obvious command to run, so dry-run is rejected in those paths.

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -326,6 +326,7 @@ var (
 		BaseBranch:  "main",
 		Plan:        "sample plan",
 		BuildOutput: "sample build output",
+		PRFeedback:  "sample PR feedback",
 	}
 	sampleCommentData = CommentData{
 		Step:        "plan",

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -289,6 +289,13 @@ validate:
     # Required unless `rounds` is set.
     prompt: |-
         Issue: {{.Identifier}} — {{.Title}}
+        {{- if .PRFeedback}}
+
+        Reviewer feedback on the PR:
+        {{.PRFeedback}}
+
+        Please address each point. Update the PR by committing and pushing to the same branch.
+        {{- end}}
 
         Run the project's tests and linters to validate the changes. Fix any failures you find. Report what passed and what you fixed.
     # Comment posted to the issue when this step finishes (single-shot mode).

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -347,6 +347,7 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 		o.unreserveSlot(issue.ID)
 		return fmt.Errorf("create worktree for %s: %w", issue.Identifier, err)
 	}
+	o.persistIssueBranchName(ctx, issue, branch)
 
 	// Add the lock label as soon as the worktree exists. The label is the
 	// quick part of the distributed claim — it signals intent across
@@ -488,6 +489,22 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 	}()
 
 	return nil
+}
+
+type branchNamePersister interface {
+	SetBranchName(ctx context.Context, issueID string, branchName string) error
+}
+
+func (o *Orchestrator) persistIssueBranchName(ctx context.Context, issue *tracker.Issue, branch string) {
+	p, ok := o.tracker.(branchNamePersister)
+	if !ok {
+		return
+	}
+	if err := p.SetBranchName(ctx, issue.ID, branch); err != nil {
+		o.logger.Warn("failed to persist issue branch name", "issue", issue.Identifier, "branch", branch, "error", err)
+		return
+	}
+	issue.BranchName = &branch
 }
 
 func (o *Orchestrator) tryStartRefineForExistingWorktree(ctx context.Context, issue *tracker.Issue, branch string) (bool, error) {

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -35,6 +35,10 @@ type WorktreeManager interface {
 	RemoveWorktree(ctx context.Context, nameOrBranch string, deleteBranch bool) error
 }
 
+type worktreeFinder interface {
+	FindWorktree(ctx context.Context, branch string) (worktreePath string, err error)
+}
+
 // IssueStatus represents the current state of a tracked issue's subprocess.
 type IssueStatus struct {
 	Issue        *tracker.Issue
@@ -332,6 +336,14 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 	branch := fmt.Sprintf("%s/%s", cfg.Source.BranchPrefix, issue.Identifier)
 	worktreePath, err := o.wtManager.NewWorktree(ctx, branch, cfg.BaseBranch, issue.Title)
 	if err != nil {
+		if strings.Contains(err.Error(), "worktree already exists") {
+			if started, refineErr := o.tryStartRefineForExistingWorktree(ctx, issue, branch); refineErr != nil {
+				o.unreserveSlot(issue.ID)
+				return refineErr
+			} else if started {
+				return nil
+			}
+		}
 		o.unreserveSlot(issue.ID)
 		return fmt.Errorf("create worktree for %s: %w", issue.Identifier, err)
 	}
@@ -476,6 +488,125 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 	}()
 
 	return nil
+}
+
+func (o *Orchestrator) tryStartRefineForExistingWorktree(ctx context.Context, issue *tracker.Issue, branch string) (bool, error) {
+	feedback, ok, err := RefineFeedbackFromIssueComment(ctx, o.tracker, issue.ID)
+	if err != nil {
+		return false, fmt.Errorf("check refine feedback for %s: %w", issue.Identifier, err)
+	}
+	if !ok {
+		return false, nil
+	}
+	finder, ok := o.wtManager.(worktreeFinder)
+	if !ok {
+		return false, nil
+	}
+	worktreePath, err := finder.FindWorktree(ctx, branch)
+	if err != nil {
+		return false, fmt.Errorf("find existing worktree for refine %s: %w", issue.Identifier, err)
+	}
+	if worktreePath == "" {
+		return false, fmt.Errorf("find existing worktree for refine %s: branch %q not found", issue.Identifier, branch)
+	}
+	return true, o.startRefineChild(ctx, issue, branch, worktreePath, feedback)
+}
+
+func (o *Orchestrator) startRefineChild(ctx context.Context, issue *tracker.Issue, branch, worktreePath, feedback string) error {
+	o.addLockLabel(ctx, issue)
+	wfCtx, cancel := context.WithCancel(ctx)
+
+	o.mu.RLock()
+	selfPath := o.selfPath
+	childArgs := append([]string(nil), o.childArgs...)
+	logDir := o.logDir
+	o.mu.RUnlock()
+
+	args := refineChildArgs(childArgs)
+	args = append(args, "--issue", issue.Identifier, "--work-dir", worktreePath, "--feedback", feedback)
+
+	cmd := exec.CommandContext(wfCtx, selfPath, args...)
+	cmd.Dir = worktreePath
+	cmd.Cancel = func() error { return cmd.Process.Signal(os.Interrupt) }
+	cmd.WaitDelay = 10 * time.Second
+
+	safeID := sanitizeForFilename(issue.Identifier)
+	now := time.Now()
+	logPath := filepath.Join(logDir, fmt.Sprintf("%s-refine-%s-%d-%d.log",
+		safeID, now.Format("20060102-150405"), now.UnixNano(), os.Getpid()))
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		cancel()
+		o.releaseLockLabelByID(issue.ID, issue.Identifier)
+		return fmt.Errorf("open refine log file for %s: %w", issue.Identifier, err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		cancel()
+		o.releaseLockLabelByID(issue.ID, issue.Identifier)
+		return fmt.Errorf("start refine subprocess for %s: %w", issue.Identifier, err)
+	}
+	o.transitionToInProgress(ctx, issue)
+
+	mw := &managedWorkflow{
+		issue:        issue,
+		cancel:       cancel,
+		worktreePath: worktreePath,
+		branch:       branch,
+		startedAt:    time.Now(),
+		cmd:          cmd,
+		logFile:      logFile,
+		pid:          cmd.Process.Pid,
+	}
+	o.mu.Lock()
+	o.active[issue.ID] = mw
+	o.mu.Unlock()
+
+	mw.lastOutputAt.Store(time.Now().UnixNano())
+	mw.tailerAlive.Store(true)
+	o.emitStatus(mw, StepInit, nil)
+	o.logger.Info("refine subprocess started", "issue", issue.Identifier, "pid", cmd.Process.Pid, "log", logPath)
+
+	stop := make(chan struct{})
+	go o.tailSubprocessLog(mw, logPath, stop)
+	go o.runWatchdog(mw, watchdogTickInterval, stop)
+
+	o.wg.Add(1)
+	go func() {
+		defer o.wg.Done()
+		defer logFile.Close()
+		defer close(stop)
+		err := cmd.Wait()
+		switch {
+		case wfCtx.Err() != nil:
+			o.logger.Warn("refine subprocess cancelled", "issue", issue.Identifier, "error", err)
+			o.emitStatus(mw, StepCancelled, wfCtx.Err())
+			o.cleanup(context.Background(), mw, StepCancelled)
+		case err == nil:
+			o.logger.Info("refine subprocess completed", "issue", issue.Identifier)
+			o.emitStatus(mw, StepDone, nil)
+			o.cleanup(context.Background(), mw, StepDone)
+		default:
+			o.logger.Error("refine subprocess failed", "issue", issue.Identifier, "error", err)
+			o.emitStatus(mw, StepFailed, err)
+			o.cleanup(context.Background(), mw, StepFailed)
+		}
+	}()
+	return nil
+}
+
+func refineChildArgs(childArgs []string) []string {
+	out := append([]string(nil), childArgs...)
+	for i, arg := range out {
+		if arg == "run" {
+			out[i] = "refine"
+			return out
+		}
+	}
+	return append(out, "refine")
 }
 
 // activeCountLocked returns the number of active subprocesses.

--- a/jiradozer/prompts.go
+++ b/jiradozer/prompts.go
@@ -39,6 +39,13 @@ No plan is available. Implement the changes based on the issue description above
 {{- end}}`
 
 const BootstrapValidatePrompt = `Issue: {{.Identifier}} — {{.Title}}
+{{- if .PRFeedback}}
+
+Reviewer feedback on the PR:
+{{.PRFeedback}}
+
+Please address each point. Update the PR by committing and pushing to the same branch.
+{{- end}}
 
 Run the project's tests and linters to validate the changes. Fix any failures you find. Report what passed and what you fixed.`
 

--- a/jiradozer/refine.go
+++ b/jiradozer/refine.go
@@ -1,0 +1,188 @@
+package jiradozer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
+	"github.com/bazelment/yoloswe/jiradozer/tracker"
+	ghtracker "github.com/bazelment/yoloswe/jiradozer/tracker/github"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+// RefineOptions configures a refinement run against an existing PR worktree.
+//
+//nolint:govet // fieldalignment: public options stay grouped by call-site concern.
+type RefineOptions struct {
+	Issue       *tracker.Issue
+	Tracker     tracker.IssueTracker
+	Config      *Config
+	Logger      *slog.Logger
+	Renderer    *render.Renderer
+	Feedback    string
+	PRRef       string
+	WorkDir     string
+	BranchName  string
+	NoPoll      bool
+	GH          wt.GHRunner
+	RunWorkflow func(*Workflow) error
+}
+
+// RunRefine locates the preserved worktree for issue, gathers PR feedback, and
+// resumes the workflow at validation.
+func RunRefine(ctx context.Context, opts RefineOptions) error {
+	if opts.Issue == nil {
+		return fmt.Errorf("refine requires an issue")
+	}
+	if opts.Tracker == nil {
+		return fmt.Errorf("refine requires a tracker")
+	}
+	if opts.Config == nil {
+		return fmt.Errorf("refine requires a config")
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	gh := opts.GH
+	if gh == nil {
+		gh = &wt.DefaultGHRunner{}
+	}
+
+	branch := opts.BranchName
+	if branch == "" && opts.Issue.BranchName != nil {
+		branch = *opts.Issue.BranchName
+	}
+	if branch == "" {
+		branch = fmt.Sprintf("%s/%s", opts.Config.Source.BranchPrefix, opts.Issue.Identifier)
+	}
+
+	workDir := opts.WorkDir
+	if workDir == "" {
+		var err error
+		workDir, err = findGitWorktreeForBranch(ctx, branch)
+		if err != nil {
+			return err
+		}
+	}
+
+	feedback := strings.TrimSpace(opts.Feedback)
+	if feedback == "" {
+		prRef := opts.PRRef
+		if prRef == "" {
+			pr, err := findPRForBranch(ctx, gh, workDir, branch)
+			if err != nil {
+				return err
+			}
+			prRef = strconv.Itoa(pr.Number)
+			logger.Info("found PR for refine", "issue", opts.Issue.Identifier, "branch", branch, "pr", pr.URL)
+		}
+		comments, err := ghtracker.FetchPRReviewComments(ctx, gh, workDir, prRef)
+		if err != nil {
+			return err
+		}
+		feedback = ghtracker.FormatPRReviewFeedback(comments)
+	}
+	if feedback == "" {
+		return fmt.Errorf("no refinement feedback found; pass --feedback/--feedback-file or add PR review comments")
+	}
+
+	cfg := cloneConfig(opts.Config)
+	cfg.WorkDir = workDir
+	wf := NewWorkflow(opts.Tracker, opts.Issue, cfg, logger)
+	wf.SetRenderer(opts.Renderer)
+	wf.PrepareRefine(feedback)
+	wf.SetStopAtReview(opts.NoPoll)
+	if opts.RunWorkflow != nil {
+		return opts.RunWorkflow(wf)
+	}
+	return wf.Run(ctx)
+}
+
+func findGitWorktreeForBranch(ctx context.Context, branch string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("list git worktrees: %w", err)
+	}
+	worktrees := parseGitWorktreePorcelain(string(out))
+	if p := worktrees[branch]; p != "" {
+		return p, nil
+	}
+	return "", fmt.Errorf("worktree for branch %q not found; pass --work-dir pointing at the preserved worktree or recreate it with gh pr checkout", branch)
+}
+
+func parseGitWorktreePorcelain(output string) map[string]string {
+	result := make(map[string]string)
+	record := make(map[string]string)
+	flush := func() {
+		path := record["worktree"]
+		branch := strings.TrimPrefix(record["branch"], "refs/heads/")
+		if path != "" && branch != "" {
+			result[branch] = path
+		}
+		record = make(map[string]string)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		switch {
+		case line == "":
+			flush()
+		case strings.HasPrefix(line, "worktree "):
+			record["worktree"] = line[len("worktree "):]
+		case strings.HasPrefix(line, "branch "):
+			record["branch"] = line[len("branch "):]
+		}
+	}
+	flush()
+	return result
+}
+
+func findPRForBranch(ctx context.Context, gh wt.GHRunner, dir, branch string) (*wt.PRInfo, error) {
+	result, err := gh.Run(ctx, []string{
+		"pr", "list",
+		"--head", branch,
+		"--json", "number,url,headRefName",
+		"--limit", "1",
+	}, dir)
+	if err != nil {
+		return nil, fmt.Errorf("find PR for branch %q: %w", branch, err)
+	}
+	var prs []wt.PRInfo
+	if err := json.Unmarshal([]byte(result.Stdout), &prs); err != nil {
+		return nil, fmt.Errorf("parse PR list: %w", err)
+	}
+	if len(prs) == 0 {
+		return nil, fmt.Errorf("no open PR found for branch %q; pass --pr or --feedback", branch)
+	}
+	return &prs[0], nil
+}
+
+// RefineFeedbackFromIssueComment returns the latest issue comment that starts
+// with "refine:". Team mode uses this as a lightweight signal: move/label the
+// issue so discovery sees it again, add "refine: <instructions>", and the
+// preserved PR branch is revised in place.
+func RefineFeedbackFromIssueComment(ctx context.Context, t tracker.IssueTracker, issueID string) (string, bool, error) {
+	comments, err := t.FetchComments(ctx, issueID, timeZero())
+	if err != nil {
+		return "", false, err
+	}
+	for i := len(comments) - 1; i >= 0; i-- {
+		body := strings.TrimSpace(comments[i].Body)
+		prefix, rest, ok := strings.Cut(body, ":")
+		if !ok || !strings.EqualFold(strings.TrimSpace(prefix), "refine") {
+			continue
+		}
+		return strings.TrimSpace(rest), true, nil
+	}
+	return "", false, nil
+}
+
+func timeZero() time.Time {
+	return time.Time{}
+}

--- a/jiradozer/refine_test.go
+++ b/jiradozer/refine_test.go
@@ -1,0 +1,42 @@
+package jiradozer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/jiradozer/tracker"
+)
+
+func TestParseGitWorktreePorcelainFindsBranch(t *testing.T) {
+	output := `worktree /repo/main
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo/jiradozer/ENG-123
+HEAD def456
+branch refs/heads/jiradozer/ENG-123
+
+`
+
+	got := parseGitWorktreePorcelain(output)
+	assert.Equal(t, "/repo/jiradozer/ENG-123", got["jiradozer/ENG-123"])
+}
+
+func TestRefineFeedbackFromIssueCommentUsesLatestRefineComment(t *testing.T) {
+	mt := &mockWorkflowTracker{
+		comments: []tracker.Comment{
+			{ID: "c1", Body: "refine: old feedback", CreatedAt: time.Now().Add(-time.Hour)},
+			{ID: "c2", Body: "ordinary comment", CreatedAt: time.Now().Add(-time.Minute)},
+			{ID: "c3", Body: "refine: address the timeout review", CreatedAt: time.Now()},
+		},
+	}
+
+	got, ok, err := RefineFeedbackFromIssueComment(context.Background(), mt, "issue-1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "address the timeout review", got)
+}

--- a/jiradozer/refine_test.go
+++ b/jiradozer/refine_test.go
@@ -2,6 +2,7 @@ package jiradozer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
+	"github.com/bazelment/yoloswe/wt"
 )
 
 func TestParseGitWorktreePorcelainFindsBranch(t *testing.T) {
@@ -39,4 +41,61 @@ func TestRefineFeedbackFromIssueCommentUsesLatestRefineComment(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, "address the timeout review", got)
+}
+
+func TestRunRefineUsesExplicitFeedbackBeforePRFetch(t *testing.T) {
+	issue := testIssue()
+	workDir := t.TempDir()
+	cfg := testConfig()
+	cfg.WorkDir = "/original"
+	cfg.Source.BranchPrefix = "jiradozer"
+
+	called := false
+	err := RunRefine(context.Background(), RefineOptions{
+		Issue:    issue,
+		Tracker:  &mockWorkflowTracker{},
+		Config:   cfg,
+		Logger:   discardLogger(),
+		Feedback: "make timeout configurable",
+		WorkDir:  workDir,
+		GH:       panicGHRunner{},
+		RunWorkflow: func(wf *Workflow) error {
+			called = true
+			assert.Equal(t, StepValidating, wf.state.Current())
+			assert.Equal(t, "make timeout configurable", wf.prFeedback)
+			assert.Equal(t, workDir, wf.config.WorkDir)
+			assert.True(t, wf.refineMode)
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "/original", cfg.WorkDir, "RunRefine must not mutate caller config")
+}
+
+func TestRunRefineMissingWorktreeError(t *testing.T) {
+	cfg := testConfig()
+	cfg.Source.BranchPrefix = "definitely-missing-jiradozer-branch"
+	issue := testIssue()
+	issue.Identifier = "NO-SUCH-BRANCH"
+
+	err := RunRefine(context.Background(), RefineOptions{
+		Issue:    issue,
+		Tracker:  &mockWorkflowTracker{},
+		Config:   cfg,
+		Logger:   discardLogger(),
+		Feedback: "manual feedback",
+		GH:       panicGHRunner{},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "worktree for branch")
+	assert.Contains(t, err.Error(), "--work-dir")
+}
+
+type panicGHRunner struct{}
+
+func (panicGHRunner) Run(_ context.Context, args []string, _ string) (*wt.CmdResult, error) {
+	return nil, fmt.Errorf("unexpected gh call: %v", args)
 }

--- a/jiradozer/state.go
+++ b/jiradozer/state.go
@@ -191,6 +191,21 @@ func (sm *StateMachine) ForceState(to WorkflowStep) {
 	sm.step = to
 }
 
+// ResetForRefine moves the machine to validation using the explicit refine
+// trigger. It is intentionally separate from the normal transition graph so
+// StepDone remains terminal for ordinary workflow execution.
+func ResetForRefine(sm *StateMachine) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.history = append(sm.history, StepTransition{
+		From:      sm.step,
+		To:        StepValidating,
+		Trigger:   "refine",
+		Timestamp: time.Now(),
+	})
+	sm.step = StepValidating
+}
+
 // History returns a copy of the transition history.
 func (sm *StateMachine) History() []StepTransition {
 	sm.mu.RLock()

--- a/jiradozer/state_test.go
+++ b/jiradozer/state_test.go
@@ -190,6 +190,19 @@ func TestStateMachineHistory(t *testing.T) {
 	assert.Equal(t, "start", sm.History()[0].Trigger)
 }
 
+func TestResetForRefine(t *testing.T) {
+	sm := NewStateMachine()
+	ResetForRefine(sm)
+
+	assert.Equal(t, StepValidating, sm.Current())
+	history := sm.History()
+	require.Len(t, history, 1)
+	assert.Equal(t, StepInit, history[0].From)
+	assert.Equal(t, StepValidating, history[0].To)
+	assert.Equal(t, "refine", history[0].Trigger)
+	assert.False(t, validTransitions[key(StepDone, StepValidating)], "StepDone remains terminal in the normal graph")
+}
+
 func TestShouldAutoApprove(t *testing.T) {
 	cfg := &Config{}
 	w := &Workflow{config: cfg}

--- a/jiradozer/tracker/github/BUILD.bazel
+++ b/jiradozer/tracker/github/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "github",
-    srcs = ["client.go"],
+    srcs = [
+        "client.go",
+        "pr_comments.go",
+    ],
     importpath = "github.com/bazelment/yoloswe/jiradozer/tracker/github",
     visibility = ["//visibility:public"],
     deps = [
@@ -13,7 +16,10 @@ go_library(
 
 go_test(
     name = "github_test",
-    srcs = ["client_test.go"],
+    srcs = [
+        "client_test.go",
+        "pr_comments_test.go",
+    ],
     embed = [":github"],
     deps = [
         "//jiradozer/tracker",

--- a/jiradozer/tracker/github/pr_comments.go
+++ b/jiradozer/tracker/github/pr_comments.go
@@ -1,0 +1,221 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bazelment/yoloswe/wt"
+)
+
+// ReviewComment is normalized feedback from GitHub PR reviews and review
+// comments.
+type ReviewComment struct {
+	CreatedAt time.Time
+	Path      string
+	Body      string
+	Author    string
+	URL       string
+	Line      int
+}
+
+// FetchPRReviewComments fetches actionable PR feedback through gh. prRef may
+// be a PR number or URL. The gh command runs in dir so {owner}/{repo}
+// placeholders resolve from the repository remote.
+func FetchPRReviewComments(ctx context.Context, gh wt.GHRunner, dir, prRef string) ([]ReviewComment, error) {
+	number, err := parsePRNumber(prRef)
+	if err != nil {
+		return nil, err
+	}
+
+	lineComments, err := fetchPRLineComments(ctx, gh, dir, number)
+	if err != nil {
+		return nil, err
+	}
+	reviewComments, err := fetchPRReviewBodies(ctx, gh, dir, number)
+	if err != nil {
+		return nil, err
+	}
+
+	lineComments = append(lineComments, reviewComments...)
+	comments := lineComments
+	sort.SliceStable(comments, func(i, j int) bool {
+		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
+	})
+	return comments, nil
+}
+
+func parsePRNumber(prRef string) (int, error) {
+	prRef = strings.TrimSpace(prRef)
+	if prRef == "" {
+		return 0, fmt.Errorf("PR reference is empty")
+	}
+	if n, err := strconv.Atoi(prRef); err == nil && n > 0 {
+		return n, nil
+	}
+	u, err := url.Parse(prRef)
+	if err != nil {
+		return 0, fmt.Errorf("invalid PR reference %q: %w", prRef, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] != "pull" {
+			continue
+		}
+		n, err := strconv.Atoi(parts[i+1])
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("invalid PR number in %q", prRef)
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("invalid PR reference %q: expected number or pull request URL", prRef)
+}
+
+func fetchPRLineComments(ctx context.Context, gh wt.GHRunner, dir string, number int) ([]ReviewComment, error) {
+	result, err := gh.Run(ctx, []string{
+		"api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", number),
+	}, dir)
+	if err != nil {
+		return nil, fmt.Errorf("fetch PR review comments: %w", err)
+	}
+
+	var raw []ghPRReviewComment
+	if err := json.Unmarshal([]byte(result.Stdout), &raw); err != nil {
+		return nil, fmt.Errorf("parse PR review comments: %w", err)
+	}
+	return normalizePRReviewComments(raw)
+}
+
+func normalizePRReviewComments(raw []ghPRReviewComment) ([]ReviewComment, error) {
+	var out []ReviewComment
+	for _, c := range raw {
+		if skipGitHubAuthor(c.User) || strings.TrimSpace(c.Body) == "" || c.Resolved || c.IsResolved {
+			continue
+		}
+		createdAt, err := parseGitHubTime(c.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+		line := c.Line
+		if line == 0 {
+			line = c.OriginalLine
+		}
+		out = append(out, ReviewComment{
+			Path:      c.Path,
+			Line:      line,
+			Body:      strings.TrimSpace(c.Body),
+			Author:    c.User.Login,
+			URL:       c.HTMLURL,
+			CreatedAt: createdAt,
+		})
+	}
+	return out, nil
+}
+
+func fetchPRReviewBodies(ctx context.Context, gh wt.GHRunner, dir string, number int) ([]ReviewComment, error) {
+	result, err := gh.Run(ctx, []string{
+		"api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/reviews", number),
+	}, dir)
+	if err != nil {
+		return nil, fmt.Errorf("fetch PR reviews: %w", err)
+	}
+
+	var raw []ghPRReview
+	if err := json.Unmarshal([]byte(result.Stdout), &raw); err != nil {
+		return nil, fmt.Errorf("parse PR reviews: %w", err)
+	}
+	return normalizePRReviews(raw)
+}
+
+func normalizePRReviews(raw []ghPRReview) ([]ReviewComment, error) {
+	var out []ReviewComment
+	for _, r := range raw {
+		body := strings.TrimSpace(r.Body)
+		if skipGitHubAuthor(r.User) || body == "" || strings.EqualFold(r.State, "APPROVED") {
+			continue
+		}
+		submittedAt, err := parseGitHubTime(r.SubmittedAt)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ReviewComment{
+			Body:      body,
+			Author:    r.User.Login,
+			URL:       r.HTMLURL,
+			CreatedAt: submittedAt,
+		})
+	}
+	return out, nil
+}
+
+// FormatPRReviewFeedback renders comments into the feedback block given to the
+// validate agent.
+func FormatPRReviewFeedback(comments []ReviewComment) string {
+	if len(comments) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range comments {
+		location := "PR review"
+		if c.Path != "" {
+			location = c.Path
+			if c.Line > 0 {
+				location += ":" + strconv.Itoa(c.Line)
+			}
+		}
+		fmt.Fprintf(&b, "- %s by @%s: %q", location, c.Author, c.Body)
+		if c.URL != "" {
+			fmt.Fprintf(&b, " (%s)", c.URL)
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func skipGitHubAuthor(user ghReviewUser) bool {
+	login := strings.ToLower(user.Login)
+	return user.Type == "Bot" || strings.HasSuffix(login, "[bot]") || strings.Contains(login, "jiradozer")
+}
+
+func parseGitHubTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse timestamp %q: %w", value, err)
+	}
+	return t, nil
+}
+
+type ghPRReviewComment struct {
+	User         ghReviewUser `json:"user"`
+	Body         string       `json:"body"`
+	Path         string       `json:"path"`
+	HTMLURL      string       `json:"html_url"`
+	CreatedAt    string       `json:"created_at"`
+	Line         int          `json:"line"`
+	OriginalLine int          `json:"original_line"`
+	Resolved     bool         `json:"resolved"`
+	IsResolved   bool         `json:"is_resolved"`
+}
+
+type ghPRReview struct {
+	User        ghReviewUser `json:"user"`
+	Body        string       `json:"body"`
+	State       string       `json:"state"`
+	HTMLURL     string       `json:"html_url"`
+	SubmittedAt string       `json:"submitted_at"`
+}
+
+type ghReviewUser struct {
+	Login string `json:"login"`
+	Type  string `json:"type"`
+}

--- a/jiradozer/tracker/github/pr_comments.go
+++ b/jiradozer/tracker/github/pr_comments.go
@@ -77,43 +77,75 @@ func parsePRNumber(prRef string) (int, error) {
 }
 
 func fetchPRLineComments(ctx context.Context, gh wt.GHRunner, dir string, number int) ([]ReviewComment, error) {
+	repo, err := fetchCurrentRepo(ctx, gh, dir)
+	if err != nil {
+		return nil, err
+	}
+
 	result, err := gh.Run(ctx, []string{
-		"api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", number),
+		"api", "graphql",
+		"-f", "query=" + prReviewThreadsQuery,
+		"-F", "owner=" + repo.Owner.Login,
+		"-F", "name=" + repo.Name,
+		"-F", "number=" + strconv.Itoa(number),
 	}, dir)
 	if err != nil {
-		return nil, fmt.Errorf("fetch PR review comments: %w", err)
+		return nil, fmt.Errorf("fetch PR review threads: %w", err)
 	}
 
-	var raw []ghPRReviewComment
+	var raw ghPRReviewThreadsResponse
 	if err := json.Unmarshal([]byte(result.Stdout), &raw); err != nil {
-		return nil, fmt.Errorf("parse PR review comments: %w", err)
+		return nil, fmt.Errorf("parse PR review threads: %w", err)
 	}
-	return normalizePRReviewComments(raw)
+	return normalizePRReviewThreads(raw.Data.Repository.PullRequest.ReviewThreads.Nodes)
 }
 
-func normalizePRReviewComments(raw []ghPRReviewComment) ([]ReviewComment, error) {
+func fetchCurrentRepo(ctx context.Context, gh wt.GHRunner, dir string) (*ghRepoView, error) {
+	result, err := gh.Run(ctx, []string{"repo", "view", "--json", "owner,name"}, dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve current GitHub repository: %w", err)
+	}
+	var repo ghRepoView
+	if err := json.Unmarshal([]byte(result.Stdout), &repo); err != nil {
+		return nil, fmt.Errorf("parse current GitHub repository: %w", err)
+	}
+	if repo.Owner.Login == "" || repo.Name == "" {
+		return nil, fmt.Errorf("current GitHub repository is missing owner or name")
+	}
+	return &repo, nil
+}
+
+func normalizePRReviewThreads(raw []ghPRReviewThread) ([]ReviewComment, error) {
 	var out []ReviewComment
-	for _, c := range raw {
-		if skipGitHubAuthor(c.User) || strings.TrimSpace(c.Body) == "" || c.Resolved || c.IsResolved {
+	for _, thread := range raw {
+		if thread.IsResolved {
 			continue
 		}
-		createdAt, err := parseGitHubTime(c.CreatedAt)
-		if err != nil {
-			return nil, err
+		for i := range thread.Comments.Nodes {
+			c := &thread.Comments.Nodes[i]
+			if skipGitHubAuthor(c.Author) || strings.TrimSpace(c.Body) == "" {
+				continue
+			}
+			createdAt, err := parseGitHubTime(c.CreatedAt)
+			if err != nil {
+				return nil, err
+			}
+			line := 0
+			if c.Line != nil {
+				line = *c.Line
+			}
+			if line == 0 && c.OriginalLine != nil {
+				line = *c.OriginalLine
+			}
+			out = append(out, ReviewComment{
+				Path:      c.Path,
+				Line:      line,
+				Body:      strings.TrimSpace(c.Body),
+				Author:    c.Author.Login,
+				URL:       c.URL,
+				CreatedAt: createdAt,
+			})
 		}
-		line := c.Line
-		if line == 0 {
-			line = c.OriginalLine
-		}
-		out = append(out, ReviewComment{
-			Path:      c.Path,
-			Line:      line,
-			Body:      strings.TrimSpace(c.Body),
-			Author:    c.User.Login,
-			URL:       c.HTMLURL,
-			CreatedAt: createdAt,
-		})
 	}
 	return out, nil
 }
@@ -181,7 +213,7 @@ func FormatPRReviewFeedback(comments []ReviewComment) string {
 
 func skipGitHubAuthor(user ghReviewUser) bool {
 	login := strings.ToLower(user.Login)
-	return user.Type == "Bot" || strings.HasSuffix(login, "[bot]") || strings.Contains(login, "jiradozer")
+	return user.Type == "Bot" || user.Typename == "Bot" || strings.HasSuffix(login, "[bot]") || strings.Contains(login, "jiradozer")
 }
 
 func parseGitHubTime(value string) (time.Time, error) {
@@ -195,18 +227,6 @@ func parseGitHubTime(value string) (time.Time, error) {
 	return t, nil
 }
 
-type ghPRReviewComment struct {
-	User         ghReviewUser `json:"user"`
-	Body         string       `json:"body"`
-	Path         string       `json:"path"`
-	HTMLURL      string       `json:"html_url"`
-	CreatedAt    string       `json:"created_at"`
-	Line         int          `json:"line"`
-	OriginalLine int          `json:"original_line"`
-	Resolved     bool         `json:"resolved"`
-	IsResolved   bool         `json:"is_resolved"`
-}
-
 type ghPRReview struct {
 	User        ghReviewUser `json:"user"`
 	Body        string       `json:"body"`
@@ -216,6 +236,68 @@ type ghPRReview struct {
 }
 
 type ghReviewUser struct {
-	Login string `json:"login"`
-	Type  string `json:"type"`
+	Login    string `json:"login"`
+	Type     string `json:"type"`
+	Typename string `json:"__typename"`
 }
+
+type ghRepoView struct {
+	Owner ghReviewUser `json:"owner"`
+	Name  string       `json:"name"`
+}
+
+type ghPRReviewThreadsResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					Nodes []ghPRReviewThread `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+type ghPRReviewThread struct {
+	Comments struct {
+		Nodes []ghPRThreadComment `json:"nodes"`
+	} `json:"comments"`
+	IsResolved bool `json:"isResolved"`
+}
+
+//nolint:govet // fieldalignment: mirrors the GitHub GraphQL response shape.
+type ghPRThreadComment struct {
+	Author       ghReviewUser `json:"author"`
+	Body         string       `json:"body"`
+	Path         string       `json:"path"`
+	URL          string       `json:"url"`
+	CreatedAt    string       `json:"createdAt"`
+	Line         *int         `json:"line"`
+	OriginalLine *int         `json:"originalLine"`
+}
+
+const prReviewThreadsQuery = `query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 100) {
+            nodes {
+              body
+              path
+              line
+              originalLine
+              url
+              createdAt
+              author {
+                login
+                __typename
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`

--- a/jiradozer/tracker/github/pr_comments_test.go
+++ b/jiradozer/tracker/github/pr_comments_test.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizePRReviewCommentsFiltersBotsAndResolved(t *testing.T) {
+	raw := []ghPRReviewComment{
+		{
+			User:      ghReviewUser{Login: "alice", Type: "User"},
+			Body:      "fix the nil case",
+			Path:      "foo.go",
+			Line:      42,
+			CreatedAt: "2026-05-05T12:00:00Z",
+		},
+		{
+			User:      ghReviewUser{Login: "dependabot[bot]", Type: "Bot"},
+			Body:      "bot noise",
+			Path:      "go.mod",
+			Line:      1,
+			CreatedAt: "2026-05-05T12:01:00Z",
+		},
+		{
+			User:       ghReviewUser{Login: "bob", Type: "User"},
+			Body:       "already resolved",
+			Path:       "bar.go",
+			Line:       3,
+			CreatedAt:  "2026-05-05T12:02:00Z",
+			IsResolved: true,
+		},
+	}
+
+	got, err := normalizePRReviewComments(raw)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "foo.go", got[0].Path)
+	assert.Equal(t, 42, got[0].Line)
+	assert.Equal(t, "fix the nil case", got[0].Body)
+	assert.Equal(t, "alice", got[0].Author)
+}
+
+func TestNormalizePRReviewsSkipsApprovedWithoutActionableBody(t *testing.T) {
+	raw := []ghPRReview{
+		{
+			User:        ghReviewUser{Login: "alice", Type: "User"},
+			State:       "APPROVED",
+			Body:        "looks good",
+			SubmittedAt: "2026-05-05T12:00:00Z",
+		},
+		{
+			User:        ghReviewUser{Login: "carol", Type: "User"},
+			State:       "CHANGES_REQUESTED",
+			Body:        "please make timeout configurable",
+			SubmittedAt: "2026-05-05T12:01:00Z",
+		},
+	}
+
+	got, err := normalizePRReviews(raw)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "carol", got[0].Author)
+	assert.Equal(t, "please make timeout configurable", got[0].Body)
+}
+
+func TestFormatPRReviewFeedback(t *testing.T) {
+	got := FormatPRReviewFeedback([]ReviewComment{{
+		Path:   "foo.go",
+		Line:   7,
+		Author: "alice",
+		Body:   "tighten this",
+	}})
+
+	assert.Contains(t, got, `foo.go:7 by @alice: "tighten this"`)
+}

--- a/jiradozer/tracker/github/pr_comments_test.go
+++ b/jiradozer/tracker/github/pr_comments_test.go
@@ -7,33 +7,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalizePRReviewCommentsFiltersBotsAndResolved(t *testing.T) {
-	raw := []ghPRReviewComment{
+func TestNormalizePRReviewThreadsFiltersBotsAndResolved(t *testing.T) {
+	line42 := 42
+	line1 := 1
+	line3 := 3
+	raw := []ghPRReviewThread{
 		{
-			User:      ghReviewUser{Login: "alice", Type: "User"},
-			Body:      "fix the nil case",
-			Path:      "foo.go",
-			Line:      42,
-			CreatedAt: "2026-05-05T12:00:00Z",
+			Comments: struct {
+				Nodes []ghPRThreadComment `json:"nodes"`
+			}{Nodes: []ghPRThreadComment{{
+				Author:    ghReviewUser{Login: "alice", Typename: "User"},
+				Body:      "fix the nil case",
+				Path:      "foo.go",
+				Line:      &line42,
+				CreatedAt: "2026-05-05T12:00:00Z",
+			}}},
 		},
 		{
-			User:      ghReviewUser{Login: "dependabot[bot]", Type: "Bot"},
-			Body:      "bot noise",
-			Path:      "go.mod",
-			Line:      1,
-			CreatedAt: "2026-05-05T12:01:00Z",
+			Comments: struct {
+				Nodes []ghPRThreadComment `json:"nodes"`
+			}{Nodes: []ghPRThreadComment{{
+				Author:    ghReviewUser{Login: "dependabot[bot]", Typename: "Bot"},
+				Body:      "bot noise",
+				Path:      "go.mod",
+				Line:      &line1,
+				CreatedAt: "2026-05-05T12:01:00Z",
+			}}},
 		},
 		{
-			User:       ghReviewUser{Login: "bob", Type: "User"},
-			Body:       "already resolved",
-			Path:       "bar.go",
-			Line:       3,
-			CreatedAt:  "2026-05-05T12:02:00Z",
 			IsResolved: true,
+			Comments: struct {
+				Nodes []ghPRThreadComment `json:"nodes"`
+			}{Nodes: []ghPRThreadComment{{
+				Author:    ghReviewUser{Login: "bob", Typename: "User"},
+				Body:      "already resolved",
+				Path:      "bar.go",
+				Line:      &line3,
+				CreatedAt: "2026-05-05T12:02:00Z",
+			}}},
 		},
 	}
 
-	got, err := normalizePRReviewComments(raw)
+	got, err := normalizePRReviewThreads(raw)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, "foo.go", got[0].Path)

--- a/jiradozer/tracker/local/local.go
+++ b/jiradozer/tracker/local/local.go
@@ -30,6 +30,7 @@ type issueData struct {
 	Identifier  string   `json:"identifier"`
 	Title       string   `json:"title"`
 	Description string   `json:"description"`
+	BranchName  string   `json:"branch_name,omitempty"`
 	State       string   `json:"state"`
 	TeamID      string   `json:"team_id"`
 	Labels      []string `json:"labels"`
@@ -379,7 +380,7 @@ func (t *Tracker) nextID() (int, error) {
 
 func toTrackerIssue(d *issueData) *tracker.Issue {
 	desc := d.Description
-	return &tracker.Issue{
+	issue := &tracker.Issue{
 		ID:          d.ID,
 		Identifier:  d.Identifier,
 		Title:       d.Title,
@@ -388,4 +389,8 @@ func toTrackerIssue(d *issueData) *tracker.Issue {
 		TeamID:      d.TeamID,
 		Labels:      d.Labels,
 	}
+	if d.BranchName != "" {
+		issue.BranchName = &d.BranchName
+	}
+	return issue
 }

--- a/jiradozer/tracker/local/local.go
+++ b/jiradozer/tracker/local/local.go
@@ -263,6 +263,21 @@ func (t *Tracker) UpdateIssueState(_ context.Context, issueID string, stateID st
 	return t.writeFile(issueID, f)
 }
 
+// SetBranchName persists the branch associated with a local issue. This is
+// used by refine runs so they can find preserved worktrees even if the branch
+// prefix configuration changed since the original run.
+func (t *Tracker) SetBranchName(_ context.Context, issueID string, branchName string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	f, err := t.readFile(issueID)
+	if err != nil {
+		return err
+	}
+	f.Issue.BranchName = branchName
+	return t.writeFile(issueID, f)
+}
+
 // AddLabel adds a label to a local issue. It is idempotent.
 func (t *Tracker) AddLabel(_ context.Context, issueID string, label string) error {
 	t.mu.Lock()

--- a/jiradozer/tracker/local/local_test.go
+++ b/jiradozer/tracker/local/local_test.go
@@ -137,6 +137,21 @@ func TestUpdateState(t *testing.T) {
 	assert.Equal(t, "Done", fetched.State)
 }
 
+func TestSetBranchNamePersists(t *testing.T) {
+	tr := newTestTracker(t)
+	ctx := context.Background()
+
+	issue, err := tr.CreateIssue("Task", "desc")
+	require.NoError(t, err)
+
+	require.NoError(t, tr.SetBranchName(ctx, issue.ID, "jiradozer/LOCAL-1"))
+
+	fetched, err := tr.FetchIssue(ctx, "LOCAL-1")
+	require.NoError(t, err)
+	require.NotNil(t, fetched.BranchName)
+	assert.Equal(t, "jiradozer/LOCAL-1", *fetched.BranchName)
+}
+
 func TestWorkflowStates(t *testing.T) {
 	tr := newTestTracker(t)
 	ctx := context.Background()

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -74,10 +74,13 @@ type Workflow struct {
 	plan                string
 	buildOutput         string
 	feedback            string
+	prFeedback          string
 	botCommentIDs       []string
 	lastLabels          []string
 	maxRedos            int
 	approveAllRemaining bool
+	refineMode          bool
+	stopAtReview        bool
 }
 
 // NewWorkflow creates a new workflow for the given issue. The caller's
@@ -112,6 +115,20 @@ func NewWorkflow(t tracker.IssueTracker, issue *tracker.Issue, cfg *Config, logg
 // SetRenderer sets the terminal renderer for streaming output.
 func (w *Workflow) SetRenderer(r *render.Renderer) {
 	w.renderer = r
+}
+
+// PrepareRefine starts the workflow directly at validation with reviewer
+// feedback. It keeps the normal state graph unchanged while allowing a
+// preserved PR worktree to be revised in place.
+func (w *Workflow) PrepareRefine(feedback string) {
+	ResetForRefine(w.state)
+	w.prFeedback = feedback
+	w.refineMode = true
+}
+
+// SetStopAtReview makes Run return when the next review gate is reached.
+func (w *Workflow) SetStopAtReview(stop bool) {
+	w.stopAtReview = stop
 }
 
 // status emits a renderer status line when a renderer is configured.
@@ -157,8 +174,12 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		return fmt.Errorf("resolve workflow states: %w", err)
 	}
 
-	if err := w.transition(StepPlanning, "start"); err != nil {
-		return err
+	if w.state.Current() == StepInit {
+		if err := w.transition(StepPlanning, "start"); err != nil {
+			return err
+		}
+	} else if w.OnTransition != nil {
+		w.OnTransition(w.state.Current())
 	}
 
 	if id, ok := w.stateIDs[stateKeyInProgress]; ok {
@@ -167,10 +188,14 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		}
 	}
 
-	// Honor pre-existing -done labels by skipping completed phases. A fresh
-	// workflow run never re-does plan/build/validate/ship that the user has
-	// already marked done. Users clear the label manually to re-run a phase.
-	w.skipDonePhases(ctx)
+	if w.refineMode {
+		w.resetRefinePhaseLabels(ctx)
+	} else {
+		// Honor pre-existing -done labels by skipping completed phases. A fresh
+		// workflow run never re-does plan/build/validate/ship that the user has
+		// already marked done. Users clear the label manually to re-run a phase.
+		w.skipDonePhases(ctx)
+	}
 	if phase := phaseForStep(w.state.Current()); phase != "" {
 		w.enterPhase(ctx, phase)
 	}
@@ -184,6 +209,9 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		case StepPlanning:
 			w.runStepOrRounds(ctx, "plan", w.config.Plan, StepPlanReview, "plan_complete")
 		case StepPlanReview:
+			if w.stopAtReview {
+				return nil
+			}
 			w.runReview(ctx, StepBuilding, StepPlanning)
 		case StepBuilding:
 			delete(w.sessionIDs, StepCreatingPR) // Fresh build cycle invalidates old create_pr session.
@@ -194,14 +222,23 @@ func (w *Workflow) Run(ctx context.Context) (runErr error) {
 		case StepCreatingPR:
 			w.runStep(ctx, "create_pr", w.config.CreatePR, StepBuildReview, "pr_created")
 		case StepBuildReview:
+			if w.stopAtReview {
+				return nil
+			}
 			w.runReview(ctx, StepValidating, StepBuilding)
 		case StepValidating:
 			w.runStepOrRounds(ctx, "validate", w.config.Validate, StepValidateReview, "validation_complete")
 		case StepValidateReview:
+			if w.stopAtReview {
+				return nil
+			}
 			w.runReview(ctx, StepShipping, StepValidating)
 		case StepShipping:
 			w.runStepOrRounds(ctx, "ship", w.config.Ship, StepShipReview, "ship_complete")
 		case StepShipReview:
+			if w.stopAtReview {
+				return nil
+			}
 			w.runReview(ctx, StepDone, StepShipping)
 		case StepDone:
 			if id, ok := w.stateIDs[stateKeyDone]; ok {
@@ -393,6 +430,9 @@ func (w *Workflow) promptData() PromptData {
 	data := NewPromptData(w.issue, w.config.BaseBranch)
 	data.Plan = w.plan
 	data.BuildOutput = w.buildOutput
+	if w.refineMode {
+		data.PRFeedback = w.prFeedback
+	}
 	return data
 }
 
@@ -811,6 +851,18 @@ func (w *Workflow) reopenPhaseOnRedo(ctx context.Context, redoTarget WorkflowSte
 			}
 			w.phases[phase] = phaseNotStarted
 		}
+	}
+}
+
+func (w *Workflow) resetRefinePhaseLabels(ctx context.Context) {
+	for _, phase := range []string{PhaseValidate, PhaseShip} {
+		if err := w.tracker.RemoveLabel(ctx, w.issue.ID, doneLabel(phase)); err != nil {
+			w.logger.Warn("failed to remove phase done label for refine", "phase", phase, "error", err)
+		}
+		if err := w.tracker.RemoveLabel(ctx, w.issue.ID, inProgressLabel(phase)); err != nil {
+			w.logger.Warn("failed to remove phase in-progress label for refine", "phase", phase, "error", err)
+		}
+		w.phases[phase] = phaseNotStarted
 	}
 }
 

--- a/yoloswe/reviewer/BUILD.bazel
+++ b/yoloswe/reviewer/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     deps = [
         "//agent-cli-wrapper/acp",
         "//agent-cli-wrapper/agentstream",
+        "//agent-cli-wrapper/claude/render",
         "//agent-cli-wrapper/codex",
     ],
 )


### PR DESCRIPTION
## Problem

`jiradozer` could not cleanly resume a preserved PR worktree after reviewer feedback. Review comments, explicit refinement notes, and preserved local branch metadata were not consistently available to the validation prompt, which made follow-up review cycles fragile or dependent on manual setup.

## Solution in this PR

- Add a `jiradozer refine` command that resumes existing PR worktrees from reviewer feedback and re-enters the workflow at validation.
- Fetch actionable GitHub PR review comments and format them for refinement prompts.
- Ensure PR feedback is appended to execution prompts when the configured template does not include a `PRFeedback` block, without duplicating template-provided feedback.
- Preserve completed worktrees, track refine state, and persist issue branch names so local refine runs can find the right branch even if branch prefix configuration changes later.
- Add config, sample prompt data, and focused tests covering refine behavior, PR comment handling, prompt feedback inclusion, and local tracker branch persistence.

## Verification

- `scripts/lint.sh`
- `bazel test //... --test_timeout=60`
- `bazel build //...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `refine` execution path that re-enters workflows at validation and shells out to `git`/`gh` to locate worktrees and fetch PR feedback; mistakes could cause incorrect branch/worktree selection or unexpected subprocess behavior in team mode.
>
> **Overview**
> Adds a new **PR feedback refinement** flow via the `jiradozer refine` subcommand, allowing a completed workflow to be resumed at `validate` with explicit feedback, `refine:` issue comments, or GitHub PR review comments.
>
> Extends the workflow/state machine to support a *refine mode* (reset to validation, inject `PRFeedback` into prompt rendering, optionally stop at the next review gate with `--no-poll`) and updates default validate prompts/sample config to include reviewer feedback.
>
> In team/subprocess mode, the orchestrator now persists an issue’s branch name (local tracker support added) and, when a worktree already exists and a `refine:` comment is present, starts a `refine` child process against the existing worktree instead of failing.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee1a4949733d1823aebbb7609d32c749b4a2042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
