### PR TITLE
Preserve fractional API retry delays

### DIFF
--- a/agent-cli-wrapper/claude/SDK_PROTOCOL.md
+++ b/agent-cli-wrapper/claude/SDK_PROTOCOL.md
@@ -167,7 +167,7 @@ no HTTP response.
 
 ```json
 {"type":"system","subtype":"api_retry","session_id":"abc","uuid":"s5",
- "attempt":1,"max_retries":5,"retry_delay_ms":2000,
+ "attempt":1,"max_retries":5,"retry_delay_ms":2000.5,
  "error":"overloaded_error","error_status":529}
 ```
 

--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -256,7 +256,7 @@ type APIRetryEvent struct {
 	ErrorType    string
 	Attempt      int
 	MaxRetries   int
-	RetryDelayMs int
+	RetryDelayMs float64
 	TurnNumber   int
 }
 

--- a/agent-cli-wrapper/claude/session_dispatch_test.go
+++ b/agent-cli-wrapper/claude/session_dispatch_test.go
@@ -177,7 +177,7 @@ func TestSessionDispatchNewEvents(t *testing.T) {
 			line: mkSystem(t, "api_retry", map[string]interface{}{
 				"attempt":        2,
 				"max_retries":    5,
-				"retry_delay_ms": 1000,
+				"retry_delay_ms": 1000.5,
 				"error":          "overloaded",
 			}),
 			check: func(t *testing.T, ev Event) {
@@ -185,6 +185,7 @@ func TestSessionDispatchNewEvents(t *testing.T) {
 				require.True(t, ok, "got %T", ev)
 				require.Equal(t, 2, e.Attempt)
 				require.Equal(t, 5, e.MaxRetries)
+				require.Equal(t, 1000.5, e.RetryDelayMs)
 			},
 		},
 		{

--- a/agent-cli-wrapper/protocol/system.go
+++ b/agent-cli-wrapper/protocol/system.go
@@ -115,13 +115,13 @@ type PostTurnSummaryPayload struct {
 // and will be retried after a delay. ErrorStatus is null for connection errors
 // (e.g. timeouts) that had no HTTP response.
 type APIRetryPayload struct {
-	ErrorStatus  *int   `json:"error_status"`
-	Error        string `json:"error"`
-	UUID         string `json:"uuid"`
-	SessionID    string `json:"session_id"`
-	Attempt      int    `json:"attempt"`
-	MaxRetries   int    `json:"max_retries"`
-	RetryDelayMs int    `json:"retry_delay_ms"`
+	ErrorStatus  *int    `json:"error_status"`
+	Error        string  `json:"error"`
+	UUID         string  `json:"uuid"`
+	SessionID    string  `json:"session_id"`
+	Attempt      int     `json:"attempt"`
+	MaxRetries   int     `json:"max_retries"`
+	RetryDelayMs float64 `json:"retry_delay_ms"`
 }
 
 // LocalCommandOutputPayload carries output from a local slash command

--- a/agent-cli-wrapper/protocol/system_test.go
+++ b/agent-cli-wrapper/protocol/system_test.go
@@ -130,13 +130,13 @@ func TestSystemSubtype_PostTurnSummary(t *testing.T) {
 }
 
 func TestSystemSubtype_APIRetry(t *testing.T) {
-	raw := `{"type":"system","subtype":"api_retry","session_id":"s1","uuid":"u1","attempt":2,"max_retries":5,"retry_delay_ms":1000,"error":"overloaded","error_status":529}`
+	raw := `{"type":"system","subtype":"api_retry","session_id":"s1","uuid":"u1","attempt":2,"max_retries":5,"retry_delay_ms":1000.5,"error":"overloaded","error_status":529}`
 	m := parseSystem(t, raw)
 	p, ok := m.AsAPIRetry()
 	if !ok {
 		t.Fatalf("AsAPIRetry failed")
 	}
-	if p.Attempt != 2 || p.MaxRetries != 5 || p.RetryDelayMs != 1000 {
+	if p.Attempt != 2 || p.MaxRetries != 5 || p.RetryDelayMs != 1000.5 {
 		t.Errorf("retry fields: %+v", p)
 	}
 	if p.Error != "overloaded" {


### PR DESCRIPTION
## Summary
- Preserve fractional `retry_delay_ms` values from `system/api_retry` messages by changing the protocol payload and dispatched Claude API retry event fields from `int` to `float64`.
- Keep API retry parsing and event dispatch behavior aligned so fractional retry delays survive JSON unmarshalling through the public event surface.
- Update SDK protocol documentation and tests to cover fractional retry delay values.

## Changed files
- `agent-cli-wrapper/protocol/system.go`
- `agent-cli-wrapper/claude/events.go`
- `agent-cli-wrapper/protocol/system_test.go`
- `agent-cli-wrapper/claude/session_dispatch_test.go`
- `agent-cli-wrapper/claude/SDK_PROTOCOL.md`

## Compatibility note
- This intentionally changes `retry_delay_ms` from an integer millisecond field to a floating-point millisecond field for API retry payloads/events so SDK-emitted fractional values are not truncated or rejected.

## Validation
- `scripts/lint.sh`
- `bazel build //...`
- `bazel test //... --test_timeout=60`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the wire/type schema for `retry_delay_ms` from `int` to `float64`, which can break downstream code expecting an integer and alters JSON unmarshalling behavior.
> 
> **Overview**
> Preserves fractional `retry_delay_ms` values in `system/api_retry` frames by changing the field type from integer milliseconds to `float64` in both the protocol payload (`protocol.APIRetryPayload`) and dispatched wrapper event (`claude.APIRetryEvent`).
> 
> Updates protocol documentation and unit tests to assert fractional retry delays survive JSON parsing and event dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1481e2d9e201134523ce50a21817338a4429a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->