### PR TITLE
Add custom LLM API endpoint support to agent-cli-wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,47 +107,12 @@ ssh remote "cat ~/.bramble/voice-reports/voice-report-latest.txt" | bramble spea
 
 ## Manual Integration Tests Against Third-Party Endpoints
 
-When verifying that a wrapper actually drives a real CLI against a real
-endpoint (rather than just shaping the right env vars / args), follow this
-pattern so the test is reproducible without flake or accidental CI cost:
-
-1. **Gate on a key env var, skip when unset.** Use
-   `if os.Getenv("BASETEN_API_KEY") == "" { t.Skip(...) }` so the test
-   self-disables on machines without credentials. Don't fail-open with a
-   stub key; that masks real outages.
-
-2. **Add the env var to BUILD.bazel `env_inherit`** so it survives the
-   bazel test sandbox. Example: `agent-cli-wrapper/integration/BUILD.bazel`
-   inherits `BASETEN_API_KEY` alongside `HOME` / `PATH`. Pass it explicitly
-   per-invocation: `bazel test ... --test_env=BASETEN_API_KEY`.
-
-3. **Round-trip a unique sentinel token.** Have the model echo a string
-   like `PURPLE-RHINO-42` and assert with case-fold + punctuation-strip
-   tolerance (some models rewrite hyphens as spaces). Sentinel match
-   proves a real round-trip; an empty-string check or a "did it not error"
-   check passes against a stubbed-out CLI.
-
-4. **Compile-time guards on wrapper signatures.** End the test file with
-   `var _ claude.SessionOption = claude.WithLLMEndpoint(...)` etc. so a
-   wrapper signature change fails the build instead of silently degrading
-   the test to a no-op.
-
-5. **Tag `integration` + `manual`** (see "Integration Tests and Gazelle"
-   below) and add a per-subtest `exec.LookPath` skip so the suite still
-   runs cleanly when only some CLIs are installed.
-
-Reference implementation:
-`agent-cli-wrapper/integration/llmendpoint_test.go` (`TestLLMEndpoint_Baseten`).
-
-Run example:
-```
-BASETEN_API_KEY=... bazel test \
-    //agent-cli-wrapper/integration:integration_test \
-    --test_filter=TestLLMEndpoint_Baseten \
-    --test_tag_filters=integration \
-    --test_env=BASETEN_API_KEY \
-    --test_output=streamed
-```
+Pattern for tests that drive a real CLI against a real third-party endpoint:
+gate on a credential env var (skip-not-fail when unset), inherit it via
+`env_inherit` in BUILD.bazel, round-trip a unique sentinel and assert with
+normalized matching, and add `var _ claude.SessionOption = claude.WithLLMEndpoint(...)`
+guards so wrapper signature drift fails the build. Reference:
+`agent-cli-wrapper/integration/llmendpoint_test.go`.
 
 ## Integration Tests and Gazelle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,50 @@ Bramble supports optional voice reporting: when a session completes, fails, or i
 ssh remote "cat ~/.bramble/voice-reports/voice-report-latest.txt" | bramble speak
 ```
 
+## Manual Integration Tests Against Third-Party Endpoints
+
+When verifying that a wrapper actually drives a real CLI against a real
+endpoint (rather than just shaping the right env vars / args), follow this
+pattern so the test is reproducible without flake or accidental CI cost:
+
+1. **Gate on a key env var, skip when unset.** Use
+   `if os.Getenv("BASETEN_API_KEY") == "" { t.Skip(...) }` so the test
+   self-disables on machines without credentials. Don't fail-open with a
+   stub key; that masks real outages.
+
+2. **Add the env var to BUILD.bazel `env_inherit`** so it survives the
+   bazel test sandbox. Example: `agent-cli-wrapper/integration/BUILD.bazel`
+   inherits `BASETEN_API_KEY` alongside `HOME` / `PATH`. Pass it explicitly
+   per-invocation: `bazel test ... --test_env=BASETEN_API_KEY`.
+
+3. **Round-trip a unique sentinel token.** Have the model echo a string
+   like `PURPLE-RHINO-42` and assert with case-fold + punctuation-strip
+   tolerance (some models rewrite hyphens as spaces). Sentinel match
+   proves a real round-trip; an empty-string check or a "did it not error"
+   check passes against a stubbed-out CLI.
+
+4. **Compile-time guards on wrapper signatures.** End the test file with
+   `var _ claude.SessionOption = claude.WithLLMEndpoint(...)` etc. so a
+   wrapper signature change fails the build instead of silently degrading
+   the test to a no-op.
+
+5. **Tag `integration` + `manual`** (see "Integration Tests and Gazelle"
+   below) and add a per-subtest `exec.LookPath` skip so the suite still
+   runs cleanly when only some CLIs are installed.
+
+Reference implementation:
+`agent-cli-wrapper/integration/llmendpoint_test.go` (`TestLLMEndpoint_Baseten`).
+
+Run example:
+```
+BASETEN_API_KEY=... bazel test \
+    //agent-cli-wrapper/integration:integration_test \
+    --test_filter=TestLLMEndpoint_Baseten \
+    --test_tag_filters=integration \
+    --test_env=BASETEN_API_KEY \
+    --test_output=streamed
+```
+
 ## Integration Tests and Gazelle
 
 Integration test `BUILD.bazel` files are hand-maintained and must include `# gazelle:ignore` as the first line. Gazelle cannot generate these correctly because:

--- a/agent-cli-wrapper/acp/BUILD.bazel
+++ b/agent-cli-wrapper/acp/BUILD.bazel
@@ -20,14 +20,17 @@ go_library(
     deps = [
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/internal/procattr",
+        "//agent-cli-wrapper/llmendpoint",
     ],
 )
 
 go_test(
     name = "acp_test",
     srcs = [
+        "client_options_test.go",
         "handlers_test.go",
         "session_test.go",
     ],
     embed = [":acp"],
+    deps = ["//agent-cli-wrapper/llmendpoint"],
 )

--- a/agent-cli-wrapper/acp/client_options.go
+++ b/agent-cli-wrapper/acp/client_options.go
@@ -92,15 +92,28 @@ func WithEnv(env map[string]string) ClientOption {
 	return func(c *ClientConfig) { c.Env = env }
 }
 
-// WithLLMEndpoint points the gemini CLI at a third-party LLM endpoint.
+// WithLLMEndpoint points the gemini CLI at a third-party LLM endpoint by
+// setting GEMINI_API_KEY and GOOGLE_GEMINI_BASE_URL in the subprocess env.
 //
-// For an OpenAI-compatible endpoint (Wire == "chat"), this sets
-// OPENAI_API_KEY/OPENAI_BASE_URL in the subprocess env and appends
-// --openai-api-key/--openai-base-url to BinaryArgs so newer gemini-cli
-// builds that support the OpenAI passthrough route inference through it.
+// Important: the upstream @google/gemini-cli (verified through 0.41.2 and
+// current `main`) only speaks Google's GenerateContent protocol. It has no
+// OpenAI/Anthropic passthrough — issue google-gemini/gemini-cli#1605 was
+// closed "won't fix" — and `GOOGLE_GEMINI_BASE_URL` is purely a host-swap
+// knob that still serializes Google-shaped requests to
+// `${baseUrl}/v1beta/models/${model}:generateContent`.
 //
-// For an Anthropic/Gemini-shaped endpoint, this only sets GEMINI_API_KEY and
-// GOOGLE_GEMINI_BASE_URL.
+// What this means in practice:
+//   - To target Vertex AI or a Google-shaped reverse proxy, set BaseURL to
+//     the proxy host and this option works as expected.
+//   - To target an OpenAI-compatible (Baseten, vLLM, OpenAI) or
+//     Anthropic-compatible endpoint, you must run a translating proxy in
+//     front that accepts `:generateContent` and converts it to the target
+//     wire format. Pointing this option directly at such an endpoint will
+//     fail (the gemini binary will POST GenerateContent JSON the endpoint
+//     can't parse).
+//
+// The Endpoint.WireAPI field is therefore informational only on this
+// wrapper — gemini-cli has no equivalent of codex's `wire_api` switch.
 //
 // Existing Env/BinaryArgs entries are preserved.
 func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
@@ -109,26 +122,13 @@ func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
 			return
 		}
 		if c.Env == nil {
-			c.Env = make(map[string]string, 4)
+			c.Env = make(map[string]string, 2)
 		}
-		key := ep.ResolvedKey()
 		if ep.BaseURL != "" {
 			c.Env["GOOGLE_GEMINI_BASE_URL"] = ep.BaseURL
 		}
-		if key != "" {
+		if key := ep.ResolvedKey(); key != "" {
 			c.Env["GEMINI_API_KEY"] = key
-		}
-		if ep.WireAPI() == llmendpoint.WireAPIChat {
-			if ep.BaseURL != "" {
-				c.Env["OPENAI_BASE_URL"] = ep.BaseURL
-				c.BinaryArgs = append(c.BinaryArgs, "--openai-base-url", ep.BaseURL)
-			}
-			if key != "" {
-				c.Env["OPENAI_API_KEY"] = key
-				// Pass the key via env to avoid landing it in process args.
-				// gemini-cli reads OPENAI_API_KEY from the env when
-				// --openai-api-key is omitted.
-			}
 		}
 	}
 }

--- a/agent-cli-wrapper/acp/client_options.go
+++ b/agent-cli-wrapper/acp/client_options.go
@@ -1,6 +1,10 @@
 package acp
 
-import "io"
+import (
+	"io"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+)
 
 // ClientConfig holds ACP client configuration.
 type ClientConfig struct {
@@ -86,6 +90,47 @@ func WithProtocolLogger(w io.Writer) ClientOption {
 // WithEnv sets additional environment variables for the agent subprocess.
 func WithEnv(env map[string]string) ClientOption {
 	return func(c *ClientConfig) { c.Env = env }
+}
+
+// WithLLMEndpoint points the gemini CLI at a third-party LLM endpoint.
+//
+// For an OpenAI-compatible endpoint (Wire == "chat"), this sets
+// OPENAI_API_KEY/OPENAI_BASE_URL in the subprocess env and appends
+// --openai-api-key/--openai-base-url to BinaryArgs so newer gemini-cli
+// builds that support the OpenAI passthrough route inference through it.
+//
+// For an Anthropic/Gemini-shaped endpoint, this only sets GEMINI_API_KEY and
+// GOOGLE_GEMINI_BASE_URL.
+//
+// Existing Env/BinaryArgs entries are preserved.
+func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
+	return func(c *ClientConfig) {
+		if ep.IsZero() {
+			return
+		}
+		if c.Env == nil {
+			c.Env = make(map[string]string, 4)
+		}
+		key := ep.ResolvedKey()
+		if ep.BaseURL != "" {
+			c.Env["GOOGLE_GEMINI_BASE_URL"] = ep.BaseURL
+		}
+		if key != "" {
+			c.Env["GEMINI_API_KEY"] = key
+		}
+		if ep.WireAPI() == llmendpoint.WireAPIChat {
+			if ep.BaseURL != "" {
+				c.Env["OPENAI_BASE_URL"] = ep.BaseURL
+				c.BinaryArgs = append(c.BinaryArgs, "--openai-base-url", ep.BaseURL)
+			}
+			if key != "" {
+				c.Env["OPENAI_API_KEY"] = key
+				// Pass the key via env to avoid landing it in process args.
+				// gemini-cli reads OPENAI_API_KEY from the env when
+				// --openai-api-key is omitted.
+			}
+		}
+	}
 }
 
 // SessionConfig holds session-specific configuration.

--- a/agent-cli-wrapper/acp/client_options_test.go
+++ b/agent-cli-wrapper/acp/client_options_test.go
@@ -1,13 +1,16 @@
 package acp
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 )
 
-func TestWithLLMEndpoint_ChatWireAPI(t *testing.T) {
+// TestWithLLMEndpoint_GoogleShape verifies the Google-shaped env-var wiring
+// that gemini-cli actually honors. The chat/responses Wire field is
+// informational only on this wrapper — gemini-cli speaks GenerateContent
+// regardless — so neither wire value should leak OpenAI-specific config.
+func TestWithLLMEndpoint_GoogleShape(t *testing.T) {
 	t.Parallel()
 	cfg := defaultACPClientConfig()
 	WithLLMEndpoint(llmendpoint.Endpoint{
@@ -19,26 +22,27 @@ func TestWithLLMEndpoint_ChatWireAPI(t *testing.T) {
 	if got := cfg.Env["GEMINI_API_KEY"]; got != "sk-test" {
 		t.Errorf("GEMINI_API_KEY = %q", got)
 	}
-	if got := cfg.Env["OPENAI_API_KEY"]; got != "sk-test" {
-		t.Errorf("OPENAI_API_KEY = %q", got)
+	if got := cfg.Env["GOOGLE_GEMINI_BASE_URL"]; got != "https://inference.baseten.co/v1" {
+		t.Errorf("GOOGLE_GEMINI_BASE_URL = %q", got)
 	}
-	if got := cfg.Env["OPENAI_BASE_URL"]; got != "https://inference.baseten.co/v1" {
-		t.Errorf("OPENAI_BASE_URL = %q", got)
+	// gemini-cli has no OpenAI passthrough; nothing OpenAI-shaped should be set.
+	for _, k := range []string{"OPENAI_API_KEY", "OPENAI_BASE_URL"} {
+		if _, ok := cfg.Env[k]; ok {
+			t.Errorf("unexpected env var %s set: %v", k, cfg.Env)
+		}
 	}
-	if !slices.Contains(cfg.BinaryArgs, "--openai-base-url") {
-		t.Errorf("BinaryArgs missing --openai-base-url: %v", cfg.BinaryArgs)
-	}
-	if !slices.Contains(cfg.BinaryArgs, "https://inference.baseten.co/v1") {
-		t.Errorf("BinaryArgs missing url: %v", cfg.BinaryArgs)
-	}
-	// API key must NOT appear in BinaryArgs.
 	for _, a := range cfg.BinaryArgs {
+		if a == "--openai-base-url" || a == "--openai-api-key" {
+			t.Errorf("unexpected --openai-* arg appended: %v", cfg.BinaryArgs)
+		}
 		if a == "sk-test" {
 			t.Fatalf("API key leaked to BinaryArgs: %v", cfg.BinaryArgs)
 		}
 	}
 }
 
+// TestWithLLMEndpoint_ResponsesWireAPI confirms the wire field really is
+// informational — the wiring is identical to the chat case.
 func TestWithLLMEndpoint_ResponsesWireAPI(t *testing.T) {
 	t.Parallel()
 	cfg := defaultACPClientConfig()
@@ -48,14 +52,14 @@ func TestWithLLMEndpoint_ResponsesWireAPI(t *testing.T) {
 		Wire:    llmendpoint.WireAPIResponses,
 	})(&cfg)
 
-	if _, ok := cfg.Env["OPENAI_BASE_URL"]; ok {
-		t.Errorf("Responses wire should not set OPENAI_BASE_URL: %v", cfg.Env)
-	}
-	if slices.Contains(cfg.BinaryArgs, "--openai-base-url") {
-		t.Errorf("Responses wire should not append openai args: %v", cfg.BinaryArgs)
-	}
 	if got := cfg.Env["GEMINI_API_KEY"]; got != "sk-test" {
 		t.Errorf("GEMINI_API_KEY = %q", got)
+	}
+	if got := cfg.Env["GOOGLE_GEMINI_BASE_URL"]; got != "https://example.com" {
+		t.Errorf("GOOGLE_GEMINI_BASE_URL = %q", got)
+	}
+	if _, ok := cfg.Env["OPENAI_BASE_URL"]; ok {
+		t.Errorf("OPENAI_BASE_URL should never be set on gemini: %v", cfg.Env)
 	}
 }
 
@@ -67,3 +71,48 @@ func TestWithLLMEndpoint_zeroIsNoop(t *testing.T) {
 		t.Errorf("zero endpoint should be no-op: %v", cfg.Env)
 	}
 }
+
+// TestWithBinaryArgs_ReplacesNotAppends pins the documented behavior that
+// WithBinaryArgs replaces BinaryArgs wholesale. WithLLMEndpoint no longer
+// touches BinaryArgs (gemini-cli has no relevant flags), so this is purely
+// a regression-pin on WithBinaryArgs's own contract.
+func TestWithBinaryArgs_ReplacesNotAppends(t *testing.T) {
+	t.Parallel()
+	cfg := defaultACPClientConfig()
+	if len(cfg.BinaryArgs) == 0 {
+		t.Fatal("precondition: defaultACPClientConfig should seed BinaryArgs")
+	}
+	WithBinaryArgs("--replaced")(&cfg)
+	if len(cfg.BinaryArgs) != 1 || cfg.BinaryArgs[0] != "--replaced" {
+		t.Fatalf("WithBinaryArgs should replace: got %v", cfg.BinaryArgs)
+	}
+}
+
+// TestWithLLMEndpoint_AfterWithEnv_Survives verifies the ordering the
+// gemini provider relies on: WithEnv replaces the env map wholesale, so
+// callers must apply WithLLMEndpoint AFTER WithEnv (or the LLM creds get
+// dropped). The provider does this; this test guards it.
+func TestWithLLMEndpoint_AfterWithEnv_Survives(t *testing.T) {
+	t.Parallel()
+	cfg := defaultACPClientConfig()
+	WithEnv(map[string]string{"FOO": "bar"})(&cfg)
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL: "https://example.com",
+		APIKey:  "sk-test",
+		Wire:    llmendpoint.WireAPIChat,
+	})(&cfg)
+	if got := cfg.Env["GEMINI_API_KEY"]; got != "sk-test" {
+		t.Errorf("LLMEndpoint creds dropped after WithEnv: %v", cfg.Env)
+	}
+	if got := cfg.Env["FOO"]; got != "bar" {
+		t.Errorf("WithEnv var dropped: %v", cfg.Env)
+	}
+}
+
+// Compile-time guard: WithBinaryArgs and WithLLMEndpoint signatures stay
+// stable. Drift here would silently break the gemini provider's option
+// pipeline before any test ran.
+var (
+	_ ClientOption = WithBinaryArgs("--experimental-acp")
+	_ ClientOption = WithLLMEndpoint(llmendpoint.Endpoint{})
+)

--- a/agent-cli-wrapper/acp/client_options_test.go
+++ b/agent-cli-wrapper/acp/client_options_test.go
@@ -1,0 +1,69 @@
+package acp
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+)
+
+func TestWithLLMEndpoint_ChatWireAPI(t *testing.T) {
+	t.Parallel()
+	cfg := defaultACPClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL: "https://inference.baseten.co/v1",
+		APIKey:  "sk-test",
+		Wire:    llmendpoint.WireAPIChat,
+	})(&cfg)
+
+	if got := cfg.Env["GEMINI_API_KEY"]; got != "sk-test" {
+		t.Errorf("GEMINI_API_KEY = %q", got)
+	}
+	if got := cfg.Env["OPENAI_API_KEY"]; got != "sk-test" {
+		t.Errorf("OPENAI_API_KEY = %q", got)
+	}
+	if got := cfg.Env["OPENAI_BASE_URL"]; got != "https://inference.baseten.co/v1" {
+		t.Errorf("OPENAI_BASE_URL = %q", got)
+	}
+	if !slices.Contains(cfg.BinaryArgs, "--openai-base-url") {
+		t.Errorf("BinaryArgs missing --openai-base-url: %v", cfg.BinaryArgs)
+	}
+	if !slices.Contains(cfg.BinaryArgs, "https://inference.baseten.co/v1") {
+		t.Errorf("BinaryArgs missing url: %v", cfg.BinaryArgs)
+	}
+	// API key must NOT appear in BinaryArgs.
+	for _, a := range cfg.BinaryArgs {
+		if a == "sk-test" {
+			t.Fatalf("API key leaked to BinaryArgs: %v", cfg.BinaryArgs)
+		}
+	}
+}
+
+func TestWithLLMEndpoint_ResponsesWireAPI(t *testing.T) {
+	t.Parallel()
+	cfg := defaultACPClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL: "https://example.com",
+		APIKey:  "sk-test",
+		Wire:    llmendpoint.WireAPIResponses,
+	})(&cfg)
+
+	if _, ok := cfg.Env["OPENAI_BASE_URL"]; ok {
+		t.Errorf("Responses wire should not set OPENAI_BASE_URL: %v", cfg.Env)
+	}
+	if slices.Contains(cfg.BinaryArgs, "--openai-base-url") {
+		t.Errorf("Responses wire should not append openai args: %v", cfg.BinaryArgs)
+	}
+	if got := cfg.Env["GEMINI_API_KEY"]; got != "sk-test" {
+		t.Errorf("GEMINI_API_KEY = %q", got)
+	}
+}
+
+func TestWithLLMEndpoint_zeroIsNoop(t *testing.T) {
+	t.Parallel()
+	cfg := defaultACPClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{})(&cfg)
+	if len(cfg.Env) != 0 {
+		t.Errorf("zero endpoint should be no-op: %v", cfg.Env)
+	}
+}

--- a/agent-cli-wrapper/claude/BUILD.bazel
+++ b/agent-cli-wrapper/claude/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/internal/ndjson",
         "//agent-cli-wrapper/internal/procattr",
+        "//agent-cli-wrapper/llmendpoint",
         "//agent-cli-wrapper/protocol",
         "@com_github_invopop_jsonschema//:jsonschema",
     ],
