### PR TITLE
Make plan-review comments trigger replanning

### DIFF
--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -547,17 +547,8 @@ func (w *Workflow) handleReviewFeedback(ctx context.Context, fb *FeedbackResult,
 		w.logger.Info("feedback: comment", "step", w.state.Current(), "message", fb.Message)
 		w.status("Feedback received")
 		w.feedback = fb.Message
-		// During plan review, general comments advance to build with feedback
-		// incorporated — they don't restart the planning step. For other review
-		// steps, redo is the right behavior (the user wants changes applied).
-		if w.state.Current() == StepPlanReview {
-			if err := w.approveTransition(ctx, approveTarget, "approved_with_feedback"); err != nil {
-				w.fail(ctx, err)
-			}
-		} else {
-			if err := w.tryRedo(ctx, redoTarget); err != nil {
-				w.fail(ctx, err)
-			}
+		if err := w.tryRedo(ctx, redoTarget); err != nil {
+			w.fail(ctx, err)
 		}
 	}
 }

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -537,19 +537,35 @@ func (w *Workflow) handleReviewFeedback(ctx context.Context, fb *FeedbackResult,
 			approveAll:       true,
 		})
 	case FeedbackRedo:
-		w.logger.Info("feedback: redo", "step", w.state.Current())
-		w.status("Redo requested")
-		w.feedback = fb.Message
-		if err := w.tryRedo(ctx, redoTarget); err != nil {
-			w.fail(ctx, err)
-		}
+		w.applyReviewRedo(ctx, redoTarget, fb.Message, reviewRedo{
+			logMessage:    "feedback: redo",
+			statusMessage: "Redo requested",
+		})
 	case FeedbackComment:
-		w.logger.Info("feedback: comment", "step", w.state.Current(), "message", fb.Message)
-		w.status("Feedback received")
-		w.feedback = fb.Message
-		if err := w.tryRedo(ctx, redoTarget); err != nil {
-			w.fail(ctx, err)
-		}
+		w.applyReviewRedo(ctx, redoTarget, fb.Message, reviewRedo{
+			logMessage:    "feedback: comment",
+			statusMessage: "Feedback received",
+			logMessageKey: "message",
+		})
+	}
+}
+
+type reviewRedo struct {
+	logMessage    string
+	statusMessage string
+	logMessageKey string
+}
+
+func (w *Workflow) applyReviewRedo(ctx context.Context, redoTarget WorkflowStep, feedback string, redo reviewRedo) {
+	logArgs := []any{"step", w.state.Current()}
+	if redo.logMessageKey != "" {
+		logArgs = append(logArgs, redo.logMessageKey, feedback)
+	}
+	w.logger.Info(redo.logMessage, logArgs...)
+	w.status(redo.statusMessage)
+	w.feedback = feedback
+	if err := w.tryRedo(ctx, redoTarget); err != nil {
+		w.fail(ctx, err)
 	}
 }
 

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -626,8 +626,7 @@ func TestWorkflow_RunReview_Comment_PlanReview(t *testing.T) {
 	}
 
 	wf := NewWorkflow(mt, testIssue(), testConfig(), discardLogger())
-	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
-	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+	walkTo(t, wf.state, StepPlanReview)
 
 	wf.runReview(context.Background(), StepBuilding, StepPlanning)
 
