### PR TITLE
Add post-result support for single-step runs

### DIFF
--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -147,7 +147,7 @@ One of `--issue`, `--filter`, or `--description`/`--description-file` is require
 | `--branch-prefix` | from config | Worktree branch prefix |
 | `--auto-approve` | | Auto-approve review steps (`plan,build,validate,ship` or `all`) |
 | `--run-step` | | Run a single step and exit (for debugging): `plan`, `build`, `validate`, `ship` |
-| `--post-result` | `false` | With `--run-step`, post the step output as an issue comment using the step's configured comment template |
+| `--post-result` | `false` | With `--run-step`, post the step output as an issue comment using the step's configured comment template. For a step with configured rounds, `--run-step --post-result` posts one aggregate round comment after all rounds complete; the full workflow posts one comment per round. |
 | `--verbose` | `false` | Debug logging |
 
 ## Workflow

--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -147,6 +147,7 @@ One of `--issue`, `--filter`, or `--description`/`--description-file` is require
 | `--branch-prefix` | from config | Worktree branch prefix |
 | `--auto-approve` | | Auto-approve review steps (`plan,build,validate,ship` or `all`) |
 | `--run-step` | | Run a single step and exit (for debugging): `plan`, `build`, `validate`, `ship` |
+| `--post-result` | `false` | With `--run-step`, post the step output as an issue comment using the step's configured comment template |
 | `--verbose` | `false` | Debug logging |
 
 ## Workflow
@@ -278,9 +279,12 @@ jiradozer --description "Create a hello.txt file containing 'hello world'" --wor
 # Run from a tracker issue
 jiradozer --issue ENG-123
 
-# Run a single step for debugging (no tracker interaction)
+# Run a single step for debugging (stdout only by default)
 jiradozer --issue ENG-123 --run-step plan
 jiradozer --issue ENG-123 --run-step build
+
+# Run a single step and post the rendered result comment
+jiradozer --issue ENG-123 --run-step plan --post-result
 
 # Use a specific model
 jiradozer --issue ENG-123 --model opus

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -229,7 +229,7 @@ func TestRunSingleStepPostResultPostsRenderedComment(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recorder.comments, 1)
 	assert.Equal(t, "issue-id", recorder.comments[0].issueID)