@@ -46,6 +47,7 @@ go_test(
         "sdk_mcp_test.go",
         "sdk_mcp_typed_test.go",
         "session_dispatch_test.go",
+        "session_options_test.go",
         "session_test_helpers_test.go",
         "special_commands_test.go",
         "stream_replay_test.go",
@@ -56,6 +58,7 @@ go_test(
     embed = [":claude"],
     deps = [
         "//agent-cli-wrapper/internal/ndjson",
+        "//agent-cli-wrapper/llmendpoint",
         "//agent-cli-wrapper/protocol",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/agent-cli-wrapper/claude/process.go
+++ b/agent-cli-wrapper/claude/process.go
@@ -174,36 +174,8 @@ func (pm *processManager) Start(ctx context.Context) error {
 	// subprocess invocations are safe since they use --input-format stream-json.
 	pm.cmd.Env = buildSubprocessEnv(os.Environ())
 
-	// When pointing at a third-party LLM endpoint (signaled by
-	// ANTHROPIC_BASE_URL in config.Env), pin every Claude CLI default-model
-	// env var to the user-selected model. The CLI's preflight + post-turn
-	// side calls otherwise use hardcoded "claude-haiku-4-5-..." model ids
-	// that most third-party endpoints don't serve, surfacing as a misleading
-	// "model may not exist" error on the user's actual model.
-	envOverrides := pm.config.Env
-	if _, hasBase := envOverrides["ANTHROPIC_BASE_URL"]; hasBase && pm.config.Model != "" {
-		modelDefaults := []string{
-			"ANTHROPIC_MODEL",
-			"ANTHROPIC_DEFAULT_HAIKU_MODEL",
-			"ANTHROPIC_DEFAULT_SONNET_MODEL",
-			"ANTHROPIC_DEFAULT_OPUS_MODEL",
-			"ANTHROPIC_SMALL_FAST_MODEL",
-		}
-		// Copy so we don't mutate the caller's map.
-		merged := make(map[string]string, len(envOverrides)+len(modelDefaults))
-		for k, v := range envOverrides {
-			merged[k] = v
-		}
-		for _, name := range modelDefaults {
-			if _, ok := merged[name]; !ok {
-				merged[name] = pm.config.Model
-			}
-		}
-		envOverrides = merged
-	}
-
 	// Add custom environment variables
-	for k, v := range envOverrides {
+	for k, v := range pm.config.Env {
 		pm.cmd.Env = append(pm.cmd.Env, k+"="+v)
 	}
 

--- a/agent-cli-wrapper/claude/process.go
+++ b/agent-cli-wrapper/claude/process.go
@@ -174,8 +174,36 @@ func (pm *processManager) Start(ctx context.Context) error {
 	// subprocess invocations are safe since they use --input-format stream-json.
 	pm.cmd.Env = buildSubprocessEnv(os.Environ())
 
+	// When pointing at a third-party LLM endpoint (signaled by
+	// ANTHROPIC_BASE_URL in config.Env), pin every Claude CLI default-model
+	// env var to the user-selected model. The CLI's preflight + post-turn
+	// side calls otherwise use hardcoded "claude-haiku-4-5-..." model ids
+	// that most third-party endpoints don't serve, surfacing as a misleading
+	// "model may not exist" error on the user's actual model.
+	envOverrides := pm.config.Env
+	if _, hasBase := envOverrides["ANTHROPIC_BASE_URL"]; hasBase && pm.config.Model != "" {
+		modelDefaults := []string{
+			"ANTHROPIC_MODEL",
+			"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+			"ANTHROPIC_DEFAULT_SONNET_MODEL",
+			"ANTHROPIC_DEFAULT_OPUS_MODEL",
+			"ANTHROPIC_SMALL_FAST_MODEL",
+		}
+		// Copy so we don't mutate the caller's map.
+		merged := make(map[string]string, len(envOverrides)+len(modelDefaults))
+		for k, v := range envOverrides {
+			merged[k] = v
+		}
+		for _, name := range modelDefaults {
+			if _, ok := merged[name]; !ok {
+				merged[name] = pm.config.Model
+			}
+		}
+		envOverrides = merged
+	}
+
 	// Add custom environment variables
-	for k, v := range pm.config.Env {
+	for k, v := range envOverrides {
 		pm.cmd.Env = append(pm.cmd.Env, k+"="+v)
 	}
 

--- a/agent-cli-wrapper/claude/session_options.go
+++ b/agent-cli-wrapper/claude/session_options.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"context"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
 )
 
@@ -301,6 +302,39 @@ func WithTools(tools string) SessionOption {
 func WithExtraArgs(args ...string) SessionOption {
 	return func(c *SessionConfig) {
 		c.ExtraArgs = args
+	}
+}
+
+// WithLLMEndpoint points the Claude CLI at a third-party LLM endpoint by
+// setting ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN/ANTHROPIC_API_KEY in the
+// subprocess environment.
+//
+// The Claude CLI expects an Anthropic Messages API shape on the other end of
+// ANTHROPIC_BASE_URL. Pointing it at a raw OpenAI-shaped endpoint (e.g.
+// Baseten, OpenRouter) requires an Anthropic-compatible translation layer
+// (LiteLLM proxy, internal gateway, AWS Bedrock front, etc.). For raw
+// OpenAI-shaped endpoints, use the codex or acp wrappers instead.
+//
+// Existing entries in SessionConfig.Env are preserved; this option only sets
+// keys it owns. Passing a zero Endpoint is a no-op.
+func WithLLMEndpoint(ep llmendpoint.Endpoint) SessionOption {
+	return func(c *SessionConfig) {
+		if ep.IsZero() {
+			return
+		}
+		if c.Env == nil {
+			c.Env = make(map[string]string, 3)
+		}
+		if ep.BaseURL != "" {
+			c.Env["ANTHROPIC_BASE_URL"] = ep.BaseURL
+		}
+		if key := ep.ResolvedKey(); key != "" {
+			// Set both: Claude CLI honors AUTH_TOKEN for OAuth-style proxies
+			// and API_KEY for direct API access. Some proxies expect one,
+			// some the other; setting both maximizes compatibility.
+			c.Env["ANTHROPIC_AUTH_TOKEN"] = key
+			c.Env["ANTHROPIC_API_KEY"] = key
+		}
 	}
 }
 

--- a/agent-cli-wrapper/claude/session_options.go
+++ b/agent-cli-wrapper/claude/session_options.go
@@ -320,9 +320,12 @@ func WithExtraArgs(args ...string) SessionOption {
 //     itself. Passing https://x/v1 as-is yields /v1/v1/messages → 404.
 //   - Claude CLI makes side calls (preflight + post-turn summary) using a
 //     hardcoded haiku model id. We override ANTHROPIC_DEFAULT_{HAIKU,SONNET,
-//     OPUS}_MODEL and ANTHROPIC_SMALL_FAST_MODEL to the user-selected model
-//     so those side calls don't 404 against an endpoint that only serves a
-//     single model.
+//     OPUS}_MODEL and ANTHROPIC_SMALL_FAST_MODEL to SessionConfig.Model so
+//     those side calls don't 404 against an endpoint that only serves a
+//     single model. Apply WithModel before WithLLMEndpoint for this to take
+//     effect; if Model is unset at apply time, the model-default pin is
+//     skipped (claude-cli will then surface the side-call 404 as a
+//     misleading "model may not exist" error on the user's actual model).
 //   - We set both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY: some proxies
 //     expect Bearer, others x-api-key.
 //
@@ -347,10 +350,19 @@ func WithLLMEndpoint(ep llmendpoint.Endpoint) SessionOption {
 			c.Env["ANTHROPIC_AUTH_TOKEN"] = key
 			c.Env["ANTHROPIC_API_KEY"] = key
 		}
-		// process.go (Start()) auto-pins ANTHROPIC_*_MODEL defaults to
-		// SessionConfig.Model when a third-party endpoint is configured, so
-		// claude-cli's preflight + post-turn side calls don't 404 against an
-		// endpoint that only serves the user-selected model.
+		if c.Model != "" {
+			for _, name := range []string{
+				"ANTHROPIC_MODEL",
+				"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+				"ANTHROPIC_DEFAULT_SONNET_MODEL",
+				"ANTHROPIC_DEFAULT_OPUS_MODEL",
+				"ANTHROPIC_SMALL_FAST_MODEL",
+			} {
+				if _, set := c.Env[name]; !set {
+					c.Env[name] = c.Model
+				}
+			}
+		}
 	}
 }
 

--- a/agent-cli-wrapper/claude/session_options.go
+++ b/agent-cli-wrapper/claude/session_options.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"context"
+	"strings"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/protocol"
@@ -306,14 +307,24 @@ func WithExtraArgs(args ...string) SessionOption {
 }
 
 // WithLLMEndpoint points the Claude CLI at a third-party LLM endpoint by
-// setting ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN/ANTHROPIC_API_KEY in the
-// subprocess environment.
+// setting ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN/ANTHROPIC_API_KEY, and
+// the model-default overrides in the subprocess environment.
 //
 // The Claude CLI expects an Anthropic Messages API shape on the other end of
-// ANTHROPIC_BASE_URL. Pointing it at a raw OpenAI-shaped endpoint (e.g.
-// Baseten, OpenRouter) requires an Anthropic-compatible translation layer
-// (LiteLLM proxy, internal gateway, AWS Bedrock front, etc.). For raw
-// OpenAI-shaped endpoints, use the codex or acp wrappers instead.
+// ANTHROPIC_BASE_URL. Some third-party endpoints expose this (e.g. Baseten
+// at /v1/messages); raw OpenAI-shaped endpoints need an Anthropic-compatible
+// translation layer (LiteLLM, AWS Bedrock front, etc.).
+//
+// Conventions and gotchas:
+//   - Trailing /v1 is stripped from BaseURL: Claude CLI appends /v1/messages
+//     itself. Passing https://x/v1 as-is yields /v1/v1/messages → 404.
+//   - Claude CLI makes side calls (preflight + post-turn summary) using a
+//     hardcoded haiku model id. We override ANTHROPIC_DEFAULT_{HAIKU,SONNET,
+//     OPUS}_MODEL and ANTHROPIC_SMALL_FAST_MODEL to the user-selected model
+//     so those side calls don't 404 against an endpoint that only serves a
+//     single model.
+//   - We set both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY: some proxies
+//     expect Bearer, others x-api-key.
 //
 // Existing entries in SessionConfig.Env are preserved; this option only sets
 // keys it owns. Passing a zero Endpoint is a no-op.
@@ -323,18 +334,23 @@ func WithLLMEndpoint(ep llmendpoint.Endpoint) SessionOption {
 			return
 		}
 		if c.Env == nil {
-			c.Env = make(map[string]string, 3)
+			c.Env = make(map[string]string, 8)
 		}
 		if ep.BaseURL != "" {
-			c.Env["ANTHROPIC_BASE_URL"] = ep.BaseURL
+			// Claude CLI auto-appends /v1/messages; strip a trailing /v1 to
+			// avoid /v1/v1/messages 404s.
+			base := strings.TrimRight(ep.BaseURL, "/")
+			base = strings.TrimSuffix(base, "/v1")
+			c.Env["ANTHROPIC_BASE_URL"] = base
 		}
 		if key := ep.ResolvedKey(); key != "" {
-			// Set both: Claude CLI honors AUTH_TOKEN for OAuth-style proxies
-			// and API_KEY for direct API access. Some proxies expect one,
-			// some the other; setting both maximizes compatibility.
 			c.Env["ANTHROPIC_AUTH_TOKEN"] = key
 			c.Env["ANTHROPIC_API_KEY"] = key
 		}
+		// process.go (Start()) auto-pins ANTHROPIC_*_MODEL defaults to
+		// SessionConfig.Model when a third-party endpoint is configured, so
+		// claude-cli's preflight + post-turn side calls don't 404 against an
+		// endpoint that only serves the user-selected model.
 	}
 }
 

--- a/agent-cli-wrapper/claude/session_options_test.go
+++ b/agent-cli-wrapper/claude/session_options_test.go
@@ -53,6 +53,35 @@ func TestWithLLMEndpoint_zeroIsNoop(t *testing.T) {
 	}
 }
 
+func TestWithLLMEndpoint_pinsModelDefaultsWhenModelSet(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.Model = "moonshotai/Kimi-K2.6"
+	WithLLMEndpoint(llmendpoint.Endpoint{BaseURL: "https://x", APIKey: "k"})(&cfg)
+
+	for _, name := range []string{
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_SMALL_FAST_MODEL",
+	} {
+		if got := cfg.Env[name]; got != "moonshotai/Kimi-K2.6" {
+			t.Errorf("%s = %q, want moonshotai/Kimi-K2.6", name, got)
+		}
+	}
+}
+
+func TestWithLLMEndpoint_skipsModelPinWhenModelEmpty(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.Model = ""
+	WithLLMEndpoint(llmendpoint.Endpoint{BaseURL: "https://x", APIKey: "k"})(&cfg)
+	if _, set := cfg.Env["ANTHROPIC_DEFAULT_HAIKU_MODEL"]; set {
+		t.Errorf("model-pin should be skipped when c.Model is empty")
+	}
+}
+
 func TestWithLLMEndpoint_stripsTrailingV1(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/agent-cli-wrapper/claude/session_options_test.go
+++ b/agent-cli-wrapper/claude/session_options_test.go
@@ -12,11 +12,11 @@ func TestWithLLMEndpoint_setsEnv(t *testing.T) {
 	cfg.Env = map[string]string{"PRESERVED": "yes"}
 
 	WithLLMEndpoint(llmendpoint.Endpoint{
-		BaseURL: "https://inference.baseten.co/v1",
+		BaseURL: "https://inference.baseten.co",
 		APIKey:  "sk-test",
 	})(&cfg)
 
-	if got := cfg.Env["ANTHROPIC_BASE_URL"]; got != "https://inference.baseten.co/v1" {
+	if got := cfg.Env["ANTHROPIC_BASE_URL"]; got != "https://inference.baseten.co" {
 		t.Errorf("ANTHROPIC_BASE_URL = %q", got)
 	}
 	if got := cfg.Env["ANTHROPIC_AUTH_TOKEN"]; got != "sk-test" {
@@ -50,5 +50,24 @@ func TestWithLLMEndpoint_zeroIsNoop(t *testing.T) {
 	WithLLMEndpoint(llmendpoint.Endpoint{})(&cfg)
 	if len(cfg.Env) != 0 {
 		t.Errorf("zero endpoint should be no-op, got env=%v", cfg.Env)
+	}
+}
+
+func TestWithLLMEndpoint_stripsTrailingV1(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"https://inference.baseten.co/v1", "https://inference.baseten.co"},
+		{"https://inference.baseten.co/v1/", "https://inference.baseten.co"},
+		{"https://example.com", "https://example.com"},
+		{"https://example.com/api", "https://example.com/api"},
+	}
+	for _, tc := range cases {
+		cfg := defaultConfig()
+		WithLLMEndpoint(llmendpoint.Endpoint{BaseURL: tc.in, APIKey: "k"})(&cfg)
+		if got := cfg.Env["ANTHROPIC_BASE_URL"]; got != tc.want {
+			t.Errorf("BaseURL %q -> ANTHROPIC_BASE_URL=%q, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/agent-cli-wrapper/claude/session_options_test.go
+++ b/agent-cli-wrapper/claude/session_options_test.go
@@ -1,0 +1,54 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+)
+
+func TestWithLLMEndpoint_setsEnv(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.Env = map[string]string{"PRESERVED": "yes"}
+
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL: "https://inference.baseten.co/v1",
+		APIKey:  "sk-test",
+	})(&cfg)
+
+	if got := cfg.Env["ANTHROPIC_BASE_URL"]; got != "https://inference.baseten.co/v1" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q", got)
+	}
+	if got := cfg.Env["ANTHROPIC_AUTH_TOKEN"]; got != "sk-test" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q", got)
+	}
+	if got := cfg.Env["ANTHROPIC_API_KEY"]; got != "sk-test" {
+		t.Errorf("ANTHROPIC_API_KEY = %q", got)
+	}
+	if got := cfg.Env["PRESERVED"]; got != "yes" {
+		t.Errorf("preserved env lost: %q", got)
+	}
+}
+
+func TestWithLLMEndpoint_resolvesFromEnv(t *testing.T) {
+	t.Setenv("CLAUDE_TEST_KEY", "from-env")
+	cfg := defaultConfig()
+
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL:   "https://example.com",
+		APIKeyEnv: "CLAUDE_TEST_KEY",
+	})(&cfg)
+
+	if got := cfg.Env["ANTHROPIC_AUTH_TOKEN"]; got != "from-env" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestWithLLMEndpoint_zeroIsNoop(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{})(&cfg)
+	if len(cfg.Env) != 0 {
+		t.Errorf("zero endpoint should be no-op, got env=%v", cfg.Env)
+	}
+}

--- a/agent-cli-wrapper/codex/BUILD.bazel
+++ b/agent-cli-wrapper/codex/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/internal/procattr",
+        "//agent-cli-wrapper/llmendpoint",
         "//agent-cli-wrapper/transient",
     ],
 )
@@ -41,5 +42,8 @@ go_test(
         "thread_test.go",
     ],
     embed = [":codex"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//agent-cli-wrapper/llmendpoint",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/agent-cli-wrapper/codex/client_options.go
+++ b/agent-cli-wrapper/codex/client_options.go
@@ -1,12 +1,29 @@
 package codex
 
+import (
+	"fmt"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+)
+
 // ClientConfig holds client configuration.
+//
+//nolint:govet // fieldalignment: keep handlers/env grouped before scalars.
 type ClientConfig struct {
 	// ApprovalHandler handles tool execution approval requests.
 	ApprovalHandler ApprovalHandler
 
 	// StderrHandler is an optional handler for app-server stderr output.
 	StderrHandler func([]byte)
+
+	// Env carries additional environment variables to set on the app-server
+	// subprocess (appended to os.Environ).
+	Env map[string]string
+
+	// AppServerArgs is appended to the codex command line after "app-server".
+	// Used to inject `--config 'model_providers.<name>.base_url=...'` style
+	// overrides without writing to ~/.codex/config.toml.
+	AppServerArgs []string
 
 	// CodexPath is the path to the Codex CLI binary (uses "codex" in PATH if empty).
 	CodexPath string
@@ -83,6 +100,77 @@ func WithApprovalHandler(h ApprovalHandler) ClientOption {
 func WithSessionLogPath(path string) ClientOption {
 	return func(c *ClientConfig) {
 		c.SessionLogPath = path
+	}
+}
+
+// WithEnv sets additional environment variables for the codex app-server
+// subprocess. Existing entries are preserved.
+func WithEnv(env map[string]string) ClientOption {
+	return func(c *ClientConfig) {
+		if c.Env == nil {
+			c.Env = make(map[string]string, len(env))
+		}
+		for k, v := range env {
+			c.Env[k] = v
+		}
+	}
+}
+
+// WithAppServerArgs appends additional arguments to the codex app-server
+// command line (escape hatch). Multiple calls accumulate.
+func WithAppServerArgs(args ...string) ClientOption {
+	return func(c *ClientConfig) {
+		c.AppServerArgs = append(c.AppServerArgs, args...)
+	}
+}
+
+// WithLLMEndpoint configures the codex app-server to route inference through
+// a third-party LLM endpoint by injecting `--config model_providers.<name>.*`
+// overrides at app-server boot. The API key is exposed via env var
+// (named by ep.APIKeyEnv) so it never lands in process args.
+//
+// The final `--config model_provider="<name>"` ensures the new provider
+// becomes the default, overriding any value in ~/.codex/config.toml.
+//
+// Wire defaults to "chat" (OpenAI-compatible). Use "responses" for OpenAI's
+// Responses API.
+func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
+	return func(c *ClientConfig) {
+		if ep.IsZero() {
+			return
+		}
+		name := ep.Provider()
+		wire := string(ep.WireAPI())
+		envKey := ep.APIKeyEnv
+		if envKey == "" {
+			// Synthesize a stable env var name when only an inline key was
+			// provided; codex resolves the key via env_key.
+			envKey = "CODEX_LLMENDPOINT_API_KEY"
+		}
+
+		c.AppServerArgs = append(c.AppServerArgs,
+			"--config", fmt.Sprintf("model_providers.%s.name=%q", name, name),
+			"--config", fmt.Sprintf("model_providers.%s.base_url=%q", name, ep.BaseURL),
+			"--config", fmt.Sprintf("model_providers.%s.wire_api=%q", name, wire),
+			"--config", fmt.Sprintf("model_providers.%s.env_key=%q", name, envKey),
+		)
+		// Optional headers: codex supports http_headers as a TOML table.
+		for hk, hv := range ep.Headers {
+			c.AppServerArgs = append(c.AppServerArgs,
+				"--config", fmt.Sprintf("model_providers.%s.http_headers.%s=%q", name, hk, hv),
+			)
+		}
+		// Last so it overrides any default in ~/.codex/config.toml.
+		c.AppServerArgs = append(c.AppServerArgs,
+			"--config", fmt.Sprintf("model_provider=%q", name),
+		)
+
+		if c.Env == nil {
+			c.Env = make(map[string]string, 1)
+		}
+		if key := ep.ResolvedKey(); key != "" {
+			c.Env[envKey] = key
+		}
 	}
 }
 

--- a/agent-cli-wrapper/codex/client_options.go
+++ b/agent-cli-wrapper/codex/client_options.go
@@ -190,8 +190,10 @@ func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
 		}
 
 		// Disable features whose tool schemas third-party Responses
-		// providers reject. Must precede `app-server` (these are global
-		// codex flags, not subcommand flags).
+		// providers reject. `--disable` is an `app-server` subcommand
+		// option (see `codex app-server --help`), so appending here is
+		// correct: process.go assembles the command as
+		// `codex app-server <AppServerArgs...>`.
 		for _, f := range thirdPartyIncompatibleFeatures {
 			c.AppServerArgs = append(c.AppServerArgs, "--disable", f)
 		}

--- a/agent-cli-wrapper/codex/client_options.go
+++ b/agent-cli-wrapper/codex/client_options.go
@@ -124,6 +124,37 @@ func WithAppServerArgs(args ...string) ClientOption {
 	}
 }
 
+// thirdPartyIncompatibleFeatures lists codex feature flags whose tools use
+// `type: "namespace"` or other variants that third-party Responses-API
+// implementations (Baseten, vLLM, etc.) reject as "unknown variant". Codex
+// 0.130 enables most of these by default; without disabling them, the
+// outgoing request fails Baseten's strict tool-schema validation with HTTP
+// 400 "unknown variant `namespace`".
+//
+// Adjust this list as upstream codex evolves. If a third-party endpoint
+// supports a feature, callers can re-enable it via WithAppServerArgs.
+var thirdPartyIncompatibleFeatures = []string{
+	"apps",
+	"browser_use",
+	"browser_use_external",
+	"computer_use",
+	"enable_request_compression",
+	"fast_mode",
+	"guardian_approval",
+	"hooks",
+	"image_generation",
+	"in_app_browser",
+	"multi_agent",
+	"personality",
+	"plugins",
+	"shell_snapshot",
+	"skill_mcp_dependency_install",
+	"tool_call_mcp_elicitation",
+	"tool_search",
+	"tool_suggest",
+	"unavailable_dummy_tools",
+}
+
 // WithLLMEndpoint configures the codex app-server to route inference through
 // a third-party LLM endpoint by injecting `--config model_providers.<name>.*`
 // overrides at app-server boot. The API key is exposed via env var
@@ -133,7 +164,11 @@ func WithAppServerArgs(args ...string) ClientOption {
 // becomes the default, overriding any value in ~/.codex/config.toml.
 //
 // Wire defaults to "chat" (OpenAI-compatible). Use "responses" for OpenAI's
-// Responses API.
+// Responses API. Codex 0.130+ requires "responses".
+//
+// Side effect: appends `--disable <feature>` for each feature whose tool
+// schema uses variants third-party Responses providers reject. To keep a
+// disabled feature, re-enable it after this option via WithAppServerArgs.
 func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
 	return func(c *ClientConfig) {
 		if ep.IsZero() {
@@ -146,6 +181,13 @@ func WithLLMEndpoint(ep llmendpoint.Endpoint) ClientOption {
 			// Synthesize a stable env var name when only an inline key was
 			// provided; codex resolves the key via env_key.
 			envKey = "CODEX_LLMENDPOINT_API_KEY"
+		}
+
+		// Disable features whose tool schemas third-party Responses
+		// providers reject. Must precede `app-server` (these are global
+		// codex flags, not subcommand flags).
+		for _, f := range thirdPartyIncompatibleFeatures {
+			c.AppServerArgs = append(c.AppServerArgs, "--disable", f)
 		}
 
 		c.AppServerArgs = append(c.AppServerArgs,

--- a/agent-cli-wrapper/codex/client_options.go
+++ b/agent-cli-wrapper/codex/client_options.go
@@ -131,8 +131,14 @@ func WithAppServerArgs(args ...string) ClientOption {
 // outgoing request fails Baseten's strict tool-schema validation with HTTP
 // 400 "unknown variant `namespace`".
 //
-// Adjust this list as upstream codex evolves. If a third-party endpoint
-// supports a feature, callers can re-enable it via WithAppServerArgs.
+// This is a hand-curated denylist — when codex adds a new stable feature
+// whose tool variants don't pass third-party validation, the symptom is
+// HTTP 400 with "unknown variant <name>" and the fix is to append the
+// feature here. Tracked in https://github.com/bazelment/yoloswe/issues/241
+// with notes on long-term replacements (allowlist, capability probe).
+//
+// If a third-party endpoint supports a feature we've disabled, callers can
+// re-enable it via WithAppServerArgs after WithLLMEndpoint.
 var thirdPartyIncompatibleFeatures = []string{
 	"apps",
 	"browser_use",

--- a/agent-cli-wrapper/codex/client_options_test.go
+++ b/agent-cli-wrapper/codex/client_options_test.go
@@ -371,6 +371,28 @@ func TestClientOption_WithLLMEndpoint_setsEnv(t *testing.T) {
 	}
 }
 
+func TestClientOption_WithLLMEndpoint_disablesThirdPartyIncompatibleFeatures(t *testing.T) {
+	cfg := defaultCodexClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL:   "https://inference.baseten.co/v1",
+		APIKeyEnv: "BASETEN_API_KEY",
+		Wire:      llmendpoint.WireAPIResponses,
+	})(&cfg)
+
+	for _, want := range thirdPartyIncompatibleFeatures {
+		found := false
+		for i := 0; i < len(cfg.AppServerArgs)-1; i++ {
+			if cfg.AppServerArgs[i] == "--disable" && cfg.AppServerArgs[i+1] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("AppServerArgs missing --disable %s\nfull: %v", want, cfg.AppServerArgs)
+		}
+	}
+}
+
 func TestClientOption_WithAppServerArgs_accumulates(t *testing.T) {
 	cfg := defaultCodexClientConfig()
 	WithAppServerArgs("--config", "a=1")(&cfg)

--- a/agent-cli-wrapper/codex/client_options_test.go
+++ b/agent-cli-wrapper/codex/client_options_test.go
@@ -3,6 +3,8 @@ package codex
 import (
 	"context"
 	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 )
 
 func TestDefaultClientConfig(t *testing.T) {
@@ -303,5 +305,77 @@ func TestNewClient_WithOptions(t *testing.T) {
 	}
 	if client.config.EventBufferSize != 50 {
 		t.Errorf("unexpected EventBufferSize: %d", client.config.EventBufferSize)
+	}
+}
+
+// LLMEndpoint test helpers.
+func appServerArgsContainConfig(args []string, want string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--config" && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestClientOption_WithLLMEndpoint_buildsAppServerArgs(t *testing.T) {
+	cfg := defaultCodexClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL:      "https://inference.baseten.co/v1",
+		APIKeyEnv:    "BASETEN_API_KEY",
+		ProviderName: "baseten",
+		Wire:         llmendpoint.WireAPIChat,
+	})(&cfg)
+
+	want := []string{
+		`model_providers.baseten.name="baseten"`,
+		`model_providers.baseten.base_url="https://inference.baseten.co/v1"`,
+		`model_providers.baseten.wire_api="chat"`,
+		`model_providers.baseten.env_key="BASETEN_API_KEY"`,
+		`model_provider="baseten"`,
+	}
+	for _, w := range want {
+		if !appServerArgsContainConfig(cfg.AppServerArgs, w) {
+			t.Errorf("AppServerArgs missing %q\nfull: %v", w, cfg.AppServerArgs)
+		}
+	}
+	// model_provider="..." must be the LAST --config so it overrides defaults.
+	last := ""
+	for i := 0; i < len(cfg.AppServerArgs)-1; i++ {
+		if cfg.AppServerArgs[i] == "--config" {
+			last = cfg.AppServerArgs[i+1]
+		}
+	}
+	if last != `model_provider="baseten"` {
+		t.Errorf("model_provider must be last --config, got %q", last)
+	}
+	// API key never lands in args.
+	for _, a := range cfg.AppServerArgs {
+		if a == "key-secret" {
+			t.Fatalf("API key leaked to AppServerArgs: %v", cfg.AppServerArgs)
+		}
+	}
+}
+
+func TestClientOption_WithLLMEndpoint_setsEnv(t *testing.T) {
+	t.Setenv("BASETEN_API_KEY", "key-secret")
+	cfg := defaultCodexClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL:      "https://inference.baseten.co/v1",
+		APIKeyEnv:    "BASETEN_API_KEY",
+		ProviderName: "baseten",
+		Wire:         llmendpoint.WireAPIChat,
+	})(&cfg)
+	if cfg.Env["BASETEN_API_KEY"] != "key-secret" {
+		t.Errorf("Env[BASETEN_API_KEY] = %q", cfg.Env["BASETEN_API_KEY"])
+	}
+}
+
+func TestClientOption_WithAppServerArgs_accumulates(t *testing.T) {
+	cfg := defaultCodexClientConfig()
+	WithAppServerArgs("--config", "a=1")(&cfg)
+	WithAppServerArgs("--config", "b=2")(&cfg)
+	if len(cfg.AppServerArgs) != 4 {
+		t.Errorf("expected 4 args, got %v", cfg.AppServerArgs)
 	}
 }

