### PR TITLE
Make /pr-polish less rigid

### DIFF
--- a/.claude/skills/code-review-eval/data/eval-runs.log
+++ b/.claude/skills/code-review-eval/data/eval-runs.log
@@ -946,3 +946,109 @@ Notes:
 - The bias-guard prompt update (2026-05-06) continues to perform well: cursor swapped its 2 findings completely between turn 1 and turn 2 rather than just ratifying. Codex moved 0→1, also a sign the resumed pass is doing real work.
 - Gemini's 0/0/0 with apparent scope confusion is the most actionable signal here. File a follow-up to verify gemini backend's diff-range argument.
 
+## 2026-05-09 — feature/improve-skill
+
+Diff: 5 files, +958 / -22 lines (pr-polish skill: SKILL.md tweaks, big
+bramble_ops.py extension, big pr_ops.py extension with inline-reply
+auto-post + _merge_actions, two new test files for bramble_ops and
+pr_ops)
+
+| Config | Turn | Resume | Findings | FPs | Verdict | Confidence | Time | Tokens (in/out) |
+|--------|------|--------|----------|-----|---------|------------|------|-----------------|
+| cursor-composer2 | 1 | — | error | — | error | — | 12s | — |
+| cursor-composer2 | 2 | ok | error | — | error | — | 4s | — |
+| cursor-composer2 | 3 | ok | error | — | error | — | 5s | — |
+| codex-5.4-mini | 1 | — | 1 | 0 | rejected | 0.97 | 166s | 0/0 |
+| codex-5.4-mini | 2 | ok | 1 | 0 | rejected | 0.98 | 67s | 0/0 |
+| codex-5.4-mini | 3 | ok | 1 | 0 | rejected | 0.98 | 11s | 0/0 |
+| gemini-3.1-flash-lite-preview | 1 | — | 0 | 0 | accepted | — | 11s | — |
+| gemini-3.1-flash-lite-preview | 2 | ok | 0 | 0 | accepted | — | 4s | — |
+| gemini-3.1-flash-lite-preview | 3 | ok | 0 | 0 | accepted | — | 1s | — |
+
+Resume incidents: cursor returned `cursor: session ended without result`
+on every turn. Stderr shows `Increase limits for faster responses You're
+out of usage. Switch to Auto, or ask your admin to increase your limit
+to continue.` — Cursor account quota is exhausted, not a transport or
+session-store fault. Cursor still emitted a session id on turn 1, so
+turns 2 and 3 dispatched as resume-with-fresh-start; the backend
+faithfully reported `resume_status=ok` (resume succeeded; the *review*
+failed for an unrelated quota reason).
+
+Consensus (all 3, turn 1): none — cursor errored, gemini found 0
+Majority (2 of 3, turn 1): none
+Unique to cursor (turn 1): n/a (errored before reviewing)
+Unique to codex-5.4-mini (turn 1):
+  - .claude/skills/pr-polish/scripts/pr_ops.py:1104 (medium, 0.97) —
+    `_merge_actions` does `by_key[_action_key(a)] = a` (new wins on
+    conflict), so a re-finalize from a freshly computed action list
+    drops `reply_url`/`reply_error` written by a prior finalize pass,
+    making `_post_inline_replies` non-idempotent across replays
+Unique to gemini-3.1-flash-lite-preview (turn 1): none
+Disagreements: codex flagged a real replay-safety bug; gemini accepted
+0 issues in 11s — clearly not engaging with the diff (verdict is a
+summary-rubber-stamp, not a code review). Cursor signal unavailable.
+
+Follow-up deltas:
+- cursor-composer2: errored on all 3 turns. Resume mechanics worked
+  (`resume_status=ok` on turn 2 and 3); the underlying review failed
+  identically each time due to the account quota cap. No findings to
+  diff.
+- codex-5.4-mini: turn 1 → turn 2 same finding, slightly tightened
+  wording, confidence 0.97 → 0.98. Turn 2 → turn 3 identical message
+  and suggestion. Turn 3 ran in 11s vs turn 2's 67s and turn 1's 166s,
+  matching the prior eval's pattern: a "fresh prompt" on a resumed
+  session mostly recalls prior reasoning rather than re-deriving it.
+  No new findings on either resume turn — the bias-guard prompt
+  worked (no ratifying-only behavior) but there genuinely wasn't more
+  to find at this depth.
+- gemini-3.1-flash-lite-preview: 0/0/0 across all three turns. Turn 1
+  ran in 10.5s after a quota retry and produced a verdict with no
+  evident file inspection (`{"verdict": "accepted", "summary": "...",
+  "issues": []}`); turn 2 ran in 4s and turn 3 in 1s — consistent with
+  recall, not analysis. Same pattern as 2026-05-08 entry: gemini-flash-
+  lite is not engaging with the actual diff. Codex's medium finding
+  matches cursor-style review territory and gemini missing it
+  reinforces the prior conclusion that this model is unfit for the
+  reviewer role at any prompt shape.
+
+Resume health: cursor=ok (resume worked, review failed for quota),
+codex=ok, gemini=ok.
+
+Notes:
+- Verified codex's finding by reading `_merge_actions` and
+  `finalize_round`. The bug is real: `existing` carries `reply_url`
+  from a prior persist; the new `actions` list is freshly computed
+  from comments and won't carry it. On re-finalize across processes,
+  the merged dict loses `reply_url` and `_post_inline_replies` will
+  re-post. Within a single process the in-memory mutation is preserved
+  before the next merge so the bug is latent, but the replay-safety
+  hazard is genuine. Codex's suggested fix (preserve
+  `reply_url`/`reply_error` when the incoming row lacks them) is the
+  right one. Severity medium is reasonable.
+- Cursor quota exhaustion masks the most useful single signal in this
+  eval — cursor is typically the strongest reviewer for the pr-polish
+  surface area. Without it, we have a single voice (codex) flagging
+  the real bug and a silent voice (gemini) that's not engaging. The
+  comparison loses cross-validation power; rerun once cursor quota
+  resets to confirm whether cursor independently flags the same
+  `_merge_actions` issue.
+- Codex stderr token counts still 0/0 — pre-existing issue, see prior
+  entries.
+
+### Cross-eval observations
+
+- Gemini's "fast verdict from summary" pattern is now stable across
+  three branches in a row (2026-05-08 design-doc PR, 2026-05-08
+  trim/verdict commits, this branch). The 1–11s turn times and the
+  zero-issue verdicts even on diffs with known real bugs make
+  gemini-3.1-flash-lite-preview not viable as the sole reviewer in
+  pr-polish at any prompt shape.
+- The "turn 3 fresh prompt mostly recalls turn 2" pattern is now seen
+  on three consecutive evals for codex (12s recall, 11s recall here).
+  The current taxonomy treats `--resume-prompt-style fresh` as a
+  separate eval signal, but in practice on codex it's degenerating
+  into a cache-of-turn-2. Worth a future change to either prepend a
+  short "ignore your prior conclusions" cue to the fresh-prompt path
+  on resumed sessions, or accept that turn 3's value here is mostly
+  the resume-fault detector, not a re-derivation.
+

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -26,7 +26,7 @@ Shell plumbing lives in Python helpers under `scripts/`. Use `SKILL_DIR=.claude/
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--rounds N` | `5` | The round number this invocation stops at (inclusive). Resuming at `current_round=5` with `--rounds 7` runs rounds 6 and 7. `--rounds 5` on the same state is a no-op. |
+| `--rounds N` | `5` | Run up to N additional rounds from current state. Resuming at `current_round=5` with `--rounds 2` runs rounds 6 and 7. `--rounds 0` is a no-op. The budget is per-invocation: re-invoking with the same `--rounds` after a converged or capped exit gives N fresh rounds. |
 | `--gemini` | off | Also run a third reviewer with `--backend gemini --model gemini-3-flash-preview`. A finding agreed on by ≥2 sources counts as consensus. |
 
 PR/branch context is auto-detected by `pr_ops.py identify`.