@@ -635,36 +634,6 @@ func TestWorkflow_RunReview_Comment_PlanReview(t *testing.T) {
 	// feedback injected into the next planning round.
 	assert.Equal(t, StepPlanning, wf.state.Current())
 	assert.Equal(t, "Can you also handle the edge case?", wf.feedback)
-}
-
-// TestWorkflow_RunReview_Comment_PlanReview_HitsRedoLimit verifies plan-review
-// comments use the same redo circuit breaker as other review gates.
-func TestWorkflow_RunReview_Comment_PlanReview_HitsRedoLimit(t *testing.T) {
-	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
-	wf.maxRedos = 1
-	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
-	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
-
-	wf.tracker = &mockWorkflowTracker{
-		commentSets: [][]tracker.Comment{
-			{{ID: "c1", Body: "Please revise the plan", IsSelf: false, CreatedAt: time.Now()}},
-		},
-	}
-	wf.runReview(context.Background(), StepBuilding, StepPlanning)
-	assert.Equal(t, StepPlanning, wf.state.Current(), "first comment should replan")
-
-	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
-
-	wf.tracker = &mockWorkflowTracker{
-		commentSets: [][]tracker.Comment{
-			{{ID: "c2", Body: "Please revise it again", IsSelf: false, CreatedAt: time.Now()}},
-		},
-	}
-	wf.runReview(context.Background(), StepBuilding, StepPlanning)
-
-	assert.Equal(t, StepFailed, wf.state.Current())
-	require.Error(t, wf.lastError)
-	assert.EqualError(t, wf.lastError, "step planning has been re-run 1 times (max 1), giving up")
 }
 
 // TestWorkflow_RunReview_Comment_BuildReview tests that a generic comment during
@@ -1264,9 +1233,8 @@ func TestWorkflow_RunReview_CommentPerStep(t *testing.T) {
 
 // --- Full Feedback Loop Simulation ---
 
-// TestWorkflow_FullFeedbackLoop_PlanCommentReplans simulates the exact
-// scenario from the bug report: plan completes, user posts a general comment,
-// workflow should loop back to planning.
+// TestWorkflow_FullFeedbackLoop_PlanCommentReplans simulates a user comment
+// after plan review starts; the workflow should loop back to planning.
 func TestWorkflow_FullFeedbackLoop_PlanCommentReplans(t *testing.T) {
 	now := time.Now()
 	approveComment := tracker.Comment{ID: "human1", Body: "Looks good, but also handle error cases", IsSelf: false, CreatedAt: now.Add(3 * time.Second)}
@@ -1303,39 +1271,52 @@ func TestWorkflow_FullFeedbackLoop_PlanCommentReplans(t *testing.T) {
 }
 
 // TestWorkflow_CircuitBreaker_TripsInRunReview verifies that the circuit breaker
-// integrates correctly with runReview — after maxRedos redo comments, the
-// workflow transitions to StepFailed.
+// integrates correctly with runReview for both explicit and implicit replans.
 func TestWorkflow_CircuitBreaker_TripsInRunReview(t *testing.T) {
-	cfg := testConfig()
-	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), cfg, discardLogger())
-	wf.maxRedos = 1
-
-	// First redo cycle.
-	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
-	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
-
-	mt1 := &mockWorkflowTracker{
-		commentSets: [][]tracker.Comment{
-			{{ID: "c1", Body: "redo: fix approach", IsSelf: false, CreatedAt: time.Now()}},
+	tests := []struct {
+		name       string
+		firstBody  string
+		secondBody string
+	}{
+		{
+			name:       "explicit_redo",
+			firstBody:  "redo: fix approach",
+			secondBody: "redo: try again",
+		},
+		{
+			name:       "generic_plan_comment",
+			firstBody:  "Please revise the plan",
+			secondBody: "Please revise it again",
 		},
 	}
-	wf.tracker = mt1
-	wf.runReview(context.Background(), StepBuilding, StepPlanning)
-	assert.Equal(t, StepPlanning, wf.state.Current(), "first redo should succeed")
 
-	// Back to review.
-	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
+			wf.maxRedos = 1
+			setComment := func(id, body string) {
+				wf.tracker = &mockWorkflowTracker{
+					commentSets: [][]tracker.Comment{
+						{{ID: id, Body: body, IsSelf: false, CreatedAt: time.Now()}},
+					},
+				}
+			}
 
-	// Second redo cycle — should trip circuit breaker.
-	mt2 := &mockWorkflowTracker{
-		commentSets: [][]tracker.Comment{
-			{{ID: "c2", Body: "redo: try again", IsSelf: false, CreatedAt: time.Now()}},
-		},
+			walkTo(t, wf.state, StepPlanReview)
+
+			setComment("c1", tt.firstBody)
+			wf.runReview(context.Background(), StepBuilding, StepPlanning)
+			assert.Equal(t, StepPlanning, wf.state.Current(), "first redo should succeed")
+
+			require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+			setComment("c2", tt.secondBody)
+			wf.runReview(context.Background(), StepBuilding, StepPlanning)
+			assert.Equal(t, StepFailed, wf.state.Current(), "second redo should trip circuit breaker")
+			require.Error(t, wf.lastError)
+			assert.Contains(t, wf.lastError.Error(), "re-run")
+		})
 	}
-	wf.tracker = mt2
-	wf.runReview(context.Background(), StepBuilding, StepPlanning)
-	assert.Equal(t, StepFailed, wf.state.Current(), "second redo should trip circuit breaker")
-	assert.Contains(t, wf.lastError.Error(), "re-run")
 }
 
 // --- Phase Label Tests ---

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -617,7 +617,7 @@ func TestWorkflow_RunReview_Redo(t *testing.T) {
 }
 
 // TestWorkflow_RunReview_Comment_PlanReview tests that a generic comment during