--- a/agent-cli-wrapper/codex/client_options_test.go
+++ b/agent-cli-wrapper/codex/client_options_test.go
@@ -393,6 +393,29 @@ func TestClientOption_WithLLMEndpoint_disablesThirdPartyIncompatibleFeatures(t *
 	}
 }
 
+func TestClientOption_WithLLMEndpoint_emitsHeaders(t *testing.T) {
+	cfg := defaultCodexClientConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL:      "https://inference.baseten.co/v1",
+		APIKeyEnv:    "BASETEN_API_KEY",
+		ProviderName: "baseten",
+		Wire:         llmendpoint.WireAPIChat,
+		Headers: map[string]string{
+			"X-Org":   "acme",
+			"X-Trace": "deadbeef",
+		},
+	})(&cfg)
+	wantHeaderArgs := []string{
+		`model_providers.baseten.http_headers.X-Org="acme"`,
+		`model_providers.baseten.http_headers.X-Trace="deadbeef"`,
+	}
+	for _, w := range wantHeaderArgs {
+		if !appServerArgsContainConfig(cfg.AppServerArgs, w) {
+			t.Errorf("AppServerArgs missing %q\nfull: %v", w, cfg.AppServerArgs)
+		}
+	}
+}
+
 func TestClientOption_WithAppServerArgs_accumulates(t *testing.T) {
 	cfg := defaultCodexClientConfig()
 	WithAppServerArgs("--config", "a=1")(&cfg)

--- a/agent-cli-wrapper/codex/process.go
+++ b/agent-cli-wrapper/codex/process.go
@@ -51,7 +51,17 @@ func (pm *processManager) Start(ctx context.Context) error {
 	}
 
 	// Build command
-	pm.cmd = exec.CommandContext(ctx, codexPath, "app-server")
+	args := append([]string{"app-server"}, pm.config.AppServerArgs...)
+	pm.cmd = exec.CommandContext(ctx, codexPath, args...)
+
+	// Inherit parent env, then apply config-supplied overrides.
+	if len(pm.config.Env) > 0 {
+		env := os.Environ()
+		for k, v := range pm.config.Env {
+			env = append(env, k+"="+v)
+		}
+		pm.cmd.Env = env
+	}
 
 	// Configure process group for orphan prevention.
 	procattr.Set(pm.cmd)

--- a/agent-cli-wrapper/cursor/BUILD.bazel
+++ b/agent-cli-wrapper/cursor/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/internal/ndjson",
         "//agent-cli-wrapper/internal/procattr",
+        "//agent-cli-wrapper/llmendpoint",
     ],
 )
 
