### PR TITLE
Add repo bootstrap worktree support

### DIFF
--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -8,6 +8,10 @@ Issue-driven development workflow CLI. Takes an issue from a tracker (Linear, Gi
 # Build
 bazel build //jiradozer/cmd/jiradozer
 
+# Bootstrap a GitHub repo into a wt-managed checkout.
+bazel-bin/jiradozer/cmd/jiradozer/jiradozer bootstrap --repo owner/repo
+cd ~/worktrees/repo/main
+
 # Run from a tracker issue
 bazel-bin/jiradozer/cmd/jiradozer/jiradozer --issue ENG-123
 
@@ -29,6 +33,16 @@ Create a `jiradozer.yaml` in your working directory:
 
 ```bash
 jiradozer bootstrap
+```
+
+To set up a repo and config in one step, pass `--repo`. The repo is cloned
+under `$WT_ROOT` or `~/worktrees`; the generated config is written next to
+the bare repo at `$WT_ROOT/<repo>/jiradozer.yaml` and points `work_dir` at
+the cloned main worktree, so the checkout stays clean. Use `--output` to
+write the config somewhere else.
+
+```bash
+jiradozer bootstrap --repo owner/repo
 ```
 
 ```yaml

--- a/jiradozer/README.md
+++ b/jiradozer/README.md
@@ -10,7 +10,7 @@ bazel build //jiradozer/cmd/jiradozer
 
 # Bootstrap a GitHub repo into a wt-managed checkout.
 bazel-bin/jiradozer/cmd/jiradozer/jiradozer bootstrap --repo owner/repo
-cd ~/worktrees/repo/main
+cd "$WT_ROOT/<repo-name>/<default-branch>"
 
 # Run from a tracker issue
 bazel-bin/jiradozer/cmd/jiradozer/jiradozer --issue ENG-123
@@ -38,8 +38,9 @@ jiradozer bootstrap
 To set up a repo and config in one step, pass `--repo`. The repo is cloned
 under `$WT_ROOT` or `~/worktrees`; the generated config is written next to
 the bare repo at `$WT_ROOT/<repo>/jiradozer.yaml` and points `work_dir` at
-the cloned main worktree, so the checkout stays clean. Use `--output` to
-write the config somewhere else.
+the cloned default-branch worktree, so the checkout stays clean. Use the
+`work_dir` in the generated config or the bootstrap output for the exact
+checkout path. Use `--output` to write the config somewhere else.
 
 ```bash
 jiradozer bootstrap --repo owner/repo

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -38,12 +38,13 @@ the wt-managed checkout unless --config or --output is explicit. Edit the
 prompts to taste; the generated file is the source of truth for what the
 agent says.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			path, err := resolveBootstrapOutputPath(args, *configPath, cmd.Flags().Changed("config") || cmd.InheritedFlags().Changed("config"))
+			configExplicit := cmd.Flags().Changed("config") || cmd.InheritedFlags().Changed("config")
+			path, err := resolveBootstrapOutputPath(args, *configPath, configExplicit)
 			if err != nil {
 				return err
 			}
 			if _, err := os.Stat(path); err == nil && !args.force {
-				if args.repo != "" {
+				if args.repo != "" && args.output == "" && !configExplicit {
 					if _, err := recoverExistingRepoWorktree(cmd.Context(), args.repo, cmd.OutOrStdout()); err != nil {
 						return err
 					}
@@ -59,7 +60,11 @@ agent says.`,
 					return err
 				}
 			}
-			content, err := bootstrapYAML(workDir)
+			baseBranch := ""
+			if workDir != "" {
+				baseBranch = filepath.Base(workDir)
+			}
+			content, err := bootstrapYAML(workDir, baseBranch)
 			if err != nil {
 				return err
 			}
@@ -236,14 +241,18 @@ func normalizeRepoURL(repoArg string) string {
 // hand-laid-out (not produced by yaml.Marshal) so each field carries the
 // doc comment from its struct tag and optional fields can be emitted as
 // commented-out lines that hint at usage without forcing a value.
-func bootstrapYAML(workDir string) ([]byte, error) {
+func bootstrapYAML(workDir string, baseBranchOverride ...string) ([]byte, error) {
+	baseBranch := ""
+	if len(baseBranchOverride) > 0 {
+		baseBranch = baseBranchOverride[0]
+	}
 	var b strings.Builder
 	b.WriteString(bootstrapHeader)
 	b.WriteString(bootstrapTrackerBlock)
 	b.WriteString(bootstrapSourceBlock)
 	b.WriteString(bootstrapStatesBlock)
 	b.WriteString(bootstrapAgentBlock)
-	b.WriteString(renderWorkDirBlock(workDir))
+	b.WriteString(renderWorkDirBlock(workDir, baseBranch))
 
 	b.WriteString(renderStepBlock(stepBlock{
 		Key:                  "plan",
@@ -416,20 +425,23 @@ agent:
 `
 
 // renderWorkDirBlock renders required scalar config values.
-func renderWorkDirBlock(workDir string) string {
+func renderWorkDirBlock(workDir string, baseBranch string) string {
 	if workDir == "" {
 		workDir = "."
 	} else {
 		workDir = strconv.Quote(workDir)
 	}
-	return fmt.Sprintf(bootstrapWorkDirBlock, workDir)
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	return fmt.Sprintf(bootstrapWorkDirBlock, workDir, baseBranch)
 }
 
 const bootstrapWorkDirBlock = `# Working directory for the agent (where it runs commands and edits files).
 work_dir: %s
 
 # Default base branch for PRs.
-base_branch: main
+base_branch: %s
 
 # Optional phases to skip for every run. Skipped phases advance in-memory
 # workflow state and clear stale -inprogress labels, but do not write -done

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -1,21 +1,27 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/bazelment/yoloswe/jiradozer"
+	"github.com/bazelment/yoloswe/wt"
 )
 
 // bootstrapArgs holds bootstrap-only flags.
 type bootstrapArgs struct {
 	output string
+	repo   string
 	force  bool
 }
 
@@ -28,19 +34,16 @@ comment templates. By default bootstrap writes to --config; use --output
 to write somewhere else. Edit the prompts to taste; the generated file is
 the source of truth for what the agent says.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			path := args.output
-			if path == "" {
-				path = *configPath
-			}
-			if path == "" {
-				path = "jiradozer.yaml"
+			path, workDir, err := resolveBootstrapTarget(cmd.Context(), args, *configPath)
+			if err != nil {
+				return err
 			}
 			if _, err := os.Stat(path); err == nil && !args.force {
 				return fmt.Errorf("%s already exists (use --force to overwrite)", path)
 			} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("stat %s: %w", path, err)
 			}
-			content, err := bootstrapYAML()
+			content, err := bootstrapYAML(workDir)
 			if err != nil {
 				return err
 			}
@@ -53,22 +56,86 @@ the source of truth for what the agent says.`,
 	}
 	cmd.SilenceUsage = true
 	cmd.Flags().StringVarP(&args.output, "output", "o", "", "Path to write the starter config; overrides --config")
+	cmd.Flags().StringVar(&args.repo, "repo", "", "Optional GitHub repo URL or owner/repo shorthand. Bootstraps a wt-managed worktree under $WT_ROOT (or ~/worktrees), reusing it if present, and points work_dir at that checkout.")
 	cmd.Flags().BoolVarP(&args.force, "force", "f", false, "Overwrite the output file if it already exists")
 	return cmd
+}
+
+func resolveBootstrapTarget(ctx context.Context, args *bootstrapArgs, configPath string) (configOutputPath string, workDir string, err error) {
+	path := args.output
+	if path == "" {
+		path = configPath
+	}
+	if path == "" {
+		path = "jiradozer.yaml"
+	}
+	if args.repo == "" {
+		return path, "", nil
+	}
+
+	mainPath, err := bootstrapRepoWorktree(ctx, args.repo)
+	if err != nil {
+		return "", "", err
+	}
+	if args.output == "" {
+		path = filepath.Join(filepath.Dir(mainPath), "jiradozer.yaml")
+	}
+	return path, mainPath, nil
+}
+
+func bootstrapRepoWorktree(ctx context.Context, repoArg string) (string, error) {
+	repoURL := normalizeRepoURL(repoArg)
+	wtRoot, err := resolveWTRoot()
+	if err != nil {
+		return "", err
+	}
+	mgr := wt.NewManager(wtRoot, wt.GetRepoNameFromURL(repoURL))
+	if _, err := os.Stat(mgr.BareDir()); err == nil {
+		defaultBranch, err := wt.GetDefaultBranch(ctx, mgr.GitRunner(), mgr.BareDir())
+		if err != nil {
+			return "", fmt.Errorf("detect default branch for existing repo: %w", err)
+		}
+		mainPath := filepath.Join(mgr.RepoDir(), defaultBranch)
+		if _, err := os.Stat(mainPath); err != nil {
+			return "", fmt.Errorf("existing repo worktree %s: %w", mainPath, err)
+		}
+		fmt.Printf("reusing existing repo at %s\n", mgr.RepoDir())
+		return mainPath, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
+	}
+	mainPath, err := mgr.Init(ctx, repoURL)
+	if err != nil {
+		return "", err
+	}
+	return mainPath, nil
+}
+
+var ownerRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+
+func normalizeRepoURL(repoArg string) string {
+	if ownerRepoPattern.MatchString(repoArg) {
+		return "https://github.com/" + repoArg + ".git"
+	}
+	return repoArg
 }
 
 // bootstrapYAML returns the bytes of a starter jiradozer.yaml. The output is
 // hand-laid-out (not produced by yaml.Marshal) so each field carries the
 // doc comment from its struct tag and optional fields can be emitted as
 // commented-out lines that hint at usage without forcing a value.
-func bootstrapYAML() ([]byte, error) {
+func bootstrapYAML(workDirOverride ...string) ([]byte, error) {
+	workDir := ""
+	if len(workDirOverride) > 0 {
+		workDir = workDirOverride[0]
+	}
 	var b strings.Builder
 	b.WriteString(bootstrapHeader)
 	b.WriteString(bootstrapTrackerBlock)
 	b.WriteString(bootstrapSourceBlock)
 	b.WriteString(bootstrapStatesBlock)
 	b.WriteString(bootstrapAgentBlock)
-	b.WriteString(bootstrapWorkDirBlock)
+	b.WriteString(renderWorkDirBlock(workDir))
 
 	b.WriteString(renderStepBlock(stepBlock{
 		Key:                  "plan",
@@ -240,8 +307,11 @@ agent:
 
 `
 
-// bootstrapWorkDirBlock — required scalars at the top level.
-const bootstrapWorkDirBlock = `# Working directory for the agent (where it runs commands and edits files).
+// renderWorkDirBlock renders required scalar config values. Empty workDir
+// preserves the historical bootstrap output exactly.
+func renderWorkDirBlock(workDir string) string {
+	if workDir == "" {
+		return `# Working directory for the agent (where it runs commands and edits files).
 work_dir: .
 
 # Default base branch for PRs.
@@ -255,6 +325,22 @@ base_branch: main
 #skip_phases: [plan]
 
 `
+	}
+	return fmt.Sprintf(`# Working directory for the agent (where it runs commands and edits files).
+work_dir: %s
+
+# Default base branch for PRs.
+base_branch: main
+
+# Optional phases to skip for every run. Skipped phases advance in-memory
+# workflow state and clear stale -inprogress labels, but do not write -done
+# labels; use tracker labels like jiradozer-plan-done for durable completion.
+# Tracker labels like jiradozer-skip-plan are also honored; label editors are
+# trusted to bypass the matching phase.
+#skip_phases: [plan]
+
+`, strconv.Quote(workDir))
+}
 
 // bootstrapTopLevelTail — top-level scalars that come after the step blocks.
 const bootstrapTopLevelTail = `# Total budget cap across all steps in a single workflow run.

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -107,10 +108,14 @@ func recoverExistingRepoWorktree(ctx context.Context, repoArg string, out io.Wri
 	} else if err != nil {
 		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
 	}
-	return bootstrapRepoWorktree(ctx, repoArg, out)
+	return bootstrapRepoWorktreeInternal(ctx, repoArg, out, false)
 }
 
 func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (string, error) {
+	return bootstrapRepoWorktreeInternal(ctx, repoArg, out, true)
+}
+
+func bootstrapRepoWorktreeInternal(ctx context.Context, repoArg string, out io.Writer, announceReuse bool) (string, error) {
 	repoURL := normalizeRepoURL(repoArg)
 	wtRoot, err := resolveWTRoot()
 	if err != nil {
@@ -132,7 +137,12 @@ func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (
 		if err != nil {
 			return "", fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
 		}
-		fmt.Fprintf(out, "reusing existing repo at %s\n", mgr.RepoDir())
+		if err := verifyGitWorktree(mainPath); err != nil {
+			return "", fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
+		}
+		if announceReuse {
+			fmt.Fprintf(out, "reusing existing repo at %s\n", mgr.RepoDir())
+		}
 		return mainPath, nil
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
@@ -142,6 +152,16 @@ func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (
 		return "", err
 	}
 	return mainPath, nil
+}
+
+func verifyGitWorktree(path string) error {
+	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%s is not a git worktree", path)
+		}
+		return fmt.Errorf("stat %s: %w", filepath.Join(path, ".git"), err)
+	}
+	return nil
 }
 
 func newBootstrapWTManager(wtRoot, repoURL string, out io.Writer) *wt.Manager {
@@ -166,9 +186,24 @@ func sameRepoRemote(a, b string) bool {
 
 func canonicalRepoRemote(remote string) string {
 	remote = strings.TrimSuffix(strings.TrimSpace(remote), ".git")
-	remote = strings.TrimPrefix(remote, "https://github.com/")
-	remote = strings.TrimPrefix(remote, "git@github.com:")
+	if host, path, ok := splitSCPRemote(remote); ok {
+		return strings.ToLower(host + "/" + strings.Trim(path, "/"))
+	}
+	if parsed, err := url.Parse(remote); err == nil && parsed.Host != "" {
+		return strings.ToLower(parsed.Host + "/" + strings.Trim(parsed.Path, "/"))
+	}
 	return remote
+}
+
+func splitSCPRemote(remote string) (string, string, bool) {
+	if !strings.Contains(remote, "://") && strings.Contains(remote, "@") && strings.Contains(remote, ":") {
+		parts := strings.SplitN(remote, "@", 2)
+		hostPath := strings.SplitN(parts[1], ":", 2)
+		if len(hostPath) == 2 && hostPath[0] != "" && hostPath[1] != "" {
+			return hostPath[0], hostPath[1], true
+		}
+	}
+	return "", "", false
 }
 
 func recreateDefaultWorktree(ctx context.Context, mgr *wt.Manager, defaultBranch string) (string, error) {

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ comment templates. By default bootstrap writes to --config; use --output
 to write somewhere else. Edit the prompts to taste; the generated file is
 the source of truth for what the agent says.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			path, workDir, err := resolveBootstrapTarget(cmd.Context(), args, *configPath)
+			path, err := resolveBootstrapOutputPath(args, *configPath)
 			if err != nil {
 				return err
 			}
@@ -42,6 +43,13 @@ the source of truth for what the agent says.`,
 				return fmt.Errorf("%s already exists (use --force to overwrite)", path)
 			} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("stat %s: %w", path, err)
+			}
+			workDir := ""
+			if args.repo != "" {
+				workDir, err = bootstrapRepoWorktree(cmd.Context(), args.repo, cmd.OutOrStdout())
+				if err != nil {
+					return err
+				}
 			}
 			content, err := bootstrapYAML(workDir)
 			if err != nil {
@@ -61,7 +69,7 @@ the source of truth for what the agent says.`,
 	return cmd
 }
 
-func resolveBootstrapTarget(ctx context.Context, args *bootstrapArgs, configPath string) (configOutputPath string, workDir string, err error) {
+func resolveBootstrapOutputPath(args *bootstrapArgs, configPath string) (string, error) {
 	path := args.output
 	if path == "" {
 		path = configPath
@@ -69,21 +77,18 @@ func resolveBootstrapTarget(ctx context.Context, args *bootstrapArgs, configPath
 	if path == "" {
 		path = "jiradozer.yaml"
 	}
-	if args.repo == "" {
-		return path, "", nil
+	if args.repo == "" || args.output != "" {
+		return path, nil
 	}
-
-	mainPath, err := bootstrapRepoWorktree(ctx, args.repo)
+	wtRoot, err := resolveWTRoot()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
-	if args.output == "" {
-		path = filepath.Join(filepath.Dir(mainPath), "jiradozer.yaml")
-	}
-	return path, mainPath, nil
+	repoURL := normalizeRepoURL(args.repo)
+	return filepath.Join(wtRoot, wt.GetRepoNameFromURL(repoURL), "jiradozer.yaml"), nil
 }
 
-func bootstrapRepoWorktree(ctx context.Context, repoArg string) (string, error) {
+func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (string, error) {
 	repoURL := normalizeRepoURL(repoArg)
 	wtRoot, err := resolveWTRoot()
 	if err != nil {
@@ -95,11 +100,11 @@ func bootstrapRepoWorktree(ctx context.Context, repoArg string) (string, error) 
 		if err != nil {
 			return "", fmt.Errorf("detect default branch for existing repo: %w", err)
 		}
-		mainPath := filepath.Join(mgr.RepoDir(), defaultBranch)
-		if _, err := os.Stat(mainPath); err != nil {
-			return "", fmt.Errorf("existing repo worktree %s: %w", mainPath, err)
+		mainPath, err := mgr.GetWorktreePath(defaultBranch)
+		if err != nil {
+			return "", fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
 		}
-		fmt.Printf("reusing existing repo at %s\n", mgr.RepoDir())
+		fmt.Fprintf(out, "reusing existing repo at %s\n", mgr.RepoDir())
 		return mainPath, nil
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
@@ -124,11 +129,7 @@ func normalizeRepoURL(repoArg string) string {
 // hand-laid-out (not produced by yaml.Marshal) so each field carries the
 // doc comment from its struct tag and optional fields can be emitted as
 // commented-out lines that hint at usage without forcing a value.
-func bootstrapYAML(workDirOverride ...string) ([]byte, error) {
-	workDir := ""
-	if len(workDirOverride) > 0 {
-		workDir = workDirOverride[0]
-	}
+func bootstrapYAML(workDir string) ([]byte, error) {
 	var b strings.Builder
 	b.WriteString(bootstrapHeader)
 	b.WriteString(bootstrapTrackerBlock)
@@ -307,26 +308,17 @@ agent:
 
 `
 
-// renderWorkDirBlock renders required scalar config values. Empty workDir
-// preserves the historical bootstrap output exactly.
+// renderWorkDirBlock renders required scalar config values.
 func renderWorkDirBlock(workDir string) string {
 	if workDir == "" {
-		return `# Working directory for the agent (where it runs commands and edits files).
-work_dir: .
-
-# Default base branch for PRs.
-base_branch: main
-
-# Optional phases to skip for every run. Skipped phases advance in-memory
-# workflow state and clear stale -inprogress labels, but do not write -done
-# labels; use tracker labels like jiradozer-plan-done for durable completion.
-# Tracker labels like jiradozer-skip-plan are also honored; label editors are
-# trusted to bypass the matching phase.
-#skip_phases: [plan]
-
-`
+		workDir = "."
+	} else {
+		workDir = strconv.Quote(workDir)
 	}
-	return fmt.Sprintf(`# Working directory for the agent (where it runs commands and edits files).
+	return fmt.Sprintf(bootstrapWorkDirBlock, workDir)
+}
+
+const bootstrapWorkDirBlock = `# Working directory for the agent (where it runs commands and edits files).
 work_dir: %s
 
 # Default base branch for PRs.
@@ -339,8 +331,7 @@ base_branch: main
 # trusted to bypass the matching phase.
 #skip_phases: [plan]
 
-`, strconv.Quote(workDir))
-}
+`
 
 // bootstrapTopLevelTail — top-level scalars that come after the step blocks.
 const bootstrapTopLevelTail = `# Total budget cap across all steps in a single workflow run.

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -27,6 +27,11 @@ type bootstrapArgs struct {
 	force  bool
 }
 
+type bootstrapRepoWorktreeResult struct {
+	workDir    string
+	baseBranch string
+}
+
 func newBootstrapCommand(args *bootstrapArgs, configPath *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
@@ -53,18 +58,14 @@ agent says.`,
 			} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("stat %s: %w", path, err)
 			}
-			workDir := ""
+			repoResult := bootstrapRepoWorktreeResult{}
 			if args.repo != "" {
-				workDir, err = bootstrapRepoWorktree(cmd.Context(), args.repo, cmd.OutOrStdout())
+				repoResult, err = bootstrapRepoWorktree(cmd.Context(), args.repo, cmd.OutOrStdout())
 				if err != nil {
 					return err
 				}
 			}
-			baseBranch := ""
-			if workDir != "" {
-				baseBranch = filepath.Base(workDir)
-			}
-			content, err := bootstrapYAML(workDir, baseBranch)
+			content, err := bootstrapYAML(repoResult.workDir, repoResult.baseBranch)
 			if err != nil {
 				return err
 			}
@@ -101,62 +102,74 @@ func resolveBootstrapOutputPath(args *bootstrapArgs, configPath string, configEx
 	return filepath.Join(wtRoot, wt.GetRepoNameFromURL(repoURL), "jiradozer.yaml"), nil
 }
 
-func recoverExistingRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (string, error) {
+func recoverExistingRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (bootstrapRepoWorktreeResult, error) {
 	repoURL := normalizeRepoURL(repoArg)
 	wtRoot, err := resolveWTRoot()
 	if err != nil {
-		return "", err
+		return bootstrapRepoWorktreeResult{}, err
 	}
 	mgr := newBootstrapWTManager(wtRoot, repoURL, out)
 	if _, err := os.Stat(mgr.BareDir()); errors.Is(err, fs.ErrNotExist) {
-		return "", nil
+		return bootstrapRepoWorktreeResult{}, nil
 	} else if err != nil {
-		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
+		return bootstrapRepoWorktreeResult{}, fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
 	}
 	return bootstrapRepoWorktreeInternal(ctx, repoArg, out, false)
 }
 
-func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (string, error) {
+func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (bootstrapRepoWorktreeResult, error) {
 	return bootstrapRepoWorktreeInternal(ctx, repoArg, out, true)
 }
 
-func bootstrapRepoWorktreeInternal(ctx context.Context, repoArg string, out io.Writer, announceReuse bool) (string, error) {
+func bootstrapRepoWorktreeInternal(ctx context.Context, repoArg string, out io.Writer, announceReuse bool) (bootstrapRepoWorktreeResult, error) {
 	repoURL := normalizeRepoURL(repoArg)
 	wtRoot, err := resolveWTRoot()
 	if err != nil {
-		return "", err
+		return bootstrapRepoWorktreeResult{}, err
 	}
 	mgr := newBootstrapWTManager(wtRoot, repoURL, out)
 	if _, err := os.Stat(mgr.BareDir()); err == nil {
 		if err := verifyExistingRepoRemote(ctx, mgr, repoURL); err != nil {
-			return "", err
+			return bootstrapRepoWorktreeResult{}, err
 		}
 		defaultBranch, err := wt.GetDefaultBranch(ctx, mgr.GitRunner(), mgr.BareDir())
 		if err != nil {
-			return "", fmt.Errorf("detect default branch for existing repo: %w", err)
+			return bootstrapRepoWorktreeResult{}, fmt.Errorf("detect default branch for existing repo: %w", err)
 		}
 		mainPath, err := mgr.GetWorktreePath(defaultBranch)
 		if errors.Is(err, wt.ErrWorktreeNotFound) {
 			mainPath, err = recreateDefaultWorktree(ctx, mgr, defaultBranch)
 		}
 		if err != nil {
-			return "", fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
+			return bootstrapRepoWorktreeResult{}, fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
 		}
 		if err := verifyGitWorktree(mainPath); err != nil {
-			return "", fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
+			return bootstrapRepoWorktreeResult{}, fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
 		}
 		if announceReuse {
 			fmt.Fprintf(out, "reusing existing repo at %s\n", mgr.RepoDir())
 		}
-		return mainPath, nil
+		return bootstrapRepoWorktreeResult{workDir: mainPath, baseBranch: defaultBranch}, nil
 	} else if !errors.Is(err, fs.ErrNotExist) {
-		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
+		return bootstrapRepoWorktreeResult{}, fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
 	}
 	mainPath, err := mgr.Init(ctx, repoURL)
 	if err != nil {
-		return "", err
+		return bootstrapRepoWorktreeResult{}, err
 	}
-	return mainPath, nil
+	baseBranch, err := branchFromWorktreePath(mgr.RepoDir(), mainPath)
+	if err != nil {
+		return bootstrapRepoWorktreeResult{}, err
+	}
+	return bootstrapRepoWorktreeResult{workDir: mainPath, baseBranch: baseBranch}, nil
+}
+
+func branchFromWorktreePath(repoDir string, workDir string) (string, error) {
+	rel, err := filepath.Rel(repoDir, workDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve default branch from %s: %w", workDir, err)
+	}
+	return filepath.ToSlash(rel), nil
 }
 
 func verifyGitWorktree(path string) error {

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -32,10 +32,12 @@ func newBootstrapCommand(args *bootstrapArgs, configPath *string) *cobra.Command
 		Short: "Generate a starter config file",
 		Long: `Write a starter config file seeded with the canonical step prompts and
 comment templates. By default bootstrap writes to --config; use --output
-to write somewhere else. Edit the prompts to taste; the generated file is
-the source of truth for what the agent says.`,
+to write somewhere else. With --repo, the default config path is next to
+the wt-managed checkout unless --config or --output is explicit. Edit the
+prompts to taste; the generated file is the source of truth for what the
+agent says.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			path, err := resolveBootstrapOutputPath(args, *configPath)
+			path, err := resolveBootstrapOutputPath(args, *configPath, cmd.Flags().Changed("config") || cmd.InheritedFlags().Changed("config"))
 			if err != nil {
 				return err
 			}
@@ -64,12 +66,12 @@ the source of truth for what the agent says.`,
 	}
 	cmd.SilenceUsage = true
 	cmd.Flags().StringVarP(&args.output, "output", "o", "", "Path to write the starter config; overrides --config")
-	cmd.Flags().StringVar(&args.repo, "repo", "", "Optional GitHub repo URL or owner/repo shorthand. Bootstraps a wt-managed worktree under $WT_ROOT (or ~/worktrees), reusing it if present, and points work_dir at that checkout.")
+	cmd.Flags().StringVar(&args.repo, "repo", "", "Optional GitHub repo URL or owner/repo shorthand. Bootstraps a wt-managed worktree under $WT_ROOT (or ~/worktrees), reusing it if present, and points work_dir at that checkout. Without explicit --config or --output, writes config beside that checkout.")
 	cmd.Flags().BoolVarP(&args.force, "force", "f", false, "Overwrite the output file if it already exists")
 	return cmd
 }
 
-func resolveBootstrapOutputPath(args *bootstrapArgs, configPath string) (string, error) {
+func resolveBootstrapOutputPath(args *bootstrapArgs, configPath string, configExplicit bool) (string, error) {
 	path := args.output
 	if path == "" {
 		path = configPath
@@ -77,7 +79,7 @@ func resolveBootstrapOutputPath(args *bootstrapArgs, configPath string) (string,
 	if path == "" {
 		path = "jiradozer.yaml"
 	}
-	if args.repo == "" || args.output != "" {
+	if args.repo == "" || args.output != "" || configExplicit {
 		return path, nil
 	}
 	wtRoot, err := resolveWTRoot()
@@ -101,6 +103,9 @@ func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (
 			return "", fmt.Errorf("detect default branch for existing repo: %w", err)
 		}
 		mainPath, err := mgr.GetWorktreePath(defaultBranch)
+		if errors.Is(err, wt.ErrWorktreeNotFound) {
+			mainPath, err = recreateDefaultWorktree(ctx, mgr, defaultBranch)
+		}
 		if err != nil {
 			return "", fmt.Errorf("existing repo worktree for %s: %w", defaultBranch, err)
 		}
@@ -112,6 +117,23 @@ func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (
 	mainPath, err := mgr.Init(ctx, repoURL)
 	if err != nil {
 		return "", err
+	}
+	return mainPath, nil
+}
+
+func recreateDefaultWorktree(ctx context.Context, mgr *wt.Manager, defaultBranch string) (string, error) {
+	mainPath := filepath.Join(mgr.RepoDir(), defaultBranch)
+	if _, err := mgr.GitRunner().Run(ctx, []string{"worktree", "prune"}, mgr.BareDir()); err != nil {
+		return "", fmt.Errorf("prune stale worktree metadata: %w", err)
+	}
+	result, err := mgr.GitRunner().Run(ctx, []string{"worktree", "add", mainPath, defaultBranch}, mgr.BareDir())
+	if err != nil {
+		if result != nil {
+			if stderr := strings.TrimSpace(result.Stderr); stderr != "" {
+				return "", fmt.Errorf("recreate default worktree: %s: %w", stderr, err)
+			}
+		}
+		return "", fmt.Errorf("recreate default worktree: %w", err)
 	}
 	return mainPath, nil
 }

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -42,6 +42,11 @@ agent says.`,
 				return err
 			}
 			if _, err := os.Stat(path); err == nil && !args.force {
+				if args.repo != "" {
+					if _, err := recoverExistingRepoWorktree(cmd.Context(), args.repo, cmd.OutOrStdout()); err != nil {
+						return err
+					}
+				}
 				return fmt.Errorf("%s already exists (use --force to overwrite)", path)
 			} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("stat %s: %w", path, err)
@@ -90,14 +95,32 @@ func resolveBootstrapOutputPath(args *bootstrapArgs, configPath string, configEx
 	return filepath.Join(wtRoot, wt.GetRepoNameFromURL(repoURL), "jiradozer.yaml"), nil
 }
 
+func recoverExistingRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (string, error) {
+	repoURL := normalizeRepoURL(repoArg)
+	wtRoot, err := resolveWTRoot()
+	if err != nil {
+		return "", err
+	}
+	mgr := newBootstrapWTManager(wtRoot, repoURL, out)
+	if _, err := os.Stat(mgr.BareDir()); errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("stat %s: %w", mgr.BareDir(), err)
+	}
+	return bootstrapRepoWorktree(ctx, repoArg, out)
+}
+
 func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (string, error) {
 	repoURL := normalizeRepoURL(repoArg)
 	wtRoot, err := resolveWTRoot()
 	if err != nil {
 		return "", err
 	}
-	mgr := wt.NewManager(wtRoot, wt.GetRepoNameFromURL(repoURL))
+	mgr := newBootstrapWTManager(wtRoot, repoURL, out)
 	if _, err := os.Stat(mgr.BareDir()); err == nil {
+		if err := verifyExistingRepoRemote(ctx, mgr, repoURL); err != nil {
+			return "", err
+		}
 		defaultBranch, err := wt.GetDefaultBranch(ctx, mgr.GitRunner(), mgr.BareDir())
 		if err != nil {
 			return "", fmt.Errorf("detect default branch for existing repo: %w", err)
@@ -121,6 +144,33 @@ func bootstrapRepoWorktree(ctx context.Context, repoArg string, out io.Writer) (
 	return mainPath, nil
 }
 
+func newBootstrapWTManager(wtRoot, repoURL string, out io.Writer) *wt.Manager {
+	return wt.NewManager(wtRoot, wt.GetRepoNameFromURL(repoURL), wt.WithOutput(wt.NewOutput(out, false)))
+}
+
+func verifyExistingRepoRemote(ctx context.Context, mgr *wt.Manager, repoURL string) error {
+	result, err := mgr.GitRunner().Run(ctx, []string{"config", "--get", "remote.origin.url"}, mgr.BareDir())
+	if err != nil {
+		return fmt.Errorf("read existing repo remote: %w", err)
+	}
+	got := strings.TrimSpace(result.Stdout)
+	if sameRepoRemote(got, repoURL) {
+		return nil
+	}
+	return fmt.Errorf("existing repo at %s uses remote %q, not %q", mgr.RepoDir(), got, repoURL)
+}
+
+func sameRepoRemote(a, b string) bool {
+	return canonicalRepoRemote(a) == canonicalRepoRemote(b)
+}
+
+func canonicalRepoRemote(remote string) string {
+	remote = strings.TrimSuffix(strings.TrimSpace(remote), ".git")
+	remote = strings.TrimPrefix(remote, "https://github.com/")
+	remote = strings.TrimPrefix(remote, "git@github.com:")
+	return remote
+}
+
 func recreateDefaultWorktree(ctx context.Context, mgr *wt.Manager, defaultBranch string) (string, error) {
 	mainPath := filepath.Join(mgr.RepoDir(), defaultBranch)
 	if _, err := mgr.GitRunner().Run(ctx, []string{"worktree", "prune"}, mgr.BareDir()); err != nil {
@@ -142,7 +192,7 @@ var ownerRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 
 func normalizeRepoURL(repoArg string) string {
 	if ownerRepoPattern.MatchString(repoArg) {
-		return "https://github.com/" + repoArg + ".git"
+		return "https://github.com/" + strings.TrimSuffix(repoArg, ".git") + ".git"
 	}
 	return repoArg
 }

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bazelment/yoloswe/jiradozer"
+	"github.com/bazelment/yoloswe/wt"
 )
 
 // TestBootstrapPromptParity catches prompt drift: a bootstrap → YAML →
@@ -253,4 +255,99 @@ func TestBootstrapDefaultPath(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(dir, "jiradozer.yaml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "jiradozer bootstrap")
+}
+
+func TestBootstrapWithRepoCreatesWorktreeAndKeepsConfigOutsideRepo(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "test")
+	wtRoot := t.TempDir()
+	t.Setenv("WT_ROOT", wtRoot)
+	outputDir := t.TempDir()
+	t.Chdir(outputDir)
+	remoteDir := newBootstrapRemote(t)
+
+	args := &bootstrapArgs{}
+	configPath := "jiradozer.yaml"
+	cmd := newBootstrapCommand(args, &configPath)
+	cmd.SetArgs([]string{"--repo", remoteDir})
+	require.NoError(t, cmd.Execute())
+
+	repoName := wt.GetRepoNameFromURL(remoteDir)
+	mainPath := filepath.Join(wtRoot, repoName, "main")
+	configPathInRepoContainer := filepath.Join(wtRoot, repoName, "jiradozer.yaml")
+	require.FileExists(t, filepath.Join(wtRoot, repoName, ".bare", "HEAD"))
+	require.DirExists(t, mainPath)
+	require.FileExists(t, configPathInRepoContainer)
+	require.NoFileExists(t, filepath.Join(outputDir, "jiradozer.yaml"))
+	require.NoFileExists(t, filepath.Join(mainPath, "jiradozer.yaml"))
+
+	cfg, err := jiradozer.LoadConfig(configPathInRepoContainer)
+	require.NoError(t, err)
+	assert.Equal(t, mainPath, cfg.WorkDir)
+
+	git := &wt.DefaultGitRunner{}
+	result, err := git.Run(context.Background(), []string{"status", "--porcelain"}, mainPath)
+	require.NoError(t, err)
+	assert.Empty(t, result.Stdout, "bootstrap --repo should leave the cloned worktree clean")
+}
+
+func TestBootstrapWithRepoReusesExistingWorktree(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "test")
+	wtRoot := t.TempDir()
+	t.Setenv("WT_ROOT", wtRoot)
+	outputDir := t.TempDir()
+	t.Chdir(outputDir)
+	remoteDir := newBootstrapRemote(t)
+
+	args := &bootstrapArgs{}
+	configPath := "jiradozer.yaml"
+	cmd := newBootstrapCommand(args, &configPath)
+	cmd.SetArgs([]string{"--repo", remoteDir})
+	require.NoError(t, cmd.Execute())
+
+	cmd = newBootstrapCommand(&bootstrapArgs{}, &configPath)
+	cmd.SetArgs([]string{"--repo", remoteDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	cmd = newBootstrapCommand(&bootstrapArgs{}, &configPath)
+	cmd.SetArgs([]string{"--repo", remoteDir, "--force"})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestBootstrapWithRepoExpandsOwnerRepoShorthand(t *testing.T) {
+	assert.Equal(t, "https://github.com/owner/repo.git", normalizeRepoURL("owner/repo"))
+	assert.Equal(t, "https://example.com/owner/repo.git", normalizeRepoURL("https://example.com/owner/repo.git"))
+	assert.Equal(t, "git@github.com:owner/repo.git", normalizeRepoURL("git@github.com:owner/repo.git"))
+}
+
+func newBootstrapRemote(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	git := &wt.DefaultGitRunner{}
+
+	remoteDir := filepath.Join(t.TempDir(), "repo.git")
+	require.NoError(t, os.MkdirAll(remoteDir, 0o755))
+	_, err := git.Run(ctx, []string{"init", "--bare"}, remoteDir)
+	require.NoError(t, err)
+
+	setupDir := t.TempDir()
+	_, err = git.Run(ctx, []string{"clone", remoteDir, setupDir}, "")
+	require.NoError(t, err)
+	_, err = git.Run(ctx, []string{"config", "user.email", "test@example.com"}, setupDir)
+	require.NoError(t, err)
+	_, err = git.Run(ctx, []string{"config", "user.name", "Test User"}, setupDir)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(setupDir, "README.md"), []byte("# Test Repo\n"), 0o644))
+	_, err = git.Run(ctx, []string{"add", "."}, setupDir)
+	require.NoError(t, err)
+	_, err = git.Run(ctx, []string{"commit", "-m", "initial commit"}, setupDir)
+	require.NoError(t, err)
+	_, err = git.Run(ctx, []string{"branch", "-M", "main"}, setupDir)
+	require.NoError(t, err)
+	_, err = git.Run(ctx, []string{"push", "-u", "origin", "main"}, setupDir)
+	require.NoError(t, err)
+	_, err = git.Run(ctx, []string{"symbolic-ref", "HEAD", "refs/heads/main"}, remoteDir)
+	require.NoError(t, err)
+	return remoteDir
 }

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -289,6 +289,11 @@ func TestBootstrapWithRepoCreatesWorktreeAndReusesExistingWorktree(t *testing.T)
 	cmd = fixture.newCommand()
 	cmd.SetArgs([]string{"--repo", fixture.remoteDir, "--force"})
 	require.NoError(t, cmd.Execute())
+
+	cfg, err = jiradozer.LoadConfig(fixture.configPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
+	assert.Equal(t, "main", cfg.BaseBranch)
 }
 
 func TestBootstrapWithRepoHonorsExplicitConfigPath(t *testing.T) {
@@ -325,8 +330,8 @@ func TestBootstrapWithRepoHonorsOutputPath(t *testing.T) {
 	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
 }
 
-func TestBootstrapWithRepoUsesRemoteDefaultBranchInConfig(t *testing.T) {
-	fixture := newBootstrapRepoFixtureWithDefaultBranch(t, "master")
+func TestBootstrapWithRepoUsesNamespacedRemoteDefaultBranchInConfig(t *testing.T) {
+	fixture := newBootstrapRepoFixtureWithDefaultBranch(t, "release/v1")
 
 	cmd := fixture.newCommand()
 	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
@@ -335,7 +340,7 @@ func TestBootstrapWithRepoUsesRemoteDefaultBranchInConfig(t *testing.T) {
 	cfg, err := jiradozer.LoadConfig(fixture.configPath)
 	require.NoError(t, err)
 	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
-	assert.Equal(t, "master", cfg.BaseBranch)
+	assert.Equal(t, "release/v1", cfg.BaseBranch)
 }
 
 func TestBootstrapWithRepoRecreatesMissingDefaultWorktree(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -325,6 +325,19 @@ func TestBootstrapWithRepoHonorsOutputPath(t *testing.T) {
 	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
 }
 
+func TestBootstrapWithRepoUsesRemoteDefaultBranchInConfig(t *testing.T) {
+	fixture := newBootstrapRepoFixtureWithDefaultBranch(t, "master")
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := jiradozer.LoadConfig(fixture.configPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
+	assert.Equal(t, "master", cfg.BaseBranch)
+}
+
 func TestBootstrapWithRepoRecreatesMissingDefaultWorktree(t *testing.T) {
 	fixture := newBootstrapRepoFixture(t)
 
@@ -414,20 +427,24 @@ type bootstrapRepoFixture struct {
 }
 
 func newBootstrapRepoFixture(t *testing.T) bootstrapRepoFixture {
+	return newBootstrapRepoFixtureWithDefaultBranch(t, "main")
+}
+
+func newBootstrapRepoFixtureWithDefaultBranch(t *testing.T, defaultBranch string) bootstrapRepoFixture {
 	t.Helper()
 	t.Setenv("LINEAR_API_KEY", "test")
 	wtRoot := t.TempDir()
 	t.Setenv("WT_ROOT", wtRoot)
 	outputDir := t.TempDir()
 	t.Chdir(outputDir)
-	remoteDir := newBootstrapRemote(t)
+	remoteDir := newBootstrapRemoteWithDefaultBranch(t, defaultBranch)
 	repoName := wt.GetRepoNameFromURL(remoteDir)
 	return bootstrapRepoFixture{
 		wtRoot:     wtRoot,
 		outputDir:  outputDir,
 		remoteDir:  remoteDir,
 		repoName:   repoName,
-		mainPath:   filepath.Join(wtRoot, repoName, "main"),
+		mainPath:   filepath.Join(wtRoot, repoName, defaultBranch),
 		configPath: filepath.Join(wtRoot, repoName, "jiradozer.yaml"),
 	}
 }
@@ -451,6 +468,10 @@ func TestSameRepoRemoteAcceptsEquivalentGitHubForms(t *testing.T) {
 }
 
 func newBootstrapRemote(t *testing.T) string {
+	return newBootstrapRemoteWithDefaultBranch(t, "main")
+}
+
+func newBootstrapRemoteWithDefaultBranch(t *testing.T, defaultBranch string) string {
 	t.Helper()
 	ctx := context.Background()
 	git := &wt.DefaultGitRunner{}
@@ -472,11 +493,11 @@ func newBootstrapRemote(t *testing.T) string {
 	require.NoError(t, err)
 	_, err = git.Run(ctx, []string{"commit", "-m", "initial commit"}, setupDir)
 	require.NoError(t, err)
-	_, err = git.Run(ctx, []string{"branch", "-M", "main"}, setupDir)
+	_, err = git.Run(ctx, []string{"branch", "-M", defaultBranch}, setupDir)
 	require.NoError(t, err)
-	_, err = git.Run(ctx, []string{"push", "-u", "origin", "main"}, setupDir)
+	_, err = git.Run(ctx, []string{"push", "-u", "origin", defaultBranch}, setupDir)
 	require.NoError(t, err)
-	_, err = git.Run(ctx, []string{"symbolic-ref", "HEAD", "refs/heads/main"}, remoteDir)
+	_, err = git.Run(ctx, []string{"symbolic-ref", "HEAD", "refs/heads/" + defaultBranch}, remoteDir)
 	require.NoError(t, err)
 	return remoteDir
 }

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -330,6 +330,22 @@ func TestBootstrapWithRepoRecreatesMissingDefaultWorktree(t *testing.T) {
 	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
 }
 
+func TestBootstrapWithRepoRecoversWorktreeBeforeExistingConfigError(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	require.NoError(t, cmd.Execute())
+	require.NoError(t, os.RemoveAll(fixture.mainPath))
+
+	cmd = fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+	require.DirExists(t, fixture.mainPath)
+}
+
 func TestBootstrapWithRepoDoesNotCloneWhenConfigExists(t *testing.T) {
 	fixture := newBootstrapRepoFixture(t)
 	require.NoError(t, os.MkdirAll(filepath.Dir(fixture.configPath), 0o755))
@@ -341,6 +357,21 @@ func TestBootstrapWithRepoDoesNotCloneWhenConfigExists(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 	require.NoDirExists(t, filepath.Join(fixture.wtRoot, fixture.repoName, ".bare"))
+}
+
+func TestBootstrapWithRepoRejectsSameNameDifferentRemote(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	require.NoError(t, cmd.Execute())
+
+	otherRemote := newBootstrapRemote(t)
+	cmd = fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", otherRemote, "--force"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uses remote")
 }
 
 type bootstrapRepoFixture struct {
@@ -378,6 +409,7 @@ func (f bootstrapRepoFixture) newCommand() *cobra.Command {
 
 func TestBootstrapWithRepoExpandsOwnerRepoShorthand(t *testing.T) {
 	assert.Equal(t, "https://github.com/owner/repo.git", normalizeRepoURL("owner/repo"))
+	assert.Equal(t, "https://github.com/owner/repo.git", normalizeRepoURL("owner/repo.git"))
 	assert.Equal(t, "https://example.com/owner/repo.git", normalizeRepoURL("https://example.com/owner/repo.git"))
 	assert.Equal(t, "git@github.com:owner/repo.git", normalizeRepoURL("git@github.com:owner/repo.git"))
 }

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -310,6 +310,21 @@ func TestBootstrapWithRepoHonorsExplicitConfigPath(t *testing.T) {
 	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
 }
 
+func TestBootstrapWithRepoHonorsOutputPath(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+	outputPath := filepath.Join(fixture.outputDir, "generated.yaml")
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir, "--output", outputPath})
+	require.NoError(t, cmd.Execute())
+	require.FileExists(t, outputPath)
+	require.NoFileExists(t, fixture.configPath)
+
+	cfg, err := jiradozer.LoadConfig(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
+}
+
 func TestBootstrapWithRepoRecreatesMissingDefaultWorktree(t *testing.T) {
 	fixture := newBootstrapRepoFixture(t)
 
@@ -344,6 +359,21 @@ func TestBootstrapWithRepoRecoversWorktreeBeforeExistingConfigError(t *testing.T
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 	require.DirExists(t, fixture.mainPath)
+}
+
+func TestBootstrapWithRepoRejectsBrokenDefaultWorktreeDirectory(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	require.NoError(t, cmd.Execute())
+	require.NoError(t, os.RemoveAll(filepath.Join(fixture.mainPath, ".git")))
+
+	cmd = fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir, "--force"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a git worktree")
 }
 
 func TestBootstrapWithRepoDoesNotCloneWhenConfigExists(t *testing.T) {
@@ -412,6 +442,12 @@ func TestBootstrapWithRepoExpandsOwnerRepoShorthand(t *testing.T) {
 	assert.Equal(t, "https://github.com/owner/repo.git", normalizeRepoURL("owner/repo.git"))
 	assert.Equal(t, "https://example.com/owner/repo.git", normalizeRepoURL("https://example.com/owner/repo.git"))
 	assert.Equal(t, "git@github.com:owner/repo.git", normalizeRepoURL("git@github.com:owner/repo.git"))
+}
+
+func TestSameRepoRemoteAcceptsEquivalentGitHubForms(t *testing.T) {
+	assert.True(t, sameRepoRemote("https://github.com/owner/repo.git", "git@github.com:owner/repo.git"))
+	assert.True(t, sameRepoRemote("ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo.git"))
+	assert.False(t, sameRepoRemote("https://github.com/other/repo.git", "https://github.com/owner/repo.git"))
 }
 
 func newBootstrapRemote(t *testing.T) string {

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,7 +22,7 @@ func TestBootstrapPromptParity(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "jiradozer.yaml")
-	content, err := bootstrapYAML()
+	content, err := bootstrapYAML("")
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, content, 0o644))
 
@@ -59,7 +60,7 @@ func TestBootstrapRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "jiradozer.yaml")
 
-	content, err := bootstrapYAML()
+	content, err := bootstrapYAML("")
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, content, 0o644))
 
@@ -100,7 +101,7 @@ func TestBootstrapRoundTrip(t *testing.T) {
 func TestExampleYAMLMatchesBootstrap(t *testing.T) {
 	t.Setenv("LINEAR_API_KEY", "test")
 
-	want, err := bootstrapYAML()
+	want, err := bootstrapYAML("")
 	require.NoError(t, err)
 
 	// rundir = "." in BUILD.bazel keeps the test cwd at the workspace
@@ -257,62 +258,83 @@ func TestBootstrapDefaultPath(t *testing.T) {
 	assert.Contains(t, string(got), "jiradozer bootstrap")
 }
 
-func TestBootstrapWithRepoCreatesWorktreeAndKeepsConfigOutsideRepo(t *testing.T) {
-	t.Setenv("LINEAR_API_KEY", "test")
-	wtRoot := t.TempDir()
-	t.Setenv("WT_ROOT", wtRoot)
-	outputDir := t.TempDir()
-	t.Chdir(outputDir)
-	remoteDir := newBootstrapRemote(t)
+func TestBootstrapWithRepoCreatesWorktreeAndReusesExistingWorktree(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
 
-	args := &bootstrapArgs{}
-	configPath := "jiradozer.yaml"
-	cmd := newBootstrapCommand(args, &configPath)
-	cmd.SetArgs([]string{"--repo", remoteDir})
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
 	require.NoError(t, cmd.Execute())
 
-	repoName := wt.GetRepoNameFromURL(remoteDir)
-	mainPath := filepath.Join(wtRoot, repoName, "main")
-	configPathInRepoContainer := filepath.Join(wtRoot, repoName, "jiradozer.yaml")
-	require.FileExists(t, filepath.Join(wtRoot, repoName, ".bare", "HEAD"))
-	require.DirExists(t, mainPath)
-	require.FileExists(t, configPathInRepoContainer)
-	require.NoFileExists(t, filepath.Join(outputDir, "jiradozer.yaml"))
-	require.NoFileExists(t, filepath.Join(mainPath, "jiradozer.yaml"))
+	require.FileExists(t, filepath.Join(fixture.wtRoot, fixture.repoName, ".bare", "HEAD"))
+	require.DirExists(t, fixture.mainPath)
+	require.FileExists(t, fixture.configPath)
+	require.NoFileExists(t, filepath.Join(fixture.outputDir, "jiradozer.yaml"))
+	require.NoFileExists(t, filepath.Join(fixture.mainPath, "jiradozer.yaml"))
 
-	cfg, err := jiradozer.LoadConfig(configPathInRepoContainer)
+	cfg, err := jiradozer.LoadConfig(fixture.configPath)
 	require.NoError(t, err)
-	assert.Equal(t, mainPath, cfg.WorkDir)
+	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
 
 	git := &wt.DefaultGitRunner{}
-	result, err := git.Run(context.Background(), []string{"status", "--porcelain"}, mainPath)
+	result, err := git.Run(context.Background(), []string{"status", "--porcelain"}, fixture.mainPath)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stdout, "bootstrap --repo should leave the cloned worktree clean")
-}
 
-func TestBootstrapWithRepoReusesExistingWorktree(t *testing.T) {
-	t.Setenv("LINEAR_API_KEY", "test")
-	wtRoot := t.TempDir()
-	t.Setenv("WT_ROOT", wtRoot)
-	outputDir := t.TempDir()
-	t.Chdir(outputDir)
-	remoteDir := newBootstrapRemote(t)
-
-	args := &bootstrapArgs{}
-	configPath := "jiradozer.yaml"
-	cmd := newBootstrapCommand(args, &configPath)
-	cmd.SetArgs([]string{"--repo", remoteDir})
-	require.NoError(t, cmd.Execute())
-
-	cmd = newBootstrapCommand(&bootstrapArgs{}, &configPath)
-	cmd.SetArgs([]string{"--repo", remoteDir})
-	err := cmd.Execute()
+	cmd = fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	err = cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 
-	cmd = newBootstrapCommand(&bootstrapArgs{}, &configPath)
-	cmd.SetArgs([]string{"--repo", remoteDir, "--force"})
+	cmd = fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir, "--force"})
 	require.NoError(t, cmd.Execute())
+}
+
+func TestBootstrapWithRepoDoesNotCloneWhenConfigExists(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fixture.configPath), 0o755))
+	require.NoError(t, os.WriteFile(fixture.configPath, []byte("# existing\n"), 0o644))
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+	require.NoDirExists(t, filepath.Join(fixture.wtRoot, fixture.repoName, ".bare"))
+}
+
+type bootstrapRepoFixture struct {
+	wtRoot     string
+	outputDir  string
+	remoteDir  string
+	repoName   string
+	mainPath   string
+	configPath string
+}
+
+func newBootstrapRepoFixture(t *testing.T) bootstrapRepoFixture {
+	t.Helper()
+	t.Setenv("LINEAR_API_KEY", "test")
+	wtRoot := t.TempDir()
+	t.Setenv("WT_ROOT", wtRoot)
+	outputDir := t.TempDir()
+	t.Chdir(outputDir)
+	remoteDir := newBootstrapRemote(t)
+	repoName := wt.GetRepoNameFromURL(remoteDir)
+	return bootstrapRepoFixture{
+		wtRoot:     wtRoot,
+		outputDir:  outputDir,
+		remoteDir:  remoteDir,
+		repoName:   repoName,
+		mainPath:   filepath.Join(wtRoot, repoName, "main"),
+		configPath: filepath.Join(wtRoot, repoName, "jiradozer.yaml"),
+	}
+}
+
+func (f bootstrapRepoFixture) newCommand() *cobra.Command {
+	configPath := "jiradozer.yaml"
+	return newBootstrapCommand(&bootstrapArgs{}, &configPath)
 }
 
 func TestBootstrapWithRepoExpandsOwnerRepoShorthand(t *testing.T) {

--- a/jiradozer/cmd/jiradozer/bootstrap_test.go
+++ b/jiradozer/cmd/jiradozer/bootstrap_test.go
@@ -291,6 +291,45 @@ func TestBootstrapWithRepoCreatesWorktreeAndReusesExistingWorktree(t *testing.T)
 	require.NoError(t, cmd.Execute())
 }
 
+func TestBootstrapWithRepoHonorsExplicitConfigPath(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+	configPath := filepath.Join(fixture.outputDir, "custom-jiradozer.yaml")
+
+	var rootConfigPath string
+	root := &cobra.Command{Use: "jiradozer"}
+	root.PersistentFlags().StringVar(&rootConfigPath, "config", "jiradozer.yaml", "Path to config file")
+	root.AddCommand(newBootstrapCommand(&bootstrapArgs{}, &rootConfigPath))
+	root.SetArgs([]string{"--config", configPath, "bootstrap", "--repo", fixture.remoteDir})
+
+	require.NoError(t, root.Execute())
+	require.FileExists(t, configPath)
+	require.NoFileExists(t, fixture.configPath)
+
+	cfg, err := jiradozer.LoadConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
+}
+
+func TestBootstrapWithRepoRecreatesMissingDefaultWorktree(t *testing.T) {
+	fixture := newBootstrapRepoFixture(t)
+
+	cmd := fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir})
+	require.NoError(t, cmd.Execute())
+	require.DirExists(t, fixture.mainPath)
+	require.NoError(t, os.RemoveAll(fixture.mainPath))
+	require.NoDirExists(t, fixture.mainPath)
+
+	cmd = fixture.newCommand()
+	cmd.SetArgs([]string{"--repo", fixture.remoteDir, "--force"})
+	require.NoError(t, cmd.Execute())
+	require.DirExists(t, fixture.mainPath)
+
+	cfg, err := jiradozer.LoadConfig(fixture.configPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.mainPath, cfg.WorkDir)
+}
+
 func TestBootstrapWithRepoDoesNotCloneWhenConfigExists(t *testing.T) {
 	fixture := newBootstrapRepoFixture(t)
 	require.NoError(t, os.MkdirAll(filepath.Dir(fixture.configPath), 0o755))

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -743,7 +743,7 @@ func writeRunConfig(t *testing.T, trackerKind, workDir string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "jiradozer.yaml")
 	t.Setenv("LINEAR_API_KEY", "test-key")
-	content, err := bootstrapYAML()
+	content, err := bootstrapYAML("")
 	require.NoError(t, err)
 	content = bytes.Replace(content, []byte("kind: linear"), []byte("kind: "+trackerKind), 1)
 	content = bytes.Replace(content, []byte("work_dir: ."), []byte("work_dir: "+workDir), 1)
@@ -873,7 +873,7 @@ func TestValidateConfigUsesConfigPathFromRoot(t *testing.T) {
 		},
 	}
 
-	content, err := bootstrapYAML()
+	content, err := bootstrapYAML("")
 	require.NoError(t, err)
 
 	for _, tt := range tests {

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -385,13 +385,9 @@ func runMultiIssue(ctx context.Context, app *cliapp.App, issueTracker tracker.Is
 // resolveWTManager detects the wt-managed repository from the current
 // working directory, using the same logic as `wt` CLI.
 func resolveWTManager() (*wt.Manager, error) {
-	wtRoot := os.Getenv("WT_ROOT")
-	if wtRoot == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("cannot determine home directory: %w", err)
-		}
-		wtRoot = filepath.Join(home, "worktrees")
+	wtRoot, err := resolveWTRoot()
+	if err != nil {
+		return nil, err
 	}
 	ctx := context.Background()
 	repoName, err := wt.GetCurrentRepoName(ctx, &wt.DefaultGitRunner{}, wtRoot)
@@ -399,6 +395,18 @@ func resolveWTManager() (*wt.Manager, error) {
 		return nil, fmt.Errorf("not in a wt-managed repository (WT_ROOT=%s): %w", wtRoot, err)
 	}
 	return wt.NewManager(wtRoot, repoName), nil
+}
+
+func resolveWTRoot() (string, error) {
+	wtRoot := os.Getenv("WT_ROOT")
+	if wtRoot != "" {
+		return wtRoot, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, "worktrees"), nil
 }
 
 // buildChildArgs constructs CLI flags to propagate from the parent

--- a/wt/git.go
+++ b/wt/git.go
@@ -94,6 +94,12 @@ func GetDefaultBranch(ctx context.Context, runner GitRunner, repoPath string) (s
 		branch = strings.TrimPrefix(branch, "refs/remotes/origin/")
 		return branch, nil
 	}
+	result, err = runner.Run(ctx, []string{"symbolic-ref", "HEAD"}, repoPath)
+	if err == nil {
+		branch := strings.TrimSpace(result.Stdout)
+		branch = strings.TrimPrefix(branch, "refs/heads/")
+		return branch, nil
+	}
 
 	// Fall back to checking main/master
 	for _, branch := range []string{"main", "master"} {


### PR DESCRIPTION
## Summary
- Add `jiradozer bootstrap --repo` so a GitHub repo URL or `owner/repo` shorthand can initialize a `wt`-managed bare repo plus default-branch worktree under `$WT_ROOT` or `~/worktrees`.
- Generate repo bootstrap configs outside the cloned worktree by default at `$WT_ROOT/<repo>/jiradozer.yaml`, with `work_dir` pointing at the clean default-branch checkout and `base_branch` matching the detected default branch.
- Reuse existing `wt` repos safely by verifying equivalent remotes across HTTPS/SSH forms, detecting the repo default branch, recreating missing default worktrees after pruning stale metadata, and rejecting broken worktree directories or same-name repos with different remotes.
- Preserve explicit `--config` and `--output` behavior, share WT root resolution with run-mode worktree detection, and document the end-to-end repo bootstrap flow.
- Expand tests for repo creation/reuse, explicit output paths, owner/repo normalization, remote equivalence, namespaced default branches, missing-worktree recovery, and failure modes.

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new filesystem + git worktree automation (clone/reuse/prune/add) and changes default config output location, which could affect user environments if edge cases slip through.
> 
> **Overview**
> `jiradozer bootstrap` now supports `--repo` to create or reuse a `wt`-managed bare repo + default-branch worktree (including remote equivalence checks, default-branch detection, and worktree recreation if missing).
> 
> When `--repo` is used and `--config/--output` aren’t explicit, bootstrap writes `jiradozer.yaml` next to the repo under `$WT_ROOT` (or `~/worktrees`) and generates `work_dir`/`base_branch` pointing at that clean default worktree.
> 
> Adds shared `WT_ROOT` resolution helper, expands default-branch detection in `wt.GetDefaultBranch`, updates docs, and introduces extensive new tests covering repo shorthand normalization, reuse behavior, and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9227e0d2853d187dc89c44a191349942dcd4dea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