@@ -49,7 +49,7 @@ Class-level fixes beyond the cited line are logged in `comment_actions` as `sour
 - Top-rated finding is a documented false positive.
 - Empty action plan after triage.
 
-**Hard stop at `--rounds N`.** When round N completes without convergence, produce Final Summary, then `AskUserQuestion` whether to continue.
+**Hard stop after N additional rounds.** When `additional_rounds_run` reaches `--rounds` without convergence, produce Final Summary, then `AskUserQuestion` whether to continue.
 
 ## Auto-decision rules
 
@@ -57,7 +57,7 @@ Bias for action and your own judgement with research. Only three things pause th
 
 1. **Integrity gate** — stale state file with PR mismatch (Step 0.5).
 2. **Budget gate** — `--rounds N` reached without convergence.
-3. **Regression gate** — `spiral_matches` non-empty (a prior-round `fixed` finding re-surfaced).
+3. **Regression gate** — **unverified** `spiral_matches` non-empty. Single-source spirals whose cited evidence is no longer at HEAD (within ±10 lines of the cited line) are auto-demoted to `batch_stale` with a `stale_reason` of `"spiral candidate auto-demoted: cited evidence absent at HEAD"` — the prior round fixed it and the resumed model is re-flagging stale context. Multi-source spirals (≥2 backends agree on the regression) always escalate. The audit row records `action: "stale"` with the demote reason. Cost of being wrong: a real regression that gets mis-demoted will likely re-surface next round — and if it does, the heuristic's evidence-at-HEAD check will find the cited code, so the second occurrence escalates correctly.
 
 ## State tracking
 
@@ -191,9 +191,12 @@ Compare against `git rev-parse HEAD`:
 - **`is_heartbeat_stale: true`** AND `completed: false` (heartbeat older than 2h, or missing): prior run abandoned. Tombstone with `state-mark-abandoned $CTX` and start fresh on current HEAD. Announce in one line; do not ask.
 - **HEAD matches `last_commit_at_round_start`** (heartbeat fresh): prior round interrupted. Resume in-progress round.
 - **HEAD differs from `last_commit_at_round_start`** (heartbeat fresh): prior round committed or user made manual changes. Auto-start next round on current HEAD. Re-invocation is the user's signal that they want another round. The new `state-append-round` clears any stale `completed: true` set by a prior `state-mark-complete`.
-- **`current_round` ≥ `--rounds`**: budget gate hard-stop. `AskUserQuestion` to authorize more rounds.
+
+Budget tracking is **per-invocation**, not derived from `current_round`. Initialize `additional_rounds_run = 0` at the top of this invocation; increment after every finalized round. The budget gate hard-stops when `additional_rounds_run >= --rounds` and `AskUserQuestion`s to authorize more rounds. State persistence does not record this counter — re-invoking after a converged or capped exit gives a fresh `--rounds` budget by definition.
 
 With a state file present, trust it and apply the rules — heartbeat distinguishes recent compaction from real abandonment. With no state file, start fresh. Do not ask.
+
+When you need to know whether the local branch and remote are in sync (e.g. surfacing "git-sync already pushed; nothing to push at end" in the round summary), use `pr_ops.py remote-head <branch>` — it routes through `git ls-remote`, not `git rev-parse origin/<branch>` (which lags in worktrees).
 
 ## Step 1: Sync base via /git:sync-base
 
@@ -244,7 +247,9 @@ python3 $SKILL_DIR/scripts/pr_ops.py ci-failed-tests > $STATE_DIR/pp-ci.json
 ## Step 3: Round loop
 
 ```
-for round = 1..ROUNDS:
+additional_rounds_run = 0
+while additional_rounds_run < --rounds:
+  ROUND = current_round_from_state + 1   # absolute round number for state
   a) commit any pending changes (WIP ok)
   b) launch bramble codex + cursor + lint via Monitor (parallel)
   c) triage findings (+ pr-comments + ci-failures if new series)
@@ -252,9 +257,10 @@ for round = 1..ROUNDS:
   e) if fixes applied: run quality gates, commit locally (NO push)
   f) finalize round state
   g) check convergence; exit if met
+  additional_rounds_run += 1
 ```
 
-Header per round: `## Round N / ROUNDS`.
+Header per round: `## Round N (M / --rounds in this invocation)` where N is the absolute round number persisted in state and M is `additional_rounds_run + 1`.
 
 ### a) Pending-change WIP commit
 
@@ -278,7 +284,8 @@ Compute the round's `--goal` text and per-backend resume id:
 ```bash
 GOAL=$(python3 $SKILL_DIR/scripts/bramble_ops.py goal {ROUND} \
         --pr-summary "$PR_SUMMARY" --state-file "$STATE_FILE" \
-        --head-before "$(git rev-parse HEAD)")
+        --head-before "$(git rev-parse HEAD)" \
+        --is-new-series "$IS_NEW_SERIES")
 CODEX_RESUME=$(python3 $SKILL_DIR/scripts/bramble_ops.py prior-session-id codex {ROUND} \
                 --state-file "$STATE_FILE" --is-new-series "$IS_NEW_SERIES")
 CURSOR_RESUME=$(python3 $SKILL_DIR/scripts/bramble_ops.py prior-session-id cursor {ROUND} \
@@ -396,13 +403,7 @@ What good looks like by the end of this step:
 - When the fix changes behavior, vocabulary, or an invariant, docs and tests that pin it are updated in the same commit.
 - Every triaged finding has a `comment_actions` entry. Sites fixed beyond a cited line are logged as `source: "sweep"`.
 - Stale buckets honored: `batch_stale` entries auto-acked; bramble findings whose cited code no longer matches are recorded as `action: "stale"` rather than silently dropped (silent drops blind the spiral guard).
-- Inline PR comments closed by this round have an auto-reply via `pr_ops.py reply-inline`. Reply bodies:
-  - `fixed`: `Fixed in <short_sha>.`
-  - `stale`: `Superseded by <short_sha> — the cited code was changed/removed in a later commit. (Auto-reply from /pr-polish.)`
-  - `false_positive`: `Marked false positive: <reason>. (Auto-reply from /pr-polish.)`
-  - `wont_fix`: `Won't fix: <reason>. (Auto-reply from /pr-polish.)`
-
-  Skip replies for `ack` and non-inline rows.
+- Inline-reply posting on github-inline rows whose action ∈ {`fixed`, `stale`, `false_positive`, `wont_fix`} is handled inside `state-finalize-round`. The orchestrator does not call `reply-inline` directly. `ack` and non-inline rows are intentionally not replied to (notification spam vs signal).
 
 `comment_actions` field shapes by source: bramble (`codex` / `cursor` / `gemini` / `lint`) → `comment_id: null`; CI → `source: "ci"`, `path: <job_id>`, `topic: <test_name>`; PR comments → `source: "github-inline"` / `-issue` / `-review` with `comment_id` from fetch; sweep → `source: "sweep"`, `comment_id: null`, `topic: "<original-topic> — class-level fix"`.
 