-// plan review advances to build (approve with feedback), not back to planning.
+// plan review triggers a replan, consistent with build/validate/ship review gates.
 func TestWorkflow_RunReview_Comment_PlanReview(t *testing.T) {
 	mt := &mockWorkflowTracker{
 		commentSets: [][]tracker.Comment{
@@ -631,9 +631,40 @@ func TestWorkflow_RunReview_Comment_PlanReview(t *testing.T) {
 
 	wf.runReview(context.Background(), StepBuilding, StepPlanning)
 
-	// During plan review, generic comments advance to build with feedback.
-	assert.Equal(t, StepBuilding, wf.state.Current())
+	// During plan review, generic comments trigger a replan with the
+	// feedback injected into the next planning round.
+	assert.Equal(t, StepPlanning, wf.state.Current())
 	assert.Equal(t, "Can you also handle the edge case?", wf.feedback)
+}
+
+// TestWorkflow_RunReview_Comment_PlanReview_HitsRedoLimit verifies plan-review
+// comments use the same redo circuit breaker as other review gates.
+func TestWorkflow_RunReview_Comment_PlanReview_HitsRedoLimit(t *testing.T) {
+	wf := NewWorkflow(&mockWorkflowTracker{}, testIssue(), testConfig(), discardLogger())
+	wf.maxRedos = 1
+	require.NoError(t, wf.state.Transition(StepPlanning, "start"))
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	wf.tracker = &mockWorkflowTracker{
+		commentSets: [][]tracker.Comment{
+			{{ID: "c1", Body: "Please revise the plan", IsSelf: false, CreatedAt: time.Now()}},
+		},
+	}
+	wf.runReview(context.Background(), StepBuilding, StepPlanning)
+	assert.Equal(t, StepPlanning, wf.state.Current(), "first comment should replan")
+
+	require.NoError(t, wf.state.Transition(StepPlanReview, "plan_done"))
+
+	wf.tracker = &mockWorkflowTracker{
+		commentSets: [][]tracker.Comment{
+			{{ID: "c2", Body: "Please revise it again", IsSelf: false, CreatedAt: time.Now()}},
+		},
+	}
+	wf.runReview(context.Background(), StepBuilding, StepPlanning)
+
+	assert.Equal(t, StepFailed, wf.state.Current())
+	require.Error(t, wf.lastError)
+	assert.EqualError(t, wf.lastError, "step planning has been re-run 1 times (max 1), giving up")
 }
 
 // TestWorkflow_RunReview_Comment_BuildReview tests that a generic comment during
@@ -1196,7 +1227,7 @@ func TestWorkflow_TryRedoClearsApproveAll(t *testing.T) {
 // --- FeedbackComment Per-Step Tests ---
 
 // TestWorkflow_RunReview_CommentPerStep verifies FeedbackComment transitions
-// correctly for each review step: PlanReview advances, others redo.
+// correctly for each review step: all review gates redo on generic comments.
 func TestWorkflow_RunReview_CommentPerStep(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -1205,7 +1236,7 @@ func TestWorkflow_RunReview_CommentPerStep(t *testing.T) {
 		redoTarget     WorkflowStep
 		expectedTarget WorkflowStep
 	}{
-		{"plan_review_advances", StepPlanReview, StepBuilding, StepPlanning, StepBuilding},
+		{"plan_review_redoes", StepPlanReview, StepBuilding, StepPlanning, StepPlanning},
 		{"build_review_redoes", StepBuildReview, StepValidating, StepBuilding, StepBuilding},
 		{"validate_review_redoes", StepValidateReview, StepShipping, StepValidating, StepValidating},
 		{"ship_review_redoes", StepShipReview, StepDone, StepShipping, StepShipping},
@@ -1233,10 +1264,10 @@ func TestWorkflow_RunReview_CommentPerStep(t *testing.T) {
 
 // --- Full Feedback Loop Simulation ---
 
-// TestWorkflow_FullFeedbackLoop_PlanCommentAdvancesToBuild simulates the exact
+// TestWorkflow_FullFeedbackLoop_PlanCommentReplans simulates the exact
 // scenario from the bug report: plan completes, user posts a general comment,
-// workflow should advance to build (not loop back to planning).
-func TestWorkflow_FullFeedbackLoop_PlanCommentAdvancesToBuild(t *testing.T) {
+// workflow should loop back to planning.
+func TestWorkflow_FullFeedbackLoop_PlanCommentReplans(t *testing.T) {
 	now := time.Now()
 	approveComment := tracker.Comment{ID: "human1", Body: "Looks good, but also handle error cases", IsSelf: false, CreatedAt: now.Add(3 * time.Second)}
 
@@ -1266,8 +1297,8 @@ func TestWorkflow_FullFeedbackLoop_PlanCommentAdvancesToBuild(t *testing.T) {
 
 	wf.runReview(context.Background(), StepBuilding, StepPlanning)
 
-	// Should advance to building, not loop back to planning.
-	assert.Equal(t, StepBuilding, wf.state.Current())
+	// Should loop back to planning, not advance to building.
+	assert.Equal(t, StepPlanning, wf.state.Current())
 	assert.Equal(t, "Looks good, but also handle error cases", wf.feedback)
 }
 


### PR DESCRIPTION
## Summary

- Make generic human comments at every review gate trigger the redo/replan path instead of approving with feedback.
- Specifically, plan-review comments now return to planning with the comment stored as feedback, so the next planning round can incorporate requested changes before build starts.
- Share explicit `redo` comments and generic review comments through the same redo handling helper, preserving status updates, feedback storage, redo circuit-breaker behavior, and approve-all clearing.
- Update workflow tests for plan-review replanning, per-review-step comment behavior, the full plan feedback loop, and the redo circuit breaker for both explicit redo requests and generic plan comments.
- Simplify affected workflow tests to use the shared state-walking setup helper.

## Validation

- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes review-gate transition behavior so generic comments now trigger redo/replan instead of approving (notably at plan review), which can alter workflow progression and failure conditions via the redo circuit breaker.
> 
> **Overview**
> **Generic review comments now always trigger the redo/replan path**, including during `StepPlanReview` (previously plan-review comments could advance to build with feedback).
> 
> Refactors redo/comment handling into a shared helper (`applyReviewRedo`) to unify logging/status messaging, feedback capture, and error handling when invoking `tryRedo`.
> 
> Updates/renames workflow tests to match the new behavior, including plan-review comment expectations, per-step comment transition coverage, full feedback-loop simulation, and circuit-breaker coverage for both explicit `redo` and generic plan comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a01c911ba1c04f4f4dcdeda98edd231a27dff95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->