-	assert.Equal(t, "## Plan Complete\n\nstep=plan\nplanned output", recorder.comments[0].body)
+	assert.Equal(t, "## Plan Complete\n\nstep=plan\n\n planned output \n", recorder.comments[0].body)
 }
 
 func TestRunSingleStepPostResultPostsEmptyOutput(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -263,6 +263,20 @@ func TestRunSingleStepPostResultReturnsPostError(t *testing.T) {
 	assert.ErrorContains(t, err, "tracker unavailable")
 }
 
+func TestRunSingleStepPostResultRequiresPoster(t *testing.T) {
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Plan = jiradozer.StepConfig{
+		Prompt:          "plan {{.Identifier}}",
+		CommentTemplate: "## {{.Heading}} Complete\n\n{{.Output}}",
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+
+	err := runSingleStepForTest(t, "plan", issue, cfg, nil, true, "planned output")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--post-result requires a comment-capable tracker")
+}
+
 func TestRunSingleStepPostResultRequiresCommentTemplate(t *testing.T) {
 	cfg := jiradozer.DefaultConfig()
 	cfg.WorkDir = t.TempDir()

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -77,37 +77,25 @@ type recordedComment struct {
 	body    string
 }
 
-func (r *recordingRunTracker) FetchIssue(_ context.Context, _ string) (*tracker.Issue, error) {
-	return nil, nil
-}
-
-func (r *recordingRunTracker) ListIssues(_ context.Context, _ tracker.IssueFilter) ([]*tracker.Issue, error) {
-	return nil, nil
-}
-
-func (r *recordingRunTracker) FetchComments(_ context.Context, _ string, _ time.Time) ([]tracker.Comment, error) {
-	return nil, nil
-}
-
-func (r *recordingRunTracker) FetchWorkflowStates(_ context.Context, _ string) ([]tracker.WorkflowState, error) {
-	return nil, nil
-}
-
 func (r *recordingRunTracker) PostComment(_ context.Context, issueID string, body string) (tracker.Comment, error) {
 	r.comments = append(r.comments, recordedComment{issueID: issueID, body: body})
 	return tracker.Comment{CreatedAt: time.Now()}, nil
 }
 
-func (r *recordingRunTracker) UpdateIssueState(_ context.Context, _ string, _ string) error {
-	return nil
-}
-
-func (r *recordingRunTracker) AddLabel(_ context.Context, _ string, _ string) error {
-	return nil
-}
-
-func (r *recordingRunTracker) RemoveLabel(_ context.Context, _ string, _ string) error {
-	return nil
+func runSingleStepForTest(t testing.TB, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, poster jiradozer.CommentPoster, postResult bool, output string) error {
+	t.Helper()
+	return (&singleStepRun{
+		ctx:        context.Background(),
+		stepName:   stepName,
+		issue:      issue,
+		cfg:        cfg,
+		poster:     poster,
+		postResult: postResult,
+		logger:     testMainLogger(t),
+		runAgent: func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+			return jiradozer.StepAgentResult{Output: output, SessionID: "session-1"}, nil
+		},
+	}).run()
 }
 
 type restoreWTManager struct{}
@@ -220,12 +208,6 @@ func TestResolveRepoName(t *testing.T) {
 }
 
 func TestRunSingleStepPostResultPostsRenderedComment(t *testing.T) {
-	origRunStepAgentDetailed := runStepAgentDetailed
-	t.Cleanup(func() { runStepAgentDetailed = origRunStepAgentDetailed })
-	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
-		return jiradozer.StepAgentResult{Output: "planned output", SessionID: "session-1"}, nil
-	}
-
 	cfg := jiradozer.DefaultConfig()
 	cfg.WorkDir = t.TempDir()
 	cfg.Plan = jiradozer.StepConfig{
@@ -235,7 +217,7 @@ func TestRunSingleStepPostResultPostsRenderedComment(t *testing.T) {
 	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
 	recorder := &recordingRunTracker{}
 
-	err := runSingleStep(context.Background(), "plan", issue, cfg, "", recorder, true, nil, testMainLogger(t))
+	err := runSingleStepForTest(t, "plan", issue, cfg, recorder, true, "\n planned output \n")
 	require.NoError(t, err)
 	require.Len(t, recorder.comments, 1)
 	assert.Equal(t, "issue-id", recorder.comments[0].issueID)
@@ -243,12 +225,6 @@ func TestRunSingleStepPostResultPostsRenderedComment(t *testing.T) {
 }
 
 func TestRunSingleStepPostResultFalseDoesNotPost(t *testing.T) {
-	origRunStepAgentDetailed := runStepAgentDetailed
-	t.Cleanup(func() { runStepAgentDetailed = origRunStepAgentDetailed })
-	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
-		return jiradozer.StepAgentResult{Output: "planned output", SessionID: "session-1"}, nil
-	}
-
 	cfg := jiradozer.DefaultConfig()
 	cfg.WorkDir = t.TempDir()
 	cfg.Plan = jiradozer.StepConfig{
@@ -258,7 +234,7 @@ func TestRunSingleStepPostResultFalseDoesNotPost(t *testing.T) {
 	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
 	recorder := &recordingRunTracker{}
 
-	err := runSingleStep(context.Background(), "plan", issue, cfg, "", recorder, false, nil, testMainLogger(t))
+	err := runSingleStepForTest(t, "plan", issue, cfg, recorder, false, "planned output")
 	require.NoError(t, err)
 	assert.Empty(t, recorder.comments)
 }

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -263,6 +263,19 @@ func TestRunSingleStepPostResultReturnsPostError(t *testing.T) {
 	assert.ErrorContains(t, err, "tracker unavailable")
 }
 
+func TestRunSingleStepPostResultRequiresCommentTemplate(t *testing.T) {
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Plan = jiradozer.StepConfig{Prompt: "plan {{.Identifier}}"}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+	recorder := &recordingRunTracker{}
+
+	err := runSingleStepForTest(t, "plan", issue, cfg, recorder, true, "planned output")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no comment_template configured")
+	assert.Empty(t, recorder.comments)
+}
+
 func TestRunSingleStepPostResultFalseDoesNotPost(t *testing.T) {
 	cfg := jiradozer.DefaultConfig()
 	cfg.WorkDir = t.TempDir()
@@ -296,6 +309,23 @@ func TestRunSingleStepRoundsPostResultPostsCombinedRoundComment(t *testing.T) {
 	require.Len(t, recorder.comments, 1)
 	assert.Equal(t, "issue-id", recorder.comments[0].issueID)
 	assert.Equal(t, "## Validate Round 2/2\n\nround one\n\n---\n\nround two", recorder.comments[0].body)
+}
+
+func TestRunSingleStepRoundsPostResultRequiresRoundCommentTemplate(t *testing.T) {
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Validate = jiradozer.StepConfig{
+		Rounds: []jiradozer.RoundConfig{
+			{Command: "printf 'round output'"},
+		},
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+	recorder := &recordingRunTracker{}
+
+	err := runSingleStep(context.Background(), "validate", issue, cfg, "", recorder, true, nil, testMainLogger(t))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no round_comment_template configured")
+	assert.Empty(t, recorder.comments)
 }
 
 func TestPostResultRequiresRunStep(t *testing.T) {
@@ -336,7 +366,7 @@ func TestRunCommandPostResultFlagReachesSingleStepPath(t *testing.T) {
 	comments, err := lt.FetchComments(context.Background(), issue.ID, time.Time{})
 	require.NoError(t, err)
 	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "cli planned output")
+	assert.Equal(t, "## Plan Complete\n\ncli planned output", comments[0].Body)
 }
 
 func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/bazelment/yoloswe/cliapp"
 	"github.com/bazelment/yoloswe/jiradozer"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
+	"github.com/bazelment/yoloswe/jiradozer/tracker/local"
 )
 
 func testMainLogger(_ testing.TB) *slog.Logger {
@@ -80,6 +82,12 @@ type recordedComment struct {
 func (r *recordingRunTracker) PostComment(_ context.Context, issueID string, body string) (tracker.Comment, error) {
 	r.comments = append(r.comments, recordedComment{issueID: issueID, body: body})
 	return tracker.Comment{CreatedAt: time.Now()}, nil
+}
+
+type failingRunTracker struct{}
+
+func (failingRunTracker) PostComment(_ context.Context, _ string, _ string) (tracker.Comment, error) {
+	return tracker.Comment{}, errors.New("tracker unavailable")
 }
 
 func runSingleStepForTest(t testing.TB, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, poster jiradozer.CommentPoster, postResult bool, output string) error {
@@ -224,6 +232,37 @@ func TestRunSingleStepPostResultPostsRenderedComment(t *testing.T) {
 	assert.Equal(t, "## Plan Complete\n\nstep=plan\nplanned output", recorder.comments[0].body)
 }
 
+func TestRunSingleStepPostResultPostsEmptyOutput(t *testing.T) {
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Plan = jiradozer.StepConfig{
+		Prompt:          "plan {{.Identifier}}",
+		CommentTemplate: "## {{.Heading}} Complete\n\n{{.Output}}",
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+	recorder := &recordingRunTracker{}
+
+	err := runSingleStepForTest(t, "plan", issue, cfg, recorder, true, "")
+	require.NoError(t, err)
+	require.Len(t, recorder.comments, 1)
+	assert.Equal(t, "## Plan Complete\n\n", recorder.comments[0].body)
+}
+
+func TestRunSingleStepPostResultReturnsPostError(t *testing.T) {
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Plan = jiradozer.StepConfig{
+		Prompt:          "plan {{.Identifier}}",
+		CommentTemplate: "## {{.Heading}} Complete\n\n{{.Output}}",
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+
+	err := runSingleStepForTest(t, "plan", issue, cfg, failingRunTracker{}, true, "planned output")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "post step result comment")
+	assert.ErrorContains(t, err, "tracker unavailable")
+}
+
 func TestRunSingleStepPostResultFalseDoesNotPost(t *testing.T) {
 	cfg := jiradozer.DefaultConfig()
 	cfg.WorkDir = t.TempDir()
@@ -257,6 +296,47 @@ func TestRunSingleStepRoundsPostResultPostsCombinedRoundComment(t *testing.T) {
 	require.Len(t, recorder.comments, 1)
 	assert.Equal(t, "issue-id", recorder.comments[0].issueID)
 	assert.Equal(t, "## Validate Round 2/2\n\nround one\n\n---\n\nround two", recorder.comments[0].body)
+}
+
+func TestPostResultRequiresRunStep(t *testing.T) {
+	app := &cliapp.App{Logger: testMainLogger(t)}
+
+	err := run(context.Background(), app, runArgs{postResult: true})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--post-result requires --run-step")
+}
+
+func TestRunCommandPostResultFlagReachesSingleStepPath(t *testing.T) {
+	workDir := t.TempDir()
+	cfgPath := writeRunConfig(t, "local", workDir)
+	prev := runStepAgentDetailed
+	runStepAgentDetailed = func(_ context.Context, _ string, data jiradozer.PromptData, _ jiradozer.StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		assert.Equal(t, "LOCAL-1", data.Identifier)
+		return jiradozer.StepAgentResult{Output: "cli planned output", SessionID: "session-1"}, nil
+	}
+	t.Cleanup(func() { runStepAgentDetailed = prev })
+
+	opts := &cliapp.Options{ToolName: "jiradozer"}
+	cmd := newRootCommand(opts)
+	app := &cliapp.App{Logger: testMainLogger(t)}
+	cmd.SetArgs([]string{
+		"--config", cfgPath,
+		"run",
+		"--description", "CLI post result task",
+		"--run-step", "plan",
+		"--post-result",
+	})
+
+	require.NoError(t, cmd.ExecuteContext(cliapp.WithApp(context.Background(), app)))
+
+	lt, err := local.NewTracker(filepath.Join(workDir, ".jiradozer", "issues"))
+	require.NoError(t, err)
+	issue, err := lt.FetchIssue(context.Background(), "LOCAL-1")
+	require.NoError(t, err)
+	comments, err := lt.FetchComments(context.Background(), issue.ID, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0].Body, "cli planned output")
 }
 
 func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -68,6 +68,48 @@ func (r *restoreDiscoveryTracker) RemoveLabel(_ context.Context, _ string, _ str
 	return nil
 }
 
+type recordingRunTracker struct {
+	comments []recordedComment
+}
+
+type recordedComment struct {
+	issueID string
+	body    string
+}
+
+func (r *recordingRunTracker) FetchIssue(_ context.Context, _ string) (*tracker.Issue, error) {
+	return nil, nil
+}
+
+func (r *recordingRunTracker) ListIssues(_ context.Context, _ tracker.IssueFilter) ([]*tracker.Issue, error) {
+	return nil, nil
+}
+
+func (r *recordingRunTracker) FetchComments(_ context.Context, _ string, _ time.Time) ([]tracker.Comment, error) {
+	return nil, nil
+}
+
+func (r *recordingRunTracker) FetchWorkflowStates(_ context.Context, _ string) ([]tracker.WorkflowState, error) {
+	return nil, nil
+}
+
+func (r *recordingRunTracker) PostComment(_ context.Context, issueID string, body string) (tracker.Comment, error) {
+	r.comments = append(r.comments, recordedComment{issueID: issueID, body: body})
+	return tracker.Comment{CreatedAt: time.Now()}, nil
+}
+
+func (r *recordingRunTracker) UpdateIssueState(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (r *recordingRunTracker) AddLabel(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (r *recordingRunTracker) RemoveLabel(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 type restoreWTManager struct{}
 
 func (restoreWTManager) NewWorktree(_ context.Context, _, _, _ string) (string, error) {
@@ -175,6 +217,70 @@ func TestResolveRepoName(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestRunSingleStepPostResultPostsRenderedComment(t *testing.T) {
+	origRunStepAgentDetailed := runStepAgentDetailed
+	t.Cleanup(func() { runStepAgentDetailed = origRunStepAgentDetailed })
+	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		return jiradozer.StepAgentResult{Output: "planned output", SessionID: "session-1"}, nil
+	}
+
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Plan = jiradozer.StepConfig{
+		Prompt:          "plan {{.Identifier}}",
+		CommentTemplate: "## {{.Heading}} Complete\n\nstep={{.Step}}\n{{.Output}}",
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+	recorder := &recordingRunTracker{}
+
+	err := runSingleStep(context.Background(), "plan", issue, cfg, "", recorder, true, nil, testMainLogger(t))
+	require.NoError(t, err)
+	require.Len(t, recorder.comments, 1)
+	assert.Equal(t, "issue-id", recorder.comments[0].issueID)
+	assert.Equal(t, "## Plan Complete\n\nstep=plan\nplanned output", recorder.comments[0].body)
+}
+
+func TestRunSingleStepPostResultFalseDoesNotPost(t *testing.T) {
+	origRunStepAgentDetailed := runStepAgentDetailed
+	t.Cleanup(func() { runStepAgentDetailed = origRunStepAgentDetailed })
+	runStepAgentDetailed = func(_ context.Context, _ string, _ jiradozer.PromptData, _ jiradozer.StepConfig, _ string, _ string, _ string, _ *render.Renderer, _ *slog.Logger) (jiradozer.StepAgentResult, error) {
+		return jiradozer.StepAgentResult{Output: "planned output", SessionID: "session-1"}, nil
+	}
+
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Plan = jiradozer.StepConfig{
+		Prompt:          "plan {{.Identifier}}",
+		CommentTemplate: "## {{.Heading}} Complete\n\n{{.Output}}",
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+	recorder := &recordingRunTracker{}
+
+	err := runSingleStep(context.Background(), "plan", issue, cfg, "", recorder, false, nil, testMainLogger(t))
+	require.NoError(t, err)
+	assert.Empty(t, recorder.comments)
+}
+
+func TestRunSingleStepRoundsPostResultPostsCombinedRoundComment(t *testing.T) {
+	cfg := jiradozer.DefaultConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.Validate = jiradozer.StepConfig{
+		RoundCommentTemplate: "## {{.Heading}} Round {{.Round}}/{{.TotalRounds}}\n\n{{.Output}}",
+		Rounds: []jiradozer.RoundConfig{
+			{Command: "printf 'round one'"},
+			{Command: "printf 'round two'"},
+		},
+	}
+	issue := &tracker.Issue{ID: "issue-id", Identifier: "INF-703", Title: "Test issue"}
+	recorder := &recordingRunTracker{}
+
+	err := runSingleStep(context.Background(), "validate", issue, cfg, "", recorder, true, nil, testMainLogger(t))
+	require.NoError(t, err)
+	require.Len(t, recorder.comments, 1)
+	assert.Equal(t, "issue-id", recorder.comments[0].issueID)
+	assert.Equal(t, "## Validate Round 2/2\n\nround one\n\n---\n\nround two", recorder.comments[0].body)
 }
 
 func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -89,7 +89,7 @@ func registerRunFlags(cmd *cobra.Command, args *runArgs) {
 	cmd.Flags().DurationVar(&args.pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	cmd.Flags().Float64Var(&args.maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	cmd.Flags().StringVar(&args.runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
-	cmd.Flags().BoolVar(&args.postResult, "post-result", false, "When used with --run-step, post the step output as a comment on the issue (uses the step's configured comment template).")
+	cmd.Flags().BoolVar(&args.postResult, "post-result", false, "When used with --run-step, post the step output as an issue comment. Single-shot steps use comment_template; steps with rounds use round_comment_template and post one aggregate comment after all rounds complete.")
 	cmd.Flags().StringVar(&args.autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
 	cmd.Flags().StringVar(&args.skipPhases, "skip-phases", "", "Skip high-level workflow phases for this run (comma-separated: plan,build,validate,ship; create_pr is part of build)")
 	cmd.Flags().StringArrayVar(&args.sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo,Backlog)")
@@ -617,7 +617,10 @@ func (r *singleStepRun) finish(stepCfg jiradozer.StepConfig, output string, tota
 	if r.stepName == "plan" {
 		jiradozer.PersistPlan(r.cfg.WorkDir, output, r.logger)
 	}
-	if r.postResult && r.poster != nil {
+	if r.postResult && r.poster == nil {
+		return fmt.Errorf("--post-result requires a comment-capable tracker")
+	}
+	if r.postResult {
 		if err := postStepResultComment(r.ctx, r.poster, r.issue, r.stepName, stepCfg, output, totalRounds); err != nil {
 			return fmt.Errorf("post step result comment: %w", err)
 		}

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -145,6 +145,9 @@ func run(ctx context.Context, app *cliapp.App, args runArgs) error {
 			return fmt.Errorf("plan file is empty")
 		}
 	}
+	if args.postResult && args.runStep == "" {
+		return fmt.Errorf("--post-result requires --run-step")
+	}
 
 	cfg, err := loadRunConfig(args)
 	if err != nil {
@@ -615,18 +618,14 @@ func (r *singleStepRun) finish(stepCfg jiradozer.StepConfig, output string, tota
 		jiradozer.PersistPlan(r.cfg.WorkDir, output, r.logger)
 	}
 	if r.postResult && r.poster != nil {
-		if err := postStepResultComment(r.ctx, r.poster, r.issue, r.stepName, stepCfg, output, totalRounds, r.logger); err != nil {
-			r.logger.Warn("failed to post step result comment", "step", r.stepName, "error", err)
+		if err := postStepResultComment(r.ctx, r.poster, r.issue, r.stepName, stepCfg, output, totalRounds); err != nil {
+			return fmt.Errorf("post step result comment: %w", err)
 		}
 	}
 	return nil
 }
 
-func postStepResultComment(ctx context.Context, t jiradozer.CommentPoster, issue *tracker.Issue, stepName string, stepCfg jiradozer.StepConfig, output string, totalRounds int, logger *slog.Logger) error {
-	if output == "" {
-		logger.Info("skipping --post-result: step produced no text output", "step", stepName)
-		return nil
-	}
+func postStepResultComment(ctx context.Context, t jiradozer.CommentPoster, issue *tracker.Issue, stepName string, stepCfg jiradozer.StepConfig, output string, totalRounds int) error {
 	if totalRounds > 0 {
 		if stepCfg.RoundCommentTemplate == "" {
 			return fmt.Errorf("step %q has no round_comment_template configured", stepName)

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -559,7 +559,7 @@ func (r *singleStepRun) run() error {
 	if err != nil {
 		return fmt.Errorf("run-step %s: %w", stepName, err)
 	}
-	output := strings.TrimSpace(res.Output)
+	output := res.Output
 	if output == "" {
 		r.logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", res.SessionID)
 	} else {

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -490,84 +490,106 @@ func runFromDescription(ctx context.Context, description, runStep, planContent s
 // runStepAgentDetailed is overridable so unit tests can stub the agent call.
 var runStepAgentDetailed = jiradozer.RunStepAgent
 
-func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, issueTracker tracker.IssueTracker, postResult bool, renderer *render.Renderer, logger *slog.Logger) error {
-	stepCfg, ok := cfg.StepByName(stepName)
+type singleStepRun struct {
+	ctx         context.Context
+	poster      jiradozer.CommentPoster
+	issue       *tracker.Issue
+	cfg         *jiradozer.Config
+	renderer    *render.Renderer
+	logger      *slog.Logger
+	runAgent    func(context.Context, string, jiradozer.PromptData, jiradozer.StepConfig, string, string, string, *render.Renderer, *slog.Logger) (jiradozer.StepAgentResult, error)
+	stepName    string
+	planContent string
+	postResult  bool
+}
+
+func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, poster jiradozer.CommentPoster, postResult bool, renderer *render.Renderer, logger *slog.Logger) error {
+	return (&singleStepRun{
+		ctx:         ctx,
+		stepName:    stepName,
+		issue:       issue,
+		cfg:         cfg,
+		planContent: planContent,
+		poster:      poster,
+		postResult:  postResult,
+		renderer:    renderer,
+		logger:      logger,
+		runAgent:    runStepAgentDetailed,
+	}).run()
+}
+
+func (r *singleStepRun) run() error {
+	stepName := r.stepName
+	stepCfg, ok := r.cfg.StepByName(stepName)
 	if !ok {
 		return fmt.Errorf("unknown step %q (valid: %s)", stepName, strings.Join(allSteps, ", "))
 	}
-	resolved := cfg.ResolveStep(stepCfg)
-	data := jiradozer.NewPromptData(issue, cfg.BaseBranch)
+	resolved := r.cfg.ResolveStep(stepCfg)
+	data := jiradozer.NewPromptData(r.issue, r.cfg.BaseBranch)
 
 	// Inject plan into prompt data for the build step.
 	// Priority: --plan-file flag > persisted plan.md > no plan.
 	if stepName == "build" {
-		if planContent != "" {
-			data.Plan = planContent
-			logger.Info("using plan from --plan-file")
+		if r.planContent != "" {
+			data.Plan = r.planContent
+			r.logger.Info("using plan from --plan-file")
 		} else {
-			content, err := jiradozer.LoadPersistedPlan(cfg.WorkDir)
+			content, err := jiradozer.LoadPersistedPlan(r.cfg.WorkDir)
 			if err != nil {
 				return err
 			}
 			if content != "" {
 				data.Plan = content
-				logger.Info("loaded persisted plan", "path", jiradozer.PlanFilePath(cfg.WorkDir))
+				r.logger.Info("loaded persisted plan", "path", jiradozer.PlanFilePath(r.cfg.WorkDir))
 			}
 		}
 		if data.Plan == "" {
-			logger.Warn("NO PLAN AVAILABLE — build step is running without a plan; use --plan-file to provide one, or run the plan step first")
+			r.logger.Warn("NO PLAN AVAILABLE — build step is running without a plan; use --plan-file to provide one, or run the plan step first")
 		}
 	}
 
 	if len(resolved.Rounds) > 0 {
-		return runSingleStepRounds(ctx, stepName, issue, data, resolved, cfg.WorkDir, issueTracker, postResult, stepCfg, renderer, logger)
+		return r.runRounds(data, stepCfg, resolved)
 	}
 
-	res, err := runStepAgentDetailed(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
+	res, err := r.runAgent(r.ctx, stepName, data, resolved, r.cfg.WorkDir, "", "", r.renderer, r.logger)
 	if err != nil {
 		return fmt.Errorf("run-step %s: %w", stepName, err)
 	}
-	output := res.Output
+	output := strings.TrimSpace(res.Output)
 	if output == "" {
-		logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", res.SessionID)
+		r.logger.Warn("agent produced no text output — the result may be in tool actions (check session log)", "step", stepName, "session_id", res.SessionID)
 	} else {
 		fmt.Printf("=== %s output ===\n%s\n", stepName, output)
 	}
-	if stepName == "plan" {
-		jiradozer.PersistPlan(cfg.WorkDir, output, logger)
-	}
-	if postResult && issueTracker != nil {
-		if err := postStepResultComment(ctx, issueTracker, issue, stepName, stepCfg, output, 0, logger); err != nil {
-			logger.Warn("failed to post step result comment", "step", stepName, "error", err)
-		}
-	}
-	return nil
+	return r.finish(stepCfg, output, 0)
 }
 
-func runSingleStepRounds(ctx context.Context, stepName string, issue *tracker.Issue, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, issueTracker tracker.IssueTracker, postResult bool, stepCfg jiradozer.StepConfig, renderer *render.Renderer, logger *slog.Logger) error {
+func (r *singleStepRun) runRounds(data jiradozer.PromptData, stepCfg, resolved jiradozer.StepConfig) error {
+	stepName := r.stepName
 	totalRounds := len(resolved.Rounds)
-	logger.Info("step: "+stepName, "rounds", totalRounds)
-	rendererStatus(renderer, fmt.Sprintf("Step: %s (%d rounds)", stepName, totalRounds))
+	r.logger.Info("step: "+stepName, "rounds", totalRounds)
+	rendererStatus(r.renderer, fmt.Sprintf("Step: %s (%d rounds)", stepName, totalRounds))
 
 	var allOutputs []string
 	var sessionIDs []string
 	for i, round := range resolved.Rounds {
-		if ctx.Err() != nil {
-			return fmt.Errorf("run-step %s: %w", stepName, ctx.Err())
+		if r.ctx.Err() != nil {
+			return fmt.Errorf("run-step %s: %w", stepName, r.ctx.Err())
 		}
-		logger.Info("round start", "step", stepName, "round", i+1, "total", totalRounds)
-		rendererStatus(renderer, fmt.Sprintf("Round %d/%d", i+1, totalRounds))
+		r.logger.Info("round start", "step", stepName, "round", i+1, "total", totalRounds)
+		rendererStatus(r.renderer, fmt.Sprintf("Round %d/%d", i+1, totalRounds))
 
 		var output string
 		if round.IsCommand() {
 			var err error
-			output, err = jiradozer.RunCommand(ctx, stepName, data, round.Command, workDir, logger)
+			output, err = jiradozer.RunCommand(r.ctx, stepName, data, round.Command, r.cfg.WorkDir, r.logger)
 			if err != nil {
 				return fmt.Errorf("run-step %s round %d/%d: %w", stepName, i+1, totalRounds, err)
 			}
 		} else {
 			roundCfg := jiradozer.ResolveRound(round, resolved)
-			res, err := runStepAgentDetailed(ctx, stepName, data, roundCfg, workDir, "", "", renderer, logger)
+			res, err := r.runAgent(r.ctx, stepName, data, roundCfg, r.cfg.WorkDir, "", "", r.renderer, r.logger)
 			if res.SessionID != "" {
 				sessionIDs = append(sessionIDs, res.SessionID)
 			}
@@ -583,49 +605,39 @@ func runSingleStepRounds(ctx context.Context, stepName string, issue *tracker.Is
 	if combined != "" {
 		fmt.Printf("=== %s output (%d rounds) ===\n%s\n", stepName, totalRounds, combined)
 	} else {
-		logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)
+		r.logger.Warn("agent produced no text output across all rounds", "step", stepName, "session_ids", sessionIDs)
 	}
-	if stepName == "plan" {
-		jiradozer.PersistPlan(workDir, combined, logger)
+	return r.finish(stepCfg, combined, totalRounds)
+}
+
+func (r *singleStepRun) finish(stepCfg jiradozer.StepConfig, output string, totalRounds int) error {
+	if r.stepName == "plan" {
+		jiradozer.PersistPlan(r.cfg.WorkDir, output, r.logger)
 	}
-	if postResult && issueTracker != nil {
-		if err := postStepResultComment(ctx, issueTracker, issue, stepName, stepCfg, combined, totalRounds, logger); err != nil {
-			logger.Warn("failed to post step result comment", "step", stepName, "error", err)
+	if r.postResult && r.poster != nil {
+		if err := postStepResultComment(r.ctx, r.poster, r.issue, r.stepName, stepCfg, output, totalRounds, r.logger); err != nil {
+			r.logger.Warn("failed to post step result comment", "step", r.stepName, "error", err)
 		}
 	}
 	return nil
 }
 
-func postStepResultComment(ctx context.Context, t tracker.IssueTracker, issue *tracker.Issue, stepName string, stepCfg jiradozer.StepConfig, output string, totalRounds int, logger *slog.Logger) error {
+func postStepResultComment(ctx context.Context, t jiradozer.CommentPoster, issue *tracker.Issue, stepName string, stepCfg jiradozer.StepConfig, output string, totalRounds int, logger *slog.Logger) error {
 	if output == "" {
 		logger.Info("skipping --post-result: step produced no text output", "step", stepName)
 		return nil
 	}
-
-	tmpl := stepCfg.CommentTemplate
-	round, total := 0, 0
 	if totalRounds > 0 {
-		tmpl = stepCfg.RoundCommentTemplate
-		round, total = totalRounds, totalRounds
-	}
-	if tmpl == "" {
-		if totalRounds > 0 {
+		if stepCfg.RoundCommentTemplate == "" {
 			return fmt.Errorf("step %q has no round_comment_template configured", stepName)
 		}
+		_, err := jiradozer.PostRoundComment(ctx, t, issue.ID, stepName, stepCfg, output, totalRounds, totalRounds)
+		return err
+	}
+	if stepCfg.CommentTemplate == "" {
 		return fmt.Errorf("step %q has no comment_template configured", stepName)
 	}
-
-	body, err := jiradozer.RenderCommentTemplate(tmpl, jiradozer.CommentData{
-		Step:        stepName,
-		Heading:     jiradozer.Capitalize(stepName),
-		Output:      output,
-		Round:       round,
-		TotalRounds: total,
-	})
-	if err != nil {
-		return fmt.Errorf("render comment: %w", err)
-	}
-	_, err = t.PostComment(ctx, issue.ID, body)
+	_, err := jiradozer.PostStepComment(ctx, t, issue.ID, stepName, stepCfg, output)
 	return err
 }
 

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -44,6 +44,7 @@ type runArgs struct {
 	dryRun          bool
 	dryRunSet       bool
 	forceCleanup    bool
+	postResult      bool
 }
 
 func newRunCommand(args *runArgs) *cobra.Command {
@@ -88,6 +89,7 @@ func registerRunFlags(cmd *cobra.Command, args *runArgs) {
 	cmd.Flags().DurationVar(&args.pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	cmd.Flags().Float64Var(&args.maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
 	cmd.Flags().StringVar(&args.runStep, "run-step", "", "Run a single step and exit (for debugging): plan, build, create_pr, validate, ship")
+	cmd.Flags().BoolVar(&args.postResult, "post-result", false, "When used with --run-step, post the step output as a comment on the issue (uses the step's configured comment template).")
 	cmd.Flags().StringVar(&args.autoApprove, "auto-approve", "", "Auto-approve review steps (comma-separated: plan,build,validate,ship or 'all')")
 	cmd.Flags().StringVar(&args.skipPhases, "skip-phases", "", "Skip high-level workflow phases for this run (comma-separated: plan,build,validate,ship; create_pr is part of build)")
 	cmd.Flags().StringArrayVar(&args.sourceFilters, "filter", nil, "Issue filter as key=value (repeatable, e.g. --filter team=ENG --filter state=Todo,Backlog)")
@@ -163,7 +165,7 @@ func run(ctx context.Context, app *cliapp.App, args runArgs) error {
 
 	// Local description mode.
 	if args.description != "" {
-		return runFromDescription(ctx, args.description, args.runStep, args.planContent, issueTracker, cfg, renderer, logger)
+		return runFromDescription(ctx, args.description, args.runStep, args.planContent, issueTracker, args.postResult, cfg, renderer, logger)
 	}
 
 	// Multi-issue team mode (only when no --issue flag was given).
@@ -180,7 +182,7 @@ func run(ctx context.Context, app *cliapp.App, args runArgs) error {
 	logger.Info("found issue", "id", issue.ID, "title", issue.Title, "state", issue.State)
 
 	if args.runStep != "" {
-		return runSingleStep(ctx, args.runStep, issue, cfg, args.planContent, renderer, logger)
+		return runSingleStep(ctx, args.runStep, issue, cfg, args.planContent, issueTracker, args.postResult, renderer, logger)
 	}
 
 	// Run the full workflow.
@@ -461,7 +463,7 @@ func createTracker(cfg *jiradozer.Config, issueID string) (tracker.IssueTracker,
 	}
 }
 
-func runFromDescription(ctx context.Context, description, runStep, planContent string, issueTracker tracker.IssueTracker, cfg *jiradozer.Config, renderer *render.Renderer, logger *slog.Logger) error {
+func runFromDescription(ctx context.Context, description, runStep, planContent string, issueTracker tracker.IssueTracker, postResult bool, cfg *jiradozer.Config, renderer *render.Renderer, logger *slog.Logger) error {
 	lt, ok := issueTracker.(*local.Tracker)
 	if !ok {
 		return fmt.Errorf("--description requires local tracker (got %T)", issueTracker)
@@ -477,7 +479,7 @@ func runFromDescription(ctx context.Context, description, runStep, planContent s
 	logger.Info("created local issue", "identifier", issue.Identifier, "title", issue.Title)
 
 	if runStep != "" {
-		return runSingleStep(ctx, runStep, issue, cfg, planContent, renderer, logger)
+		return runSingleStep(ctx, runStep, issue, cfg, planContent, issueTracker, postResult, renderer, logger)
 	}
 
 	wf := jiradozer.NewWorkflow(issueTracker, issue, cfg, logger)
@@ -488,7 +490,7 @@ func runFromDescription(ctx context.Context, description, runStep, planContent s
 // runStepAgentDetailed is overridable so unit tests can stub the agent call.
 var runStepAgentDetailed = jiradozer.RunStepAgent
 
-func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, renderer *render.Renderer, logger *slog.Logger) error {
+func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, cfg *jiradozer.Config, planContent string, issueTracker tracker.IssueTracker, postResult bool, renderer *render.Renderer, logger *slog.Logger) error {
 	stepCfg, ok := cfg.StepByName(stepName)
 	if !ok {
 		return fmt.Errorf("unknown step %q (valid: %s)", stepName, strings.Join(allSteps, ", "))
@@ -518,7 +520,7 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	}
 
 	if len(resolved.Rounds) > 0 {
-		return runSingleStepRounds(ctx, stepName, data, resolved, cfg.WorkDir, renderer, logger)
+		return runSingleStepRounds(ctx, stepName, issue, data, resolved, cfg.WorkDir, issueTracker, postResult, stepCfg, renderer, logger)
 	}
 
 	res, err := runStepAgentDetailed(ctx, stepName, data, resolved, cfg.WorkDir, "", "", renderer, logger)
@@ -534,10 +536,15 @@ func runSingleStep(ctx context.Context, stepName string, issue *tracker.Issue, c
 	if stepName == "plan" {
 		jiradozer.PersistPlan(cfg.WorkDir, output, logger)
 	}
+	if postResult && issueTracker != nil {
+		if err := postStepResultComment(ctx, issueTracker, issue, stepName, stepCfg, output, 0, logger); err != nil {
+			logger.Warn("failed to post step result comment", "step", stepName, "error", err)
+		}
+	}
 	return nil
 }
 
-func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, renderer *render.Renderer, logger *slog.Logger) error {
+func runSingleStepRounds(ctx context.Context, stepName string, issue *tracker.Issue, data jiradozer.PromptData, resolved jiradozer.StepConfig, workDir string, issueTracker tracker.IssueTracker, postResult bool, stepCfg jiradozer.StepConfig, renderer *render.Renderer, logger *slog.Logger) error {
 	totalRounds := len(resolved.Rounds)
 	logger.Info("step: "+stepName, "rounds", totalRounds)
 	rendererStatus(renderer, fmt.Sprintf("Step: %s (%d rounds)", stepName, totalRounds))
@@ -581,7 +588,45 @@ func runSingleStepRounds(ctx context.Context, stepName string, data jiradozer.Pr
 	if stepName == "plan" {
 		jiradozer.PersistPlan(workDir, combined, logger)
 	}
+	if postResult && issueTracker != nil {
+		if err := postStepResultComment(ctx, issueTracker, issue, stepName, stepCfg, combined, totalRounds, logger); err != nil {
+			logger.Warn("failed to post step result comment", "step", stepName, "error", err)
+		}
+	}
 	return nil
+}
+
+func postStepResultComment(ctx context.Context, t tracker.IssueTracker, issue *tracker.Issue, stepName string, stepCfg jiradozer.StepConfig, output string, totalRounds int, logger *slog.Logger) error {
+	if output == "" {
+		logger.Info("skipping --post-result: step produced no text output", "step", stepName)
+		return nil
+	}
+
+	tmpl := stepCfg.CommentTemplate
+	round, total := 0, 0
+	if totalRounds > 0 {
+		tmpl = stepCfg.RoundCommentTemplate
+		round, total = totalRounds, totalRounds
+	}
+	if tmpl == "" {
+		if totalRounds > 0 {
+			return fmt.Errorf("step %q has no round_comment_template configured", stepName)
+		}
+		return fmt.Errorf("step %q has no comment_template configured", stepName)
+	}
+
+	body, err := jiradozer.RenderCommentTemplate(tmpl, jiradozer.CommentData{
+		Step:        stepName,
+		Heading:     jiradozer.Capitalize(stepName),
+		Output:      output,
+		Round:       round,
+		TotalRounds: total,
+	})
+	if err != nil {
+		return fmt.Errorf("render comment: %w", err)
+	}
+	_, err = t.PostComment(ctx, issue.ID, body)
+	return err
 }
 
 // readFileOrStdin reads from the given path, or from stdin if path is "-".

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -22,7 +22,8 @@ type CommentData struct {
 	TotalRounds int    // total rounds; only meaningful for round comments
 }
 
-func renderCommentTemplate(tmplStr string, data CommentData) (string, error) {
+// RenderCommentTemplate renders a configured tracker comment template.
+func RenderCommentTemplate(tmplStr string, data CommentData) (string, error) {
 	return renderTemplate("comment", tmplStr, data)
 }
 
@@ -360,8 +361,8 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		}
 		allOutputs = append(allOutputs, output)
 
-		heading := capitalize(stepName)
-		comment, err := renderCommentTemplate(stepCfg.RoundCommentTemplate, CommentData{
+		heading := Capitalize(stepName)
+		comment, err := RenderCommentTemplate(stepCfg.RoundCommentTemplate, CommentData{
 			Step:        stepName,
 			Heading:     heading,
 			Output:      output,
@@ -432,8 +433,8 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	w.sessionIDs[currentStep] = newSessionID
 	w.captureOutput(stepName, output)
 
-	heading := capitalize(stepName)
-	comment, err := renderCommentTemplate(stepCfg.CommentTemplate, CommentData{
+	heading := Capitalize(stepName)
+	comment, err := RenderCommentTemplate(stepCfg.CommentTemplate, CommentData{
 		Step:    stepName,
 		Heading: heading,
 		Output:  output,
@@ -478,8 +479,8 @@ func (w *Workflow) captureOutput(stepName, output string) {
 	}
 }
 
-// capitalize returns s with the first letter uppercased.
-func capitalize(s string) string {
+// Capitalize returns s with the first letter uppercased.
+func Capitalize(s string) string {
 	if s == "" {
 		return s
 	}

--- a/jiradozer/workflow.go
+++ b/jiradozer/workflow.go
@@ -2,6 +2,7 @@ package jiradozer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -22,9 +23,53 @@ type CommentData struct {
 	TotalRounds int    // total rounds; only meaningful for round comments
 }
 
-// RenderCommentTemplate renders a configured tracker comment template.
-func RenderCommentTemplate(tmplStr string, data CommentData) (string, error) {
+// CommentPoster is the write-side tracker capability needed for result comments.
+type CommentPoster interface {
+	PostComment(ctx context.Context, issueID string, body string) (tracker.Comment, error)
+}
+
+var errRenderComment = errors.New("render comment")
+
+func renderCommentTemplate(tmplStr string, data CommentData) (string, error) {
 	return renderTemplate("comment", tmplStr, data)
+}
+
+// RenderStepComment renders the configured result comment for a workflow step.
+func RenderStepComment(stepName string, stepCfg StepConfig, output string) (string, error) {
+	return renderCommentTemplate(stepCfg.CommentTemplate, CommentData{
+		Step:    stepName,
+		Heading: capitalize(stepName),
+		Output:  output,
+	})
+}
+
+// RenderRoundComment renders the configured result comment for one workflow round.
+func RenderRoundComment(stepName string, stepCfg StepConfig, output string, round, totalRounds int) (string, error) {
+	return renderCommentTemplate(stepCfg.RoundCommentTemplate, CommentData{
+		Step:        stepName,
+		Heading:     capitalize(stepName),
+		Output:      output,
+		Round:       round,
+		TotalRounds: totalRounds,
+	})
+}
+
+// PostStepComment renders and posts the configured result comment for a workflow step.
+func PostStepComment(ctx context.Context, t CommentPoster, issueID string, stepName string, stepCfg StepConfig, output string) (tracker.Comment, error) {
+	comment, err := RenderStepComment(stepName, stepCfg, output)
+	if err != nil {
+		return tracker.Comment{}, fmt.Errorf("%w: %w", errRenderComment, err)
+	}
+	return t.PostComment(ctx, issueID, comment)
+}
+
+// PostRoundComment renders and posts the configured result comment for one workflow round.
+func PostRoundComment(ctx context.Context, t CommentPoster, issueID string, stepName string, stepCfg StepConfig, output string, round, totalRounds int) (tracker.Comment, error) {
+	comment, err := RenderRoundComment(stepName, stepCfg, output, round, totalRounds)
+	if err != nil {
+		return tracker.Comment{}, fmt.Errorf("%w: %w", errRenderComment, err)
+	}
+	return t.PostComment(ctx, issueID, comment)
 }
 
 // State keys for the stateIDs map, mapping logical workflow states to tracker state IDs.
@@ -361,20 +406,12 @@ func (w *Workflow) runStepRounds(ctx context.Context, stepName string, stepCfg S
 		}
 		allOutputs = append(allOutputs, output)
 
-		heading := Capitalize(stepName)
-		comment, err := RenderCommentTemplate(stepCfg.RoundCommentTemplate, CommentData{
-			Step:        stepName,
-			Heading:     heading,
-			Output:      output,
-			Round:       i + 1,
-			TotalRounds: totalRounds,
-		})
+		roundComment, err := PostRoundComment(ctx, w.tracker, w.issue.ID, stepName, stepCfg, output, i+1, totalRounds)
 		if err != nil {
-			w.fail(ctx, fmt.Errorf("%s round %d/%d: render round_comment_template: %w", stepName, i+1, totalRounds, err))
-			return
-		}
-		roundComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
-		if err != nil {
+			if errors.Is(err, errRenderComment) {
+				w.fail(ctx, fmt.Errorf("%s round %d/%d: render round_comment_template: %w", stepName, i+1, totalRounds, err))
+				return
+			}
 			w.logger.Warn("failed to post round comment", "step", stepName, "round", i+1, "error", err)
 		} else {
 			if roundComment.ID != "" {
@@ -433,18 +470,12 @@ func (w *Workflow) runStep(ctx context.Context, stepName string, stepCfg StepCon
 	w.sessionIDs[currentStep] = newSessionID
 	w.captureOutput(stepName, output)
 
-	heading := Capitalize(stepName)
-	comment, err := RenderCommentTemplate(stepCfg.CommentTemplate, CommentData{
-		Step:    stepName,
-		Heading: heading,
-		Output:  output,
-	})
+	resultComment, err := PostStepComment(ctx, w.tracker, w.issue.ID, stepName, stepCfg, output)
 	if err != nil {
-		w.fail(ctx, fmt.Errorf("%s: render comment_template: %w", stepName, err))
-		return
-	}
-	resultComment, err := w.tracker.PostComment(ctx, w.issue.ID, comment)
-	if err != nil {
+		if errors.Is(err, errRenderComment) {
+			w.fail(ctx, fmt.Errorf("%s: render comment_template: %w", stepName, err))
+			return
+		}
 		w.logger.Warn("failed to post step comment", "step", stepName, "error", err)
 	} else {
 		if resultComment.ID != "" {
@@ -479,8 +510,8 @@ func (w *Workflow) captureOutput(stepName, output string) {
 	}
 }
 
-// Capitalize returns s with the first letter uppercased.
-func Capitalize(s string) string {
+// capitalize returns s with the first letter uppercased.
+func capitalize(s string) string {
 	if s == "" {
 		return s
 	}

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -224,36 +224,30 @@ func testWorkflowStates() []tracker.WorkflowState {
 	}
 }
 
-// TestRenderCommentTemplate exercises the comment-template engine the
+// TestRenderStepAndRoundComment exercises the comment-template engine the
 // workflow uses for both step-complete and per-round comments. Verifies
 // the {{.Round}}/{{.TotalRounds}} substitution path that distinguishes
 // round comments from step-complete comments.
-func TestRenderCommentTemplate(t *testing.T) {
+func TestRenderStepAndRoundComment(t *testing.T) {
 	t.Parallel()
 
 	t.Run("step complete", func(t *testing.T) {
 		t.Parallel()
-		out, err := RenderCommentTemplate(
-			"## {{.Heading}} Complete\n\n{{.Output}}",
-			CommentData{Step: "build", Heading: "Build", Output: "all done"},
-		)
+		out, err := RenderStepComment("build", StepConfig{CommentTemplate: "## {{.Heading}} Complete\n\n{{.Output}}"}, "all done")
 		require.NoError(t, err)
 		assert.Equal(t, "## Build Complete\n\nall done", out)
 	})
 
 	t.Run("round comment", func(t *testing.T) {
 		t.Parallel()
-		out, err := RenderCommentTemplate(
-			"## {{.Heading}} Round {{.Round}}/{{.TotalRounds}}\n\n{{.Output}}",
-			CommentData{Step: "validate", Heading: "Validate", Output: "passed", Round: 2, TotalRounds: 3},
-		)
+		out, err := RenderRoundComment("validate", StepConfig{RoundCommentTemplate: "## {{.Heading}} Round {{.Round}}/{{.TotalRounds}}\n\n{{.Output}}"}, "passed", 2, 3)
 		require.NoError(t, err)
 		assert.Equal(t, "## Validate Round 2/3\n\npassed", out)
 	})
 
 	t.Run("invalid template", func(t *testing.T) {
 		t.Parallel()
-		_, err := RenderCommentTemplate("{{.Heading}", CommentData{})
+		_, err := RenderStepComment("plan", StepConfig{CommentTemplate: "{{.Heading}"}, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parse template")
 	})
@@ -262,7 +256,7 @@ func TestRenderCommentTemplate(t *testing.T) {
 		t.Parallel()
 		// .Missing is not a field on CommentData; text/template errors at
 		// execute time when calling on a missing field of a struct.
-		_, err := RenderCommentTemplate("{{.Missing}}", CommentData{})
+		_, err := RenderStepComment("plan", StepConfig{CommentTemplate: "{{.Missing}}"}, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "execute template")
 	})
@@ -845,7 +839,7 @@ func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
 	assert.Equal(t, resultTime, wf.lastCommentAt, "lastCommentAt should be set from result comment, not waiting comment or stale value")
 
 	// Lock in PostComment body so a regression that drops
-	// RenderCommentTemplate or sidesteps CommentTemplate is caught here.
+	// RenderStepComment or sidesteps CommentTemplate is caught here.
 	// First call is the step result comment (rendered from
 	// CommentTemplate); the waiting comment follows.
 	postCalls := mt.getCalls("PostComment")
@@ -905,7 +899,7 @@ func TestWorkflow_RunStepRounds_SetsLastCommentAtFromFinalRound(t *testing.T) {
 	assert.Equal(t, round2Time, wf.lastCommentAt, "lastCommentAt should be set from final round's result comment")
 
 	// Lock in PostComment bodies so a regression that drops
-	// RenderCommentTemplate or routes around RoundCommentTemplate is
+	// RenderRoundComment or routes around RoundCommentTemplate is
 	// caught here, not in the field. Order: round1, round2, waiting.
 	postCalls := mt.getCalls("PostComment")
 	require.GreaterOrEqual(t, len(postCalls), 2, "expected round comments + waiting comment")

--- a/jiradozer/workflow_test.go
+++ b/jiradozer/workflow_test.go
@@ -233,7 +233,7 @@ func TestRenderCommentTemplate(t *testing.T) {
 
 	t.Run("step complete", func(t *testing.T) {
 		t.Parallel()
-		out, err := renderCommentTemplate(
+		out, err := RenderCommentTemplate(
 			"## {{.Heading}} Complete\n\n{{.Output}}",
 			CommentData{Step: "build", Heading: "Build", Output: "all done"},
 		)
@@ -243,7 +243,7 @@ func TestRenderCommentTemplate(t *testing.T) {
 
 	t.Run("round comment", func(t *testing.T) {
 		t.Parallel()
-		out, err := renderCommentTemplate(
+		out, err := RenderCommentTemplate(
 			"## {{.Heading}} Round {{.Round}}/{{.TotalRounds}}\n\n{{.Output}}",
 			CommentData{Step: "validate", Heading: "Validate", Output: "passed", Round: 2, TotalRounds: 3},
 		)
@@ -253,7 +253,7 @@ func TestRenderCommentTemplate(t *testing.T) {
 
 	t.Run("invalid template", func(t *testing.T) {
 		t.Parallel()
-		_, err := renderCommentTemplate("{{.Heading}", CommentData{})
+		_, err := RenderCommentTemplate("{{.Heading}", CommentData{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parse template")
 	})
@@ -262,7 +262,7 @@ func TestRenderCommentTemplate(t *testing.T) {
 		t.Parallel()
 		// .Missing is not a field on CommentData; text/template errors at
 		// execute time when calling on a missing field of a struct.
-		_, err := renderCommentTemplate("{{.Missing}}", CommentData{})
+		_, err := RenderCommentTemplate("{{.Missing}}", CommentData{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "execute template")
 	})
@@ -845,7 +845,7 @@ func TestWorkflow_RunStep_SetsLastCommentAt(t *testing.T) {
 	assert.Equal(t, resultTime, wf.lastCommentAt, "lastCommentAt should be set from result comment, not waiting comment or stale value")
 
 	// Lock in PostComment body so a regression that drops
-	// renderCommentTemplate or sidesteps CommentTemplate is caught here.
+	// RenderCommentTemplate or sidesteps CommentTemplate is caught here.
 	// First call is the step result comment (rendered from
 	// CommentTemplate); the waiting comment follows.
 	postCalls := mt.getCalls("PostComment")
@@ -905,7 +905,7 @@ func TestWorkflow_RunStepRounds_SetsLastCommentAtFromFinalRound(t *testing.T) {
 	assert.Equal(t, round2Time, wf.lastCommentAt, "lastCommentAt should be set from final round's result comment")
 
 	// Lock in PostComment bodies so a regression that drops
-	// renderCommentTemplate or routes around RoundCommentTemplate is
+	// RenderCommentTemplate or routes around RoundCommentTemplate is
 	// caught here, not in the field. Order: round1, round2, waiting.
 	postCalls := mt.getCalls("PostComment")
 	require.GreaterOrEqual(t, len(postCalls), 2, "expected round comments + waiting comment")


### PR DESCRIPTION
## Summary

Adds optional result posting for single-step jiradozer runs via `jiradozer run --run-step <step> --post-result`. Single-shot steps render and post the step's configured `comment_template`; steps configured with rounds run all rounds, combine their output, and post one aggregate comment using the step's `round_comment_template`. `--run-step` remains stdout-only by default, and `--post-result` is rejected unless `--run-step` is also set.

Refactors workflow comment rendering/posting into reusable helpers so the full workflow and single-step CLI path share the same template behavior. The workflow now distinguishes template-rendering failures from tracker posting failures: bad templates still fail the workflow, while tracker post failures continue to warn without losing the step output behavior.

Tightens single-step execution around result handling: plan output is still persisted after `--run-step plan`, build continues to load `--plan-file` or the persisted plan, empty outputs can still be posted, missing comment templates return clear errors, and tracker posting failures are surfaced to the CLI.

Adds focused coverage for rendered step comments, aggregate round comments, disabled posting, missing poster/template guardrails, posting failures, empty output handling, and the top-level CLI flag path with the local tracker. Updates the jiradozer README flag table and examples to document stdout-only default behavior and the new `--post-result` mode.

## Validation

- `scripts/lint.sh`
- `bazel test //... --test_timeout=60`
- `bazel build //...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI path that posts rendered step/round comments to trackers and refactors shared comment rendering/posting in `workflow.go`, which could affect how workflow comments are rendered/handled on failures.
> 
> **Overview**
> Adds `--post-result` for `jiradozer run --run-step` so single-step debugging can optionally **post the rendered step output back to the issue**, including **one aggregated comment for multi-round steps**.
> 
> Refactors comment rendering/posting into reusable helpers (`RenderStepComment`/`RenderRoundComment`, `PostStepComment`/`PostRoundComment`) and updates the workflow to use them with clearer render-vs-post error handling; extends CLI single-step execution (`singleStepRun`) to persist plans and (optionally) post results, with comprehensive unit tests and README updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd04b99284e6920af928b24c23960d3e9b6028fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->