@@ -433,7 +434,7 @@ python3 $SKILL_DIR/scripts/pr_ops.py state-finalize-round $CTX $ROUND $(git rev-
 
 ### g) Convergence check
 
-Apply the convergence rules from the top. If converged, break. If `round == ROUNDS` and not converged, produce Final Summary and `AskUserQuestion`.
+Apply the convergence rules from the top. If converged, break. If `additional_rounds_run + 1 == --rounds` and not converged, produce Final Summary and `AskUserQuestion`.
 
 Track progress concisely:
 
@@ -447,11 +448,19 @@ Round 3: codex=0, cursor=0 -> EXIT (converged)
 
 **Why defer push.** Every push to a PR's branch triggers configured GitHub bots (CodeRabbit, Cursor Bugbot, etc.) to re-review. Mid-loop pushes burn bot budget on intermediate commits and reliably generate new comments on round-N-fix diffs — even when the fix was correct. Batching means bots see the polished tree; CI runs once on the final state.
 
-```
-git push --force-with-lease --force-if-includes origin HEAD
+Before pushing, check whether the remote already holds local HEAD — git-sync may have pushed during the run, and `origin/<branch>` can lag in worktrees. Use `pr_ops.py remote-head <branch>` (which routes through `git ls-remote`, not `git rev-parse origin/<branch>`) so the diagnostic reflects what the remote actually holds:
+
+```bash
+SYNC=$(python3 $SKILL_DIR/scripts/pr_ops.py remote-head "$BRANCH")
+echo "$SYNC" | jq -r '"local=\(.local_head[0:7])  remote=\(.remote_head[0:7])  in_sync=\(.in_sync)"'
+if [ "$(echo "$SYNC" | jq -r .in_sync)" = "true" ]; then
+  echo "remote already has local HEAD — skip push"
+else
+  git push --force-with-lease --force-if-includes origin HEAD
+fi
 ```
 
-Branch-only first push: `git push -u origin <branch>` (no prior remote to protect).
+Branch-only first push: `git push -u origin <branch>` (no prior remote to protect; `remote_present: false` from `remote-head` is the signal).
 
 ## Step 5: Final summary + mark complete
 

--- a/.claude/skills/pr-polish/scripts/bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/bramble_ops.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -100,6 +101,11 @@ def _files_changed_between(a: str | None, b: str | None) -> list[str]:
     git fails (no remote, shallow clone, or the commits aren't reachable
     from the worktree). The caller treats an empty list as "no signal,
     omit the line" rather than "definitely no changes".
+
+    Writes a one-line stderr warning when git rejects the range: a
+    silently-empty result on a 200-file diff was the symptom that
+    surfaced the new-series goal-text bug, and the caller can't see
+    the unreachable SHA without it.
     """
     if not a or not b or a == b:
         return []
@@ -110,9 +116,19 @@ def _files_changed_between(a: str | None, b: str | None) -> list[str]:
 
     try:
         res = run(["git", "diff", "--name-only", f"{a}..{b}"], check=False)
-    except Exception:  # noqa: BLE001 — best-effort git invocation
+    except Exception as e:  # noqa: BLE001 — best-effort git invocation
+        print(
+            f"bramble_ops: git diff --name-only {a[:7]}..{b[:7]} failed: {e}",
+            file=sys.stderr,
+        )
         return []
     if res.returncode != 0:
+        print(
+            f"bramble_ops: git diff --name-only {a[:7]}..{b[:7]} returned "
+            f"{res.returncode}; cited SHA may be unreachable. stderr: "
+            f"{res.stderr.strip() or '(empty)'}",
+            file=sys.stderr,
+        )
         return []
     return [line.strip() for line in res.stdout.splitlines() if line.strip()]
 
@@ -276,6 +292,7 @@ def goal_for_round(
     state: dict[str, Any] | None,
     *,
     head_before: str | None = None,
+    is_new_series: bool | None = None,
 ) -> str:
     """Return the ``--goal`` text bramble should see for this round.
 
@@ -287,8 +304,15 @@ def goal_for_round(
 
     ``head_before`` is this round's HEAD, used to compute the
     files-changed-since-prior-round line.
+
+    ``is_new_series`` is the orchestrator's series-boundary decision
+    captured at Step 0.5 (before ``state_append_round`` clears
+    ``completed: true``). When true, the round is a real round 1 from
+    the model's perspective even when ``round_`` is high — the prior
+    series' state is unreachable and walking it produces a noisy
+    goal blob. PR_SUMMARY is the right anchor for a fresh series.
     """
-    if round_ < 2:
+    if round_ < 2 or is_new_series:
         return pr_summary
     history = action_history_goal(state, round_, head_before=head_before)
     return history or pr_summary
@@ -603,6 +627,118 @@ _HIGH_SEVERITY_KEYWORDS = (
 )
 
 
+# Window around the cited line searched for evidence of a spiral candidate.
+# ±10 lines tolerates small drift from a fix that nudged surrounding lines
+# without removing the cited code; bigger windows would risk false positives
+# on long files where another instance of the same identifier is unrelated.
+_SPIRAL_EVIDENCE_WINDOW = 10
+
+# Minimum length of a quoted phrase or identifier extracted from the
+# finding's message before we accept it as evidence. 8 chars rules out
+# common stop-words (like "function", "missing") that appear everywhere.
+_SPIRAL_EVIDENCE_MIN_LEN = 8
+
+
+def _evidence_tokens(text: str) -> list[str]:
+    """Extract candidate substrings from a finding's message that, if
+    present near the cited line, count as the cited evidence still being
+    at HEAD.
+
+    Returns a deduplicated list of: any backtick/quote-quoted phrase ≥
+    _SPIRAL_EVIDENCE_MIN_LEN chars, plus any bare identifier-like token
+    (Letters / digits / underscore / dot, ≥ _SPIRAL_EVIDENCE_MIN_LEN
+    chars). Conservative — we'd rather miss a token and let the
+    multi-source spiral fallback escalate than coin a false-evidence
+    match from a generic English word.
+    """
+    if not text:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def _add(tok: str) -> None:
+        s = (tok or "").strip().lower()
+        if len(s) < _SPIRAL_EVIDENCE_MIN_LEN:
+            return
+        if s in seen:
+            return
+        seen.add(s)
+        out.append(s)
+
+    # Quoted/back-ticked phrases first — reviewers typically quote the
+    # specific code they want changed, so these are the strongest signal.
+    for m in re.findall(r"`([^`]{%d,})`" % _SPIRAL_EVIDENCE_MIN_LEN, text):
+        _add(m)
+    for m in re.findall(r'"([^"]{%d,})"' % _SPIRAL_EVIDENCE_MIN_LEN, text):
+        _add(m)
+    for m in re.findall(r"'([^']{%d,})'" % _SPIRAL_EVIDENCE_MIN_LEN, text):
+        _add(m)
+    # Identifier-shaped tokens (camelCase, snake_case, dotted names).
+    for m in re.findall(r"[A-Za-z_][A-Za-z0-9_.]{%d,}" % (_SPIRAL_EVIDENCE_MIN_LEN - 1), text):
+        _add(m)
+    return out
+
+
+def _spiral_evidence_present(
+    finding: dict[str, Any],
+    head: Path | None = None,
+    *,
+    window: int = _SPIRAL_EVIDENCE_WINDOW,
+) -> bool:
+    """True when the finding's cited evidence is still at HEAD.
+
+    ``head`` is the worktree root (defaults to CWD). The check is:
+
+        for each token derived from finding.message + finding.suggestion,
+            if any token (lowercased, whitespace-collapsed) appears in
+            <path> at lines [line-window .. line+window] (inclusive),
+            the evidence is present.
+
+    Returns True (conservative — keep the spiral escalation) when the
+    file can't be read, the finding has no addressable file/line, or
+    no tokens of sufficient length could be extracted. Callers
+    interpret False as "definitely-absent enough to demote", and a
+    permissive default protects against silently auto-demoting real
+    regressions when the heuristic can't say either way.
+    """
+    path = finding.get("file") or finding.get("path")
+    line = finding.get("line")
+    if not path or line is None:
+        return True
+    try:
+        line = int(line)
+    except (TypeError, ValueError):
+        return True
+    root = head or Path(".")
+    file_path = root / path
+    try:
+        text = file_path.read_text(errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return True
+    lines = text.splitlines()
+    if not lines:
+        return True
+    # Convert to 0-based and clamp to file extent.
+    start = max(0, line - 1 - window)
+    end = min(len(lines), line + window)  # exclusive
+    window_text = "\n".join(lines[start:end]).lower()
+    # Collapse whitespace so a multi-line quoted phrase still matches when
+    # the file's wrapping changed.
+    window_norm = re.sub(r"\s+", " ", window_text)
+    tokens = _evidence_tokens(
+        " ".join(
+            s for s in (finding.get("message"), finding.get("suggestion")) if s
+        )
+    )
+    if not tokens:
+        return True
+    for tok in tokens:
+        norm = re.sub(r"\s+", " ", tok)
+        if norm in window_norm:
+            return True
+    return False
+
+
 def pr_comment_to_finding(c: dict[str, Any]) -> dict[str, Any]:
     """Convert a classify_comments output row into a triage-ready finding.
 
@@ -718,6 +854,7 @@ def triage(
     pr_comments: list[dict[str, Any]] | None = None,
     ci_failures: list[dict[str, Any]] | None = None,
     mode: str | None = None,
+    head_path: Path | None = None,
 ) -> dict[str, Any]:
     """Group findings, surface consensus, detect N+1 spiral matches.
 
@@ -834,7 +971,37 @@ def triage(
         # topic string and the new finding's topic_of(message) drift
         # apart.
         location_key = (key[0], key[1], None)
-        if key in prior_fixed_keys or location_key in prior_fixed_keys:
+        is_spiral = key in prior_fixed_keys or location_key in prior_fixed_keys
+        if is_spiral:
+            sources_in_group = {g.get("source") for g in group if g.get("source")}
+            is_multi_source = len(sources_in_group) >= 2
+            # Single-source spirals whose cited evidence isn't at HEAD
+            # anymore are auto-demoted to stale_prior_commit: the prior
+            # round fixed it and the resumed model is re-flagging stale
+            # context. Multi-source spirals always escalate — two
+            # backends agreeing the regression is real is a stronger
+            # signal than a heuristic file read.
+            #
+            # Code mode only: design-doc spirals don't have a file/line
+            # to grep, so the evidence check would always be conservative-
+            # True and the demote would never fire anyway. Keep the
+            # branch explicit so the heuristic doesn't quietly leak.
+            if (
+                resolved_mode == REVIEW_MODE_CODE
+                and not is_multi_source
+                and not _spiral_evidence_present(repr_, head=head_path)
+            ):
+                demoted = dict(repr_)
+                demoted["stale_reason"] = (
+                    "spiral candidate auto-demoted: cited evidence absent at HEAD"
+                )
+                stale_prior_commit.append(
+                    {"key": list(_triage_key(repr_, resolved_mode)), "finding": demoted}
+                )
+                # Skip the rest of the per-key dispatch — this finding
+                # is now in batch_stale and must not also land in any
+                # severity bucket.
+                continue
             spiral_matches.append({"key": list(key), "findings": group})
         if key in consensus_triage_keys:
             # Already routed to consensus by location-based grouping;
@@ -1020,6 +1187,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "--head-before",
         help="This round's HEAD; used to compute the files-changed-since-prior-round line.",
     )
+    sp.add_argument(
+        "--is-new-series",
+        choices=["0", "1"],
+        help=(
+            "Captured at Step 0.5 before state_append_round clears "
+            "completed=true. When 1, return PR_SUMMARY regardless of "
+            "round number — round N of a fresh series is a real round 1 "
+            "from the model's perspective, and walking the prior series' "
+            "head_after produces a noisy goal blob (the SHA may be unreachable)."
+        ),
+    )
 
     sp = sub.add_parser(
         "prior-session-id",
@@ -1067,6 +1245,15 @@ def _build_parser() -> argparse.ArgumentParser:
              "envelope's review_mode field), falling back to code. Pass "
              "explicitly to assert a mode and reject mismatched envelopes.",
     )
+    sp.add_argument(
+        "--head-path",
+        help=(
+            "Worktree root used to grep for spiral-candidate evidence at HEAD. "
+            "Defaults to CWD. Single-source spirals whose cited evidence is "
+            "absent within ±10 lines of the cited line auto-demote to "
+            "batch_stale; multi-source spirals always escalate."
+        ),
+    )
 
     return p
 
@@ -1094,9 +1281,14 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.cmd == "goal":
             state = read_json(Path(args.state_file), default=None) if args.state_file else None
+            is_new = (args.is_new_series == "1") if args.is_new_series is not None else None
             print(
                 goal_for_round(
-                    args.round_, args.pr_summary, state, head_before=args.head_before
+                    args.round_,
+                    args.pr_summary,
+                    state,
+                    head_before=args.head_before,
+                    is_new_series=is_new,
                 )
             )
         elif args.cmd == "prior-session-id":
@@ -1153,12 +1345,14 @@ def main(argv: list[str] | None = None) -> int:
                     )
                 resolved_mode = next(iter(real_modes), None) or REVIEW_MODE_CODE
             findings = parse_round(streams, fallback_mode=resolved_mode)
+            head_path = Path(args.head_path) if args.head_path else None
             result = triage(
                 findings,
                 prior_fixed_keys(prior, resolved_mode),
                 pr_comments=pr_comments,
                 ci_failures=ci_failures,
                 mode=resolved_mode,
+                head_path=head_path,
             )
             print_json(result)
         else:  # pragma: no cover

--- a/.claude/skills/pr-polish/scripts/pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/pr_ops.py
@@ -1093,15 +1093,32 @@ def _persist_round_findings(
         entry.setdefault("ci_findings", [])
 
 
+_REPLY_PERSIST_KEYS = ("reply_url", "reply_error")
+
+
 def _merge_actions(
     existing: list[dict[str, Any]], new: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """Append new actions; dedupe on (comment_id) or (source, path, line, topic)."""
+    """Append new actions; dedupe on (comment_id) or (source, path, line, topic).
+
+    On key collision the incoming row wins, but reply-persistence fields
+    (``reply_url`` / ``reply_error``) carry forward from the existing row
+    when the incoming one omits them. Without this, re-finalizing a round
+    from a freshly recomputed action list would drop the reply_url written
+    by a prior finalize pass and ``_post_inline_replies`` would repost the
+    same inline comment.
+    """
     by_key: dict[tuple, dict[str, Any]] = {}
     for a in existing:
         by_key[_action_key(a)] = a
     for a in new:
-        by_key[_action_key(a)] = a  # new wins on conflict
+        key = _action_key(a)
+        prior = by_key.get(key)
+        if prior is not None:
+            for k in _REPLY_PERSIST_KEYS:
+                if k in prior and k not in a:
+                    a[k] = prior[k]
+        by_key[key] = a
     return list(by_key.values())
 
 

--- a/.claude/skills/pr-polish/scripts/pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/pr_ops.py
@@ -858,6 +858,7 @@ def state_finalize_round(
     actions: list[dict[str, Any]],
     *,
     envelope_overrides: dict[str, Path] | None = None,
+    auto_reply: bool = True,
 ) -> dict[str, Any]:
     """Finalize a round and persist its results.
 
@@ -865,6 +866,12 @@ def state_finalize_round(
     Monitor captured for that backend (canonically
     ``$STATE_DIR/r<n>/<backend>-envelope.json``). Backends absent from the
     mapping are skipped — finalize hydrates only what was actually run.
+
+    ``auto_reply`` posts a GitHub inline reply on every github-inline row
+    whose action ∈ {fixed, stale, false_positive, wont_fix} and which
+    doesn't already carry a ``reply_url``. The resulting URL (or per-row
+    ``reply_error`` on failure) is written back into the persisted action
+    entry. Idempotent across re-runs. Disable for tests / dry-run flows.
     """
     pr_number, branch = _resolve_ctx(ctx)
     state_dir, path = state_paths(pr_number, branch=branch)
@@ -877,12 +884,114 @@ def state_finalize_round(
         raise RuntimeError(f"round {n} not found in state")
     existing = entry.get("comment_actions") or []
     merged = _merge_actions(existing, actions)
+    if auto_reply and pr_number is not None:
+        _post_inline_replies(merged, pr_number, head_after)
     entry["comment_actions"] = merged
     entry["head_after"] = head_after
     entry.update(recompute_counts(merged))
     _persist_round_findings(state_dir, entry, pr_number, branch, n, envelope_overrides or {})
     atomic_write_json(path, state)
     return state
+
+
+# Action verbs eligible for an auto-reply on the inline comment they
+# triaged. ``ack`` is intentionally omitted: low/nit batch acks would
+# generate notification spam without giving the bot useful signal.
+_AUTO_REPLY_ACTIONS = ("fixed", "stale", "false_positive", "wont_fix")
+
+
+def _reply_body(action: dict[str, Any], head_after: str) -> str:
+    """Render the auto-reply body for one comment_actions row.
+
+    Bodies match the contract in SKILL.md Step 3.d so consumers (bots,
+    humans skimming a PR thread) can grep for the marker phrase. The
+    short SHA is the round's head_after — the commit that the round's
+    fixes actually landed in.
+    """
+    short_sha = (head_after or "")[:7]
+    verb = action.get("action")
+    reason = (action.get("reason") or "").strip()
+    if verb == "fixed":
+        return f"Fixed in {short_sha}." if short_sha else "Fixed."
+    if verb == "stale":
+        if short_sha:
+            return (
+                f"Superseded by {short_sha} — the cited code was changed/removed "
+                "in a later commit. (Auto-reply from /pr-polish.)"
+            )
+        return (
+            "Superseded — the cited code was changed/removed in a later commit. "
+            "(Auto-reply from /pr-polish.)"
+        )
+    if verb == "false_positive":
+        tail = f": {reason}" if reason else ""
+        return f"Marked false positive{tail}. (Auto-reply from /pr-polish.)"
+    if verb == "wont_fix":
+        tail = f": {reason}" if reason else ""
+        return f"Won't fix{tail}. (Auto-reply from /pr-polish.)"
+    return ""
+
+
+def _post_inline_replies(
+    actions: list[dict[str, Any]], pr_number: int, head_after: str
+) -> None:
+    """Post auto-replies on github-inline rows; mutate ``actions`` in place.
+
+    Side-effect: every row that gets a successful reply gains a
+    ``reply_url`` key; rows whose POST fails gain a ``reply_error`` key
+    (the next finalize attempt retries). Rows already carrying a
+    ``reply_url`` are skipped — idempotent across replays. Failures
+    are stderr-warned but never raised: the loss of one bot reply must
+    not block finalize for the rest of the round.
+    """
+    eligible = [
+        a
+        for a in actions
+        if a.get("source") == "github-inline"
+        and a.get("action") in _AUTO_REPLY_ACTIONS
+        and not a.get("reply_url")
+        and a.get("comment_id") is not None
+    ]
+    if not eligible:
+        return
+    # Resolve owner/repo once. If gh isn't usable here, mark each row's
+    # reply_error and bail rather than crashing finalize.
+    try:
+        _, _, owner_repo = _owner_repo()
+    except Exception as e:  # noqa: BLE001 — gh failure must not brick finalize
+        msg = f"_owner_repo failed: {e}"
+        print(f"pr_ops: auto-reply skipped — {msg}", file=sys.stderr)
+        for a in eligible:
+            a["reply_error"] = msg
+        return
+    for a in eligible:
+        body = _reply_body(a, head_after)
+        if not body:
+            continue
+        try:
+            res = reply_inline(owner_repo, pr_number, int(a["comment_id"]), body)
+        except Exception as e:  # noqa: BLE001 — rate limits / deleted comments / network
+            msg = str(e)
+            a["reply_error"] = msg
+            print(
+                f"pr_ops: reply-inline comment_id={a.get('comment_id')} failed: {msg}",
+                file=sys.stderr,
+            )
+            continue
+        url = (
+            res.get("html_url")
+            or res.get("url")
+            or (
+                f"https://github.com/{owner_repo}/pull/{pr_number}#discussion_r{a['comment_id']}"
+                if res
+                else None
+            )
+        )
+        if url:
+            a["reply_url"] = url
+            # Clear any prior reply_error left by an earlier failed
+            # finalize attempt — the retry succeeded.
+            a.pop("reply_error", None)
 
 
 def _persist_round_findings(
@@ -1057,6 +1166,57 @@ def _utc_now() -> str:
 # ---------------------------------------------------------------------------
 
 
+def remote_head(branch: str) -> dict[str, Any]:
+    """Return the current ``HEAD`` SHA of ``origin/<branch>`` from the remote.
+
+    Uses ``git ls-remote`` rather than ``git rev-parse origin/<branch>``:
+    in bare-repo / worktree setups, the local ``origin/<branch>`` ref can
+    lag the remote even after a successful push (memory:
+    ``feedback_force_with_lease_in_worktrees``). ``ls-remote`` is the
+    only reliable way to ask "what does the remote currently hold?"
+    without a prior fetch.
+
+    Returns a dict with::
+        {
+            "branch": "<branch>",
+            "local_head": "<sha-or-empty>",     # git rev-parse HEAD
+            "remote_head": "<sha-or-empty>",    # git ls-remote origin refs/heads/<branch>
+            "in_sync": <bool>,                  # local == remote (both non-empty)
+            "remote_present": <bool>,           # remote has the branch at all
+        }
+    """
+    try:
+        local = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+    except (CommandError, FileNotFoundError):
+        local = ""
+    try:
+        ls = run(
+            ["git", "ls-remote", "origin", f"refs/heads/{branch}"], check=False
+        )
+    except FileNotFoundError:
+        return {
+            "branch": branch,
+            "local_head": local,
+            "remote_head": "",
+            "in_sync": False,
+            "remote_present": False,
+        }
+    remote = ""
+    if ls.returncode == 0:
+        # ls-remote output: "<sha>\trefs/heads/<branch>\n" or empty when
+        # the branch doesn't exist on the remote.
+        first = ls.stdout.splitlines()[:1]
+        if first:
+            remote = first[0].split()[0].strip()
+    return {
+        "branch": branch,
+        "local_head": local,
+        "remote_head": remote,
+        "in_sync": bool(local) and bool(remote) and local == remote,
+        "remote_present": bool(remote),
+    }
+
+
 def reply_inline(owner_repo: str, pr: int, comment_id: int, body: str) -> dict[str, Any]:
     # Pipe JSON via stdin rather than `-f body=...`: gh treats values starting
     # with `@` as file references, so a comment body starting with `@` would
@@ -1099,6 +1259,16 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sp = sub.add_parser("comment-pr")
     sp.add_argument("body")
+
+    sp = sub.add_parser(
+        "remote-head",
+        help=(
+            "Compare local HEAD to origin/<branch> via git ls-remote (not "
+            "rev-parse origin/<branch>, which lags in worktrees). Emits "
+            "{local_head, remote_head, in_sync, remote_present}."
+        ),
+    )
+    sp.add_argument("branch")
 
     sp = sub.add_parser("ci-failed-tests")
     sp.add_argument("--pr", type=int)
@@ -1195,6 +1365,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise RuntimeError("comment-pr requires a PR; current branch has none")
             url = comment_pr(pr["pr_number"], args.body)
             print_json({"url": url})
+        elif args.cmd == "remote-head":
+            print_json(remote_head(args.branch))
         elif args.cmd == "ci-failed-tests":
             pr_number = args.pr if args.pr is not None else identify_pr().get("pr_number")
             if pr_number is None:

--- a/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
@@ -70,6 +70,85 @@ class TestGoalForRound(unittest.TestCase):
             "PR_SUMMARY",
         )
 
+    def test_is_new_series_returns_pr_summary_at_round_n(self) -> None:
+        """Re-invocation after a converged series with the orchestrator's
+        IS_NEW_SERIES=1 must return PR_SUMMARY, not walk the prior round's
+        head_after to build a 200-file 'Files changed' line."""
+        state = {
+            "completed": True,  # prior series finished
+            "rounds": [
+                {
+                    "n": 10,
+                    "head_after": "deadbeef",  # may be unreachable after rebase
+                    "comment_actions": [
+                        {"action": "fixed", "path": "a.go", "line": 5, "source": "codex"},
+                    ],
+                }
+            ],
+        }
+        out = bramble_ops.goal_for_round(
+            11, "PR #42: refactor", state, head_before="cafef00d", is_new_series=True
+        )
+        self.assertEqual(out, "PR #42: refactor")
+
+    def test_is_new_series_false_still_walks_history(self) -> None:
+        """Continuation rounds (is_new_series=False) keep the prior behavior."""
+        state = {
+            "rounds": [
+                {
+                    "n": 1,
+                    "comment_actions": [
+                        {"action": "fixed", "path": "a.go", "line": 5, "source": "codex"},
+                    ],
+                }
+            ]
+        }
+        out = bramble_ops.goal_for_round(2, "PR_SUMMARY", state, is_new_series=False)
+        self.assertIn("Round 2", out)
+        self.assertIn("a.go:5", out)
+
+
+class TestFilesChangedBetweenWarnings(unittest.TestCase):
+    """Stderr warning when git diff rejects the cited range — the noisy
+    new-series goal blob symptom comes from the unreachable SHA being
+    silently swallowed."""
+
+    def test_unreachable_sha_warns_to_stderr(self) -> None:
+        import io
+        from contextlib import redirect_stderr  # noqa: PLC0415
+
+        buf = io.StringIO()
+        with patch("_common.run") as run_mock, redirect_stderr(buf):
+            run_mock.return_value = type(
+                "R",
+                (),
+                {
+                    "returncode": 128,
+                    "stdout": "",
+                    "stderr": "fatal: bad revision 'deadbeef..cafef00d'",
+                },
+            )()
+            result = bramble_ops._files_changed_between("deadbeef0000", "cafef00d0000")
+        self.assertEqual(result, [])
+        stderr = buf.getvalue()
+        self.assertIn("git diff", stderr)
+        self.assertIn("deadbee", stderr)  # short sha included
+        self.assertIn("cafef00", stderr)
+        self.assertIn("128", stderr)
+
+    def test_success_does_not_warn(self) -> None:
+        import io
+        from contextlib import redirect_stderr  # noqa: PLC0415
+
+        buf = io.StringIO()
+        with patch("_common.run") as run_mock, redirect_stderr(buf):
+            run_mock.return_value = type(
+                "R", (), {"returncode": 0, "stdout": "a.go\nb.py\n", "stderr": ""}
+            )()
+            result = bramble_ops._files_changed_between("aaa", "bbb")
+        self.assertEqual(result, ["a.go", "b.py"])
+        self.assertEqual(buf.getvalue(), "")
+
 
 class TestActionHistoryGoal(unittest.TestCase):
     """Per-turn metadata for the resumed model: what the immediately-prior
@@ -825,6 +904,221 @@ class TestTriage(unittest.TestCase):
         self.assertEqual(len(out["single_medium"]), 1)
 
 
+class TestSpiralEvidencePresent(unittest.TestCase):
+    """The spiral auto-demote heuristic depends on this helper. Round 13 of
+    pr-polish saw codex re-flag a finding on a line whose code was rewritten
+    in round 12 — the resumed model was reading stale context, but the
+    spiral guard couldn't tell. We grep ±10 lines around the cited line for
+    distinctive tokens from the finding's message; absent → not a spiral.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _write(self, rel: str, body: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    def test_returns_true_when_quoted_phrase_at_cited_line(self) -> None:
+        self._write(
+            "a.go",
+            "\n".join([f"line {i}" for i in range(1, 30)] + ["return ctx.Err()"]),
+        )
+        finding = {
+            "file": "a.go",
+            "line": 30,
+            "message": "still returns `ctx.Err()` instead of context-aware error",
+            "suggestion": None,
+        }
+        self.assertTrue(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+    def test_returns_false_when_token_absent(self) -> None:
+        self._write(
+            "a.go",
+            "\n".join(
+                [f"line {i}" for i in range(1, 30)]
+                + ["return fmt.Errorf(\"waitForObject timed out\")"]
+            ),
+        )
+        finding = {
+            "file": "a.go",
+            "line": 30,
+            "message": "still returns `ctx.Err()` instead of a typed error",
+            "suggestion": None,
+        }
+        self.assertFalse(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+    def test_window_extends_above_and_below(self) -> None:
+        self._write(
+            "a.go",
+            "\n".join([f"line {i}" for i in range(1, 50)] + ["return ctx.Err()"] + [f"line {i}" for i in range(51, 70)]),
+        )
+        # cited line is 60, evidence is at line 50 — within ±10.
+        finding = {
+            "file": "a.go",
+            "line": 60,
+            "message": "still returns `ctx.Err()`",
+        }
+        self.assertTrue(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+    def test_token_outside_window_is_absent(self) -> None:
+        self._write(
+            "a.go",
+            "\n".join(["return ctx.Err()"] + [f"line {i}" for i in range(2, 200)]),
+        )
+        finding = {
+            "file": "a.go",
+            "line": 150,  # window 140..160; evidence at line 1
+            "message": "still returns `ctx.Err()`",
+        }
+        self.assertFalse(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+    def test_unreadable_file_returns_true_conservatively(self) -> None:
+        finding = {
+            "file": "missing.go",
+            "line": 1,
+            "message": "still returns `ctx.Err()` instead of a typed error",
+        }
+        self.assertTrue(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+    def test_no_extractable_tokens_returns_true(self) -> None:
+        self._write("a.go", "return\n")
+        finding = {
+            "file": "a.go",
+            "line": 1,
+            "message": "this code is bad",  # all words below the 8-char floor
+        }
+        self.assertTrue(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+    def test_no_address_returns_true(self) -> None:
+        # PR-level / sourceless findings can't have evidence checked.
+        self.assertTrue(
+            bramble_ops._spiral_evidence_present(
+                {"file": None, "line": None, "message": "topical foo"}, head=self.root
+            )
+        )
+
+    def test_identifier_token_picks_up(self) -> None:
+        # A bare identifier ≥ _SPIRAL_EVIDENCE_MIN_LEN chars must match
+        # even when the message has no quotes/backticks.
+        self._write(
+            "h.py",
+            "\n".join(
+                [f"line {i}" for i in range(1, 10)]
+                + ["def waitForObjectReady(client):"]
+                + [f"line {i}" for i in range(11, 20)]
+            ),
+        )
+        finding = {
+            "file": "h.py",
+            "line": 10,
+            "message": "waitForObjectReady should respect timeout",
+        }
+        self.assertTrue(bramble_ops._spiral_evidence_present(finding, head=self.root))
+
+
+class TestTriageSpiralAutoDemote(unittest.TestCase):
+    """Single-source spirals whose cited evidence isn't at HEAD are auto-
+    demoted to batch_stale; multi-source spirals always escalate; the
+    behavior gates on resolved review_mode (design-doc spirals don't have
+    addressable file/line, so the heuristic short-circuits to "escalate")."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _f(self, source: str, file: str, line: int, severity: str, message: str) -> dict:
+        return {
+            "source": source,
+            "severity": severity,
+            "file": file,
+            "line": line,
+            "message": message,
+            "suggestion": None,
+            "topic": _common.topic_of(message),
+        }
+
+    def _write_file(self, rel: str, body: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    def test_single_source_spiral_with_evidence_absent_demotes_to_stale(self) -> None:
+        # File at HEAD has the *fix*, not the prior buggy code.
+        self._write_file(
+            "a.go",
+            "\n".join(
+                [f"line {i}" for i in range(1, 50)]
+                + ["return fmt.Errorf(\"waitForObject timed out\")"]
+                + [f"line {i}" for i in range(51, 100)]
+            ),
+        )
+        # codex re-flags ctx.Err(), but it isn't at HEAD anymore.
+        f = self._f("codex", "a.go", 50, "high", "still returns `ctx.Err()` instead of a typed error")
+        prior = {(f["file"], f["line"], f["topic"]), (f["file"], f["line"], None)}
+        out = bramble_ops.triage([f], prior_fixed_keys=prior, head_path=self.root)
+        self.assertEqual(out["spiral_matches"], [])
+        self.assertEqual(len(out["stale_prior_commit"]), 1)
+        demoted = out["stale_prior_commit"][0]["finding"]
+        self.assertIn("auto-demoted", demoted.get("stale_reason", ""))
+        # The auto-demoted finding must not also surface in single_critical.
+        self.assertEqual(out["single_critical"], [])
+        # action_plan reflects the demote: nothing in escalate, the finding
+        # in batch_stale.
+        self.assertEqual(out["action_plan"]["escalate"], [])
+        self.assertEqual(len(out["action_plan"]["batch_stale"]), 1)
+
+    def test_single_source_spiral_with_evidence_present_still_escalates(self) -> None:
+        # File at HEAD still has the cited code — keep the spiral.
+        self._write_file(
+            "a.go",
+            "\n".join(
+                [f"line {i}" for i in range(1, 50)]
+                + ["return ctx.Err()"]
+                + [f"line {i}" for i in range(51, 100)]
+            ),
+        )
+        f = self._f("codex", "a.go", 50, "high", "still returns `ctx.Err()` instead of a typed error")
+        prior = {(f["file"], f["line"], f["topic"])}
+        out = bramble_ops.triage([f], prior_fixed_keys=prior, head_path=self.root)
+        self.assertEqual(len(out["spiral_matches"]), 1)
+        self.assertEqual(out["stale_prior_commit"], [])
+
+    def test_multi_source_spiral_always_escalates_even_with_evidence_absent(self) -> None:
+        # Even with a "real" file that doesn't have ctx.Err(), two
+        # backends agreeing on the spiral is a stronger signal than the
+        # heuristic. Don't demote.
+        self._write_file("a.go", "return fmt.Errorf(\"timed out\")\n")
+        f1 = self._f("codex", "a.go", 1, "high", "still returns `ctx.Err()`")
+        f2 = self._f("cursor", "a.go", 1, "high", "still returns `ctx.Err()`")
+        prior = {(f1["file"], f1["line"], None)}
+        out = bramble_ops.triage([f1, f2], prior_fixed_keys=prior, head_path=self.root)
+        self.assertEqual(len(out["spiral_matches"]), 1)
+        self.assertEqual(out["stale_prior_commit"], [])
+        # Multi-source spiral must NOT also land in batch_stale.
+        self.assertEqual(out["action_plan"]["batch_stale"], [])
+        self.assertEqual(len(out["action_plan"]["escalate"]), 1)
+
+    def test_demoted_spiral_does_not_double_appear_in_severity_buckets(self) -> None:
+        """An auto-demoted spiral lives only in batch_stale — never in
+        single_critical/single_medium/low_acks (those would re-route it
+        to a fix and undo the demote)."""
+        self._write_file("a.go", "return fmt.Errorf(\"timed out\")\n")
+        f = self._f("codex", "a.go", 1, "high", "still returns `ctx.Err()`")
+        prior = {(f["file"], f["line"], None)}
+        out = bramble_ops.triage([f], prior_fixed_keys=prior, head_path=self.root)
+        # Not in any of the active severity buckets.
+        self.assertEqual(out["single_critical"], [])
+        self.assertEqual(out["single_medium"], [])
+        self.assertEqual(out["low_acks"], [])
+        # Only in batch_stale.
+        self.assertEqual(len(out["stale_prior_commit"]), 1)
+
+
 class TestTriageWithPRComments(unittest.TestCase):
     def test_total_includes_pr_comments_and_ci_failures(self) -> None:
         # Regression guard: round 5 fixed `total` to count all merged
@@ -1151,6 +1445,36 @@ class TestGoalCLI(unittest.TestCase):
             out = self._run("goal", "2", "--pr-summary", "PR_SUM", "--state-file", str(sf))
         self.assertIn("Round 2", out)
         self.assertIn("a.go:5", out)
+
+    def test_is_new_series_flag_returns_pr_summary(self) -> None:
+        """--is-new-series 1 must short-circuit to PR_SUMMARY even when the
+        state file has a converged prior round whose head_after is set."""
+        with tempfile.TemporaryDirectory() as d:
+            sf = Path(d) / "state.json"
+            sf.write_text(
+                json.dumps(
+                    {
+                        "completed": True,
+                        "rounds": [
+                            {
+                                "n": 10,
+                                "head_after": "deadbeef",
+                                "comment_actions": [
+                                    {"action": "fixed", "path": "a.go", "line": 5},
+                                ],
+                            }
+                        ],
+                    }
+                )
+            )
+            out = self._run(
+                "goal", "11",
+                "--pr-summary", "PR #99: refactor",
+                "--state-file", str(sf),
+                "--head-before", "cafef00d",
+                "--is-new-series", "1",
+            )
+        self.assertEqual(out, "PR #99: refactor")
 
     def test_head_before_flag_emits_files_changed_line(self) -> None:
         # SKILL passes --head-before "$(git rev-parse HEAD)"; the CLI must

--- a/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
@@ -1495,5 +1495,242 @@ class TestReplyInlineSafeBody(unittest.TestCase):
 
 
 
+class TestRemoteHead(unittest.TestCase):
+    """Series-boundary detection prefers `git ls-remote refs/heads/<branch>`
+    over `git rev-parse origin/<branch>` because the latter lags in
+    worktrees (existing memory: feedback_force_with_lease_in_worktrees).
+    Round 13 of pr-polish surfaced this when git-sync had pushed during
+    the run but origin/<branch> still pointed at the pre-push SHA,
+    confusing the operator about whether to push again."""
+
+    def test_in_sync_when_remote_matches_local(self) -> None:
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _common.RunResult(stdout="abc123\n", stderr="", returncode=0)
+            if cmd[:2] == ["git", "ls-remote"]:
+                return _common.RunResult(
+                    stdout="abc123\trefs/heads/feature/foo\n",
+                    stderr="",
+                    returncode=0,
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch.object(pr_ops, "run", side_effect=fake_run):
+            out = pr_ops.remote_head("feature/foo")
+        self.assertEqual(out["local_head"], "abc123")
+        self.assertEqual(out["remote_head"], "abc123")
+        self.assertTrue(out["in_sync"])
+        self.assertTrue(out["remote_present"])
+
+    def test_remote_absent_yields_remote_present_false(self) -> None:
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _common.RunResult(stdout="abc123\n", stderr="", returncode=0)
+            return _common.RunResult(stdout="", stderr="", returncode=0)
+
+        with patch.object(pr_ops, "run", side_effect=fake_run):
+            out = pr_ops.remote_head("feature/foo")
+        self.assertFalse(out["remote_present"])
+        self.assertFalse(out["in_sync"])
+        self.assertEqual(out["remote_head"], "")
+
+    def test_diverged_branch_is_not_in_sync(self) -> None:
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _common.RunResult(stdout="local-sha\n", stderr="", returncode=0)
+            return _common.RunResult(
+                stdout="remote-sha\trefs/heads/feature/foo\n",
+                stderr="",
+                returncode=0,
+            )
+
+        with patch.object(pr_ops, "run", side_effect=fake_run):
+            out = pr_ops.remote_head("feature/foo")
+        self.assertEqual(out["local_head"], "local-sha")
+        self.assertEqual(out["remote_head"], "remote-sha")
+        self.assertFalse(out["in_sync"])
+        self.assertTrue(out["remote_present"])
+
+    def test_uses_ls_remote_not_rev_parse_origin(self) -> None:
+        # Regression guard: rev-parse origin/<branch> would silently lag in
+        # worktrees. The helper must call ls-remote.
+        called_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            called_cmds.append(list(cmd))
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _common.RunResult(stdout="abc\n", stderr="", returncode=0)
+            return _common.RunResult(
+                stdout="abc\trefs/heads/main\n", stderr="", returncode=0
+            )
+
+        with patch.object(pr_ops, "run", side_effect=fake_run):
+            pr_ops.remote_head("main")
+        kinds = [tuple(c[:2]) for c in called_cmds]
+        self.assertIn(("git", "ls-remote"), kinds)
+        # Must NOT use rev-parse on origin/<branch> — that's the buggy path.
+        for c in called_cmds:
+            if c[:2] == ["git", "rev-parse"]:
+                self.assertNotIn("origin/main", c)
+
+
+class TestAutoReplyInFinalize(unittest.TestCase):
+    """state-finalize-round must post auto-replies on github-inline rows
+    whose action ∈ {fixed, stale, false_positive, wont_fix} that don't
+    already carry a reply_url. Idempotent across replays. Failures are
+    captured as reply_error and never block finalize.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmp_root = Path(self.tmp.name)
+        self.state_dir = self.tmp_root / "proj-77"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        def fake_state_paths(pr, branch=None):
+            return self.state_dir, self.state_dir / "pr-polish-state.json"
+
+        p = patch.object(pr_ops, "state_paths", side_effect=fake_state_paths)
+        p.start()
+        self.addCleanup(p.stop)
+
+        # Stub _owner_repo so finalize doesn't shell out to gh.
+        p2 = patch.object(
+            pr_ops, "_owner_repo", return_value=("owner", "repo", "owner/repo")
+        )
+        p2.start()
+        self.addCleanup(p2.stop)
+
+    def _action(self, **kw):
+        base = {
+            "comment_id": kw.get("comment_id", 1001),
+            "source": kw.get("source", "github-inline"),
+            "author": "coderabbitai[bot]",
+            "path": "a.py",
+            "line": 42,
+            "severity": "high",
+            "topic": "missing null check",
+            "action": kw.get("action", "fixed"),
+            "reason": kw.get("reason"),
+            "commit_sha": "abc123f",
+        }
+        base.update(kw)
+        return base
+
+    def test_posts_replies_for_fixed_inline_rows(self) -> None:
+        calls = []
+
+        def fake_reply(owner_repo, pr, cid, body):
+            calls.append((owner_repo, pr, cid, body))
+            return {"html_url": f"https://github.com/owner/repo/pull/{pr}#discussion_r{cid}"}
+
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        actions = [self._action(comment_id=2001, action="fixed")]
+        with patch.object(pr_ops, "reply_inline", side_effect=fake_reply):
+            state = pr_ops.state_finalize_round(77, 1, "abc123fdeadbeef", actions)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][2], 2001)
+        self.assertIn("Fixed in abc123f", calls[0][3])
+        rnd = state["rounds"][0]
+        row = rnd["comment_actions"][0]
+        self.assertTrue(row.get("reply_url", "").startswith("https://github.com/"))
+
+    def test_skips_rows_already_carrying_reply_url(self) -> None:
+        """Replays must not double-post."""
+        calls = []
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        actions = [
+            self._action(
+                comment_id=2002,
+                action="fixed",
+                reply_url="https://github.com/owner/repo/pull/77#discussion_r2002",
+            )
+        ]
+        with patch.object(pr_ops, "reply_inline", side_effect=lambda *a: calls.append(a) or {}):
+            pr_ops.state_finalize_round(77, 1, "sha2", actions)
+        self.assertEqual(calls, [])
+
+    def test_skips_ack_and_non_inline_rows(self) -> None:
+        calls = []
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        actions = [
+            self._action(comment_id=2003, action="ack"),
+            self._action(source="codex", comment_id=None, action="fixed"),
+            self._action(source="github-issue", comment_id=2004, action="fixed"),
+        ]
+        with patch.object(pr_ops, "reply_inline", side_effect=lambda *a: calls.append(a) or {}):
+            pr_ops.state_finalize_round(77, 1, "sha2", actions)
+        # github-issue rows still skipped: only inline review threads
+        # support the /comments/<id>/replies endpoint.
+        self.assertEqual(calls, [])
+
+    def test_records_reply_error_on_failure_without_blocking_finalize(self) -> None:
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        actions = [
+            self._action(comment_id=2005, action="fixed"),
+            self._action(comment_id=2006, action="stale"),
+        ]
+
+        def fake_reply(owner_repo, pr, cid, body):
+            if cid == 2005:
+                raise RuntimeError("rate limit exceeded")
+            return {"html_url": f"https://github.com/owner/repo/pull/{pr}#discussion_r{cid}"}
+
+        with patch.object(pr_ops, "reply_inline", side_effect=fake_reply):
+            state = pr_ops.state_finalize_round(77, 1, "sha2", actions)
+        rows = {r["comment_id"]: r for r in state["rounds"][0]["comment_actions"]}
+        self.assertIn("rate limit", rows[2005].get("reply_error", ""))
+        self.assertNotIn("reply_url", rows[2005])  # failed row left without URL
+        # Other row in same finalize call still posts.
+        self.assertTrue(rows[2006].get("reply_url", "").startswith("https://"))
+
+    def test_retry_on_next_finalize_clears_prior_error(self) -> None:
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        actions_initial = [self._action(comment_id=2007, action="fixed")]
+
+        def fake_fail(*a, **kw):
+            raise RuntimeError("transient")
+
+        with patch.object(pr_ops, "reply_inline", side_effect=fake_fail):
+            pr_ops.state_finalize_round(77, 1, "sha2", actions_initial)
+
+        def fake_ok(owner_repo, pr, cid, body):
+            return {"html_url": f"https://github.com/owner/repo/pull/{pr}#discussion_r{cid}"}
+
+        with patch.object(pr_ops, "reply_inline", side_effect=fake_ok):
+            state = pr_ops.state_finalize_round(77, 1, "sha3", actions_initial)
+        row = state["rounds"][0]["comment_actions"][0]
+        self.assertTrue(row.get("reply_url"))
+        self.assertNotIn("reply_error", row)
+
+    def test_branch_mode_skips_auto_reply(self) -> None:
+        # Branch-only mode (no PR number) has no inline-comment endpoint.
+        # _owner_repo would still resolve, but there's no PR to post to.
+        calls = []
+        pr_ops.state_append_round("branch:foo", 1, "sha", verify_head=False)
+        actions = [self._action(comment_id=2008, action="fixed")]
+        with patch.object(pr_ops, "reply_inline", side_effect=lambda *a: calls.append(a) or {}):
+            pr_ops.state_finalize_round("branch:foo", 1, "sha2", actions)
+        self.assertEqual(calls, [])
+
+    def test_reply_body_shapes(self) -> None:
+        # Direct exercise of the body renderer — golden-shape contract
+        # documented in SKILL.md Step 3.d.
+        body_fixed = pr_ops._reply_body({"action": "fixed"}, "abc123fdeadbeef")
+        self.assertEqual(body_fixed, "Fixed in abc123f.")
+        body_stale = pr_ops._reply_body({"action": "stale"}, "abc123fdeadbeef")
+        self.assertIn("Superseded by abc123f", body_stale)
+        self.assertIn("/pr-polish.", body_stale)
+        body_fp = pr_ops._reply_body(
+            {"action": "false_positive", "reason": "see foo.py:10"}, "abc123fdeadbeef"
+        )
+        self.assertIn("Marked false positive: see foo.py:10", body_fp)
+        body_wf = pr_ops._reply_body(
+            {"action": "wont_fix", "reason": "design tradeoff"}, "abc123fdeadbeef"
+        )
+        self.assertIn("Won't fix: design tradeoff", body_wf)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
@@ -1651,6 +1651,37 @@ class TestAutoReplyInFinalize(unittest.TestCase):
             pr_ops.state_finalize_round(77, 1, "sha2", actions)
         self.assertEqual(calls, [])
 
+    def test_replay_with_fresh_action_list_does_not_repost(self) -> None:
+        """Re-finalize from a freshly recomputed action list (no reply_url
+        carried forward in the caller) must still skip already-replied rows.
+
+        This is the cross-process replay path: round 1 finalizes and persists
+        reply_url; later, finalize is called again with `actions` rebuilt
+        from comments — it does not carry reply_url. ``_merge_actions`` must
+        preserve the persisted reply_url so ``_post_inline_replies`` skips
+        the row.
+        """
+        calls = []
+
+        def fake_reply(owner_repo, pr, cid, body):
+            calls.append((owner_repo, pr, cid, body))
+            return {"html_url": f"https://github.com/owner/repo/pull/{pr}#discussion_r{cid}"}
+
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        with patch.object(pr_ops, "reply_inline", side_effect=fake_reply):
+            pr_ops.state_finalize_round(
+                77, 1, "abc123fdeadbeef", [self._action(comment_id=2099, action="fixed")]
+            )
+        self.assertEqual(len(calls), 1)
+
+        with patch.object(pr_ops, "reply_inline", side_effect=fake_reply):
+            state = pr_ops.state_finalize_round(
+                77, 1, "abc123fdeadbeef", [self._action(comment_id=2099, action="fixed")]
+            )
+        self.assertEqual(len(calls), 1)
+        row = state["rounds"][0]["comment_actions"][0]
+        self.assertTrue(row.get("reply_url", "").startswith("https://"))
+
     def test_skips_ack_and_non_inline_rows(self) -> None:
         calls = []
         pr_ops.state_append_round(77, 1, "sha", verify_head=False)


### PR DESCRIPTION
## Summary

Five rigidity points surfaced by PR #3600's 14-round /pr-polish run, addressed in priority order from `~/.claude/plans/greedy-plotting-papert.md`. The convergence math, schema, and resume continuity were all fine — these only soften where the orchestrator forced manual intervention or ate cache TTL.

1. **Goal helper sees `is_new_series`** — `bramble_ops.goal_for_round` accepts `is_new_series` (CLI `--is-new-series`); when true, returns `pr_summary` regardless of round number. Fixes round-11 of a fresh series emitting `"Round 11. Files changed since round 10: <197 files>"` walked from an unreachable prior-series `head_after`. `_files_changed_between` now warns to stderr when git rejects the range.
2. **Auto-replies on github-inline rows** — `pr_ops.state_finalize_round` now posts a GitHub inline reply (`fixed`/`stale`/`false_positive`/`wont_fix`) on every github-inline row lacking a `reply_url` and writes the URL back. Idempotent across replays; failures captured as `reply_error`. The 14-round run had `reply_url: null` on every row; now bots see acknowledgement.
3. **Spiral guard auto-demotes when evidence absent** — new `_spiral_evidence_present` helper greps ±10 lines around the cited line for distinctive tokens. Single-source spirals (code mode only) whose evidence isn't at HEAD demote to `batch_stale` with `stale_reason`; multi-source spirals always escalate. Fixes round-13 codex re-flagging `waitForObject:343` as `ctx.Err()` when HEAD already had `fmt.Errorf("waitForObject timed out…")`.
4. **`--rounds N` semantic flip** — now means "run N additional rounds from current state", tracked per-invocation as `additional_rounds_run`. `--rounds 5` after a converged round 10 now runs rounds 11–15 instead of being a no-op.
5. **`pr_ops.remote_head`** — new helper using `git ls-remote refs/heads/<branch>` (not `git rev-parse origin/<branch>`, which lags in worktrees). Step 4 push diagnostic now reflects what the remote actually holds.

Stream-error severity demotion (originally #3 in exploration) is intentionally out of scope.

## Test plan

- [x] `python3 -m unittest discover` from `.claude/skills/pr-polish/scripts/tests/` — 318 tests, all green
- [x] 21 new tests added across `test_bramble_ops.py` (goal `is_new_series` short-circuit, `_files_changed_between` stderr warning, `_spiral_evidence_present` window/token/conservative-default, triage auto-demote single-source vs multi-source vs evidence-present) and `test_pr_ops.py` (auto-reply happy path / skip-already-replied / skip-ack / failure→`reply_error` / retry-clears-error / branch-mode / body shapes; `remote-head` in-sync / diverged / remote-absent / regression-guard against `rev-parse origin/<branch>`)
- [x] CLI sanity: `bramble_ops.py goal --help` shows `--is-new-series`; `pr_ops.py --help` lists `remote-head`
- [ ] End-to-end smoke on a tiny throwaway PR (deferred — exercised via the next /pr-polish invocation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes add automated GitHub side effects (posting inline replies) and introduce heuristics that can suppress spiral regressions, so misclassification or idempotency bugs could affect PR threads and review gating. Scope is contained to the `/pr-polish` automation with added unit coverage, but it touches state-finalization behavior and remote/push diagnostics.
> 
> **Overview**
> Makes `/pr-polish` less rigid and more replay-safe by adjusting round budgeting, series handling, and end-of-loop ergonomics.
> 
> `--rounds` is redefined to mean **N additional rounds per invocation** (tracked via `additional_rounds_run`), and `bramble_ops.goal_for_round` now accepts `--is-new-series` to **force PR summary goal text** on fresh series instead of walking prior (possibly unreachable) history; `_files_changed_between` now emits stderr warnings when git diff ranges fail.
> 
> Adds two behavior changes in the automation layer: **auto-replies** on eligible `github-inline` actions during `state_finalize_round` (persisting `reply_url`/`reply_error` and preserving them across re-finalize merges for idempotency), and a **spiral guard auto-demotion** that moves single-source spiral candidates to `batch_stale` when their cited evidence is absent near the cited line at HEAD (multi-source spirals still escalate). Also adds `pr_ops.remote-head` (via `git ls-remote`) to reliably detect whether the remote already has local HEAD before pushing. Extensive new unit tests cover these new paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a56add49dde843d7909f7dcfbc833ee9b27beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->