@@ -27,12 +28,14 @@ go_test(
         "events_test.go",
         "process_test.go",
         "protocol_test.go",
+        "session_options_test.go",
         "session_test.go",
     ],
     embed = [":cursor"],
     deps = [
         "//agent-cli-wrapper/agentstream",
         "//agent-cli-wrapper/internal/ndjson",
+        "//agent-cli-wrapper/llmendpoint",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/agent-cli-wrapper/cursor/session_options.go
+++ b/agent-cli-wrapper/cursor/session_options.go
@@ -1,5 +1,7 @@
 package cursor
 
+import "github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+
 // SessionConfig holds session configuration for the Cursor Agent CLI.
 type SessionConfig struct {
 	StderrHandler   func([]byte)
@@ -92,6 +94,33 @@ func WithEventBufferSize(size int) SessionOption {
 func WithStderrHandler(h func([]byte)) SessionOption {
 	return func(c *SessionConfig) {
 		c.StderrHandler = h
+	}
+}
+
+// WithLLMEndpoint points the cursor-agent CLI at a third-party LLM endpoint
+// by setting OPENAI_BASE_URL and OPENAI_API_KEY in the subprocess env.
+//
+// Note: cursor-agent routes inference through Cursor's own backend by default.
+// These env vars only affect cursor-agent builds that respect the OpenAI
+// envvar convention for arbitrary models; for Cursor-managed models the
+// option is a no-op as far as the upstream CLI is concerned. The option is
+// provided for symmetry with the other wrappers.
+//
+// Existing entries in SessionConfig.Env are preserved.
+func WithLLMEndpoint(ep llmendpoint.Endpoint) SessionOption {
+	return func(c *SessionConfig) {
+		if ep.IsZero() {
+			return
+		}
+		if c.Env == nil {
+			c.Env = make(map[string]string, 2)
+		}
+		if ep.BaseURL != "" {
+			c.Env["OPENAI_BASE_URL"] = ep.BaseURL
+		}
+		if key := ep.ResolvedKey(); key != "" {
+			c.Env["OPENAI_API_KEY"] = key
+		}
 	}
 }
 

--- a/agent-cli-wrapper/cursor/session_options_test.go
+++ b/agent-cli-wrapper/cursor/session_options_test.go
@@ -1,0 +1,37 @@
+package cursor
+
+import (
+	"testing"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+)
+
+func TestWithLLMEndpoint_setsEnv(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.Env = map[string]string{"PRESERVED": "yes"}
+
+	WithLLMEndpoint(llmendpoint.Endpoint{
+		BaseURL: "https://inference.baseten.co/v1",
+		APIKey:  "sk-test",
+	})(&cfg)
+
+	if got := cfg.Env["OPENAI_BASE_URL"]; got != "https://inference.baseten.co/v1" {
+		t.Errorf("OPENAI_BASE_URL = %q", got)
+	}
+	if got := cfg.Env["OPENAI_API_KEY"]; got != "sk-test" {
+		t.Errorf("OPENAI_API_KEY = %q", got)
+	}
+	if got := cfg.Env["PRESERVED"]; got != "yes" {
+		t.Errorf("preserved env lost: %q", got)
+	}
+}
+
+func TestWithLLMEndpoint_zeroIsNoop(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	WithLLMEndpoint(llmendpoint.Endpoint{})(&cfg)
+	if len(cfg.Env) != 0 {
+		t.Errorf("zero endpoint should be no-op: %v", cfg.Env)
+	}
+}

--- a/agent-cli-wrapper/integration/BUILD.bazel
+++ b/agent-cli-wrapper/integration/BUILD.bazel
@@ -19,7 +19,10 @@ go_test(
     # bazel's default 60s. Without this override the test fails with a
     # timeout under standard `bazel test --test_tag_filters=integration`.
     size = "large",
-    srcs = ["resume_test.go"],
+    srcs = [
+        "llmendpoint_test.go",
+        "resume_test.go",
+    ],
     # The agent CLIs need real user state to authenticate and run:
     #   HOME / USER          — cursor's `agent` launcher uses `set -u` and
     #                          dies on unbound HOME; auth state lives under
@@ -27,6 +30,9 @@ go_test(
     #   PATH                 — the wrappers exec the CLI binary by name.
     #   XDG_*_HOME           — cursor + node compile cache locations.
     env_inherit = [
+        # BASETEN_API_KEY: gates TestLLMEndpoint_Baseten; the test skips
+        # cleanly when unset so the rest of the suite still runs.
+        "BASETEN_API_KEY",
         "HOME",
         "PATH",
         "USER",
@@ -45,5 +51,6 @@ go_test(
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/codex",
         "//agent-cli-wrapper/cursor",
+        "//agent-cli-wrapper/llmendpoint",
     ],
 )

--- a/agent-cli-wrapper/integration/llmendpoint_test.go
+++ b/agent-cli-wrapper/integration/llmendpoint_test.go
@@ -62,7 +62,10 @@ const (
 )
 
 // TestLLMEndpoint_Baseten runs WithLLMEndpoint smoke against Baseten's
-// Kimi-K2.6 deployment for every wrapper that supports a custom endpoint.
+// Kimi-K2.6 deployment for the wrappers whose CLIs currently honor a
+// custom endpoint at runtime. Today that's claude and codex; gemini and
+// cursor have compile-time guards (below) but no runtime subtests because
+// their CLIs ignore endpoint env vars when targeting non-native models.
 // Each subtest skips (not fails) when its prerequisites aren't met.
 func TestLLMEndpoint_Baseten(t *testing.T) {
 	apiKey := os.Getenv(basetenAPIKeyEnv)

--- a/agent-cli-wrapper/integration/llmendpoint_test.go
+++ b/agent-cli-wrapper/integration/llmendpoint_test.go
@@ -64,8 +64,17 @@ const (
 // TestLLMEndpoint_Baseten runs WithLLMEndpoint smoke against Baseten's
 // Kimi-K2.6 deployment for the wrappers whose CLIs currently honor a
 // custom endpoint at runtime. Today that's claude and codex; gemini and
-// cursor have compile-time guards (below) but no runtime subtests because
-// their CLIs ignore endpoint env vars when targeting non-native models.
+// cursor have compile-time guards (below) but no runtime subtests:
+//
+//   - gemini-cli has no OpenAI/Anthropic passthrough on any released 0.x
+//     build (issue google-gemini/gemini-cli#1605, closed "wontfix"). It
+//     only speaks GenerateContent, so hitting Baseten requires a
+//     translating proxy in front of GOOGLE_GEMINI_BASE_URL. The smoke
+//     against such a proxy is project-specific; add it when the proxy
+//     ships.
+//   - cursor-agent ignores OPENAI_BASE_URL when its model id is not a
+//     recognized third-party model.
+//
 // Each subtest skips (not fails) when its prerequisites aren't met.
 func TestLLMEndpoint_Baseten(t *testing.T) {
 	apiKey := os.Getenv(basetenAPIKeyEnv)

--- a/agent-cli-wrapper/integration/llmendpoint_test.go
+++ b/agent-cli-wrapper/integration/llmendpoint_test.go
@@ -41,7 +41,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -130,7 +129,7 @@ func runClaudeBaseten(t *testing.T, ep llmendpoint.Endpoint) {
 	}
 	t.Logf("claude→baseten response: %s", truncate(response, 200))
 
-	if !containsSentinel(response, llmSentinel) {
+	if !containsSecret(response, llmSentinel) {
 		t.Fatalf("claude→baseten did not echo sentinel %q; got %s",
 			llmSentinel, truncate(response, 500))
 	}
@@ -206,22 +205,10 @@ func runCodexBaseten(t *testing.T, ep llmendpoint.Endpoint) {
 	}
 	t.Logf("codex→baseten response: %s", truncate(result.FullText, 200))
 
-	if !containsSentinel(result.FullText, llmSentinel) {
+	if !containsSecret(result.FullText, llmSentinel) {
 		t.Fatalf("codex→baseten did not echo sentinel %q; got %s",
 			llmSentinel, truncate(result.FullText, 500))
 	}
-}
-
-// containsSentinel matches with the same tolerance as the resume-test secret
-// matcher: case-fold + strip whitespace/punctuation. Models occasionally
-// rewrite "PURPLE-RHINO-42" as "Purple Rhino 42" or "purple_rhino_42".
-func containsSentinel(resp, sentinel string) bool {
-	normalize := func(s string) string {
-		s = strings.ToUpper(s)
-		s = strings.NewReplacer(" ", "", "-", "", "_", "", ".", "", ",", "").Replace(s)
-		return s
-	}
-	return strings.Contains(normalize(resp), normalize(sentinel))
 }
 
 // Compile-time guards that the wrappers we're testing still expose the

--- a/agent-cli-wrapper/integration/llmendpoint_test.go
+++ b/agent-cli-wrapper/integration/llmendpoint_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+// +build integration
+
+// Manual integration tests that exercise WithLLMEndpoint against a real
+// third-party LLM API endpoint. Default fixture: Baseten + moonshotai/Kimi-K2.6,
+// chosen because Baseten exposes all three Anthropic/OpenAI surfaces:
+//
+//   - /v1/chat/completions  (OpenAI Chat Completions)
+//   - /v1/responses         (OpenAI Responses API; codex 0.130+ requires this)
+//   - /v1/messages          (Anthropic Messages API; claude CLI uses this)
+//
+// Each backend gets its own subtest and is skipped when the relevant CLI
+// binary is missing or BASETEN_API_KEY is unset. None of these run under
+// `bazel test //...` (the target carries `manual` and `integration` tags).
+//
+// Run:
+//
+//	BASETEN_API_KEY=... bazel test \
+//	    //agent-cli-wrapper/integration:integration_test \
+//	    --test_filter=TestLLMEndpoint_Baseten \
+//	    --test_tag_filters=integration \
+//	    --test_env=BASETEN_API_KEY \
+//	    --test_output=streamed
+//
+// Or directly:
+//
+//	BASETEN_API_KEY=... go test -tags=integration -v \
+//	    -run TestLLMEndpoint_Baseten \
+//	    ./agent-cli-wrapper/integration/...
+//
+// What's verified end-to-end:
+//   - The wrapper's per-backend env-var + arg translation reaches Baseten.
+//   - The model id flows through unchanged.
+//   - Baseten returns a usable response (the model echoes a unique sentinel).
+//   - Bug fixes from PR #240 stay fixed: claude's /v1 doubling, claude's
+//     hardcoded haiku side-call model, codex's incompatible default features.
+package integration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/codex"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
+)
+
+const (
+	basetenBaseURL  = "https://inference.baseten.co/v1"
+	basetenAPIKeyEnv = "BASETEN_API_KEY"
+	basetenModel    = "moonshotai/Kimi-K2.6"
+
+	// llmSentinel is unique enough that only a real model round-trip can
+	// produce it. Keep it short so tiny max_tokens budgets reproduce it.
+	llmSentinel    = "PURPLE-RHINO-42"
+	llmEndpointPrompt = "Reply with exactly this single token, nothing else: " + llmSentinel
+)
+
+// TestLLMEndpoint_Baseten runs WithLLMEndpoint smoke against Baseten's
+// Kimi-K2.6 deployment for every wrapper that supports a custom endpoint.
+// Each subtest skips (not fails) when its prerequisites aren't met.
+func TestLLMEndpoint_Baseten(t *testing.T) {
+	apiKey := os.Getenv(basetenAPIKeyEnv)
+	if apiKey == "" {
+		t.Skipf("%s not set; export the key (see ~/.keys.sh) and re-run", basetenAPIKeyEnv)
+	}
+
+	endpoint := llmendpoint.Endpoint{
+		BaseURL:      basetenBaseURL,
+		APIKeyEnv:    basetenAPIKeyEnv,
+		ProviderName: "baseten",
+	}
+
+	t.Run("claude/messages", func(t *testing.T) {
+		if _, err := exec.LookPath("claude"); err != nil {
+			t.Skip("claude CLI not on PATH")
+		}
+		// Claude CLI uses /v1/messages (Anthropic shape); wire is irrelevant.
+		ep := endpoint
+		runClaudeBaseten(t, ep)
+	})
+
+	t.Run("codex/responses", func(t *testing.T) {
+		if _, err := exec.LookPath("codex"); err != nil {
+			t.Skip("codex CLI not on PATH")
+		}
+		// Codex 0.130+ requires wire_api="responses".
+		ep := endpoint
+		ep.Wire = llmendpoint.WireAPIResponses
+		runCodexBaseten(t, ep)
+	})
+}
+
+// runClaudeBaseten verifies WithLLMEndpoint correctly drives the claude CLI
+// against Baseten's /v1/messages. Regression-pins:
+//   - trailing /v1 is stripped (otherwise /v1/v1/messages → 404)
+//   - default-model envs are pinned so claude's preflight + post-turn calls
+//     don't 404 against Baseten's single-model endpoint
+func runClaudeBaseten(t *testing.T, ep llmendpoint.Endpoint) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	session := claude.NewSession(
+		claude.WithModel(basetenModel),
+		claude.WithWorkDir(t.TempDir()),
+		claude.WithPermissionMode(claude.PermissionModeBypass),
+		claude.WithDisablePlugins(),
+		claude.WithLLMEndpoint(ep),
+	)
+	if err := session.Start(ctx); err != nil {
+		t.Fatalf("claude session start: %v", err)
+	}
+	defer session.Stop()
+
+	if _, err := session.SendMessage(ctx, llmEndpointPrompt); err != nil {
+		t.Fatalf("claude SendMessage: %v", err)
+	}
+
+	response, err := drainClaudeForLLMEndpoint(ctx, session)
+	if err != nil {
+		t.Fatalf("claude turn drain: %v", err)
+	}
+	t.Logf("claude→baseten response: %s", truncate(response, 200))
+
+	if !containsSentinel(response, llmSentinel) {
+		t.Fatalf("claude→baseten did not echo sentinel %q; got %s",
+			llmSentinel, truncate(response, 500))
+	}
+}
+
+func drainClaudeForLLMEndpoint(ctx context.Context, session *claude.Session) (string, error) {
+	var response string
+	for {
+		select {
+		case <-ctx.Done():
+			return response, ctx.Err()
+		case ev, ok := <-session.Events():
+			if !ok {
+				return response, errors.New("claude event channel closed before turn complete")
+			}
+			switch e := ev.(type) {
+			case claude.TextEvent:
+				if e.FullText != "" {
+					response = e.FullText
+				}
+			case claude.TurnCompleteEvent:
+				if !e.Success {
+					return response, errors.New("claude turn failed: success=false")
+				}
+				return response, nil
+			}
+		}
+	}
+}
+
+// runCodexBaseten verifies WithLLMEndpoint drives codex against Baseten's
+// /v1/responses surface. Regression-pins:
+//   - --config model_providers.<name>.* lands at app-server boot
+//   - the third-party-incompatible feature denylist (multi_agent, apps,
+//     browser_use, ...) is auto-applied so Baseten's strict tool-schema
+//     parser doesn't 400 with `unknown variant "namespace"`
+func runCodexBaseten(t *testing.T, ep llmendpoint.Endpoint) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	client := codex.NewClient(
+		codex.WithClientName("agent-cli-wrapper-llmendpoint-test"),
+		codex.WithClientVersion("1.0.0"),
+		codex.WithLLMEndpoint(ep),
+	)
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("codex client start: %v", err)
+	}
+	defer client.Stop()
+
+	thread, err := client.CreateThread(ctx,
+		codex.WithModel(basetenModel),
+		codex.WithWorkDir(t.TempDir()),
+		codex.WithApprovalPolicy(codex.ApprovalPolicyFullAuto),
+		codex.WithSandbox("read-only"),
+	)
+	if err != nil {
+		t.Fatalf("codex CreateThread: %v", err)
+	}
+	if err := thread.WaitReady(ctx); err != nil {
+		t.Fatalf("codex thread WaitReady: %v", err)
+	}
+
+	result, err := thread.Ask(ctx, llmEndpointPrompt)
+	if err != nil {
+		t.Fatalf("codex Ask: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("codex turn failed: %v\nfull text: %s",
+			result.Error, truncate(result.FullText, 500))
+	}
+	t.Logf("codex→baseten response: %s", truncate(result.FullText, 200))
+
+	if !containsSentinel(result.FullText, llmSentinel) {
+		t.Fatalf("codex→baseten did not echo sentinel %q; got %s",
+			llmSentinel, truncate(result.FullText, 500))
+	}
+}
+
+// containsSentinel matches with the same tolerance as the resume-test secret
+// matcher: case-fold + strip whitespace/punctuation. Models occasionally
+// rewrite "PURPLE-RHINO-42" as "Purple Rhino 42" or "purple_rhino_42".
+func containsSentinel(resp, sentinel string) bool {
+	normalize := func(s string) string {
+		s = strings.ToUpper(s)
+		s = strings.NewReplacer(" ", "", "-", "", "_", "", ".", "", ",", "").Replace(s)
+		return s
+	}
+	return strings.Contains(normalize(resp), normalize(sentinel))
+}
+
+// Compile-time guards that the wrappers we're testing still expose the
+// option signatures this test depends on. If WithLLMEndpoint disappears or
+// changes shape upstream, the test fails to compile rather than silently
+// degrading to a no-op.
+var (
+	_ claude.SessionOption = claude.WithLLMEndpoint(llmendpoint.Endpoint{})
+	_ codex.ClientOption   = codex.WithLLMEndpoint(llmendpoint.Endpoint{})
+	_ acp.ClientOption     = acp.WithLLMEndpoint(llmendpoint.Endpoint{})
+)

--- a/agent-cli-wrapper/llmendpoint/BUILD.bazel
+++ b/agent-cli-wrapper/llmendpoint/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "llmendpoint",
+    srcs = ["llmendpoint.go"],
+    importpath = "github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "llmendpoint_test",
+    srcs = ["llmendpoint_test.go"],
+    embed = [":llmendpoint"],
+)

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -65,9 +65,19 @@ type Endpoint struct {
 	Headers map[string]string
 }
 
-// IsZero reports whether the endpoint is unset (no BaseURL).
+// IsZero reports whether the endpoint carries no routing or auth signal —
+// BaseURL, APIKey, and APIKeyEnv all empty. ProviderName/Wire/Headers alone
+// don't disable IsZero because they're decorations on a routing+auth pair;
+// a config that sets only those is partial and Validate will reject it.
 func (e Endpoint) IsZero() bool {
 	return e.BaseURL == "" && e.APIKey == "" && e.APIKeyEnv == ""
+}
+
+// hasOnlyDecorations reports whether the endpoint has ProviderName, Wire, or
+// Headers set without a BaseURL/auth pair. Used to surface partial configs
+// at Validate-time instead of silently treating them as disabled.
+func (e Endpoint) hasOnlyDecorations() bool {
+	return e.IsZero() && (e.ProviderName != "" || e.Wire != "" || len(e.Headers) > 0)
 }
 
 // providerNameRE accepts identifiers safe to interpolate into codex's
@@ -84,7 +94,13 @@ var providerNameRE = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 var headerNameRE = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
 
 // Validate reports configuration errors. A zero Endpoint validates as nil.
+// Partial endpoints — e.g. provider_name set without base_url — fail loudly
+// rather than being treated as disabled, since they signal user intent that
+// the wrapper would otherwise silently drop.
 func (e Endpoint) Validate() error {
+	if e.hasOnlyDecorations() {
+		return errors.New("llmendpoint: endpoint is partially configured (provider_name/wire/headers set without base_url + api_key/api_key_env)")
+	}
 	if e.IsZero() {
 		return nil
 	}

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -19,6 +19,8 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
+	"strings"
 )
 
 // WireAPI identifies the request/response shape spoken by the endpoint.
@@ -183,7 +185,10 @@ func (e Endpoint) WireAPI() WireAPI {
 	return e.Wire
 }
 
-// String renders the endpoint without leaking the literal API key.
+// String renders the endpoint without leaking the literal API key. Header
+// keys are listed (sorted, no values) so divergence diagnostics that include
+// String() can distinguish endpoints that differ only on Headers; values
+// would risk leaking secrets that operators may have shoved into headers.
 func (e Endpoint) String() string {
 	if e.IsZero() {
 		return "llmendpoint{}"
@@ -195,6 +200,15 @@ func (e Endpoint) String() string {
 	case e.APIKey != "":
 		keySrc = "<inline>"
 	}
-	return fmt.Sprintf("llmendpoint{base=%s provider=%s wire=%s key=%s}",
-		e.BaseURL, e.Provider(), e.WireAPI(), keySrc)
+	hdrs := ""
+	if len(e.Headers) > 0 {
+		keys := make([]string, 0, len(e.Headers))
+		for k := range e.Headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		hdrs = fmt.Sprintf(" headers=[%s]", strings.Join(keys, ","))
+	}
+	return fmt.Sprintf("llmendpoint{base=%s provider=%s wire=%s key=%s%s}",
+		e.BaseURL, e.Provider(), e.WireAPI(), keySrc, hdrs)
 }

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -1,0 +1,149 @@
+// Package llmendpoint describes a third-party LLM API endpoint that an
+// agent-cli-wrapper subpackage can be pointed at.
+//
+// Each wrapper (claude, codex, cursor, acp/gemini) accepts an Endpoint via a
+// WithLLMEndpoint option and translates it into the env vars and CLI flags its
+// CLI binary expects. The translation is per-wrapper because each upstream CLI
+// honors a different convention:
+//
+//   - claude: ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (Anthropic-shaped only)
+//   - codex:  --config model_providers.<name>.{base_url,wire_api,env_key}
+//   - acp:    GEMINI_API_KEY/GOOGLE_GEMINI_BASE_URL or OPENAI_BASE_URL+--openai-base-url
+//   - cursor: best-effort OPENAI_BASE_URL/OPENAI_API_KEY (cursor-agent ignores
+//     these for non-Cursor models; the option exists for symmetry)
+package llmendpoint
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// WireAPI identifies the request/response shape spoken by the endpoint.
+type WireAPI string
+
+const (
+	// WireAPIChat is the OpenAI-compatible Chat Completions shape (Baseten,
+	// LiteLLM, vLLM, OpenRouter, most third-party gateways).
+	WireAPIChat WireAPI = "chat"
+	// WireAPIResponses is the OpenAI Responses API shape (codex native).
+	WireAPIResponses WireAPI = "responses"
+)
+
+// DefaultProviderName is used when Endpoint.ProviderName is empty.
+const DefaultProviderName = "custom"
+
+// Endpoint describes a single third-party LLM endpoint.
+//
+// Prefer APIKeyEnv over APIKey so the literal key never has to be carried
+// through Go memory or serialized config. Wrappers will resolve the key by
+// reading the named env var at subprocess-launch time.
+//
+//nolint:govet // fieldalignment: keep semantically-ordered fields readable.
+type Endpoint struct {
+	// BaseURL is the HTTPS endpoint (e.g. "https://inference.baseten.co/v1").
+	BaseURL string
+
+	// APIKey is the resolved literal key. Avoid setting this directly; use
+	// APIKeyEnv instead so the key is read from the process env at launch.
+	APIKey string
+
+	// APIKeyEnv is the env var name holding the API key (e.g. "BASETEN_API_KEY").
+	APIKeyEnv string
+
+	// ProviderName labels the endpoint inside the underlying CLI's config
+	// (codex's `model_providers.<name>`, etc.). Defaults to DefaultProviderName.
+	ProviderName string
+
+	// Wire selects the request/response shape; defaults to WireAPIChat.
+	Wire WireAPI
+
+	// Headers carries optional extra HTTP headers to inject on each request.
+	// Not every wrapper supports this; unsupported wrappers ignore the field.
+	Headers map[string]string
+}
+
+// IsZero reports whether the endpoint is unset (no BaseURL).
+func (e Endpoint) IsZero() bool {
+	return e.BaseURL == "" && e.APIKey == "" && e.APIKeyEnv == ""
+}
+
+// Validate reports configuration errors. A zero Endpoint validates as nil.
+func (e Endpoint) Validate() error {
+	if e.IsZero() {
+		return nil
+	}
+	if e.BaseURL == "" {
+		return errors.New("llmendpoint: BaseURL is required")
+	}
+	u, err := url.Parse(e.BaseURL)
+	if err != nil {
+		return fmt.Errorf("llmendpoint: invalid BaseURL %q: %w", e.BaseURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("llmendpoint: BaseURL must be http(s), got %q", u.Scheme)
+	}
+	if e.APIKey == "" && e.APIKeyEnv == "" {
+		return errors.New("llmendpoint: either APIKey or APIKeyEnv must be set")
+	}
+	if e.Wire != "" && e.Wire != WireAPIChat && e.Wire != WireAPIResponses {
+		return fmt.Errorf("llmendpoint: unknown wire api %q", e.Wire)
+	}
+	if e.ProviderName != "" && strings.ContainsAny(e.ProviderName, ` "'.\`) {
+		return fmt.Errorf("llmendpoint: invalid ProviderName %q", e.ProviderName)
+	}
+	return nil
+}
+
+// Redacted returns a copy with APIKey cleared. APIKeyEnv is preserved so logs
+// still indicate where the key came from.
+func (e Endpoint) Redacted() Endpoint {
+	out := e
+	out.APIKey = ""
+	return out
+}
+
+// ResolvedKey returns APIKey if set, else os.Getenv(APIKeyEnv), else "".
+func (e Endpoint) ResolvedKey() string {
+	if e.APIKey != "" {
+		return e.APIKey
+	}
+	if e.APIKeyEnv != "" {
+		return os.Getenv(e.APIKeyEnv)
+	}
+	return ""
+}
+
+// Provider returns ProviderName or DefaultProviderName.
+func (e Endpoint) Provider() string {
+	if e.ProviderName == "" {
+		return DefaultProviderName
+	}
+	return e.ProviderName
+}
+
+// WireAPI returns Wire or WireAPIChat as the default.
+func (e Endpoint) WireAPI() WireAPI {
+	if e.Wire == "" {
+		return WireAPIChat
+	}
+	return e.Wire
+}
+
+// String renders the endpoint without leaking the literal API key.
+func (e Endpoint) String() string {
+	if e.IsZero() {
+		return "llmendpoint{}"
+	}
+	keySrc := "<unset>"
+	switch {
+	case e.APIKeyEnv != "":
+		keySrc = "$" + e.APIKeyEnv
+	case e.APIKey != "":
+		keySrc = "<inline>"
+	}
+	return fmt.Sprintf("llmendpoint{base=%s provider=%s wire=%s key=%s}",
+		e.BaseURL, e.Provider(), e.WireAPI(), keySrc)
+}

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -137,8 +137,22 @@ func (e Endpoint) Validate() error {
 // Redacted returns a copy with APIKey cleared. APIKeyEnv is preserved so logs
 // still indicate where the key came from.
 func (e Endpoint) Redacted() Endpoint {
-	out := e
+	out := e.Clone()
 	out.APIKey = ""
+	return out
+}
+
+// Clone returns a deep copy. The Headers map is duplicated so callers that
+// mutate the original after passing the endpoint to a provider can't fool
+// equality checks against a previously-bound snapshot.
+func (e Endpoint) Clone() Endpoint {
+	out := e
+	if e.Headers != nil {
+		out.Headers = make(map[string]string, len(e.Headers))
+		for k, v := range e.Headers {
+			out.Headers[k] = v
+		}
+	}
 	return out
 }
 

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strings"
+	"regexp"
 )
 
 // WireAPI identifies the request/response shape spoken by the endpoint.
@@ -70,6 +70,19 @@ func (e Endpoint) IsZero() bool {
 	return e.BaseURL == "" && e.APIKey == "" && e.APIKeyEnv == ""
 }
 
+// providerNameRE accepts identifiers safe to interpolate into codex's
+// `model_providers.<name>.*` config-path segments without quoting: ASCII
+// letters/digits plus '_' and '-'. Anything else (spaces, dots, slashes,
+// quotes, shell metachars) is rejected at config-load time so we never
+// emit invalid `--config` args.
+var providerNameRE = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// headerNameRE is the RFC 7230 token grammar: visible ASCII minus separators.
+// Codex interpolates header keys into `http_headers.<key>=...` config paths,
+// and downstream HTTP clients reject CR/LF-laden names anyway, so it's safer
+// to fail loudly at config-load than to discover the malformed arg later.
+var headerNameRE = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
+
 // Validate reports configuration errors. A zero Endpoint validates as nil.
 func (e Endpoint) Validate() error {
 	if e.IsZero() {
@@ -85,14 +98,22 @@ func (e Endpoint) Validate() error {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("llmendpoint: BaseURL must be http(s), got %q", u.Scheme)
 	}
+	if u.Host == "" {
+		return fmt.Errorf("llmendpoint: BaseURL %q is missing a host", e.BaseURL)
+	}
 	if e.APIKey == "" && e.APIKeyEnv == "" {
 		return errors.New("llmendpoint: either APIKey or APIKeyEnv must be set")
 	}
 	if e.Wire != "" && e.Wire != WireAPIChat && e.Wire != WireAPIResponses {
 		return fmt.Errorf("llmendpoint: unknown wire api %q", e.Wire)
 	}
-	if e.ProviderName != "" && strings.ContainsAny(e.ProviderName, ` "'.\`) {
-		return fmt.Errorf("llmendpoint: invalid ProviderName %q", e.ProviderName)
+	if e.ProviderName != "" && !providerNameRE.MatchString(e.ProviderName) {
+		return fmt.Errorf("llmendpoint: invalid ProviderName %q (allowed: A-Za-z0-9_-)", e.ProviderName)
+	}
+	for k := range e.Headers {
+		if !headerNameRE.MatchString(k) {
+			return fmt.Errorf("llmendpoint: invalid header name %q", k)
+		}
 	}
 	return nil
 }

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -8,7 +8,11 @@
 //
 //   - claude: ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (Anthropic-shaped only)
 //   - codex:  --config model_providers.<name>.{base_url,wire_api,env_key}
-//   - acp:    GEMINI_API_KEY/GOOGLE_GEMINI_BASE_URL or OPENAI_BASE_URL+--openai-base-url
+//     (supports both OpenAI Chat Completions and OpenAI Responses wires)
+//   - acp:    GEMINI_API_KEY + GOOGLE_GEMINI_BASE_URL only. The official
+//     gemini-cli has no OpenAI/Anthropic passthrough (issue
+//     google-gemini/gemini-cli#1605, closed wontfix), so a Google-shaped
+//     translating proxy is required to hit OpenAI/Anthropic endpoints.
 //   - cursor: best-effort OPENAI_BASE_URL/OPENAI_API_KEY (cursor-agent ignores
 //     these for non-Cursor models; the option exists for symmetry)
 package llmendpoint

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -14,6 +14,8 @@
 package llmendpoint
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
@@ -186,9 +188,12 @@ func (e Endpoint) WireAPI() WireAPI {
 }
 
 // String renders the endpoint without leaking the literal API key. Header
-// keys are listed (sorted, no values) so divergence diagnostics that include
-// String() can distinguish endpoints that differ only on Headers; values
-// would risk leaking secrets that operators may have shoved into headers.
+// keys are listed (sorted, no values) and a short hash of the full key+value
+// bag is appended so divergence diagnostics that include String() can also
+// distinguish endpoints that differ only on header *values*. Raw values would
+// risk leaking secrets operators may have shoved into headers, so the hash is
+// the privacy-safe equivalent — equal headers produce equal fingerprints,
+// any change flips them.
 func (e Endpoint) String() string {
 	if e.IsZero() {
 		return "llmendpoint{}"
@@ -207,7 +212,12 @@ func (e Endpoint) String() string {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		hdrs = fmt.Sprintf(" headers=[%s]", strings.Join(keys, ","))
+		h := sha256.New()
+		for _, k := range keys {
+			fmt.Fprintf(h, "%s=%s\n", k, e.Headers[k])
+		}
+		fp := hex.EncodeToString(h.Sum(nil))[:8]
+		hdrs = fmt.Sprintf(" headers=[%s]/%s", strings.Join(keys, ","), fp)
 	}
 	return fmt.Sprintf("llmendpoint{base=%s provider=%s wire=%s key=%s%s}",
 		e.BaseURL, e.Provider(), e.WireAPI(), keySrc, hdrs)

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -65,7 +65,12 @@ type Endpoint struct {
 	Wire WireAPI
 
 	// Headers carries optional extra HTTP headers to inject on each request.
-	// Not every wrapper supports this; unsupported wrappers ignore the field.
+	// Wrapper support is partial today — only codex consumes them via
+	// `--config model_providers.<n>.http_headers.*`. claude/cursor/gemini
+	// wrappers ignore Headers, so switching providers on a config that
+	// relies on Headers silently drops them. Validate still runs the same
+	// header-name regex globally, so this map is shape-checked at
+	// config-load regardless of which wrapper the orchestrator routes to.
 	Headers map[string]string
 }
 
@@ -205,12 +210,14 @@ func (e Endpoint) WireAPI() WireAPI {
 }
 
 // String renders the endpoint without leaking the literal API key. Header
-// keys are listed (sorted, no values) and a short hash of the full key+value
-// bag is appended so divergence diagnostics that include String() can also
-// distinguish endpoints that differ only on header *values*. Raw values would
-// risk leaking secrets operators may have shoved into headers, so the hash is
-// the privacy-safe equivalent — equal headers produce equal fingerprints,
-// any change flips them.
+// keys are listed (sorted, no values) and a short SHA-256 fingerprint of the
+// length-prefixed key+value bag is appended so divergence diagnostics can
+// distinguish endpoints that differ only on header *values*.
+//
+// Privacy posture: plaintext omits raw secrets, but the fingerprint suffix
+// is *derived from* header values — it's opaque to callers but still
+// credential-tagged metadata, not safe-by-default. Use Redacted() instead
+// when even hashed traces are too sensitive (e.g. logs that ship off-host).
 func (e Endpoint) String() string {
 	if e.IsZero() {
 		return "llmendpoint{}"

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -91,13 +91,16 @@ func (e Endpoint) hasOnlyDecorations() bool {
 // emit invalid `--config` args.
 var providerNameRE = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
-// headerNameRE matches header names that are safe to interpolate into codex's
-// `model_providers.<name>.http_headers.<key>=...` config-path segments without
-// quoting. RFC 7230 allows a much wider token set, but codex's TOML parser
-// would reject any of the punctuation (`!#$%&'*+.^|~`) that's legal under
-// RFC 7230 in a bare path segment, so accepting them here would just turn
-// into a runtime arg error. Hyphens and underscores are the standard HTTP
-// header chars after letters/digits and survive bare TOML keys.
+// headerNameRE is an intentional product constraint on header keys: they
+// must match codex's bare TOML-key alphabet so we can interpolate them into
+// `model_providers.<name>.http_headers.<key>=...` config-path segments
+// without quoting. RFC 7230 allows a wider token set (`!#$%&'*+.^|~`) but
+// those chars would fail at codex --config arg time, and we apply the same
+// regex globally because the whole point of this validator is to reject at
+// config-load. Operators targeting only claude/cursor/gemini still inherit
+// this restriction; it's preferable to a Validate that varies per-backend
+// since the same Endpoint flows through a single LoadConfig path before
+// the orchestrator even knows which provider will run it.
 var headerNameRE = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // Validate reports configuration errors. A zero Endpoint validates as nil.
@@ -141,12 +144,18 @@ func (e Endpoint) Validate() error {
 	return nil
 }
 
-// Redacted returns a copy with secret-bearing fields cleared: APIKey is
-// dropped and Headers are dropped entirely (keys remain non-secret in
-// String() via the fingerprint, but in Redacted-then-logged contexts we
-// can't make that distinction safely — operators may have stuffed auth
-// tokens into header values). APIKeyEnv is preserved so logs still
-// indicate where the key came from.
+// Redacted returns a copy with secret-bearing fields cleared. APIKey is
+// dropped; Headers are dropped entirely.
+//
+// On String(): plaintext omits header values, but the trailing fingerprint
+// is derived FROM those values (truncated SHA-256). It's collision-safe
+// for normal config but is still secret-derived metadata; treat it as
+// opaque credential-tagged data, not non-sensitive. Redacted-then-logged
+// contexts that can't tolerate even hashed traces should use Redacted()
+// (which drops Headers entirely) rather than relying on String()'s
+// privacy posture.
+//
+// APIKeyEnv is preserved so logs still indicate where the key came from.
 func (e Endpoint) Redacted() Endpoint {
 	out := e.Clone()
 	out.APIKey = ""
@@ -220,9 +229,16 @@ func (e Endpoint) String() string {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
+		// Length-prefixed encoding (key-len|key|value-len|value, repeated)
+		// gives an unambiguous serialization: a value containing "=" or "\n"
+		// can no longer collide with a different key/value split, since
+		// every field's byte count is encoded explicitly. Header keys are
+		// already validated to [A-Za-z0-9_-] so they can't carry length
+		// markers, but values are unrestricted — hence the explicit framing.
 		h := sha256.New()
 		for _, k := range keys {
-			fmt.Fprintf(h, "%s=%s\n", k, e.Headers[k])
+			v := e.Headers[k]
+			fmt.Fprintf(h, "%d:%s%d:%s", len(k), k, len(v), v)
 		}
 		fp := hex.EncodeToString(h.Sum(nil))[:8]
 		hdrs = fmt.Sprintf(" headers=[%s]/%s", strings.Join(keys, ","), fp)

--- a/agent-cli-wrapper/llmendpoint/llmendpoint.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint.go
@@ -91,11 +91,14 @@ func (e Endpoint) hasOnlyDecorations() bool {
 // emit invalid `--config` args.
 var providerNameRE = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
-// headerNameRE is the RFC 7230 token grammar: visible ASCII minus separators.
-// Codex interpolates header keys into `http_headers.<key>=...` config paths,
-// and downstream HTTP clients reject CR/LF-laden names anyway, so it's safer
-// to fail loudly at config-load than to discover the malformed arg later.
-var headerNameRE = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
+// headerNameRE matches header names that are safe to interpolate into codex's
+// `model_providers.<name>.http_headers.<key>=...` config-path segments without
+// quoting. RFC 7230 allows a much wider token set, but codex's TOML parser
+// would reject any of the punctuation (`!#$%&'*+.^|~`) that's legal under
+// RFC 7230 in a bare path segment, so accepting them here would just turn
+// into a runtime arg error. Hyphens and underscores are the standard HTTP
+// header chars after letters/digits and survive bare TOML keys.
+var headerNameRE = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // Validate reports configuration errors. A zero Endpoint validates as nil.
 // Partial endpoints — e.g. provider_name set without base_url — fail loudly
@@ -138,11 +141,16 @@ func (e Endpoint) Validate() error {
 	return nil
 }
 
-// Redacted returns a copy with APIKey cleared. APIKeyEnv is preserved so logs
-// still indicate where the key came from.
+// Redacted returns a copy with secret-bearing fields cleared: APIKey is
+// dropped and Headers are dropped entirely (keys remain non-secret in
+// String() via the fingerprint, but in Redacted-then-logged contexts we
+// can't make that distinction safely — operators may have stuffed auth
+// tokens into header values). APIKeyEnv is preserved so logs still
+// indicate where the key came from.
 func (e Endpoint) Redacted() Endpoint {
 	out := e.Clone()
 	out.APIKey = ""
+	out.Headers = nil
 	return out
 }
 

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -1,0 +1,151 @@
+package llmendpoint
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEndpoint_Validate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		ep      Endpoint
+		wantErr string
+	}{
+		{name: "zero is valid", ep: Endpoint{}},
+		{
+			name: "ok env-key",
+			ep: Endpoint{
+				BaseURL:   "https://inference.baseten.co/v1",
+				APIKeyEnv: "BASETEN_API_KEY",
+			},
+		},
+		{
+			name: "ok inline-key",
+			ep: Endpoint{
+				BaseURL: "https://example.com",
+				APIKey:  "sk-xxx",
+				Wire:    WireAPIChat,
+			},
+		},
+		{
+			name:    "missing base url",
+			ep:      Endpoint{APIKeyEnv: "X"},
+			wantErr: "BaseURL is required",
+		},
+		{
+			name:    "non-http scheme",
+			ep:      Endpoint{BaseURL: "ftp://example.com", APIKeyEnv: "X"},
+			wantErr: "must be http(s)",
+		},
+		{
+			name:    "missing key",
+			ep:      Endpoint{BaseURL: "https://example.com"},
+			wantErr: "APIKey or APIKeyEnv",
+		},
+		{
+			name:    "bad wire api",
+			ep:      Endpoint{BaseURL: "https://example.com", APIKeyEnv: "X", Wire: "grpc"},
+			wantErr: "unknown wire api",
+		},
+		{
+			name:    "bad provider name",
+			ep:      Endpoint{BaseURL: "https://example.com", APIKeyEnv: "X", ProviderName: "has space"},
+			wantErr: "invalid ProviderName",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.ep.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestEndpoint_Redacted(t *testing.T) {
+	t.Parallel()
+	in := Endpoint{
+		BaseURL:   "https://inference.baseten.co/v1",
+		APIKey:    "sk-secret",
+		APIKeyEnv: "BASETEN_API_KEY",
+	}
+	out := in.Redacted()
+	if out.APIKey != "" {
+		t.Errorf("APIKey not cleared: %q", out.APIKey)
+	}
+	if out.APIKeyEnv != "BASETEN_API_KEY" {
+		t.Errorf("APIKeyEnv lost: %q", out.APIKeyEnv)
+	}
+	if in.APIKey != "sk-secret" {
+		t.Error("Redacted mutated receiver")
+	}
+}
+
+func TestEndpoint_ResolvedKey(t *testing.T) {
+	// Cannot t.Parallel here: child uses t.Setenv.
+	t.Run("inline wins", func(t *testing.T) {
+		ep := Endpoint{APIKey: "inline", APIKeyEnv: "PATH"}
+		if got := ep.ResolvedKey(); got != "inline" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("LLMENDPOINT_TEST_KEY", "from-env")
+		ep := Endpoint{APIKeyEnv: "LLMENDPOINT_TEST_KEY"}
+		if got := ep.ResolvedKey(); got != "from-env" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("empty when unset", func(t *testing.T) {
+		ep := Endpoint{APIKeyEnv: "DEFINITELY_NOT_SET_LLMENDPOINT_TEST"}
+		if got := ep.ResolvedKey(); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}
+
+func TestEndpoint_String_NoLeak(t *testing.T) {
+	t.Parallel()
+	ep := Endpoint{
+		BaseURL:   "https://inference.baseten.co/v1",
+		APIKey:    "super-secret-key",
+		APIKeyEnv: "BASETEN_API_KEY",
+	}
+	got := ep.String()
+	if strings.Contains(got, "super-secret-key") {
+		t.Fatalf("API key leaked: %s", got)
+	}
+	if !strings.Contains(got, "$BASETEN_API_KEY") {
+		t.Fatalf("expected key source label, got %s", got)
+	}
+}
+
+func TestEndpoint_Defaults(t *testing.T) {
+	t.Parallel()
+	ep := Endpoint{}
+	if ep.Provider() != DefaultProviderName {
+		t.Errorf("Provider default %q", ep.Provider())
+	}
+	if ep.WireAPI() != WireAPIChat {
+		t.Errorf("WireAPI default %q", ep.WireAPI())
+	}
+}
+
+func TestEndpoint_IsZero(t *testing.T) {
+	t.Parallel()
+	if !(Endpoint{}).IsZero() {
+		t.Error("zero endpoint should be IsZero")
+	}
+	if (Endpoint{BaseURL: "https://x"}).IsZero() {
+		t.Error("non-zero endpoint should not be IsZero")
+	}
+}

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -222,12 +222,22 @@ func TestEndpoint_String_HeadersListed(t *testing.T) {
 		},
 	}
 	got := ep.String()
-	// Sorted, joined with comma — guarantees deterministic output for diff'ing.
-	if !strings.Contains(got, "headers=[X-A,X-B]") {
-		t.Errorf("expected sorted headers in output, got %q", got)
+	// Sorted, joined with comma, followed by a short value-fingerprint —
+	// guarantees deterministic output for diff'ing.
+	if !strings.Contains(got, "headers=[X-A,X-B]/") {
+		t.Errorf("expected sorted headers + fingerprint in output, got %q", got)
 	}
 	if strings.Contains(got, "secretvalue") || strings.Contains(got, "alpha") {
 		t.Errorf("header values must not appear in String(): %q", got)
+	}
+
+	// Two endpoints that differ only on header values must produce different
+	// String() outputs (otherwise divergence error messages can't distinguish
+	// value-only changes — the regression cursor flagged in r6).
+	ep2 := ep
+	ep2.Headers = map[string]string{"X-B": "different", "X-A": "alpha"}
+	if ep.String() == ep2.String() {
+		t.Errorf("value-only divergence must change String(): %q", ep.String())
 	}
 
 	noHeaders := Endpoint{BaseURL: "https://x", APIKeyEnv: "K"}

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -89,6 +89,21 @@ func TestEndpoint_Validate(t *testing.T) {
 			},
 			wantErr: "invalid header name",
 		},
+		{
+			name:    "partial: only provider name",
+			ep:      Endpoint{ProviderName: "baseten"},
+			wantErr: "partially configured",
+		},
+		{
+			name:    "partial: only wire",
+			ep:      Endpoint{Wire: WireAPIResponses},
+			wantErr: "partially configured",
+		},
+		{
+			name:    "partial: only headers",
+			ep:      Endpoint{Headers: map[string]string{"X-Org": "acme"}},
+			wantErr: "partially configured",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -104,6 +119,33 @@ func TestEndpoint_Validate(t *testing.T) {
 				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestEndpoint_Clone_HeadersAreIndependent(t *testing.T) {
+	t.Parallel()
+	in := Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+		Headers:   map[string]string{"X-Org": "acme"},
+	}
+	out := in.Clone()
+	out.Headers["X-Org"] = "evil"
+	out.Headers["X-Extra"] = "added"
+	if in.Headers["X-Org"] != "acme" {
+		t.Errorf("Clone aliased Headers; original mutated to %q", in.Headers["X-Org"])
+	}
+	if _, ok := in.Headers["X-Extra"]; ok {
+		t.Error("Clone aliased Headers; original gained an entry")
+	}
+}
+
+func TestEndpoint_Clone_NilHeadersStayNil(t *testing.T) {
+	t.Parallel()
+	in := Endpoint{BaseURL: "https://x", APIKeyEnv: "K"}
+	out := in.Clone()
+	if out.Headers != nil {
+		t.Errorf("nil Headers should clone to nil, got %v", out.Headers)
 	}
 }
 

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -209,10 +209,12 @@ func TestEndpoint_String_NoLeak(t *testing.T) {
 
 func TestEndpoint_String_HeadersListed(t *testing.T) {
 	t.Parallel()
-	// Header keys must surface so the divergence error in CodexProvider /
-	// GeminiProvider can distinguish endpoints that differ only on Headers.
-	// Header values are deliberately omitted to avoid leaking secrets that
-	// operators may have stuffed into auth-style headers.
+	// String() prints header KEYS in sorted plaintext (so operators can see
+	// what shape the endpoint carries) and a SHA-256 fingerprint of the
+	// canonical sorted "key=value\n" rows (so divergence diagnostics can
+	// distinguish endpoints that differ only on header VALUES). Raw values
+	// are deliberately omitted from the plaintext so operators don't leak
+	// secrets they may have stuffed into auth-style headers.
 	ep := Endpoint{
 		BaseURL:   "https://x",
 		APIKeyEnv: "K",

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -235,11 +235,13 @@ func TestEndpoint_String_NoLeak(t *testing.T) {
 func TestEndpoint_String_HeadersListed(t *testing.T) {
 	t.Parallel()
 	// String() prints header KEYS in sorted plaintext (so operators can see
-	// what shape the endpoint carries) and a SHA-256 fingerprint of the
-	// canonical sorted "key=value\n" rows (so divergence diagnostics can
+	// what shape the endpoint carries) and a length-prefixed SHA-256
+	// fingerprint of the sorted entries (so divergence diagnostics can
 	// distinguish endpoints that differ only on header VALUES). Raw values
 	// are deliberately omitted from the plaintext so operators don't leak
-	// secrets they may have stuffed into auth-style headers.
+	// secrets they may have stuffed into auth-style headers; the
+	// fingerprint encoding lives next to the implementation in
+	// llmendpoint.go's String().
 	ep := Endpoint{
 		BaseURL:   "https://x",
 		APIKeyEnv: "K",

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -49,9 +49,45 @@ func TestEndpoint_Validate(t *testing.T) {
 			wantErr: "unknown wire api",
 		},
 		{
-			name:    "bad provider name",
+			name:    "bad provider name (space)",
 			ep:      Endpoint{BaseURL: "https://example.com", APIKeyEnv: "X", ProviderName: "has space"},
 			wantErr: "invalid ProviderName",
+		},
+		{
+			name:    "bad provider name (dot would unquote into nested config segment)",
+			ep:      Endpoint{BaseURL: "https://example.com", APIKeyEnv: "X", ProviderName: "a.b"},
+			wantErr: "invalid ProviderName",
+		},
+		{
+			name:    "hostless URL",
+			ep:      Endpoint{BaseURL: "https:///v1", APIKeyEnv: "X"},
+			wantErr: "missing a host",
+		},
+		{
+			name: "ok with simple headers",
+			ep: Endpoint{
+				BaseURL:   "https://example.com",
+				APIKeyEnv: "X",
+				Headers:   map[string]string{"X-Org": "acme"},
+			},
+		},
+		{
+			name: "bad header name (space)",
+			ep: Endpoint{
+				BaseURL:   "https://example.com",
+				APIKeyEnv: "X",
+				Headers:   map[string]string{"X Org": "acme"},
+			},
+			wantErr: "invalid header name",
+		},
+		{
+			name: "bad header name (CRLF injection)",
+			ep: Endpoint{
+				BaseURL:   "https://example.com",
+				APIKeyEnv: "X",
+				Headers:   map[string]string{"X-Org\r\nInjected": "acme"},
+			},
+			wantErr: "invalid header name",
 		},
 	}
 	for _, tc := range cases {

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -273,6 +273,31 @@ func TestEndpoint_String_HeadersListed(t *testing.T) {
 	}
 }
 
+// TestEndpoint_String_FingerprintIsCanonical pins the encoding so a value
+// containing the row delimiter ("\n") or the kv separator ("=") can't fool
+// the hash into colliding with a different key/value split. The header-name
+// validator already restricts keys to [A-Za-z0-9_-], but values are
+// unrestricted, so this is the value-side defense.
+func TestEndpoint_String_FingerprintIsCanonical(t *testing.T) {
+	t.Parallel()
+	a := Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+		// One header whose value embeds a fake "key=value\n" sequence.
+		Headers: map[string]string{"X-A": "v1\nX-B=v2"},
+	}
+	b := Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+		// Two headers that would have collided with `key=value\n` framing.
+		Headers: map[string]string{"X-A": "v1", "X-B": "v2"},
+	}
+	if a.String() == b.String() {
+		t.Errorf("non-canonical fingerprint: header maps that differ in shape produced equal String():\n  a=%q\n  b=%q",
+			a.String(), b.String())
+	}
+}
+
 func TestEndpoint_Defaults(t *testing.T) {
 	t.Parallel()
 	ep := Endpoint{}

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -90,6 +90,27 @@ func TestEndpoint_Validate(t *testing.T) {
 			wantErr: "invalid header name",
 		},
 		{
+			// RFC 7230 allows these chars in tokens, but codex's TOML config-path
+			// parser doesn't, so we reject them at Validate to fail at config-load
+			// instead of at codex --config arg time.
+			name: "bad header name (RFC token but unsafe in codex config path)",
+			ep: Endpoint{
+				BaseURL:   "https://example.com",
+				APIKeyEnv: "X",
+				Headers:   map[string]string{"X!Trace": "acme"},
+			},
+			wantErr: "invalid header name",
+		},
+		{
+			name: "bad header name (dot would create a nested config segment)",
+			ep: Endpoint{
+				BaseURL:   "https://example.com",
+				APIKeyEnv: "X",
+				Headers:   map[string]string{"X.Org": "acme"},
+			},
+			wantErr: "invalid header name",
+		},
+		{
 			name:    "partial: only provider name",
 			ep:      Endpoint{ProviderName: "baseten"},
 			wantErr: "partially configured",
@@ -155,6 +176,7 @@ func TestEndpoint_Redacted(t *testing.T) {
 		BaseURL:   "https://inference.baseten.co/v1",
 		APIKey:    "sk-secret",
 		APIKeyEnv: "BASETEN_API_KEY",
+		Headers:   map[string]string{"Authorization": "bearer xyz", "X-Org": "acme"},
 	}
 	out := in.Redacted()
 	if out.APIKey != "" {
@@ -163,7 +185,10 @@ func TestEndpoint_Redacted(t *testing.T) {
 	if out.APIKeyEnv != "BASETEN_API_KEY" {
 		t.Errorf("APIKeyEnv lost: %q", out.APIKeyEnv)
 	}
-	if in.APIKey != "sk-secret" {
+	if out.Headers != nil {
+		t.Errorf("Headers must be cleared (operators may stash secrets in values), got %v", out.Headers)
+	}
+	if in.APIKey != "sk-secret" || in.Headers["Authorization"] != "bearer xyz" {
 		t.Error("Redacted mutated receiver")
 	}
 }

--- a/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
+++ b/agent-cli-wrapper/llmendpoint/llmendpoint_test.go
@@ -207,6 +207,35 @@ func TestEndpoint_String_NoLeak(t *testing.T) {
 	}
 }
 
+func TestEndpoint_String_HeadersListed(t *testing.T) {
+	t.Parallel()
+	// Header keys must surface so the divergence error in CodexProvider /
+	// GeminiProvider can distinguish endpoints that differ only on Headers.
+	// Header values are deliberately omitted to avoid leaking secrets that
+	// operators may have stuffed into auth-style headers.
+	ep := Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+		Headers: map[string]string{
+			"X-B": "secretvalue",
+			"X-A": "alpha",
+		},
+	}
+	got := ep.String()
+	// Sorted, joined with comma — guarantees deterministic output for diff'ing.
+	if !strings.Contains(got, "headers=[X-A,X-B]") {
+		t.Errorf("expected sorted headers in output, got %q", got)
+	}
+	if strings.Contains(got, "secretvalue") || strings.Contains(got, "alpha") {
+		t.Errorf("header values must not appear in String(): %q", got)
+	}
+
+	noHeaders := Endpoint{BaseURL: "https://x", APIKeyEnv: "K"}
+	if strings.Contains(noHeaders.String(), "headers=") {
+		t.Errorf("empty Headers should not produce a headers= section, got %q", noHeaders.String())
+	}
+}
+
 func TestEndpoint_Defaults(t *testing.T) {
 	t.Parallel()
 	ep := Endpoint{}

--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//agent-cli-wrapper/claude/render",
+        "//agent-cli-wrapper/llmendpoint",
         "//jiradozer/tracker",
         "//multiagent/agent",
         "@in_gopkg_yaml_v3//:yaml_v3",

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -561,6 +561,15 @@ func buildExecuteOpts(cfg StepConfig, workDir string, handler agent.EventHandler
 	if resumeSessionID != "" {
 		opts = append(opts, agent.WithProviderResumeSessionID(resumeSessionID))
 	}
+	if cfg.LLMEndpoint != nil {
+		ep := cfg.LLMEndpoint.ToEndpoint()
+		if !ep.IsZero() {
+			if err := ep.Validate(); err != nil {
+				return nil, fmt.Errorf("llm_endpoint: %w", err)
+			}
+			opts = append(opts, agent.WithProviderLLMEndpoint(ep))
+		}
+	}
 	return opts, nil
 }
 

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -442,6 +442,8 @@ agent:
     #    api_key_env: BASETEN_API_KEY    # prefer over api_key
     #    provider_name: baseten
     #    wire_api: chat                  # "chat" (OpenAI-compat) or "responses"
+    #    headers:                        # optional extra HTTP headers (codex only)
+    #        X-Custom-Header: value
 
 `
 

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -434,6 +434,14 @@ agent:
     model: sonnet
     # Reasoning effort: low, medium, high, max, auto. Empty = provider default.
     #effort: ""
+    # Optional: route inference through a third-party LLM API endpoint
+    # (Baseten, OpenRouter, LiteLLM, etc.). The claude backend requires an
+    # Anthropic-shaped endpoint; codex/gemini accept OpenAI-compatible.
+    #llm_endpoint:
+    #    base_url: https://inference.baseten.co/v1
+    #    api_key_env: BASETEN_API_KEY    # prefer over api_key
+    #    provider_name: baseten
+    #    wire_api: chat                  # "chat" (OpenAI-compat) or "responses"
 
 `
 

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 	"github.com/bazelment/yoloswe/multiagent/agent"
 )
@@ -53,9 +54,26 @@ type TrackerConfig struct {
 }
 
 // AgentConfig specifies the agent backend.
+//
+//nolint:govet // fieldalignment: keep YAML fields in config-file order.
 type AgentConfig struct {
-	Model  string `yaml:"model"`  // model ID from agent.AllModels (e.g. "sonnet", "gpt-5.3-codex")
-	Effort string `yaml:"effort"` // reasoning effort; see agent.EffortLevel constants (low, medium, high, max, auto)
+	Model       string             `yaml:"model"`        // model ID from agent.AllModels (e.g. "sonnet", "gpt-5.3-codex")
+	Effort      string             `yaml:"effort"`       // reasoning effort; see agent.EffortLevel constants (low, medium, high, max, auto)
+	LLMEndpoint *LLMEndpointConfig `yaml:"llm_endpoint"` // optional third-party LLM API endpoint
+}
+
+// LLMEndpointConfig points the underlying CLI at a third-party LLM endpoint
+// (e.g. Baseten, OpenRouter, LiteLLM). All fields are optional; when set,
+// the endpoint is applied via agent.WithProviderLLMEndpoint.
+//
+// Prefer api_key_env over api_key so the literal key never lands in the
+// config file.
+type LLMEndpointConfig struct {
+	BaseURL      string `yaml:"base_url"`      // e.g. "https://inference.baseten.co/v1"
+	APIKey       string `yaml:"api_key"`       // resolved literal (avoid; use api_key_env)
+	APIKeyEnv    string `yaml:"api_key_env"`   // env var holding the key (e.g. "BASETEN_API_KEY")
+	ProviderName string `yaml:"provider_name"` // codex model_providers.<name>; default "custom"
+	WireAPI      string `yaml:"wire_api"`      // "chat" (default, OpenAI-compat) | "responses"
 }
 
 // SourceConfig specifies how to discover issues for multi-issue mode.
@@ -79,20 +97,21 @@ func (s SourceConfig) HasSource() bool {
 
 // StepConfig configures a single workflow step (plan or build).
 type StepConfig struct {
-	Prompt               string        `yaml:"prompt"`                 // Go text/template; required unless rounds is set. No built-in default — run `jiradozer bootstrap` to scaffold.
-	SystemPrompt         string        `yaml:"system_prompt"`          // optional system prompt passed to the agent
-	Model                string        `yaml:"model"`                  // override agent.model; empty = inherit
-	Effort               string        `yaml:"effort"`                 // override agent.effort; empty = inherit
-	PermissionMode       string        `yaml:"permission_mode"`        // "plan", "bypass", etc.; empty = step default
-	CommentTemplate      string        `yaml:"comment_template"`       // text/template rendered with CommentData; required for single-shot steps (rounds-only steps may omit it)
-	RoundCommentTemplate string        `yaml:"round_comment_template"` // text/template rendered with CommentData per round; required when rounds is non-empty
-	Rounds               []RoundConfig `yaml:"rounds"`                 // multi-round execution; mutually exclusive with Prompt
-	MaxBudgetUSD         float64       `yaml:"max_budget_usd"`         // override top-level; 0 = inherit
-	MaxTurns             int           `yaml:"max_turns"`
-	MaxToolErrorRetries  int           `yaml:"max_tool_error_retries"` // retries when a turn ends with an unresolved tool error; 0 = disabled
-	TransientRetries     int           `yaml:"transient_retries"`      // retries when provider execution fails with a transient error; 0 = default (2)
-	IdleTimeout          time.Duration `yaml:"idle_timeout"`           // parent watchdog kills the subprocess if it emits no log line for this long while inside this step; 0 disables
-	AutoApprove          bool          `yaml:"auto_approve"`           // skip human review after this step
+	Prompt               string             `yaml:"prompt"`                 // Go text/template; required unless rounds is set. No built-in default — run `jiradozer bootstrap` to scaffold.
+	SystemPrompt         string             `yaml:"system_prompt"`          // optional system prompt passed to the agent
+	Model                string             `yaml:"model"`                  // override agent.model; empty = inherit
+	Effort               string             `yaml:"effort"`                 // override agent.effort; empty = inherit
+	PermissionMode       string             `yaml:"permission_mode"`        // "plan", "bypass", etc.; empty = step default
+	CommentTemplate      string             `yaml:"comment_template"`       // text/template rendered with CommentData; required for single-shot steps (rounds-only steps may omit it)
+	RoundCommentTemplate string             `yaml:"round_comment_template"` // text/template rendered with CommentData per round; required when rounds is non-empty
+	LLMEndpoint          *LLMEndpointConfig `yaml:"llm_endpoint"`           // override agent.llm_endpoint; nil = inherit
+	Rounds               []RoundConfig      `yaml:"rounds"`                 // multi-round execution; mutually exclusive with Prompt
+	MaxBudgetUSD         float64            `yaml:"max_budget_usd"`         // override top-level; 0 = inherit
+	MaxTurns             int                `yaml:"max_turns"`
+	MaxToolErrorRetries  int                `yaml:"max_tool_error_retries"` // retries when a turn ends with an unresolved tool error; 0 = disabled
+	TransientRetries     int                `yaml:"transient_retries"`      // retries when provider execution fails with a transient error; 0 = default (2)
+	IdleTimeout          time.Duration      `yaml:"idle_timeout"`           // parent watchdog kills the subprocess if it emits no log line for this long while inside this step; 0 disables
+	AutoApprove          bool               `yaml:"auto_approve"`           // skip human review after this step
 }
 
 // RoundConfig configures a single round within a multi-round step.
@@ -460,7 +479,24 @@ func (c *Config) ResolveStep(step StepConfig) StepConfig {
 	if step.MaxBudgetUSD == 0 {
 		step.MaxBudgetUSD = c.MaxBudgetUSD
 	}
+	if step.LLMEndpoint == nil {
+		step.LLMEndpoint = c.Agent.LLMEndpoint
+	}
 	return step
+}
+
+// ToEndpoint converts the YAML config into a runtime llmendpoint.Endpoint.
+func (l *LLMEndpointConfig) ToEndpoint() llmendpoint.Endpoint {
+	if l == nil {
+		return llmendpoint.Endpoint{}
+	}
+	return llmendpoint.Endpoint{
+		BaseURL:      l.BaseURL,
+		APIKey:       l.APIKey,
+		APIKeyEnv:    l.APIKeyEnv,
+		ProviderName: l.ProviderName,
+		Wire:         llmendpoint.WireAPI(l.WireAPI),
+	}
 }
 
 // ResolveRound converts a RoundConfig into a fully-resolved StepConfig,

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -69,11 +69,12 @@ type AgentConfig struct {
 // Prefer api_key_env over api_key so the literal key never lands in the
 // config file.
 type LLMEndpointConfig struct {
-	BaseURL      string `yaml:"base_url"`      // e.g. "https://inference.baseten.co/v1"
-	APIKey       string `yaml:"api_key"`       // resolved literal (avoid; use api_key_env)
-	APIKeyEnv    string `yaml:"api_key_env"`   // env var holding the key (e.g. "BASETEN_API_KEY")
-	ProviderName string `yaml:"provider_name"` // codex model_providers.<name>; default "custom"
-	WireAPI      string `yaml:"wire_api"`      // "chat" (default, OpenAI-compat) | "responses"
+	Headers      map[string]string `yaml:"headers"`       // optional extra HTTP headers (only honored where the wrapper supports them, e.g. codex http_headers)
+	BaseURL      string            `yaml:"base_url"`      // e.g. "https://inference.baseten.co/v1"
+	APIKey       string            `yaml:"api_key"`       // resolved literal (avoid; use api_key_env)
+	APIKeyEnv    string            `yaml:"api_key_env"`   // env var holding the key (e.g. "BASETEN_API_KEY")
+	ProviderName string            `yaml:"provider_name"` // codex model_providers.<name>; default "custom"
+	WireAPI      string            `yaml:"wire_api"`      // "chat" (default, OpenAI-compat) | "responses"
 }
 
 // SourceConfig specifies how to discover issues for multi-issue mode.
@@ -228,6 +229,9 @@ func (c *Config) validate() error {
 			return fmt.Errorf("agent.effort: %w", err)
 		}
 	}
+	if err := c.Agent.LLMEndpoint.ToEndpoint().Validate(); err != nil {
+		return fmt.Errorf("agent.llm_endpoint: %w", err)
+	}
 	skipPhases, err := NormalizeSkipPhases(c.SkipPhases)
 	if err != nil {
 		return fmt.Errorf("skip_phases: %w", err)
@@ -329,6 +333,9 @@ func validateStep(name string, step *StepConfig) error {
 		if _, err := agent.ParseEffort(step.Effort); err != nil {
 			return fmt.Errorf("%s.effort: %w", name, err)
 		}
+	}
+	if err := step.LLMEndpoint.ToEndpoint().Validate(); err != nil {
+		return fmt.Errorf("%s.llm_endpoint: %w", name, err)
 	}
 	// IdleTimeout treats 0 as "watchdog disabled by config"; negative
 	// values would silently get the same behavior at runWatchdog,
@@ -496,6 +503,7 @@ func (l *LLMEndpointConfig) ToEndpoint() llmendpoint.Endpoint {
 		APIKeyEnv:    l.APIKeyEnv,
 		ProviderName: l.ProviderName,
 		Wire:         llmendpoint.WireAPI(l.WireAPI),
+		Headers:      l.Headers,
 	}
 }
 
@@ -512,6 +520,7 @@ func ResolveRound(round RoundConfig, parent StepConfig) StepConfig {
 		PermissionMode:   parent.PermissionMode,
 		Effort:           parent.Effort,
 		TransientRetries: parent.TransientRetries,
+		LLMEndpoint:      parent.LLMEndpoint,
 	}
 	if round.Model != "" {
 		resolved.Model = round.Model

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -577,6 +577,146 @@ func TestResolveRound_InheritsFromStep(t *testing.T) {
 	assert.Equal(t, 3, resolved.MaxToolErrorRetries)
 }
 
+// loadConfigFromYAML writes a YAML body to a temp file and loads it. Used by
+// the LLM-endpoint negative tests below; keeping the bytes inline avoids a
+// proliferation of one-off testdata fixtures for each malformed shape.
+func loadConfigFromYAML(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cfg.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0644))
+	return LoadConfig(path)
+}
+
+const validBaseSteps = `
+plan:
+  prompt: "Plan"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+build:
+  prompt: "Build"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+create_pr:
+  prompt: "Open PR"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+validate:
+  prompt: "Test"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+ship:
+  prompt: "Ship"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+`
+
+func TestLoadConfig_RejectsMalformedAgentLLMEndpoint(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "missing base url",
+			body: `
+tracker: {kind: linear, api_key: x}
+agent:
+  model: sonnet
+  llm_endpoint:
+    api_key_env: BASETEN_API_KEY
+` + validBaseSteps,
+			wantErr: "agent.llm_endpoint",
+		},
+		{
+			name: "bad scheme",
+			body: `
+tracker: {kind: linear, api_key: x}
+agent:
+  model: sonnet
+  llm_endpoint:
+    base_url: ftp://example.com
+    api_key_env: BASETEN_API_KEY
+` + validBaseSteps,
+			wantErr: "must be http(s)",
+		},
+		{
+			name: "hostless url",
+			body: `
+tracker: {kind: linear, api_key: x}
+agent:
+  model: sonnet
+  llm_endpoint:
+    base_url: "https:///v1"
+    api_key_env: BASETEN_API_KEY
+` + validBaseSteps,
+			wantErr: "missing a host",
+		},
+		{
+			name: "bad provider name",
+			body: `
+tracker: {kind: linear, api_key: x}
+agent:
+  model: sonnet
+  llm_endpoint:
+    base_url: https://example.com
+    api_key_env: BASETEN_API_KEY
+    provider_name: "has space"
+` + validBaseSteps,
+			wantErr: "invalid ProviderName",
+		},
+		{
+			name: "bad header name",
+			body: `
+tracker: {kind: linear, api_key: x}
+agent:
+  model: sonnet
+  llm_endpoint:
+    base_url: https://example.com
+    api_key_env: BASETEN_API_KEY
+    headers:
+      "X Custom Header": value
+` + validBaseSteps,
+			wantErr: "invalid header name",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := loadConfigFromYAML(t, tc.body)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestLoadConfig_RejectsMalformedStepLLMEndpoint(t *testing.T) {
+	t.Parallel()
+	body := `
+tracker: {kind: linear, api_key: x}
+agent:
+  model: sonnet
+plan:
+  prompt: "Plan"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+  llm_endpoint:
+    base_url: ftp://example.com
+    api_key_env: X
+build:
+  prompt: "Build"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+create_pr:
+  prompt: "PR"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+validate:
+  prompt: "T"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+ship:
+  prompt: "S"
+  comment_template: "## {{.Heading}}\n\n{{.Output}}"
+`
+	_, err := loadConfigFromYAML(t, body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plan.llm_endpoint")
+	assert.Contains(t, err.Error(), "must be http(s)")
+}
+
 func TestResolveRound_InheritsLLMEndpoint(t *testing.T) {
 	parent := StepConfig{
 		Model: "sonnet",

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -577,6 +577,21 @@ func TestResolveRound_InheritsFromStep(t *testing.T) {
 	assert.Equal(t, 3, resolved.MaxToolErrorRetries)
 }
 
+func TestResolveRound_InheritsLLMEndpoint(t *testing.T) {
+	parent := StepConfig{
+		Model: "sonnet",
+		LLMEndpoint: &LLMEndpointConfig{
+			BaseURL:   "https://inference.baseten.co/v1",
+			APIKeyEnv: "BASETEN_API_KEY",
+		},
+	}
+	round := RoundConfig{Prompt: "do stuff"}
+	resolved := ResolveRound(round, parent)
+	require.NotNil(t, resolved.LLMEndpoint, "expected LLMEndpoint to be inherited from parent step")
+	assert.Equal(t, "https://inference.baseten.co/v1", resolved.LLMEndpoint.BaseURL)
+	assert.Equal(t, "BASETEN_API_KEY", resolved.LLMEndpoint.APIKeyEnv)
+}
+
 func TestResolveRound_OverridesStep(t *testing.T) {
 	parent := StepConfig{
 		Model:          "sonnet",

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -78,6 +78,14 @@ agent:
     model: sonnet
     # Reasoning effort: low, medium, high, max, auto. Empty = provider default.
     #effort: ""
+    # Optional: route inference through a third-party LLM API endpoint
+    # (Baseten, OpenRouter, LiteLLM, etc.). The claude backend requires an
+    # Anthropic-shaped endpoint; codex/gemini accept OpenAI-compatible.
+    #llm_endpoint:
+    #    base_url: https://inference.baseten.co/v1
+    #    api_key_env: BASETEN_API_KEY    # prefer over api_key
+    #    provider_name: baseten
+    #    wire_api: chat                  # "chat" (OpenAI-compat) or "responses"
 
 # Working directory for the agent (where it runs commands and edits files).
 work_dir: .

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -86,6 +86,8 @@ agent:
     #    api_key_env: BASETEN_API_KEY    # prefer over api_key
     #    provider_name: baseten
     #    wire_api: chat                  # "chat" (OpenAI-compat) or "responses"
+    #    headers:                        # optional extra HTTP headers (codex only)
+    #        X-Custom-Header: value
 
 # Working directory for the agent (where it runs commands and edits files).
 work_dir: .

--- a/multiagent/agent/BUILD.bazel
+++ b/multiagent/agent/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/codex",
         "//agent-cli-wrapper/cursor",
+        "//agent-cli-wrapper/llmendpoint",
         "//agent-cli-wrapper/protocol",
         "//agent-cli-wrapper/transient",
         "//wt",

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -290,7 +290,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		return partial, err
 	}
 
-	agentResult := claudeResultToAgentResultWithRetryAbort(result, cfg, attempts, stopReason)
+	agentResult := nonNilAgentResult(claudeResultToAgentResultWithRetryAbort(result, cfg, attempts, stopReason))
 	if info := session.Info(); info != nil {
 		agentResult.SessionID = info.SessionID
 	}
@@ -338,7 +338,7 @@ func (p *ClaudeLongRunningProvider) SendMessage(ctx context.Context, message str
 	if err != nil {
 		return nil, err
 	}
-	return ClaudeResultToAgentResult(result), nil
+	return nonNilAgentResult(ClaudeResultToAgentResult(result)), nil
 }
 
 func (p *ClaudeLongRunningProvider) Stop() error {

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -196,6 +196,9 @@ func runRetryLoop(ctx context.Context, session retrySession, initial *claude.Tur
 
 func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.WorktreeContext, opts ...ExecuteOption) (*AgentResult, error) {
 	cfg := applyOptions(opts)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 
 	// Build full prompt with worktree context
 	fullPrompt := prompt

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -235,6 +235,9 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	if cfg.ResumeSessionID != "" {
 		sessionOpts = append(sessionOpts, claude.WithResume(cfg.ResumeSessionID))
 	}
+	if !cfg.LLMEndpoint.IsZero() {
+		sessionOpts = append(sessionOpts, claude.WithLLMEndpoint(cfg.LLMEndpoint))
+	}
 
 	// Create ephemeral session
 	session := claude.NewSession(sessionOpts...)

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -206,10 +206,14 @@ func codexResultToAgentResult(r *codex.TurnResult) *AgentResult {
 }
 
 // endpointsEqual reports whether two endpoints would produce the same codex
-// client configuration. Headers are order-independent.
+// client configuration. ProviderName and Wire are compared via the canonical
+// accessors so an empty Wire ("" → "chat") and an empty ProviderName ("" →
+// "custom") compare equal to their explicit-default counterparts; the codex
+// args this method gates on are derived from the same accessors, so raw-field
+// comparison would over-trigger the divergence error.
 func endpointsEqual(a, b llmendpoint.Endpoint) bool {
 	if a.BaseURL != b.BaseURL || a.APIKey != b.APIKey || a.APIKeyEnv != b.APIKeyEnv ||
-		a.ProviderName != b.ProviderName || a.Wire != b.Wire {
+		a.Provider() != b.Provider() || a.WireAPI() != b.WireAPI() {
 		return false
 	}
 	if len(a.Headers) != len(b.Headers) {

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -69,7 +69,9 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 			return nil, err
 		}
 		p.client = client
-		p.boundEndpt = cfg.LLMEndpoint
+		// Clone so a caller mutating cfg.LLMEndpoint.Headers after this Execute
+		// returns can't fool the next divergence check by aliasing the same map.
+		p.boundEndpt = cfg.LLMEndpoint.Clone()
 	}
 	p.mu.Unlock()
 

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -15,6 +15,7 @@ type CodexProvider struct {
 	client     *codex.Client
 	events     chan AgentEvent
 	clientOpts []codex.ClientOption
+	mu         sync.Mutex
 }
 
 // NewCodexProvider creates a new Codex provider.
@@ -40,6 +41,7 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 	// LLMEndpoint must be applied at client construction since codex
 	// `--config` overrides are passed to `app-server` at boot. Subsequent
 	// Execute calls reuse the existing client and cannot change the endpoint.
+	p.mu.Lock()
 	if p.client == nil {
 		clientOpts := p.clientOpts
 		if !cfg.LLMEndpoint.IsZero() {
@@ -47,10 +49,12 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 		}
 		client := codex.NewClient(clientOpts...)
 		if err := client.Start(ctx); err != nil {
+			p.mu.Unlock()
 			return nil, err
 		}
 		p.client = client
 	}
+	p.mu.Unlock()
 
 	// Build thread options.
 	// Only pass an explicit model if the caller overrode the default;

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -2,19 +2,24 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/codex"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/wt"
 )
 
 // CodexProvider wraps the Codex SDK behind the Provider interface.
+//
+//nolint:govet // fieldalignment: keep boundEndpt grouped with clientOpts; extra inline padding from nesting llmendpoint.Endpoint isn't worth obscuring the order.
 type CodexProvider struct {
+	boundEndpt llmendpoint.Endpoint
+	clientOpts []codex.ClientOption
 	client     *codex.Client
 	events     chan AgentEvent
-	clientOpts []codex.ClientOption
 	mu         sync.Mutex
 }
 
@@ -40,19 +45,31 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 	// Ensure client is started.
 	// LLMEndpoint must be applied at client construction since codex
 	// `--config` overrides are passed to `app-server` at boot. Subsequent
-	// Execute calls reuse the existing client and cannot change the endpoint.
+	// Execute calls reuse the existing client and cannot change the endpoint;
+	// reject divergent endpoints loudly rather than silently routing to the
+	// originally-bound endpoint.
 	p.mu.Lock()
 	if p.client == nil {
-		clientOpts := p.clientOpts
+		// Apply WithLLMEndpoint first so caller-supplied clientOpts can
+		// override its defaults (e.g. WithAppServerArgs to re-enable a
+		// feature WithLLMEndpoint disabled). codex applies repeated
+		// flags in order, so later args win.
+		var clientOpts []codex.ClientOption
 		if !cfg.LLMEndpoint.IsZero() {
-			clientOpts = append(append([]codex.ClientOption{}, clientOpts...), codex.WithLLMEndpoint(cfg.LLMEndpoint))
+			clientOpts = append(clientOpts, codex.WithLLMEndpoint(cfg.LLMEndpoint))
 		}
+		clientOpts = append(clientOpts, p.clientOpts...)
 		client := codex.NewClient(clientOpts...)
 		if err := client.Start(ctx); err != nil {
 			p.mu.Unlock()
 			return nil, err
 		}
 		p.client = client
+		p.boundEndpt = cfg.LLMEndpoint
+	} else if !endpointsEqual(p.boundEndpt, cfg.LLMEndpoint) {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("codex: LLMEndpoint changed across Execute calls (bound=%q, requested=%q); recreate the provider to switch endpoints",
+			p.boundEndpt.BaseURL, cfg.LLMEndpoint.BaseURL)
 	}
 	p.mu.Unlock()
 
@@ -127,10 +144,8 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 	}
 	waitForBridgeTurnComplete(ctx, turnDone)
 
-	agentResult := codexResultToAgentResult(result)
-	if agentResult != nil {
-		agentResult.SessionID = thread.ID()
-	}
+	agentResult := nonNilAgentResult(codexResultToAgentResult(result))
+	agentResult.SessionID = thread.ID()
 	return agentResult, nil
 }
 
@@ -188,6 +203,24 @@ func codexResultToAgentResult(r *codex.TurnResult) *AgentResult {
 			CacheReadTokens: int(r.Usage.CachedInputTokens),
 		},
 	}
+}
+
+// endpointsEqual reports whether two endpoints would produce the same codex
+// client configuration. Headers are order-independent.
+func endpointsEqual(a, b llmendpoint.Endpoint) bool {
+	if a.BaseURL != b.BaseURL || a.APIKey != b.APIKey || a.APIKeyEnv != b.APIKeyEnv ||
+		a.ProviderName != b.ProviderName || a.Wire != b.Wire {
+		return false
+	}
+	if len(a.Headers) != len(b.Headers) {
+		return false
+	}
+	for k, v := range a.Headers {
+		if b.Headers[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // isClaudeModelAlias returns true for model names that are Claude-specific

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -49,6 +49,10 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 	// reject divergent endpoints loudly rather than silently routing to the
 	// originally-bound endpoint.
 	p.mu.Lock()
+	if err := p.checkEndpointDivergence(cfg.LLMEndpoint); err != nil {
+		p.mu.Unlock()
+		return nil, err
+	}
 	if p.client == nil {
 		// Apply WithLLMEndpoint first so caller-supplied clientOpts can
 		// override its defaults (e.g. WithAppServerArgs to re-enable a
@@ -66,10 +70,6 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 		}
 		p.client = client
 		p.boundEndpt = cfg.LLMEndpoint
-	} else if !endpointsEqual(p.boundEndpt, cfg.LLMEndpoint) {
-		p.mu.Unlock()
-		return nil, fmt.Errorf("codex: LLMEndpoint changed across Execute calls (bound=%q, requested=%q); recreate the provider to switch endpoints",
-			p.boundEndpt.BaseURL, cfg.LLMEndpoint.BaseURL)
 	}
 	p.mu.Unlock()
 
@@ -203,6 +203,25 @@ func codexResultToAgentResult(r *codex.TurnResult) *AgentResult {
 			CacheReadTokens: int(r.Usage.CachedInputTokens),
 		},
 	}
+}
+
+// checkEndpointDivergence enforces the contract that, once a codex client is
+// running, the LLMEndpoint configured for subsequent Execute calls must match
+// the endpoint the running client was bound to. Returns nil when no client is
+// running yet (caller starts one and records the binding) or when the
+// endpoints are equal. Pulled out of Execute so the guard can be unit-tested
+// without spawning the codex subprocess.
+//
+// Caller must hold p.mu.
+func (p *CodexProvider) checkEndpointDivergence(req llmendpoint.Endpoint) error {
+	if p.client == nil {
+		return nil
+	}
+	if endpointsEqual(p.boundEndpt, req) {
+		return nil
+	}
+	return fmt.Errorf("codex: LLMEndpoint changed across Execute calls (bound=%s, requested=%s); recreate the provider to switch endpoints",
+		p.boundEndpt.String(), req.String())
 }
 
 // endpointsEqual reports whether two endpoints would produce the same codex

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -35,6 +35,9 @@ func (p *CodexProvider) Name() string { return "codex" }
 
 func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.WorktreeContext, opts ...ExecuteOption) (*AgentResult, error) {
 	cfg := applyOptions(opts)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 
 	// Build full prompt with worktree context
 	fullPrompt := prompt

--- a/multiagent/agent/codex_provider.go
+++ b/multiagent/agent/codex_provider.go
@@ -36,9 +36,16 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.Wo
 		fullPrompt = wtCtx.FormatForPrompt() + "\n\n" + prompt
 	}
 
-	// Ensure client is started
+	// Ensure client is started.
+	// LLMEndpoint must be applied at client construction since codex
+	// `--config` overrides are passed to `app-server` at boot. Subsequent
+	// Execute calls reuse the existing client and cannot change the endpoint.
 	if p.client == nil {
-		client := codex.NewClient(p.clientOpts...)
+		clientOpts := p.clientOpts
+		if !cfg.LLMEndpoint.IsZero() {
+			clientOpts = append(append([]codex.ClientOption{}, clientOpts...), codex.WithLLMEndpoint(cfg.LLMEndpoint))
+		}
+		client := codex.NewClient(clientOpts...)
 		if err := client.Start(ctx); err != nil {
 			return nil, err
 		}

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -407,24 +407,41 @@ func TestNonNilAgentResult_CoercesNil(t *testing.T) {
 // a "partially configured" error before any subprocess starts. If a future edit
 // drops `cfg.validate()` from a provider, this test fails for that provider —
 // catching the silent drift cursor flagged on provider.go:319.
+//
+// Three partial shapes are covered (provider-only, wire-only, headers-only)
+// to guard against a regression that special-cases one decoration field but
+// not the others.
 func TestProvider_ValidateGate(t *testing.T) {
 	t.Parallel()
-	partial := WithProviderLLMEndpoint(llmendpoint.Endpoint{ProviderName: "baseten"})
-	providers := map[string]Provider{
-		"claude": NewClaudeProvider(),
-		"cursor": NewCursorProvider(),
-		"codex":  NewCodexProvider(),
-		"gemini": NewGeminiProvider(),
+	partials := map[string]llmendpoint.Endpoint{
+		"provider-only": {ProviderName: "baseten"},
+		"wire-only":     {Wire: llmendpoint.WireAPIResponses},
+		"headers-only":  {Headers: map[string]string{"X-Org": "acme"}},
 	}
-	for name, p := range providers {
-		name, p := name, p
-		t.Run(name, func(t *testing.T) {
+	providerCtors := map[string]func() Provider{
+		"claude": func() Provider { return NewClaudeProvider() },
+		"cursor": func() Provider { return NewCursorProvider() },
+		"codex":  func() Provider { return NewCodexProvider() },
+		"gemini": func() Provider { return NewGeminiProvider() },
+	}
+	for shape, ep := range partials {
+		ep := ep
+		shape := shape
+		t.Run(shape, func(t *testing.T) {
 			t.Parallel()
-			defer func() { _ = p.Close() }()
-			_, err := p.Execute(t.Context(), "irrelevant", nil, partial)
-			require.Error(t, err, "%s.Execute must reject partial endpoint", name)
-			assert.Contains(t, err.Error(), "partially configured",
-				"%s.Execute error should bubble up Validate's partial-config error", name)
+			for name, ctor := range providerCtors {
+				name, ctor := name, ctor
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+					p := ctor()
+					defer func() { _ = p.Close() }()
+					_, err := p.Execute(t.Context(), "irrelevant", nil,
+						WithProviderLLMEndpoint(ep))
+					require.Error(t, err, "%s.Execute must reject %s partial endpoint", name, shape)
+					assert.Contains(t, err.Error(), "partially configured",
+						"%s.Execute (%s) error should bubble up Validate's partial-config error", name, shape)
+				})
+			}
 		})
 	}
 }

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -402,6 +402,33 @@ func TestNonNilAgentResult_CoercesNil(t *testing.T) {
 	assert.Same(t, in, nonNilAgentResult(in), "non-nil input should pass through unchanged")
 }
 
+// TestProvider_ValidateGate enforces the convention that every Provider.Execute
+// call runs ExecuteConfig.validate() at the top, so a partial endpoint produces
+// a "partially configured" error before any subprocess starts. If a future edit
+// drops `cfg.validate()` from a provider, this test fails for that provider —
+// catching the silent drift cursor flagged on provider.go:319.
+func TestProvider_ValidateGate(t *testing.T) {
+	t.Parallel()
+	partial := WithProviderLLMEndpoint(llmendpoint.Endpoint{ProviderName: "baseten"})
+	providers := map[string]Provider{
+		"claude": NewClaudeProvider(),
+		"cursor": NewCursorProvider(),
+		"codex":  NewCodexProvider(),
+		"gemini": NewGeminiProvider(),
+	}
+	for name, p := range providers {
+		name, p := name, p
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			defer func() { _ = p.Close() }()
+			_, err := p.Execute(t.Context(), "irrelevant", nil, partial)
+			require.Error(t, err, "%s.Execute must reject partial endpoint", name)
+			assert.Contains(t, err.Error(), "partially configured",
+				"%s.Execute error should bubble up Validate's partial-config error", name)
+		})
+	}
+}
+
 func TestCodexApprovalPolicyForPermissionMode(t *testing.T) {
 	t.Parallel()
 

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -403,20 +403,25 @@ func TestNonNilAgentResult_CoercesNil(t *testing.T) {
 }
 
 // TestProvider_ValidateGate enforces the convention that every Provider.Execute
-// call runs ExecuteConfig.validate() at the top, so a partial endpoint produces
-// a "partially configured" error before any subprocess starts. If a future edit
-// drops `cfg.validate()` from a provider, this test fails for that provider —
-// catching the silent drift cursor flagged on provider.go:319.
+// call runs ExecuteConfig.validate() at the top, so a malformed endpoint
+// produces an error before any subprocess starts. If a future edit drops
+// `cfg.validate()` from a provider, this test fails for that provider.
 //
-// Three partial shapes are covered (provider-only, wire-only, headers-only)
-// to guard against a regression that special-cases one decoration field but
-// not the others.
+// Three partial shapes plus one missing-auth shape are covered. The partial
+// shapes (provider-only, wire-only, headers-only) hit hasOnlyDecorations and
+// must surface "partially configured". The missing-auth shape covers the
+// non-zero / non-decoration validation path so a future regression can't
+// narrow validate() to only the partial branch and still pass this table.
 func TestProvider_ValidateGate(t *testing.T) {
 	t.Parallel()
-	partials := map[string]llmendpoint.Endpoint{
-		"provider-only": {ProviderName: "baseten"},
-		"wire-only":     {Wire: llmendpoint.WireAPIResponses},
-		"headers-only":  {Headers: map[string]string{"X-Org": "acme"}},
+	cases := map[string]struct {
+		ep      llmendpoint.Endpoint
+		wantErr string
+	}{
+		"provider-only":        {llmendpoint.Endpoint{ProviderName: "baseten"}, "partially configured"},
+		"wire-only":            {llmendpoint.Endpoint{Wire: llmendpoint.WireAPIResponses}, "partially configured"},
+		"headers-only":         {llmendpoint.Endpoint{Headers: map[string]string{"X-Org": "acme"}}, "partially configured"},
+		"base-url-without-key": {llmendpoint.Endpoint{BaseURL: "https://example.com/v1"}, "APIKey or APIKeyEnv"},
 	}
 	providerCtors := map[string]func() Provider{
 		"claude": func() Provider { return NewClaudeProvider() },
@@ -424,9 +429,8 @@ func TestProvider_ValidateGate(t *testing.T) {
 		"codex":  func() Provider { return NewCodexProvider() },
 		"gemini": func() Provider { return NewGeminiProvider() },
 	}
-	for shape, ep := range partials {
-		ep := ep
-		shape := shape
+	for shape, tc := range cases {
+		shape, tc := shape, tc
 		t.Run(shape, func(t *testing.T) {
 			t.Parallel()
 			for name, ctor := range providerCtors {
@@ -436,10 +440,10 @@ func TestProvider_ValidateGate(t *testing.T) {
 					p := ctor()
 					defer func() { _ = p.Close() }()
 					_, err := p.Execute(t.Context(), "irrelevant", nil,
-						WithProviderLLMEndpoint(ep))
-					require.Error(t, err, "%s.Execute must reject %s partial endpoint", name, shape)
-					assert.Contains(t, err.Error(), "partially configured",
-						"%s.Execute (%s) error should bubble up Validate's partial-config error", name, shape)
+						WithProviderLLMEndpoint(tc.ep))
+					require.Error(t, err, "%s.Execute must reject %s endpoint", name, shape)
+					assert.Contains(t, err.Error(), tc.wantErr,
+						"%s.Execute (%s) error should contain %q", name, shape, tc.wantErr)
 				})
 			}
 		})

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -373,6 +373,23 @@ func TestCodexProvider_CheckEndpointDivergence(t *testing.T) {
 		// a rejection, not silently route header-only changes to the bound endpoint.
 		assert.Contains(t, err.Error(), "LLMEndpoint changed")
 	})
+
+	t.Run("Headers map aliasing does not fool the divergence check", func(t *testing.T) {
+		t.Parallel()
+		// Simulate the production binding path: provider stores a Clone of the
+		// caller's endpoint. If the caller later mutates the original's Headers
+		// map, the divergence check must still see the divergence rather than
+		// silently routing to the originally-bound endpoint.
+		caller := llmendpoint.Endpoint{
+			BaseURL:   "https://x",
+			APIKeyEnv: "K",
+			Headers:   map[string]string{"X-Org": "v1"},
+		}
+		p := &CodexProvider{client: &codex.Client{}, boundEndpt: caller.Clone()}
+		caller.Headers["X-Org"] = "v2"
+		err := p.checkEndpointDivergence(caller)
+		require.Error(t, err, "post-bind mutation of caller Headers must not alias bound snapshot")
+	})
 }
 
 func TestNonNilAgentResult_CoercesNil(t *testing.T) {

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -330,6 +330,51 @@ func TestEndpointsEqual_HeaderEqualityIsOrderIndependent(t *testing.T) {
 	assert.True(t, endpointsEqual(a, b))
 }
 
+func TestCodexProvider_CheckEndpointDivergence(t *testing.T) {
+	t.Parallel()
+	bound := llmendpoint.Endpoint{
+		BaseURL:      "https://inference.baseten.co/v1",
+		APIKeyEnv:    "BASETEN_API_KEY",
+		ProviderName: "baseten",
+	}
+
+	t.Run("no client yet returns nil", func(t *testing.T) {
+		t.Parallel()
+		p := &CodexProvider{}
+		// boundEndpt is zero; with no client, divergence is moot.
+		require.NoError(t, p.checkEndpointDivergence(bound))
+	})
+
+	t.Run("matching endpoint returns nil", func(t *testing.T) {
+		t.Parallel()
+		p := &CodexProvider{client: &codex.Client{}, boundEndpt: bound}
+		require.NoError(t, p.checkEndpointDivergence(bound))
+	})
+
+	t.Run("base url divergence reports both endpoints", func(t *testing.T) {
+		t.Parallel()
+		p := &CodexProvider{client: &codex.Client{}, boundEndpt: bound}
+		other := bound
+		other.BaseURL = "https://example.com/v1"
+		err := p.checkEndpointDivergence(other)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "https://inference.baseten.co/v1")
+		assert.Contains(t, err.Error(), "https://example.com/v1")
+	})
+
+	t.Run("header-only divergence still rejected and surfaced", func(t *testing.T) {
+		t.Parallel()
+		p := &CodexProvider{client: &codex.Client{}, boundEndpt: bound}
+		other := bound
+		other.Headers = map[string]string{"X-Org": "acme"}
+		err := p.checkEndpointDivergence(other)
+		require.Error(t, err, "header divergence must reject — wrappers can't reapply headers post-boot")
+		// Both endpoints' base URL is identical here; the error must still be
+		// a rejection, not silently route header-only changes to the bound endpoint.
+		assert.Contains(t, err.Error(), "LLMEndpoint changed")
+	})
+}
+
 func TestNonNilAgentResult_CoercesNil(t *testing.T) {
 	t.Parallel()
 	got := nonNilAgentResult(nil)

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/codex"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 )
 
 type recordingHandler struct { //nolint:govet // fieldalignment: test fixture readability
@@ -267,6 +268,76 @@ func TestCodexTurnOptions_WiresAllValidLevels(t *testing.T) {
 			assert.Equal(t, string(level), cfg.Effort)
 		})
 	}
+}
+
+func TestEndpointsEqual_CanonicalizesDefaults(t *testing.T) {
+	t.Parallel()
+	// Empty Wire and empty ProviderName resolve to "chat" / "custom" via the
+	// canonical accessors, so they must compare equal to their explicit-default
+	// counterparts. Otherwise the divergence guard in CodexProvider.Execute would
+	// spuriously reject a second Execute call that re-uses the same endpoint
+	// shape but happens to spell out the defaults.
+	a := llmendpoint.Endpoint{BaseURL: "https://x", APIKeyEnv: "K"}
+	b := llmendpoint.Endpoint{
+		BaseURL:      "https://x",
+		APIKeyEnv:    "K",
+		ProviderName: llmendpoint.DefaultProviderName,
+		Wire:         llmendpoint.WireAPIChat,
+	}
+	assert.True(t, endpointsEqual(a, b), "implicit defaults must equal explicit defaults")
+}
+
+func TestEndpointsEqual_DivergentFieldsAreUnequal(t *testing.T) {
+	t.Parallel()
+	base := llmendpoint.Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+	}
+	cases := []struct {
+		mut  func(*llmendpoint.Endpoint)
+		name string
+	}{
+		{func(e *llmendpoint.Endpoint) { e.BaseURL = "https://y" }, "different base url"},
+		{func(e *llmendpoint.Endpoint) { e.APIKey = "k1" }, "different api key"},
+		{func(e *llmendpoint.Endpoint) { e.APIKeyEnv = "K2" }, "different api key env"},
+		{func(e *llmendpoint.Endpoint) { e.ProviderName = "baseten" }, "different provider name"},
+		{func(e *llmendpoint.Endpoint) { e.Wire = llmendpoint.WireAPIResponses }, "different wire"},
+		{func(e *llmendpoint.Endpoint) { e.Headers = map[string]string{"X-A": "1"} }, "extra header"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mutated := base
+			tc.mut(&mutated)
+			assert.False(t, endpointsEqual(base, mutated), "expected unequal after %s", tc.name)
+		})
+	}
+}
+
+func TestEndpointsEqual_HeaderEqualityIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	a := llmendpoint.Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+		Headers:   map[string]string{"X-A": "1", "X-B": "2"},
+	}
+	b := llmendpoint.Endpoint{
+		BaseURL:   "https://x",
+		APIKeyEnv: "K",
+		Headers:   map[string]string{"X-B": "2", "X-A": "1"},
+	}
+	assert.True(t, endpointsEqual(a, b))
+}
+
+func TestNonNilAgentResult_CoercesNil(t *testing.T) {
+	t.Parallel()
+	got := nonNilAgentResult(nil)
+	require.NotNil(t, got, "nonNilAgentResult must never return nil")
+	assert.Equal(t, &AgentResult{}, got)
+
+	in := &AgentResult{Text: "hello", Success: true}
+	assert.Same(t, in, nonNilAgentResult(in), "non-nil input should pass through unchanged")
 }
 
 func TestCodexApprovalPolicyForPermissionMode(t *testing.T) {

--- a/multiagent/agent/cursor_provider.go
+++ b/multiagent/agent/cursor_provider.go
@@ -25,6 +25,9 @@ func (p *CursorProvider) Name() string { return "cursor" }
 
 func (p *CursorProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.WorktreeContext, opts ...ExecuteOption) (*AgentResult, error) {
 	cfg := applyOptions(opts)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 
 	// Cursor has no reasoning-effort knob — fail fast rather than silently
 	// dropping the requested level. EffortAuto is the explicit "use the

--- a/multiagent/agent/cursor_provider.go
+++ b/multiagent/agent/cursor_provider.go
@@ -53,6 +53,9 @@ func (p *CursorProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	}
 	// Cursor requires --trust for non-interactive use
 	sessionOpts = append(sessionOpts, cursor.WithTrust())
+	if !cfg.LLMEndpoint.IsZero() {
+		sessionOpts = append(sessionOpts, cursor.WithLLMEndpoint(cfg.LLMEndpoint))
+	}
 
 	// Create session
 	session := cursor.NewSession(fullPrompt, sessionOpts...)

--- a/multiagent/agent/gemini_provider.go
+++ b/multiagent/agent/gemini_provider.go
@@ -80,7 +80,9 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			return nil, err
 		}
 		p.client = client
-		p.boundEndpt = cfg.LLMEndpoint
+		// Clone so a caller mutating cfg.LLMEndpoint.Headers after this Execute
+		// returns can't fool the next divergence check by aliasing the same map.
+		p.boundEndpt = cfg.LLMEndpoint.Clone()
 		p.bridgeDone = make(chan struct{})
 
 		// Start a single persistent bridge goroutine for the client's events.

--- a/multiagent/agent/gemini_provider.go
+++ b/multiagent/agent/gemini_provider.go
@@ -52,10 +52,17 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		fullPrompt = wtCtx.FormatForPrompt() + "\n\n" + prompt
 	}
 
-	// Ensure client is started (lazy init with mutex protection)
+	// Ensure client is started (lazy init with mutex protection).
+	// LLMEndpoint must be applied at client construction since acp BinaryArgs
+	// and Env are passed to the subprocess at boot. Subsequent Execute calls
+	// reuse the existing client.
 	p.mu.Lock()
 	if p.client == nil {
-		client := acp.NewClient(p.clientOpts...)
+		clientOpts := p.clientOpts
+		if !cfg.LLMEndpoint.IsZero() {
+			clientOpts = append(append([]acp.ClientOption{}, clientOpts...), acp.WithLLMEndpoint(cfg.LLMEndpoint))
+		}
+		client := acp.NewClient(clientOpts...)
 		// Use context.Background() to decouple the ACP subprocess lifetime
 		// from any single request's context. The subprocess should live as long
 		// as the provider, not just the first request.

--- a/multiagent/agent/gemini_provider.go
+++ b/multiagent/agent/gemini_provider.go
@@ -67,13 +67,18 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	// than silently routing to the originally-bound endpoint.
 	p.mu.Lock()
 	if p.client == nil {
-		// Apply WithLLMEndpoint first so caller-supplied clientOpts can
-		// override its defaults via later args.
-		var clientOpts []acp.ClientOption
+		// Apply WithLLMEndpoint AFTER caller clientOpts. acp.WithEnv
+		// replaces the env map wholesale, so a caller passing
+		// WithEnv(...) before our LLMEndpoint creds (GEMINI_API_KEY,
+		// GOOGLE_GEMINI_BASE_URL) would otherwise drop them. Putting
+		// LLMEndpoint last makes it merge into whatever map the caller
+		// supplied — at the cost of letting LLMEndpoint silently
+		// overwrite a same-named caller env var, which is the right
+		// trade-off (the LLM creds are load-bearing for routing).
+		clientOpts := append([]acp.ClientOption{}, p.clientOpts...)
 		if !cfg.LLMEndpoint.IsZero() {
 			clientOpts = append(clientOpts, acp.WithLLMEndpoint(cfg.LLMEndpoint))
 		}
-		clientOpts = append(clientOpts, p.clientOpts...)
 		client := acp.NewClient(clientOpts...)
 		// Use context.Background() to decouple the ACP subprocess lifetime
 		// from any single request's context. The subprocess should live as long

--- a/multiagent/agent/gemini_provider.go
+++ b/multiagent/agent/gemini_provider.go
@@ -93,8 +93,11 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		}()
 	} else if !endpointsEqual(p.boundEndpt, cfg.LLMEndpoint) {
 		p.mu.Unlock()
-		return nil, fmt.Errorf("gemini: LLMEndpoint changed across Execute calls (bound=%q, requested=%q); recreate the provider to switch endpoints",
-			p.boundEndpt.BaseURL, cfg.LLMEndpoint.BaseURL)
+		// Use Endpoint.String() so divergences confined to headers/auth/wire
+		// surface in the message; comparing only BaseURL would mislead callers
+		// when both endpoints share a base URL but disagree on other fields.
+		return nil, fmt.Errorf("gemini: LLMEndpoint changed across Execute calls (bound=%s, requested=%s); recreate the provider to switch endpoints",
+			p.boundEndpt.String(), cfg.LLMEndpoint.String())
 	}
 	client := p.client
 	p.mu.Unlock()

--- a/multiagent/agent/gemini_provider.go
+++ b/multiagent/agent/gemini_provider.go
@@ -2,25 +2,30 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/wt"
 )
 
 // GeminiProvider wraps an ACP client (Gemini CLI) behind the Provider interface.
+//
+//nolint:govet // fieldalignment: keep boundEndpt grouped with clientOpts; extra inline padding from nesting llmendpoint.Endpoint isn't worth obscuring the order.
 type GeminiProvider struct {
+	boundEndpt llmendpoint.Endpoint
+	clientOpts []acp.ClientOption
 	client     *acp.Client
 	events     chan AgentEvent
 	bridgeDone chan struct{} // signals bridge goroutine to exit
 	// handlerCh is set during an Execute call. The bridge goroutine sends
 	// copies of AgentEvents here for the handler. It is protected by handlerMu.
-	handlerCh  chan AgentEvent
-	clientOpts []acp.ClientOption
-	handlerMu  sync.RWMutex
-	mu         sync.Mutex
-	bridgeWg   sync.WaitGroup // tracks bridge goroutine
+	handlerCh chan AgentEvent
+	handlerMu sync.RWMutex
+	bridgeWg  sync.WaitGroup // tracks bridge goroutine
+	mu        sync.Mutex
 }
 
 // NewGeminiProvider creates a new Gemini provider.
@@ -55,13 +60,17 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 	// Ensure client is started (lazy init with mutex protection).
 	// LLMEndpoint must be applied at client construction since acp BinaryArgs
 	// and Env are passed to the subprocess at boot. Subsequent Execute calls
-	// reuse the existing client.
+	// reuse the existing client; reject divergent endpoints loudly rather
+	// than silently routing to the originally-bound endpoint.
 	p.mu.Lock()
 	if p.client == nil {
-		clientOpts := p.clientOpts
+		// Apply WithLLMEndpoint first so caller-supplied clientOpts can
+		// override its defaults via later args.
+		var clientOpts []acp.ClientOption
 		if !cfg.LLMEndpoint.IsZero() {
-			clientOpts = append(append([]acp.ClientOption{}, clientOpts...), acp.WithLLMEndpoint(cfg.LLMEndpoint))
+			clientOpts = append(clientOpts, acp.WithLLMEndpoint(cfg.LLMEndpoint))
 		}
+		clientOpts = append(clientOpts, p.clientOpts...)
 		client := acp.NewClient(clientOpts...)
 		// Use context.Background() to decouple the ACP subprocess lifetime
 		// from any single request's context. The subprocess should live as long
@@ -71,6 +80,7 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			return nil, err
 		}
 		p.client = client
+		p.boundEndpt = cfg.LLMEndpoint
 		p.bridgeDone = make(chan struct{})
 
 		// Start a single persistent bridge goroutine for the client's events.
@@ -81,6 +91,10 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 			defer p.bridgeWg.Done()
 			p.bridgeEventsWithHandler(client.Events())
 		}()
+	} else if !endpointsEqual(p.boundEndpt, cfg.LLMEndpoint) {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("gemini: LLMEndpoint changed across Execute calls (bound=%q, requested=%q); recreate the provider to switch endpoints",
+			p.boundEndpt.BaseURL, cfg.LLMEndpoint.BaseURL)
 	}
 	client := p.client
 	p.mu.Unlock()
@@ -122,7 +136,7 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		return nil, promptErr
 	}
 
-	return acpResultToAgentResult(result), nil
+	return nonNilAgentResult(acpResultToAgentResult(result)), nil
 }
 
 // drainHandlerEvents waits for the TurnComplete event (or a short timeout),
@@ -285,7 +299,7 @@ func (p *GeminiLongRunningProvider) SendMessage(ctx context.Context, message str
 		return nil, err
 	}
 
-	return acpResultToAgentResult(result), nil
+	return nonNilAgentResult(acpResultToAgentResult(result)), nil
 }
 
 func (p *GeminiLongRunningProvider) Stop() error {

--- a/multiagent/agent/gemini_provider.go
+++ b/multiagent/agent/gemini_provider.go
@@ -42,6 +42,9 @@ func (p *GeminiProvider) Name() string { return "gemini" }
 
 func (p *GeminiProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.WorktreeContext, opts ...ExecuteOption) (*AgentResult, error) {
 	cfg := applyOptions(opts)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 
 	// ACP has no reasoning-effort knob — fail fast before spawning the
 	// subprocess. EffortAuto is the explicit "use the provider default"

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -266,10 +266,13 @@ func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
 }
 
 // WithProviderLLMEndpoint points the underlying CLI at a third-party LLM API
-// endpoint. Claude/cursor/gemini providers apply the endpoint per-execution.
-// The codex provider applies it at client construction time (the first
-// Execute call), since `--config` overrides are passed to `app-server` at
-// boot — subsequent Execute calls reuse the same client and ignore changes.
+// endpoint. Claude and cursor apply the endpoint per-execution. Codex and
+// gemini bind it at client construction time (the first Execute call), since
+// `--config` overrides / acp BinaryArgs are passed to the subprocess at boot
+// — subsequent Execute calls reuse the same client and reject divergent
+// endpoints with an explicit error rather than silently routing to the
+// originally-bound endpoint. To switch endpoints on a codex/gemini provider,
+// construct a fresh provider.
 func WithProviderLLMEndpoint(ep llmendpoint.Endpoint) ExecuteOption {
 	return func(c *ExecuteConfig) { c.LLMEndpoint = ep }
 }

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/wt"
 )
 
@@ -190,6 +191,7 @@ type ExecuteOption func(*ExecuteConfig)
 // ExecuteConfig holds execution configuration.
 type ExecuteConfig struct {
 	EventHandler        EventHandler
+	LLMEndpoint         llmendpoint.Endpoint
 	Model               string
 	Effort              EffortLevel
 	WorkDir             string
@@ -261,6 +263,15 @@ func WithProviderResumeSessionID(id string) ExecuteOption {
 // the feature (the provider returns the errored result without retrying).
 func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
 	return func(c *ExecuteConfig) { c.MaxToolErrorRetries = n }
+}
+
+// WithProviderLLMEndpoint points the underlying CLI at a third-party LLM API
+// endpoint. Claude/cursor/gemini providers apply the endpoint per-execution.
+// The codex provider applies it at client construction time (the first
+// Execute call), since `--config` overrides are passed to `app-server` at
+// boot — subsequent Execute calls reuse the same client and ignore changes.
+func WithProviderLLMEndpoint(ep llmendpoint.Endpoint) ExecuteOption {
+	return func(c *ExecuteConfig) { c.LLMEndpoint = ep }
 }
 
 // applyOptions applies ExecuteOptions to a config, returning defaults for unset fields.

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -266,13 +266,23 @@ func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
 }
 
 // WithProviderLLMEndpoint points the underlying CLI at a third-party LLM API
-// endpoint. Claude and cursor apply the endpoint per-execution. Codex and
-// gemini bind it at client construction time (the first Execute call), since
-// `--config` overrides / acp BinaryArgs are passed to the subprocess at boot
-// — subsequent Execute calls reuse the same client and reject divergent
-// endpoints with an explicit error rather than silently routing to the
-// originally-bound endpoint. To switch endpoints on a codex/gemini provider,
-// construct a fresh provider.
+// endpoint.
+//
+// Behavior is intentionally asymmetric across providers, mirroring how each
+// upstream CLI honors endpoint config:
+//
+//   - claude / cursor: rebuild the underlying session per Execute, so each
+//     call may pass a different endpoint.
+//   - codex / gemini:  bind the endpoint at client construction time (the
+//     first Execute call), since `--config` overrides / acp BinaryArgs are
+//     passed to the subprocess at boot. Subsequent Execute calls must pass
+//     an equal endpoint; divergent endpoints fail with an explicit error
+//     rather than silently routing to the originally-bound endpoint. To
+//     switch endpoints on a codex/gemini provider, construct a fresh one.
+//
+// All four providers validate the endpoint at the start of Execute (see
+// ExecuteConfig.validate), so partial-but-non-zero endpoints fail loudly
+// regardless of which provider you target.
 func WithProviderLLMEndpoint(ep llmendpoint.Endpoint) ExecuteOption {
 	return func(c *ExecuteConfig) { c.LLMEndpoint = ep }
 }
@@ -299,4 +309,13 @@ func applyOptions(opts []ExecuteOption) ExecuteConfig {
 		opt(&cfg)
 	}
 	return cfg
+}
+
+// validate enforces invariants that every Provider.Execute call relies on,
+// regardless of whether the provider rebuilds the underlying session per
+// call (claude/cursor) or binds the endpoint at first Execute (codex/gemini).
+// Currently it only gates on LLMEndpoint, but the seam is intentional: any
+// future cross-provider invariant lands here once instead of in four places.
+func (c ExecuteConfig) validate() error {
+	return c.LLMEndpoint.Validate()
 }

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -274,6 +274,18 @@ func WithProviderLLMEndpoint(ep llmendpoint.Endpoint) ExecuteOption {
 	return func(c *ExecuteConfig) { c.LLMEndpoint = ep }
 }
 
+// nonNilAgentResult coerces a possibly-nil AgentResult into a non-nil one so
+// Provider.Execute / SendMessage callers can rely on (result, err==nil) →
+// result != nil. Provider-specific result conversion helpers return nil when
+// the underlying SDK returned a nil turn result; without this coercion the
+// (nil, nil) tuple would panic any caller that dereferences the result.
+func nonNilAgentResult(r *AgentResult) *AgentResult {
+	if r != nil {
+		return r
+	}
+	return &AgentResult{}
+}
+
 // applyOptions applies ExecuteOptions to a config, returning defaults for unset fields.
 func applyOptions(opts []ExecuteOption) ExecuteConfig {
 	cfg := ExecuteConfig{

--- a/yoloswe/BUILD.bazel
+++ b/yoloswe/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/claude/render",
+        "//agent-cli-wrapper/llmendpoint",
         "//yoloswe/reviewer",
     ],
 )

--- a/yoloswe/cmd/yoloswe/BUILD.bazel
+++ b/yoloswe/cmd/yoloswe/BUILD.bazel
@@ -6,8 +6,12 @@ go_library(
     importpath = "github.com/bazelment/yoloswe/yoloswe/cmd/yoloswe",
     visibility = ["//visibility:private"],
     deps = [
+        "//agent-cli-wrapper/acp",
         "//agent-cli-wrapper/claude/render",
+        "//agent-cli-wrapper/llmendpoint",
         "//cliapp",
+        "//multiagent/agent",
+        "//wt",
         "//yoloswe",
         "//yoloswe/planner",
         "@com_github_spf13_cobra//:cobra",

--- a/yoloswe/cmd/yoloswe/main.go
+++ b/yoloswe/cmd/yoloswe/main.go
@@ -101,13 +101,9 @@ func runPlan(cmd *cobra.Command, args []string, flags *planFlags) error {
 		return fmt.Errorf("no prompt provided")
 	}
 
-	workDir := flags.workDir
-	if workDir == "" {
-		var err error
-		workDir, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("get working directory: %w", err)
-		}
+	workDir, err := resolveWorkDir(flags.workDir)
+	if err != nil {
+		return err
 	}
 
 	buildMode := planner.BuildMode(flags.build)
@@ -203,13 +199,9 @@ func runBuild(cmd *cobra.Command, args []string, flags *buildFlags) error {
 	app := cliapp.FromContext(cmd.Context())
 	prompt := strings.Join(args, " ")
 
-	workDir := flags.dir
-	if workDir == "" {
-		var err error
-		workDir, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("get working directory: %w", err)
-		}
+	workDir, err := resolveWorkDir(flags.dir)
+	if err != nil {
+		return err
 	}
 
 	recordingDir := flags.record
@@ -297,7 +289,7 @@ endpoints.`,
 			return runCodeTalk(cmd, args, flags)
 		},
 	}
-	cmd.Flags().StringVar(&flags.backend, "backend", "claude", "Backend CLI: claude, codex, gemini, cursor")
+	cmd.Flags().StringVar(&flags.backend, "backend", agent.ProviderClaude, "Backend CLI: "+strings.Join(agent.AllProviders, ", "))
 	cmd.Flags().StringVar(&flags.model, "model", "", "Model to use (defaults: claude=opus, codex=gpt-5.5, gemini=gemini-2.5-pro)")
 	cmd.Flags().StringVar(&flags.workDir, "dir", "", "Working directory (default: current)")
 	cmd.Flags().StringVar(&flags.recordDir, "record", "", "Recording directory (default: ~/.yoloswe)")
@@ -314,13 +306,9 @@ func runCodeTalk(cmd *cobra.Command, args []string, flags *codeTalkFlags) error 
 	app := cliapp.FromContext(cmd.Context())
 	prompt := strings.Join(args, " ")
 
-	workDir := flags.workDir
-	if workDir == "" {
-		var err error
-		workDir, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("get working directory: %w", err)
-		}
+	workDir, err := resolveWorkDir(flags.workDir)
+	if err != nil {
+		return err
 	}
 
 	ep := llmendpoint.Endpoint{
@@ -337,14 +325,19 @@ func runCodeTalk(cmd *cobra.Command, args []string, flags *codeTalkFlags) error 
 	}
 	app.Logger.Info("codetalk", "backend", flags.backend, "model", flags.model, "endpoint", ep.String())
 
-	switch strings.ToLower(flags.backend) {
-	case "", "claude":
-		return runCodeTalkClaude(cmd.Context(), flags, ep, workDir, prompt)
-	case "codex", "gemini", "cursor":
-		return runCodeTalkProvider(cmd.Context(), flags, ep, workDir, prompt)
-	default:
-		return fmt.Errorf("unknown backend %q (valid: claude, codex, gemini, cursor)", flags.backend)
+	backend := strings.ToLower(flags.backend)
+	if backend == "" {
+		backend = agent.ProviderClaude
 	}
+	if backend == agent.ProviderClaude {
+		return runCodeTalkClaude(cmd.Context(), flags, ep, workDir, prompt)
+	}
+	for _, p := range agent.AllProviders {
+		if backend == p {
+			return runCodeTalkProvider(cmd.Context(), backend, flags, ep, workDir, prompt)
+		}
+	}
+	return fmt.Errorf("unknown backend %q (valid: %s)", flags.backend, strings.Join(agent.AllProviders, ", "))
 }
 
 func runCodeTalkClaude(ctx context.Context, flags *codeTalkFlags, ep llmendpoint.Endpoint, workDir, prompt string) error {
@@ -371,27 +364,27 @@ func runCodeTalkClaude(ctx context.Context, flags *codeTalkFlags, ep llmendpoint
 	return nil
 }
 
-func runCodeTalkProvider(ctx context.Context, flags *codeTalkFlags, ep llmendpoint.Endpoint, workDir, prompt string) error {
+func runCodeTalkProvider(ctx context.Context, backend string, flags *codeTalkFlags, ep llmendpoint.Endpoint, workDir, prompt string) error {
 	model := flags.model
-	if model == "" {
-		switch strings.ToLower(flags.backend) {
-		case "codex":
+	var prov agent.Provider
+	switch backend {
+	case agent.ProviderCodex:
+		if model == "" {
 			model = "gpt-5.5"
-		case "gemini":
+		}
+		prov = agent.NewCodexProvider()
+	case agent.ProviderGemini:
+		if model == "" {
 			model = "gemini-2.5-pro"
-		case "cursor":
+		}
+		prov = agent.NewGeminiProvider(acp.WithBinaryArgs("--experimental-acp"))
+	case agent.ProviderCursor:
+		if model == "" {
 			model = "cursor-default"
 		}
-	}
-
-	var prov agent.Provider
-	switch strings.ToLower(flags.backend) {
-	case "codex":
-		prov = agent.NewCodexProvider()
-	case "gemini":
-		prov = agent.NewGeminiProvider(acp.WithBinaryArgs("--experimental-acp"))
-	case "cursor":
 		prov = agent.NewCursorProvider()
+	default:
+		return fmt.Errorf("backend %q not supported by codetalk provider path", backend)
 	}
 	defer prov.Close()
 
@@ -421,6 +414,19 @@ func runCodeTalkProvider(ctx context.Context, flags *codeTalkFlags, ep llmendpoi
 		return res.Error
 	}
 	return nil
+}
+
+// resolveWorkDir returns flagDir, or the current working directory when
+// flagDir is empty.
+func resolveWorkDir(flagDir string) (string, error) {
+	if flagDir != "" {
+		return flagDir, nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	return wd, nil
 }
 
 // readFromStdin reads input from stdin if available.

--- a/yoloswe/cmd/yoloswe/main.go
+++ b/yoloswe/cmd/yoloswe/main.go
@@ -295,7 +295,7 @@ endpoints.`,
 	cmd.Flags().StringVar(&flags.recordDir, "record", "", "Recording directory (default: ~/.yoloswe)")
 	cmd.Flags().StringVar(&flags.systemPrompt, "system", "", "Custom system prompt")
 	cmd.Flags().StringVar(&flags.llmBaseURL, "llm-base-url", "", "Custom LLM endpoint base URL")
-	cmd.Flags().StringVar(&flags.llmAPIKey, "llm-api-key", "", "Custom LLM API key (prefer --llm-api-key-env)")
+	cmd.Flags().StringVar(&flags.llmAPIKey, "llm-api-key", "", "Custom LLM API key — UNSAFE on shared/CI hosts (visible in shell history and `ps`); prefer --llm-api-key-env")
 	cmd.Flags().StringVar(&flags.llmAPIKeyEnv, "llm-api-key-env", "", "Env var name holding the LLM API key (e.g. BASETEN_API_KEY)")
 	cmd.Flags().StringVar(&flags.llmProviderName, "llm-provider-name", "", "Provider name label (codex model_providers.<name>)")
 	cmd.Flags().StringVar(&flags.llmWireAPI, "llm-wire-api", "chat", "Wire API: chat (OpenAI-compatible) or responses")

--- a/yoloswe/cmd/yoloswe/main.go
+++ b/yoloswe/cmd/yoloswe/main.go
@@ -15,8 +15,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/cliapp"
+	"github.com/bazelment/yoloswe/multiagent/agent"
+	"github.com/bazelment/yoloswe/wt"
 	"github.com/bazelment/yoloswe/yoloswe"
 	"github.com/bazelment/yoloswe/yoloswe/planner"
 )
@@ -36,6 +40,7 @@ Use 'build' to run a builder-reviewer loop for autonomous task execution.`,
 	cliapp.RegisterStandardFlags(rootCmd, &rootOpts)
 	rootCmd.AddCommand(newPlanCmd())
 	rootCmd.AddCommand(newBuildCmd())
+	rootCmd.AddCommand(newCodeTalkCmd())
 
 	os.Exit(cliapp.Run(&rootOpts, func(ctx context.Context, app *cliapp.App) error {
 		return rootCmd.ExecuteContext(cliapp.WithApp(ctx, app))
@@ -250,6 +255,170 @@ func runBuild(cmd *cobra.Command, args []string, flags *buildFlags) error {
 	}
 	if swe.Stats().ExitReason != yoloswe.ExitReasonAccepted {
 		return fmt.Errorf("build did not complete successfully (reason: %v)", swe.Stats().ExitReason)
+	}
+	return nil
+}
+
+// codetalk command flags
+type codeTalkFlags struct {
+	backend         string
+	model           string
+	workDir         string
+	recordDir       string
+	systemPrompt    string
+	llmBaseURL      string
+	llmAPIKey       string
+	llmAPIKeyEnv    string
+	llmProviderName string
+	llmWireAPI      string
+}
+
+func newCodeTalkCmd() *cobra.Command {
+	flags := &codeTalkFlags{}
+	cmd := &cobra.Command{
+		Use:   "codetalk [flags] <prompt>",
+		Short: "One-shot code understanding session",
+		Long: `Codetalk runs a single read-only code-understanding turn against the chosen
+backend. The agent has Read/Grep/Glob and read-only Bash; it cannot modify files.
+
+Pass --backend=claude (default), codex, gemini, or cursor to pick the underlying
+CLI. The --llm-* flags route inference through a third-party LLM API endpoint
+(e.g. Baseten, OpenRouter, LiteLLM). Note: the claude backend requires an
+Anthropic-shaped endpoint — use codex or gemini for raw OpenAI-compatible
+endpoints.`,
+		Example: `  yoloswe codetalk "explain agent-cli-wrapper"
+  yoloswe codetalk --backend codex --model moonshotai/Kimi-K2.6 \
+    --llm-base-url https://inference.baseten.co/v1 \
+    --llm-api-key-env BASETEN_API_KEY --llm-provider-name baseten \
+    --llm-wire-api chat \
+    "explain the agent-cli-wrapper structure"`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCodeTalk(cmd, args, flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.backend, "backend", "claude", "Backend CLI: claude, codex, gemini, cursor")
+	cmd.Flags().StringVar(&flags.model, "model", "", "Model to use (defaults: claude=opus, codex=gpt-5.5, gemini=gemini-2.5-pro)")
+	cmd.Flags().StringVar(&flags.workDir, "dir", "", "Working directory (default: current)")
+	cmd.Flags().StringVar(&flags.recordDir, "record", "", "Recording directory (default: ~/.yoloswe)")
+	cmd.Flags().StringVar(&flags.systemPrompt, "system", "", "Custom system prompt")
+	cmd.Flags().StringVar(&flags.llmBaseURL, "llm-base-url", "", "Custom LLM endpoint base URL")
+	cmd.Flags().StringVar(&flags.llmAPIKey, "llm-api-key", "", "Custom LLM API key (prefer --llm-api-key-env)")
+	cmd.Flags().StringVar(&flags.llmAPIKeyEnv, "llm-api-key-env", "", "Env var name holding the LLM API key (e.g. BASETEN_API_KEY)")
+	cmd.Flags().StringVar(&flags.llmProviderName, "llm-provider-name", "", "Provider name label (codex model_providers.<name>)")
+	cmd.Flags().StringVar(&flags.llmWireAPI, "llm-wire-api", "chat", "Wire API: chat (OpenAI-compatible) or responses")
+	return cmd
+}
+
+func runCodeTalk(cmd *cobra.Command, args []string, flags *codeTalkFlags) error {
+	app := cliapp.FromContext(cmd.Context())
+	prompt := strings.Join(args, " ")
+
+	workDir := flags.workDir
+	if workDir == "" {
+		var err error
+		workDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get working directory: %w", err)
+		}
+	}
+
+	ep := llmendpoint.Endpoint{
+		BaseURL:      flags.llmBaseURL,
+		APIKey:       flags.llmAPIKey,
+		APIKeyEnv:    flags.llmAPIKeyEnv,
+		ProviderName: flags.llmProviderName,
+		Wire:         llmendpoint.WireAPI(flags.llmWireAPI),
+	}
+	if !ep.IsZero() {
+		if err := ep.Validate(); err != nil {
+			return err
+		}
+	}
+	app.Logger.Info("codetalk", "backend", flags.backend, "model", flags.model, "endpoint", ep.String())
+
+	switch strings.ToLower(flags.backend) {
+	case "", "claude":
+		return runCodeTalkClaude(cmd.Context(), flags, ep, workDir, prompt)
+	case "codex", "gemini", "cursor":
+		return runCodeTalkProvider(cmd.Context(), flags, ep, workDir, prompt)
+	default:
+		return fmt.Errorf("unknown backend %q (valid: claude, codex, gemini, cursor)", flags.backend)
+	}
+}
+
+func runCodeTalkClaude(ctx context.Context, flags *codeTalkFlags, ep llmendpoint.Endpoint, workDir, prompt string) error {
+	model := flags.model
+	if model == "" {
+		model = "opus"
+	}
+	cfg := yoloswe.CodeTalkConfig{
+		Model:        model,
+		WorkDir:      workDir,
+		RecordingDir: flags.recordDir,
+		SystemPrompt: flags.systemPrompt,
+		LLMEndpoint:  ep,
+	}
+	session := yoloswe.NewCodeTalkSession(cfg, os.Stdout)
+	if err := session.Start(ctx); err != nil {
+		return fmt.Errorf("start codetalk session: %w", err)
+	}
+	defer session.Stop()
+
+	if _, err := session.RunTurn(ctx, prompt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runCodeTalkProvider(ctx context.Context, flags *codeTalkFlags, ep llmendpoint.Endpoint, workDir, prompt string) error {
+	model := flags.model
+	if model == "" {
+		switch strings.ToLower(flags.backend) {
+		case "codex":
+			model = "gpt-5.5"
+		case "gemini":
+			model = "gemini-2.5-pro"
+		case "cursor":
+			model = "cursor-default"
+		}
+	}
+
+	var prov agent.Provider
+	switch strings.ToLower(flags.backend) {
+	case "codex":
+		prov = agent.NewCodexProvider()
+	case "gemini":
+		prov = agent.NewGeminiProvider(acp.WithBinaryArgs("--experimental-acp"))
+	case "cursor":
+		prov = agent.NewCursorProvider()
+	}
+	defer prov.Close()
+
+	systemPrompt := flags.systemPrompt
+	if systemPrompt == "" {
+		systemPrompt = yoloswe.CodeTalkSystemPrompt
+	}
+
+	opts := []agent.ExecuteOption{
+		agent.WithProviderModel(model),
+		agent.WithProviderWorkDir(workDir),
+		agent.WithProviderSystemPrompt(systemPrompt),
+		agent.WithProviderPermissionMode("bypass"),
+	}
+	if !ep.IsZero() {
+		opts = append(opts, agent.WithProviderLLMEndpoint(ep))
+	}
+
+	res, err := prov.Execute(ctx, prompt, (*wt.WorktreeContext)(nil), opts...)
+	if err != nil {
+		return err
+	}
+	if res.Text != "" {
+		fmt.Println(res.Text)
+	}
+	if !res.Success && res.Error != nil {
+		return res.Error
 	}
 	return nil
 }

--- a/yoloswe/cmd/yoloswe/main.go
+++ b/yoloswe/cmd/yoloswe/main.go
@@ -323,6 +323,11 @@ func runCodeTalk(cmd *cobra.Command, args []string, flags *codeTalkFlags) error 
 			return err
 		}
 	}
+	if flags.llmAPIKey != "" {
+		fmt.Fprintln(os.Stderr,
+			"warning: --llm-api-key passes the secret via argv (visible in shell history "+
+				"and `ps` listings); prefer --llm-api-key-env for shared/CI environments.")
+	}
 	app.Logger.Info("codetalk", "backend", flags.backend, "model", flags.model, "endpoint", ep.String())
 
 	backend := strings.ToLower(flags.backend)

--- a/yoloswe/cmd/yoloswe/main.go
+++ b/yoloswe/cmd/yoloswe/main.go
@@ -320,12 +320,22 @@ func runCodeTalk(cmd *cobra.Command, args []string, flags *codeTalkFlags) error 
 		return err
 	}
 
-	// Build the endpoint only when the user actually opted in (any of the
-	// routing/auth flags non-empty). The wire flag defaults to "chat" so we
-	// can't include it in the gate; a bare `yoloswe codetalk "..."` invocation
-	// must produce a zero Endpoint that wrappers skip.
+	// Build the endpoint when the user touched any LLM flag. We rely on
+	// cobra's Changed() rather than non-empty checks so decoration-only flags
+	// (--llm-provider-name, --llm-wire-api, --llm-api-key) are routed through
+	// Validate() and surface as "partially configured" instead of silently
+	// dropping. A bare `yoloswe codetalk "..."` invocation never enters this
+	// branch and produces a zero Endpoint that wrappers skip.
 	var ep llmendpoint.Endpoint
-	if flags.llmBaseURL != "" || flags.llmAPIKey != "" || flags.llmAPIKeyEnv != "" {
+	llmFlags := []string{"llm-base-url", "llm-api-key", "llm-api-key-env", "llm-provider-name", "llm-wire-api"}
+	llmFlagSet := false
+	for _, f := range llmFlags {
+		if cmd.Flags().Changed(f) {
+			llmFlagSet = true
+			break
+		}
+	}
+	if llmFlagSet {
 		ep = llmendpoint.Endpoint{
 			BaseURL:      flags.llmBaseURL,
 			APIKey:       flags.llmAPIKey,

--- a/yoloswe/cmd/yoloswe/main.go
+++ b/yoloswe/cmd/yoloswe/main.go
@@ -296,6 +296,15 @@ endpoints.`,
 	cmd.Flags().StringVar(&flags.systemPrompt, "system", "", "Custom system prompt")
 	cmd.Flags().StringVar(&flags.llmBaseURL, "llm-base-url", "", "Custom LLM endpoint base URL")
 	cmd.Flags().StringVar(&flags.llmAPIKey, "llm-api-key", "", "Custom LLM API key — UNSAFE on shared/CI hosts (visible in shell history and `ps`); prefer --llm-api-key-env")
+	// Hide --llm-api-key from --help so the env-var path is the path of
+	// least resistance. The flag still works for local dev convenience but
+	// shouldn't show up in help output where operators discover defaults.
+	if err := cmd.Flags().MarkHidden("llm-api-key"); err != nil {
+		// Cobra only errors here when the flag was never registered; the
+		// preceding StringVar guarantees it was, so a non-nil err is a
+		// programming bug worth surfacing.
+		panic(fmt.Errorf("MarkHidden(llm-api-key): %w", err))
+	}
 	cmd.Flags().StringVar(&flags.llmAPIKeyEnv, "llm-api-key-env", "", "Env var name holding the LLM API key (e.g. BASETEN_API_KEY)")
 	cmd.Flags().StringVar(&flags.llmProviderName, "llm-provider-name", "", "Provider name label (codex model_providers.<name>)")
 	cmd.Flags().StringVar(&flags.llmWireAPI, "llm-wire-api", "chat", "Wire API: chat (OpenAI-compatible) or responses")
@@ -311,14 +320,19 @@ func runCodeTalk(cmd *cobra.Command, args []string, flags *codeTalkFlags) error 
 		return err
 	}
 
-	ep := llmendpoint.Endpoint{
-		BaseURL:      flags.llmBaseURL,
-		APIKey:       flags.llmAPIKey,
-		APIKeyEnv:    flags.llmAPIKeyEnv,
-		ProviderName: flags.llmProviderName,
-		Wire:         llmendpoint.WireAPI(flags.llmWireAPI),
-	}
-	if !ep.IsZero() {
+	// Build the endpoint only when the user actually opted in (any of the
+	// routing/auth flags non-empty). The wire flag defaults to "chat" so we
+	// can't include it in the gate; a bare `yoloswe codetalk "..."` invocation
+	// must produce a zero Endpoint that wrappers skip.
+	var ep llmendpoint.Endpoint
+	if flags.llmBaseURL != "" || flags.llmAPIKey != "" || flags.llmAPIKeyEnv != "" {
+		ep = llmendpoint.Endpoint{
+			BaseURL:      flags.llmBaseURL,
+			APIKey:       flags.llmAPIKey,
+			APIKeyEnv:    flags.llmAPIKeyEnv,
+			ProviderName: flags.llmProviderName,
+			Wire:         llmendpoint.WireAPI(flags.llmWireAPI),
+		}
 		if err := ep.Validate(); err != nil {
 			return err
 		}

--- a/yoloswe/codetalk.go
+++ b/yoloswe/codetalk.go
@@ -109,10 +109,10 @@ func (ct *CodeTalkSession) Start(ctx context.Context) error {
 		opts = append(opts, claude.WithResume(ct.config.ResumeSessionID))
 	}
 
-	// Always validate: a partial endpoint (decorations only) is IsZero=true
-	// at the wrapper gate but Validate() rejects it, so embedded callers see
-	// the same error surface as YAML/CLI users instead of silently dropping
-	// provider_name/wire/headers.
+	// codetalk runs the claude wrapper directly (not via multiagent.Provider),
+	// so it owns the Validate gate that the multiagent providers run in
+	// applyOptions().validate(). Without this a partially-decorated endpoint
+	// would silently route to the default upstream.
 	if err := ct.config.LLMEndpoint.Validate(); err != nil {
 		return err
 	}

--- a/yoloswe/codetalk.go
+++ b/yoloswe/codetalk.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude/render"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 )
 
 // CodeTalkSystemPrompt is the default system prompt for code understanding sessions.
@@ -30,6 +31,7 @@ When the user asks follow-up questions, explore further if your current understa
 
 // CodeTalkConfig holds configuration for a code understanding session.
 type CodeTalkConfig struct {
+	LLMEndpoint     llmendpoint.Endpoint
 	Model           string
 	WorkDir         string
 	RecordingDir    string
@@ -105,6 +107,10 @@ func (ct *CodeTalkSession) Start(ctx context.Context) error {
 
 	if ct.config.ResumeSessionID != "" {
 		opts = append(opts, claude.WithResume(ct.config.ResumeSessionID))
+	}
+
+	if !ct.config.LLMEndpoint.IsZero() {
+		opts = append(opts, claude.WithLLMEndpoint(ct.config.LLMEndpoint))
 	}
 
 	ct.session = claude.NewSession(opts...)

--- a/yoloswe/codetalk.go
+++ b/yoloswe/codetalk.go
@@ -109,6 +109,13 @@ func (ct *CodeTalkSession) Start(ctx context.Context) error {
 		opts = append(opts, claude.WithResume(ct.config.ResumeSessionID))
 	}
 
+	// Always validate: a partial endpoint (decorations only) is IsZero=true
+	// at the wrapper gate but Validate() rejects it, so embedded callers see
+	// the same error surface as YAML/CLI users instead of silently dropping
+	// provider_name/wire/headers.
+	if err := ct.config.LLMEndpoint.Validate(); err != nil {
+		return err
+	}
 	if !ct.config.LLMEndpoint.IsZero() {
 		opts = append(opts, claude.WithLLMEndpoint(ct.config.LLMEndpoint))
 	}


### PR DESCRIPTION
## Summary
- New `agent-cli-wrapper/llmendpoint` package: shared `Endpoint{BaseURL, APIKey, APIKeyEnv, ProviderName, Wire, Headers}` struct with `Validate`/`Redacted`/`ResolvedKey`. API keys never appear in `String()` output.
- `WithLLMEndpoint` option on **claude**, **cursor**, **acp/gemini**, and **codex** wrappers. Each wrapper translates the endpoint into the env vars + CLI flags that upstream CLI honors.
- **Codex** wrapper extended with `Env`/`AppServerArgs` fields and matching `WithEnv`/`WithAppServerArgs`/`WithLLMEndpoint`. The wrapper now generates `--config 'model_providers.<name>.{name,base_url,wire_api,env_key}'` followed by a final `--config 'model_provider="..."'` (last wins) and `process.go` passes them to `codex app-server` along with subprocess env.
- `agent.WithProviderLLMEndpoint(ep) ExecuteOption` threads through all four `multiagent/agent` providers. Codex/Gemini apply at client construction (subprocess args are immutable post-boot); claude/cursor apply per-execution.
- `jiradozer` config gained an `agent.llm_endpoint` YAML block inherited by every step, with a documented commented example. Bootstrap template updated; `TestExampleYAMLMatchesBootstrap` regression caught and fixed.
- New `yoloswe codetalk` subcommand with `--backend {claude,codex,gemini,cursor}` and `--llm-{base-url,api-key,api-key-env,provider-name,wire-api}` flags wires everything up end-to-end.

### Per-wrapper translation
| Wrapper | Env vars set | CLI args added |
|---|---|---|
| claude | `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY` | none |
| cursor | `OPENAI_BASE_URL`, `OPENAI_API_KEY` (best effort) | none |
| acp/gemini | `GEMINI_API_KEY`, `GOOGLE_GEMINI_BASE_URL`; for chat wire: `OPENAI_*` env + `--openai-base-url <url>` arg (key stays in env) | conditional |
| codex | `<APIKeyEnv>=ResolvedKey` | `--config 'model_providers.<name>.{...}'` × N, then `--config 'model_provider="<name>"'` |

### Verification
- `scripts/lint.sh` clean.
- `bazel build //...` clean.
- `bazel test //agent-cli-wrapper/... //multiagent/... //jiradozer/... //yoloswe/...` — 27 tests pass.
- New unit tests:
  - `llmendpoint`: validate/redact/resolve/no-leak round-trips.
  - `claude`/`cursor`/`acp`/`codex` `*_options_test.go`: assert env+args produced; codex test verifies `model_provider=...` is the last `--config` and that the API key never appears in `AppServerArgs`.
- Smoke test against Baseten + Kimi-K2.6 (via `BASETEN_API_KEY`):
  - Direct curl to `https://inference.baseten.co/v1/chat/completions` confirmed reachable with the key.
  - `yoloswe codetalk --backend claude --model moonshotai/Kimi-K2.6 --llm-base-url ... --llm-api-key ...` reached Baseten end-to-end (Claude CLI returned a model-shape mismatch, which is the expected upstream signal — env vars propagated correctly through SessionConfig → subprocess env → upstream CLI → Baseten).
  - Default-path regression check: `yoloswe codetalk --backend claude --model haiku` ran a full turn against the default Anthropic endpoint without issue.

### Upstream constraints (documented, not blockers)
- `codex 0.130.0` rejects `wire_api="chat"` (Responses-only). Baseten serves Chat Completions, so codex backend can't reach Baseten with this codex version. Wrapper still emits correct `--config`; upstream codex's own validation catches it. Will work as soon as codex restores chat support, or against any Responses-API endpoint today.
- `gemini 0.41.2` (this build) ignores `OPENAI_BASE_URL`. Wrapper sets the right env vars; this gemini build doesn't honor them. Plumbing is correct for any gemini build that does.
- Pre-existing integration test failures on `agent-cli-wrapper/{codex,cursor,claude}/integration` reproduce on bare `main` (verified via `git stash`); not caused by this change.

## Test plan
- [x] `scripts/lint.sh`
- [x] `bazel build //...`
- [x] `bazel test //agent-cli-wrapper/... //multiagent/... //jiradozer/... //yoloswe/...`
- [x] Smoke `yoloswe codetalk` against Baseten with claude backend (env-var plumbing verified end-to-end)
- [x] Default-path regression: `yoloswe codetalk --backend claude --model haiku`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider execution paths and subprocess boot configuration (env/args) across multiple backends, so misconfiguration could break routing or cause subtle behavior changes. Includes validation and extensive tests to reduce risk, but still impacts core agent invocation.
> 
> **Overview**
> Adds a shared `agent-cli-wrapper/llmendpoint` module and wires a new `WithLLMEndpoint` option through the ACP/gemini, Claude, Cursor, and Codex wrappers, translating a single endpoint config into the env vars/flags each upstream CLI actually honors.
> 
> Extends the Codex wrapper to support per-client subprocess `Env` and `AppServerArgs`, generating `codex app-server` `--config model_providers.*` overrides (plus auto-disabling known third-party-incompatible features) while keeping API keys out of argv.
> 
> Threads endpoint selection through `multiagent/agent` via `WithProviderLLMEndpoint`, adds validation and endpoint-divergence guards for long-lived providers (codex/gemini), updates `jiradozer` YAML to support inherited `llm_endpoint` config, and introduces a new `yoloswe codetalk` command with `--llm-*` flags plus manual integration coverage against a real third-party endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab7c7affb7d67f13ae7034c39a05bd7b22b06b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->