### PR TITLE
Reduce /pr-polish rounds-to-converge

### DIFF
--- a/.claude/skills/code-review-eval/data/eval-runs.log
+++ b/.claude/skills/code-review-eval/data/eval-runs.log
@@ -1052,3 +1052,38 @@ Notes:
   on resumed sessions, or accept that turn 3's value here is mostly
   the resume-fault detector, not a re-derivation.
 
+
+## 2026-05-10 — pr-polish-improvements
+
+Diff: 6 files, +1158/-31 lines (round-reduction work for /pr-polish: low_only_streak convergence, inter-round goal diff, modified-hunk spiral demote, session-reset-K, recover_envelope helper, A1 pre-commit checklist).
+
+| Config | Turn | Resume | Findings | FPs | Verdict | Confidence | Time | Tokens (in/out) |
+|--------|------|--------|----------|-----|---------|------------|------|-----------------|
+| cursor-composer2 | 1 | — | 2 (1H/1M) | 0 | rejected | 0.95/0.85 | 142s | — |
+| cursor-composer2 | 2 | ok | 3 (1H/2M) | 0 | rejected | 0.96/0.92/0.82 | 34s | — |
+| cursor-composer2 | 3 | ok | 3 (1H/2M) | 0 | rejected | 0.96/0.91/0.84 | 23s | — |
+| codex-5.4-mini | 1 | — | 2 (1H/1M) | 0 | rejected | 0.87/0.92 | 150s | 0/0 |
+| codex-5.4-mini | 2 | ok | 3 (1H/2M) | 0 | rejected | 0.95/0.92/0.83 | 119s | 0/0 |
+| codex-5.4-mini | 3 | ok | 3 (1H/2M) | 0 | rejected | 0.95/0.92/0.83 | 21s | 0/0 |
+| gemini-3.1-flash-lite-preview | 1 | — | 0 | — | accepted | — | 531s | 0/0 |
+| gemini-3.1-flash-lite-preview | 2 | ok | 0 | — | accepted | — | 1s | 0/0 |
+| gemini-3.1-flash-lite-preview | 3 | ok | 0 | — | accepted | — | 1s | 0/0 |
+
+Consensus (all 3, turn 1): none.
+Majority (2 of 3, turn 1): none. Becomes 2-of-3 by turn 2 on the recovery-substring bug (cursor turn 1 + codex turn 2).
+Unique to cursor (turn 1): _classify_recovery_verdict substring matching (high; `approve` matches `disapprove`, `changes` matches `exchanges`, etc., with empirical repro — verified post-hoc by directly calling the helper); parse-stream CLI fails to thread --mode (medium).
+Unique to codex (turn 1): modified-hunk spiral demote uses OR with evidence-absent rather than AND, can suppress real regressions on touched lines (high); low_only_streak missing-field default=0 breaks streak continuity on existing in-progress state files (medium).
+Unique to gemini (turn 1): nothing.
+Disagreements: gemini accepts (0 issues) while both other backends reject with at least one high finding apiece. This is a competence gap, not a phrasing disagreement.
+
+Both real bugs are confirmed: cursor's recovery-substring bug is a real correctness defect (running the helper on `"verdict error: disapprove not allowed"` returns `"accepted"`, silently salvaging an envelope that should stay rejected); codex's spiral-demote OR is a real false-negative risk (a single-source spiral whose cited line is inside any prior-round hunk gets demoted even when the cited code still exists at HEAD).
+
+Follow-up deltas:
+- cursor-composer2: turn 2 +1 new (negative-test gap for the substring fix at test_bramble_ops:2179, medium 0.92), tightens turn-1 high with explicit `disapprove`/`exchanges`/`ownership`/`blocking` repro, and adds a perf observation about parse_round being decoded twice. Turn 3 mirrors turn 2 with the negative-test entry rewritten to a different line anchor (2080 vs 2179) — same finding shape, same severities. Cursor's resume cadence is the most useful in this eval: the headline became sharper across turns.
+- codex-5.4-mini: turn 2 +1 new (independently flags the recovery substring bug at bramble_ops:1337, medium 0.83 — three turns later than cursor saw it); same two prior issues unchanged. Turn 3 is identical to turn 2 (same 3 issues, same line numbers, same suggestions), in 21s vs 118s — classic fresh-prompt-on-resumed-session degenerating to a cache of turn 2.
+- gemini-3.1-flash-lite-preview: 0 findings all three turns. Turn 1 took 531s of actual reading; turns 2 and 3 returned in 1s with "secondary/comprehensive review confirms initial assessment" summaries. Same fast-recall-from-summary pattern as prior runs.
+
+Notes:
+- Cross-backend complementarity is unusually clean here: each non-gemini backend caught one critical bug the other missed in turn 1. Running cursor + codex in parallel (the production /pr-polish setup) catches both highs in round 1, which is the relevant practical signal.
+- Codex turn 3 = turn 2 cache pattern is now consistent across four consecutive evals.
+- Gemini's "fast verdict from summary" on resume is now consistent across four consecutive evals; combined with the turn-1 0-issue verdict on a diff with two confirmed bugs, gemini-3.1-flash-lite-preview remains not viable as a sole reviewer.

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -45,9 +45,12 @@ PR/branch context is auto-detected by `pr_ops.py identify`.
 Class-level fixes beyond the cited line are logged in `comment_actions` as `source: "sweep"`, `comment_id: null`, `topic: "<original-topic> — class-level fix"`.
 
 **Convergence — stop when any one holds:**
-- Zero findings, or all remaining are low/nit.
-- Top-rated finding is a documented false positive.
+- Zero findings.
+- 2 consecutive rounds where top severity is low across all sources, AND every low has been fixed or recorded as `ack`/`wont_fix` with a written reason. The streak is persisted in `rounds[n].low_only_streak` (incremented when this round's `top_severity ∈ {low, nit, null}`, reset to 0 otherwise). Read it via `state-load`.
+- Top finding is a documented false positive AND the prior round had no `must_fix`.
 - Empty action plan after triage.
+
+If the last 2 rounds were low-only, treat as converged regardless of remaining `--rounds` budget — the streak rule wins over the budget. The motivation: the reviewer is incentivized to find *something* every round, and one persistent low keeps the loop alive forever otherwise. After two rounds where everything triaged was low/nit, the next round of fixes is rounding error.
 
 **Hard stop after N additional rounds.** When `additional_rounds_run` reaches `--rounds` without convergence, produce Final Summary, then `AskUserQuestion` whether to continue.
 
@@ -57,7 +60,7 @@ Bias for action and your own judgement with research. Only three things pause th
 
 1. **Integrity gate** — stale state file with PR mismatch (Step 0.5).
 2. **Budget gate** — `--rounds N` reached without convergence.
-3. **Regression gate** — **unverified** `spiral_matches` non-empty. Single-source spirals whose cited evidence is no longer at HEAD (within ±10 lines of the cited line) are auto-demoted to `batch_stale` with a `stale_reason` of `"spiral candidate auto-demoted: cited evidence absent at HEAD"` — the prior round fixed it and the resumed model is re-flagging stale context. Multi-source spirals (≥2 backends agree on the regression) always escalate. The audit row records `action: "stale"` with the demote reason. Cost of being wrong: a real regression that gets mis-demoted will likely re-surface next round — and if it does, the heuristic's evidence-at-HEAD check will find the cited code, so the second occurrence escalates correctly.
+3. **Regression gate** — **unverified** `spiral_matches` non-empty. Single-source spirals auto-demote to `batch_stale` when *either* of two heuristics fires: (a) the cited evidence is no longer at HEAD within ±10 lines of the cited line, or (b) the cited file:line falls inside a hunk that any prior round of this series modified (read from `head_before..head_after` of each prior round in state). Both are pure git/state lookups, no judgment. Multi-source spirals (≥2 backends agree) always escalate. The audit row records `action: "stale"` with the demote reason. Cost of being wrong: a real regression that gets mis-demoted will resurface next round, and the heuristic catches it on the second occurrence.
 
 ## State tracking
 
@@ -89,6 +92,7 @@ Schema:
       "skipped_count": 1,
       "top_severity": "high",
       "top_was_false_positive": false,
+      "low_only_streak": 0,
       "noise_filtered": 2,
       "noise_samples": [
         {"id": 4300306871, "author": "linear[bot]", "pattern": "linear-linkback"}
@@ -116,6 +120,8 @@ Schema:
 `{codex,cursor,gemini}_findings` hold raw issues from each backend's envelope, hydrated by `state-finalize-round`. The verbatim envelope is copied to `<state_dir>/reviews/r<n>-<backend>.json`. `gemini_findings` is omitted when `--gemini` was not passed.
 
 `noise_filtered` / `noise_samples` count bot process-noise dropped at fetch time (linear linkbacks, claude-bot progress posts). These never enter `comment_actions` — kept as a round-level audit trail. Samples capped at 5 entries.
+
+`low_only_streak` is incremented at finalize time when this round's `top_severity` is `low`, `nit`, or `null` (zero findings counts), reset to 0 otherwise. The convergence rule reads `>= 2` to trigger early exit; the goal-builder reads `>= 2` to inject a one-sentence pressure note (see "The goal channel" below).
 
 **`comment_actions` schema — load-bearing, other tooling depends on exact strings:**
 
@@ -215,9 +221,9 @@ Each round resumes the same bramble session, so the model accumulates context ac
 | Round | Goal text | Why |
 |---|---|---|
 | 1 | `$PR_SUMMARY` | First turn: establish PR-level intent and surface area. |
-| 2+, prior round had actions | Per-turn briefing: prior round's fixed/skipped + files changed | Tells resumed model what it actioned (so it doesn't re-flag fixes) and which files moved. |
-| 2+, no prior actions, files changed | `Round N.` + files-changed line | Even with no prior-round actions, a non-empty diff between rounds is worth orienting around. |
-| 2+, no prior actions, no diff | Falls back to `$PR_SUMMARY` | Re-anchor rather than send a goal that's just "Round N." |
+| 2+ | Per-turn briefing: prior round's fixed/skipped + files changed; falls back to `$PR_SUMMARY` when there's nothing to say | Tells the resumed model what was actioned (so it doesn't re-flag fixes) and which files moved. |
+
+Edge cases: when round 2+ has no prior-round actions but files did change, the goal opens with `Round N.` plus the files-changed line; when both are empty (pristine round, no diff since prior), we re-anchor to `$PR_SUMMARY` rather than send a goal that's just "Round N."
 
 Action-history shape (`action_history_goal`, only the immediately-prior round):
 
@@ -227,11 +233,13 @@ Skipped: b.py:42 wont_fix: design tradeoff; d.go:8 ack: rename helper.
 Files changed since round 5: a.go, b.py.
 ```
 
-The `fixed: X — topic; skipped: Y verb: reason` shape stops the resumed model from re-flagging its own prior findings. Source labels (`(codex)`/`(cursor)`) are deliberately omitted. Each entry capped at `_TOPIC_CHAR_CAP=80`; bucket capped at `_ACTION_HISTORY_CAP=20` with a `(N more)` suffix.
+The `fixed: X — topic; skipped: Y verb: reason` shape stops the resumed model from re-flagging its own prior findings. Source labels (`(codex)`/`(cursor)`) are deliberately omitted. Each entry capped at `_TOPIC_CHAR_CAP=80`; bucket capped at `_ACTION_HISTORY_CAP=20` with a `(N more)` suffix. The "Files changed" line is the diff between the prior round's `head_after` (falling back to `head_before` for an interrupted prior round) and current HEAD; omitted when empty.
 
-The "Files changed" line is the diff between the prior round's `head_after` (falling back to `head_before` for an interrupted prior round that never finalized) and current HEAD. Omitted when the diff is empty or `head_before` wasn't passed.
+**Inter-round diff (D1).** `bramble_ops.py goal` also appends `git diff <prior_head_after>..<HEAD>` (truncated at 200 lines with `...elided N lines` footer when over) under a `Diff since round N-1:` header. Skipped when the prior round never finalized or the SHAs are unreachable. The reviewer is resuming the same session and re-reading the worktree at launch; the diff between rounds is the actual delta worth scanning.
 
-The goal channel deliberately does **not** carry: the diff body (bramble re-snapshots the worktree), `stale` actions (already absent from the snapshot), per-finding rationale text written into PR replies, earlier rounds' actions (already in session history), or repeated round-1 PR_SUMMARY.
+**Convergence pressure when low-only streak ≥ 2 (B1).** When the prior round's `low_only_streak >= 2`, the goal-builder appends one sentence: "The last N rounds returned only low-severity findings. The fixer treats your output as authoritative, and every finding costs a round; if the diff has no structural issue, returning zero findings is the right call." One sentence, one trigger — not a table of phrasings. The reviewer is incentivized to find *something* every round and one persistent low keeps the loop alive forever otherwise; this just states the cost frame.
+
+The goal channel deliberately does **not** carry: `stale` actions (already absent from the snapshot), per-finding rationale text written into PR replies, earlier rounds' actions (already in session history), or repeated round-1 PR_SUMMARY.
 
 ## Step 2: Fetch existing PR comments + failing CI jobs
 
@@ -292,7 +300,7 @@ CURSOR_RESUME=$(python3 $SKILL_DIR/scripts/bramble_ops.py prior-session-id curso
                 --state-file "$STATE_FILE" --is-new-series "$IS_NEW_SERIES")
 ```
 
-`prior-session-id` returns empty across series boundaries so a new audit gets a fresh session.
+`prior-session-id` returns empty across series boundaries so a new audit gets a fresh session, and every K=4 rounds within a series (E2) — accumulated session context compounds staleness across long audits. Override with `--session-reset-k N`; pass 0 to disable. Spiral demote also fires (E1) when the cited file:line falls inside a hunk any prior round modified — see "Auto-decision rules → Regression gate". Both are pure git+state lookups; no judgment.
 
 When `IS_NEW_SERIES=1`, re-fetch PR comments and CI failures (prior series' fetch is now stale):
 
@@ -361,7 +369,7 @@ Monitor({
 
 Each Monitor runs independently; a crash in one doesn't affect the others. `timeout_ms=720000` is bramble's 10-minute `--timeout` plus two minutes of slack. `--skip-test-execution` defers tests to quality gates.
 
-If a backend envelope reports `status: "error"` but `review.raw_text` contains a fenced ```json``` block (cursor occasionally returns malformed JSON the wrapper can't unmarshal), recover by extracting the inner JSON, synthesizing a clean envelope, writing it to `<backend>-envelope-recovered.json`, and passing that path to `triage --stream`. Don't drop the round — the findings inside are still the model's review.
+If a backend envelope reports a verdict-validation `status: "error"` (cursor returning `approve_with_notes`, `request_changes`, etc.) with populated `review.issues` underneath, run `python3 $SKILL_DIR/scripts/bramble_ops.py recover-envelope <path>` and pass the printed path to `triage --stream`. The helper is idempotent — it returns the original path unchanged when no recovery applies, so it's safe to wrap every `--stream` argument unconditionally. Recovery vocabulary is documented in the helper's docstring.
 
 ### c) Triage
 
@@ -411,6 +419,18 @@ What good looks like by the end of this step:
 
 Skip if step d produced zero file changes.
 
+#### Pre-commit fix-completeness checklist
+
+Reviewers who see one site of a class-level problem will keep finding the next site round after round. Before running quality gates, read the diff against your fixes and answer five questions:
+
+1. **Sibling sites** — are there other call sites of the same producer / consumers of the same invariant? If yes, extend the fix or record the asymmetry below.
+2. **Tests** — will a reviewer ask for a regression test for this fix? If yes, add it now in the same commit.
+3. **Docs** — did this fix change a contract described in a godoc, README, or example file? Update those too.
+4. **Type contract** — did you add a new exported helper / method? Document its semantics in a godoc.
+5. **Symmetry** — did you fix this in N of M places (e.g. codex but not gemini)? List the M places explicitly and either fix all or record the asymmetry as `ack` with reasoning.
+
+These are questions, not MUSTs — the codebase decides. Recording an intentional asymmetry as `ack` with a one-line reason is fine and beats next round's finding. Silent partial fixes are the failure mode.
+
 Follow project quality gates (separate turn from any Monitor arm). On pass, commit locally with subject `pr-polish round {ROUND}: <summary>` and a body listing fixed/skipped findings. **Do NOT push.**
 
 **Before committing, ask whether the fix is durable.** For each finding addressed: would a reviewer running the same review on the new tree raise the same finding at a different site? If yes, that's a missed sibling — extend the fix. If you deliberately left a sibling unfixed (different semantics, different invariant), record it as `action: "ack"` with a one-line reason. Visible intentional non-uniformity beats next round's finding.
@@ -446,7 +466,7 @@ Round 3: codex=0, cursor=0 -> EXIT (converged)
 
 ## Step 4: Push once on loop exit
 
-**Why defer push.** Every push to a PR's branch triggers configured GitHub bots (CodeRabbit, Cursor Bugbot, etc.) to re-review. Mid-loop pushes burn bot budget on intermediate commits and reliably generate new comments on round-N-fix diffs — even when the fix was correct. Batching means bots see the polished tree; CI runs once on the final state.
+The loop accumulates commits locally and pushes once at the end so GitHub bots see the polished tree, not intermediate fix diffs. Full rationale lives at `references/why-defer-push.md`.
 
 Before pushing, check whether the remote already holds local HEAD — git-sync may have pushed during the run, and `origin/<branch>` can lag in worktrees. Use `pr_ops.py remote-head <branch>` (which routes through `git ls-remote`, not `git rev-parse origin/<branch>`) so the diagnostic reflects what the remote actually holds:
 

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -60,7 +60,7 @@ Bias for action and your own judgement with research. Only three things pause th
 
 1. **Integrity gate** — stale state file with PR mismatch (Step 0.5).
 2. **Budget gate** — `--rounds N` reached without convergence.
-3. **Regression gate** — **unverified** `spiral_matches` non-empty. Single-source spirals auto-demote to `batch_stale` when *either* of two heuristics fires: (a) the cited evidence is no longer at HEAD within ±10 lines of the cited line, or (b) the cited file:line falls inside a hunk that any prior round of this series modified (read from `head_before..head_after` of each prior round in state). Both are pure git/state lookups, no judgment. Multi-source spirals (≥2 backends agree) always escalate. The audit row records `action: "stale"` with the demote reason. Cost of being wrong: a real regression that gets mis-demoted will resurface next round, and the heuristic catches it on the second occurrence.
+3. **Regression gate** — **unverified** `spiral_matches` non-empty. Single-source spirals auto-demote to `batch_stale` when *either* of two heuristics fires: (a) the cited evidence is no longer at HEAD within ±10 lines of the cited line, or (b) the cited file:line falls inside a hunk that the **immediately-prior** round modified (read from `head_before..head_after` of round N-1 only — not any ancestor round, which would let a long audit suppress real regressions on any file an early round happened to touch). Both are pure git/state lookups, no judgment. Multi-source spirals (≥2 backends agree) always escalate. The audit row records `action: "stale"` with the demote reason. Cost of being wrong: a real regression that gets mis-demoted will resurface next round, and the heuristic catches it on the second occurrence.
 
 ## State tracking
 

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -42,6 +42,8 @@ PR/branch context is auto-detected by `pr_ops.py identify`.
 
 **A finding is a symptom; the fix is the cure.** Each cited finding observes one underlying problem. Before patching, identify the actual invariant being violated, look for sibling sites in the same module, and decide whether the right fix is at the cited line or upstream. A defensive guard at every consumer often signals a producer should normalize once. If docs or tests pin the contract that just changed, they're part of the same fix. A cascade of medium-severity rounds is usually one missed invariant.
 
+**The reviewer now names invariants for you.** Bramble code-review v2 lets the model emit `issues[].invariant` + `issues[].sites[]` when it finds N ≥ 2 sibling sites of one rule. When a finding carries `invariant`, the goal-builder mirrors the name into next round's prompt so the resumed reviewer folds new sites into the same finding rather than re-flagging per-site. Two reviewers naming the same invariant — even at different sites — also form consensus, routing every site to `must_fix` in one triage pass. Read `comment_actions[].invariant` when triaging: if it's set, the producer-side fix is usually the right move; record any consumer site you intentionally leave alone as `ack` with the reason.
+
 Class-level fixes beyond the cited line are logged in `comment_actions` as `source: "sweep"`, `comment_id: null`, `topic: "<original-topic> — class-level fix"`.
 
 **Convergence — stop when any one holds:**
@@ -106,12 +108,17 @@ Schema:
           "line": 142,
           "severity": "high",
           "topic": "missing error handling for BUILDER_LITE",
+          "invariant": "ambient env vars shadow explicit proxy keys",
           "action": "fixed",
           "reason": null,
           "commit_sha": "abc123f",
           "reply_url": "https://github.com/owner/repo/pull/2318#discussion_r2034881234"
         }
-      ]
+      ],
+      "sufficiency_claims": {
+        "codex": {"is_confident_complete": true, "evidence": "all named invariants addressed; remaining medium issues are doc-only"},
+        "cursor": {"is_confident_complete": false, "evidence": "suspect more sites in src/streaming/"}
+      }
     }
   ]
 }
@@ -137,6 +144,9 @@ Schema:
   - `stale` — cited code no longer exists.
   - `pre_existing` — `source: "ci"` only. Failure also fails on base branch; `reason` cites `ci-compare-base` output. Counts as skipped.
   - `flake` — `source: "ci"` only. `reason` names the `flake_reason` (ETXTBSY, bazel cache, `ci_deadline`). Counts as skipped.
+- `invariant` (optional, v2): name of the class-level rule the reviewer claimed when it emitted an `invariant + sites[]` finding. Surfaced verbatim from the envelope. Reviewer-emitted; the orchestrator does not synthesize. Used by the next round's goal-builder to remind the resumed reviewer to fold new sites into the same finding rather than re-flag.
+
+**`sufficiency_claims` (optional, v2)**: per-backend dict capturing each reviewer's self-assessment for this round. Each entry: `{"is_confident_complete": bool, "evidence": "..."}`. Populated by `state-finalize-round` when the envelope's `review.sufficiency` is present. Absence means the reviewer didn't claim either way — do not infer. The orchestrator surfaces consensus claims in round summaries and final reports as audit-trail context; this is NOT a new exit gate, the existing convergence rules still decide.
 
 **Context token for state subcommands.** All `state-*` take a single positional `ctx` — the bare PR number when one exists, otherwise `branch:<name>`.
 
@@ -155,28 +165,23 @@ python3 $SKILL_DIR/scripts/pr_ops.py identify
 
 Returns `{pr_number, title, url, base, head, branch, owner, repo, owner_repo, state_dir, state_file}`. `pr_number` is `null` for branches without a PR — the rest of the flow still works, just with PR-comment and CI-failure fetches skipped. Pin `$CTX` to either the PR number or `branch:<head>`.
 
-### Step 0.1: Pick the bramble binary
-
-Prefer the freshly-built worktree artifact (matches the code under review); otherwise fall back to PATH:
-
-```
-export BRAMBLE_BIN="$([ -x "$(pwd)/bazel-bin/bramble/bramble_/bramble" ] \
-    && echo "$(pwd)/bazel-bin/bramble/bramble_/bramble" \
-    || echo bramble)"
-```
-
-Every `bramble code-review` invocation must reference `$BRAMBLE_BIN`.
-
-### Step 0.2: Bramble must support `--resume-session-id`
-
-Continuous review is the whole reason this skill exists. Probe once and fail fast:
+### Step 0.1: Preflight — resolve binaries + helpers in one call
 
 ```bash
-"$BRAMBLE_BIN" code-review --help 2>&1 | grep -q -- '--resume-session-id' || {
-  echo "error: '$BRAMBLE_BIN' does not support --resume-session-id." >&2
+PREFLIGHT=$(python3 $SKILL_DIR/scripts/pr_ops.py preflight)
+export BRAMBLE_BIN=$(echo "$PREFLIGHT" | jq -r .bramble_bin)
+GIT_SYNC=$(echo "$PREFLIGHT" | jq -r .git_sync_path)
+# Non-empty errors[] means a hard precondition failed (bramble missing
+# --resume-session-id support, git-sync not on disk). Surface the list
+# and exit before launching any Monitor.
+if [ "$(echo "$PREFLIGHT" | jq -r '.errors | length')" != "0" ]; then
+  echo "preflight errors:" >&2
+  echo "$PREFLIGHT" | jq -r '.errors[]' >&2
   exit 1
-}
+fi
 ```
+
+`preflight` resolves the bramble binary (preferring the worktree-local `bazel-bin/` artifact over `$PATH`), probes for `--resume-session-id` support, locates `git:sync-base/git-sync.py` (skill-local → installed fallback), and probes for `--no-push` support. Every `bramble code-review` invocation references `$BRAMBLE_BIN`.
 
 ## Step 0.5: Resume check
 
@@ -207,10 +212,14 @@ When you need to know whether the local branch and remote are in sync (e.g. surf
 ## Step 1: Sync base via /git:sync-base
 
 ```
-python3 .claude/skills/git:sync-base/git-sync.py --verbose
+python3 .claude/skills/git:sync-base/git-sync.py --verbose --no-push
 ```
 
-That script owns rebasing onto `origin/<base>` and force-pushing the rebased branch with precise-lease. Do not reimplement. On conflict (exit 2) **abort with `state-mark-complete <ctx> sync-conflict`** and emit Final Summary pointing at the conflict — do not pause mid-run.
+That script owns rebasing onto `origin/<base>`. Pass `--no-push` so the rebase stays local — the loop accumulates commits and pushes once at Step 4, matching the "no mid-loop push" promise at the top of this file. Without `--no-push` the script force-pushes the rebased branch immediately and triggers GitHub bots before round 1's review even starts.
+
+**Clean-tree preflight.** Before invoking git-sync, if `git status --porcelain` is non-empty AND state has no in-progress round to resume, print one line ("uncommitted changes — commit, stash, or rebase manually before /pr-polish") and call `state-mark-complete <ctx> dirty-tree-preflight`. Do NOT `AskUserQuestion`. Snapshot-commit-before-push races (codex-feedback 2026-05-19, item #2) come from skipping this gate; the local snapshot + base-sync push showed bots an intermediate tree.
+
+On conflict (exit 2) **abort with `state-mark-complete <ctx> sync-conflict`** and emit Final Summary pointing at the conflict — do not pause mid-run.
 
 Build a short `$PR_SUMMARY` from `git log --oneline origin/<base>..HEAD` + diff-stat (≤10 lines). Pass it to `bramble_ops.py goal` every round.
 
@@ -287,7 +296,19 @@ SCOPE_HINTS=$(python3 $SKILL_DIR/scripts/scope_gate.py \
 
 Then arm Monitors in the same turn — codex + cursor + lint always, plus gemini when `--gemini`. Bramble Monitors pass `--scope-hints-file "$SCOPE_HINTS"`; lint has its own diff walk.
 
-Compute the round's `--goal` text and per-backend resume id:
+Compute the round's `--goal` text and per-backend resume id. Either run the helpers individually, or pull everything in one call via `round-bundle` and split with `jq`:
+
+```bash
+BUNDLE=$(python3 $SKILL_DIR/scripts/pr_ops.py round-bundle "$CTX" {ROUND})
+GOAL=$(echo "$BUNDLE" | jq -r .goal_text)
+CODEX_RESUME=$(echo "$BUNDLE" | jq -r '.resume_ids.codex')
+CURSOR_RESUME=$(echo "$BUNDLE" | jq -r '.resume_ids.cursor')
+# round-bundle threads its own PR_SUMMARY-free goal; on round 1 you still
+# want `$PR_SUMMARY` as the goal, so override:
+[ "{ROUND}" = "1" ] && GOAL="$PR_SUMMARY"
+```
+
+Or the long form, one helper per piece:
 
 ```bash
 GOAL=$(python3 $SKILL_DIR/scripts/bramble_ops.py goal {ROUND} \
@@ -371,6 +392,8 @@ Each Monitor runs independently; a crash in one doesn't affect the others. `time
 
 If a backend envelope reports a verdict-validation `status: "error"` (cursor returning `approve_with_notes`, `request_changes`, etc.) with populated `review.issues` underneath, run `python3 $SKILL_DIR/scripts/bramble_ops.py recover-envelope <path>` and pass the printed path to `triage --stream`. The helper is idempotent — it returns the original path unchanged when no recovery applies, so it's safe to wrap every `--stream` argument unconditionally. Recovery vocabulary is documented in the helper's docstring.
 
+**Back-compat note (v2 envelopes).** The bramble code-review wrapper now normalizes common verdict aliases (`approve_with_notes`/`approve`/`lgtm`/`request_changes`/etc.) inside `validateReviewBody` so envelopes emitted by an up-to-date bramble already carry the canonical `accepted`/`rejected` token — `recover-envelope` becomes a no-op there. Keep wrapping `--stream` arguments unconditionally so older envelopes (e.g. when an operator runs an unbuilt bramble) still recover; the cost is one stat() per stream.
+
 ### c) Triage
 
 ```
@@ -448,9 +471,21 @@ python3 $SKILL_DIR/scripts/pr_ops.py state-finalize-round $CTX $ROUND $(git rev-
     $( [ "$USE_GEMINI" = "1" ] && echo --envelope gemini=$ENVELOPE_GEMINI )
 ```
 
-`--envelope` flags tell finalize where to read each backend's envelope so `rounds[n].session_ids` and `resume_status` populate for next round's resume plumbing. Pass `--envelope lint=...` too — it has no session id, but its envelope feeds `lint_findings` into the persisted reviews directory. Backends not passed are skipped (no automatic fallback).
+`--envelope` flags tell finalize where to read each backend's envelope so `rounds[n].session_ids`, `resume_status`, and `sufficiency_claims` populate for next round's resume plumbing and the final report. Pass `--envelope lint=...` too — it has no session id, but its envelope feeds `lint_findings` into the persisted reviews directory. Backends not passed are skipped (no automatic fallback).
 
 `state-finalize-round` auto-populates `rounds[n].ci_findings` from `ci_failed_tests` when a PR exists; branch-only runs leave it empty.
+
+**One-shot variant for the round-summary line.** When you want the orchestrator-visible audit-trail digest in the same call, use `finalize-and-report` instead. Same finalize semantics; emits `{converged_signal, exit_reason_hint, low_only_streak, top_severity, sufficiency_consensus, next_round_n, round_summary}` so the loop printout in Step 3.g doesn't need separate `jq` calls into the state file:
+
+```bash
+python3 $SKILL_DIR/scripts/pr_ops.py finalize-and-report $CTX $ROUND $(git rev-parse HEAD) \
+    $STATE_DIR/actions-r$ROUND.json \
+    --envelope codex=$ENVELOPE_CODEX --envelope cursor=$ENVELOPE_CURSOR \
+    --envelope lint=$ENVELOPE_LINT \
+    $( [ "$USE_GEMINI" = "1" ] && echo --envelope gemini=$ENVELOPE_GEMINI )
+```
+
+`converged_signal` mirrors the existing convergence rules (low_only_streak ≥ 2, or top_severity ∈ {low, nit, null} with no fix/skip activity). It's a *hint*, not a gate — convergence prose at the top of this file is still authoritative. Sufficiency consensus is purely audit-trail context; do NOT treat it as a new exit rule.
 
 ### g) Convergence check
 

--- a/.claude/skills/pr-polish/references/why-defer-push.md
+++ b/.claude/skills/pr-polish/references/why-defer-push.md
@@ -1,0 +1,12 @@
+# Why /pr-polish defers push until loop exit
+
+Every push to a PR's branch triggers configured GitHub bots (CodeRabbit, Cursor Bugbot, etc.) to re-review. Mid-loop pushes burn bot budget on intermediate commits and reliably generate new comments on round-N-fix diffs — even when the fix was correct.
+
+Batching has two payoffs:
+
+1. Bots see the final, polished tree once instead of N intermediate trees, so the comment stream represents what's actually being merged.
+2. CI runs once on the final state instead of N times on transient WIP, freeing runner capacity for other PRs.
+
+The trade-off is recoverability: if the loop crashes mid-run, local commits exist but no remote backup. The state file at `~/.bramble/projects/<repo>-<pr>/pr-polish-state.json` captures the per-round commit SHAs so the next invocation can pick up where it left off; full audit trail survives even when push never happens.
+
+This is a deliberate inversion of the "push early, push often" default: pr-polish optimizes for bot signal-to-noise, not git resilience, because the loop is short (minutes, not days) and the work is reproducible from the same review inputs.

--- a/.claude/skills/pr-polish/scripts/bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/bramble_ops.py
@@ -303,12 +303,15 @@ _LOW_STREAK_PRESSURE_THRESHOLD = 2
 
 
 def _low_only_streak_pressure(state: dict[str, Any] | None, round_: int) -> str:
-    """Return the convergence-pressure sentence when streak >= 2, else ""
+    """Return the convergence-pressure sentence when streak >= 2, else "".
 
     Reads the immediately-prior round's ``low_only_streak`` rather than
-    walking history — the counter is finalize-time persistent. The
-    sentence is appended to whatever ``goal_for_round`` produces, so
-    triage routing and action-history are unaffected.
+    walking history — the counter is finalize-time persistent. Falls back
+    to reconstructing the streak from ``top_severity`` history when the
+    field is missing (state file from before low_only_streak existed) so
+    upgraded mid-loop runs don't lose streak continuity. The sentence is
+    appended to whatever ``goal_for_round`` produces, so triage routing
+    and action-history are unaffected.
 
     Wording is fixed: it states a fact ("the last N rounds returned only
     low-severity findings") and a frame ("every finding costs a round")
@@ -322,7 +325,14 @@ def _low_only_streak_pressure(state: dict[str, Any] | None, round_: int) -> str:
     if not prior:
         return ""
     prev = max(prior, key=lambda r: r.get("n") or 0)
-    streak = prev.get("low_only_streak") or 0
+    streak = prev.get("low_only_streak")
+    if streak is None:
+        # Lazy import to avoid pulling pr_ops at module load (pr_ops
+        # already lazy-imports bramble_ops; the inverse is fine when
+        # gated to one fallback path).
+        from pr_ops import _backfill_low_only_streak  # noqa: PLC0415
+
+        streak = _backfill_low_only_streak(prior)
     if streak < _LOW_STREAK_PRESSURE_THRESHOLD:
         return ""
     return (
@@ -1340,17 +1350,26 @@ def _classify_recovery_verdict(error_text: str) -> str | None:
     Looks for verdict-validation language. Anything ambiguous (no verdict
     keyword, or a recognized non-merge verdict like ``comment``) returns
     None so the caller treats it as "no recovery applicable".
+
+    Token matching is word-boundary aware (``\\b`` regex), not raw
+    substring: bare ``token in t`` would classify ``disapprove`` →
+    ``accepted`` (because ``approve`` is a substring) and ``exchanges``
+    → ``rejected`` (because ``changes`` is a substring), silently
+    salvaging envelopes that should stay rejected. Word boundaries
+    treat both ``-`` and ``_`` as separators (so ``approve_with_notes``
+    and ``needs-changes`` still match), which is what we want for
+    verdict tokens that come in either spelling.
     """
     if not error_text:
         return None
     t = error_text.lower()
-    if "verdict" not in t:
+    if not re.search(r"\bverdict\b", t):
         return None
     for token in _RECOVERY_ACCEPTED_TOKENS:
-        if token in t:
+        if re.search(rf"(?<![A-Za-z0-9]){re.escape(token)}(?![A-Za-z0-9])", t):
             return "accepted"
     for token in _RECOVERY_REJECTED_TOKENS:
-        if token in t:
+        if re.search(rf"(?<![A-Za-z0-9]){re.escape(token)}(?![A-Za-z0-9])", t):
             return "rejected"
     return None
 
@@ -1518,18 +1537,26 @@ def _parse_hunk_ranges(diff_text: str) -> list[tuple[int, int]]:
 
 def prior_round_modified_hunks(
     state: dict[str, Any] | None,
+    *,
+    only_round: int | None = None,
 ) -> dict[str, list[tuple[int, int]]]:
     """Map each file path to ``[(start, end), ...]`` line ranges modified by
-    any prior round's commit (``head_before..head_after``).
+    a prior round's commit (``head_before..head_after``).
 
-    Returns ``{}`` when state is missing or no prior round has both SHAs.
-    Pure git plumbing — runs ``git diff -U0 <head_before>..<head_after>``
-    once per prior round, parses hunk headers, unions ranges per file.
+    With ``only_round=N``, only that round's hunks are returned. Default
+    behavior unions across all prior rounds. Triage passes the
+    immediately-prior round (current_round - 1) so the demote heuristic
+    only fires on findings that landed inside the most recent fix's
+    edited region — older rounds' edits are part of the stable
+    background and a finding there is more likely a real lingering bug
+    than stale session context. Without this narrowing, a long audit
+    accumulates touched ranges and starts demoting real regressions
+    just because a long-ago round happened to edit the same file.
 
-    The SKILL feeds this into ``triage`` so a single-source spiral whose
-    cited line falls inside a prior-round-modified hunk auto-demotes to
-    ``batch_stale`` — the reviewer is replaying cached context against
-    code we already moved.
+    Returns ``{}`` when state is missing, or no matching round has both
+    head_before and head_after. Pure git plumbing — runs
+    ``git diff -U0 <head_before>..<head_after>`` once per matching
+    round, parses hunk headers, unions ranges per file.
     """
     if not state:
         return {}
@@ -1538,6 +1565,8 @@ def prior_round_modified_hunks(
     out: dict[str, list[tuple[int, int]]] = {}
     rounds = state.get("rounds") or []
     for rnd in rounds:
+        if only_round is not None and (rnd.get("n") or 0) != only_round:
+            continue
         head_before = rnd.get("head_before")
         head_after = rnd.get("head_after")
         if not head_before or not head_after or head_before == head_after:
@@ -1877,7 +1906,21 @@ def main(argv: list[str] | None = None) -> int:
             # doesn't spam stderr with "unreachable SHA" warnings.
             modified_hunks: dict[str, list[tuple[int, int]]] | None = None
             if resolved_mode == REVIEW_MODE_CODE:
-                modified_hunks = prior_round_modified_hunks(prior)
+                # Narrow to the immediately-prior round so the demote
+                # heuristic doesn't accumulate touched ranges across a
+                # long audit (which would suppress real regressions on
+                # any file an early round happened to touch). The
+                # use case it's designed for — doc-comment fix shifts
+                # words within the same function — is N→N+1, not "any
+                # ancestor round".
+                last_round = max(
+                    (r.get("n") or 0 for r in (prior.get("rounds") or [])),
+                    default=0,
+                ) if prior else 0
+                if last_round > 0:
+                    modified_hunks = prior_round_modified_hunks(
+                        prior, only_round=last_round
+                    )
             result = triage(
                 findings,
                 prior_fixed_keys(prior, resolved_mode),

--- a/.claude/skills/pr-polish/scripts/bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/bramble_ops.py
@@ -302,6 +302,42 @@ def _skipped_label(action: dict[str, Any], verb: str) -> str:
 _LOW_STREAK_PRESSURE_THRESHOLD = 2
 
 
+def _prior_invariants_note(state: dict[str, Any] | None, round_: int) -> str:
+    """Return a one-line "prior invariants" signal for the goal, or "".
+
+    Walks the immediately-prior round's ``comment_actions`` for entries
+    that carry an ``invariant`` field. Emits a single line listing each
+    distinct invariant name so the resumed reviewer sees them as
+    structured data, not free-form action history. The reviewer is then
+    told (by the wrapper's follow-up prompt) to fold new sites into the
+    existing invariant's sites[] array rather than re-flagging.
+
+    Reads from prior round only — same scoping as the spiral guard's
+    modified-hunk heuristic. A long audit shouldn't drag every old
+    invariant into every turn's goal.
+    """
+    if not state or round_ < 2:
+        return ""
+    rounds = state.get("rounds") or []
+    prior = [r for r in rounds if (r.get("n") or 0) < round_]
+    if not prior:
+        return ""
+    prev = max(prior, key=lambda r: r.get("n") or 0)
+    seen: list[str] = []
+    for action in prev.get("comment_actions") or []:
+        inv = action.get("invariant")
+        if inv and inv not in seen:
+            seen.append(inv)
+    if not seen:
+        return ""
+    bulleted = "".join(f"\n- {inv}" for inv in seen)
+    return (
+        "Invariants named in the prior round (fold new sites into the "
+        "existing finding's sites[] array, do not re-flag as separate "
+        f"issues):{bulleted}"
+    )
+
+
 def _low_only_streak_pressure(state: dict[str, Any] | None, round_: int) -> str:
     """Return the convergence-pressure sentence when streak >= 2, else "".
 
@@ -385,6 +421,9 @@ def goal_for_round(
     history = action_history_goal(state, round_, head_before=head_before)
     body = history or pr_summary
     parts = [body]
+    invariants = _prior_invariants_note(state, round_)
+    if invariants:
+        parts.append(invariants)
     pressure = _low_only_streak_pressure(state, round_)
     if pressure:
         parts.append(pressure)
@@ -546,22 +585,82 @@ def parse_envelope(obj: dict[str, Any] | None, *, source: str) -> list[dict[str,
     out = []
     for i in issues:
         msg = i.get("message") or ""
-        finding = {
-            "source": source,
-            "severity": i.get("severity"),
-            "message": msg,
-            "suggestion": i.get("suggestion"),
-            "topic": topic_of(msg),
-            "review_mode": mode,
-        }
+        # v2 schema: a code-mode issue may carry an "invariant" + "sites"
+        # array when the reviewer found N sibling sites of one class-level
+        # rule. We expand to N findings sharing the same invariant and
+        # topic so the existing (file, line) consensus and per-site fix
+        # routing keeps working unchanged — the orchestrator sees N
+        # actionable rows, each labeled with the invariant they belong to.
+        # File/line at the top of the issue is the representative site
+        # (validated to match one entry in sites[]); we don't double-emit
+        # it. Design-doc mode doesn't carry sites[].
+        invariant = i.get("invariant") or None
+        sites = i.get("sites") or []
+        topic = topic_of(msg)
+
+        def _build_base() -> dict[str, Any]:
+            base: dict[str, Any] = {
+                "source": source,
+                "severity": i.get("severity"),
+                "message": msg,
+                "suggestion": i.get("suggestion"),
+                "topic": topic,
+                "review_mode": mode,
+            }
+            if invariant:
+                base["invariant"] = invariant
+            return base
+
         if mode == REVIEW_MODE_DESIGN_DOC:
+            finding = _build_base()
             finding["section"] = i.get("section")
             finding["dimension"] = i.get("dimension")
+            out.append(finding)
+            continue
+
+        if sites:
+            # Expand sites[] to one finding per site. The validator
+            # guarantees file/line at the top matches one entry, so the
+            # representative-site row is already covered by the loop.
+            for site in sites:
+                finding = _build_base()
+                finding["file"] = site.get("file")
+                finding["line"] = site.get("line")
+                note = site.get("note")
+                if note:
+                    finding["site_note"] = note
+                out.append(finding)
         else:
+            finding = _build_base()
             finding["file"] = i.get("file")
             finding["line"] = i.get("line")
-        out.append(finding)
+            out.append(finding)
     return out
+
+
+def parse_sufficiency(obj: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the reviewer's per-turn sufficiency claim, or None.
+
+    Reviewer schema v2 lets the model emit a top-level
+    ``review.sufficiency`` object with ``is_confident_complete`` (bool)
+    and ``evidence`` (string). It's an audit-trail signal — the
+    orchestrator surfaces it in round summaries and the final report but
+    does NOT use it as a new exit gate. Absence means no signal; do not
+    synthesize a default.
+    """
+    if obj is None:
+        return None
+    if (obj.get("status") or "") != "ok":
+        return None
+    suff = (obj.get("review") or {}).get("sufficiency")
+    if not isinstance(suff, dict):
+        return None
+    if "is_confident_complete" not in suff:
+        return None
+    return {
+        "is_confident_complete": bool(suff.get("is_confident_complete")),
+        "evidence": suff.get("evidence") or "",
+    }
 
 
 def parse_round(
@@ -1040,6 +1139,54 @@ def triage(
             )
             for g in group:
                 consensus_triage_keys.add(_triage_key(g, resolved_mode))
+
+    # Invariant-tier consensus (v2 schema, code mode only). Two reviewers
+    # naming the same invariant — even at different sites — are claiming
+    # the same class-level rule. Reward that: route every finding sharing
+    # the invariant to must_fix as one consensus row, even when no two
+    # findings shared a (file, line). Codex saying "ambient env vars
+    # shadow explicit proxy keys" at site A and cursor saying the same
+    # invariant at site B is exactly the signal we want to fold.
+    #
+    # Skipped in design-doc mode: the rubric dimension already partitions
+    # class-level claims there, and the invariant field is reserved for
+    # code mode in the wrapper schema.
+    if resolved_mode == REVIEW_MODE_CODE:
+        by_invariant: dict[str, list[dict[str, Any]]] = {}
+        for f in fresh_findings:
+            inv = f.get("invariant")
+            if not inv:
+                continue
+            by_invariant.setdefault(inv, []).append(f)
+        for inv, group in by_invariant.items():
+            sources = {g["source"] for g in group}
+            if len(sources) < 2:
+                # Single-source named invariant: leave it to per-site
+                # dispatch. Each site already routes individually, so the
+                # invariant name surfaces in the action_plan via the
+                # finding's invariant field without a forced consensus
+                # row.
+                continue
+            # Mark every site-finding's triage_key as handled so the
+            # per-key loop below doesn't double-list these under
+            # single_critical/medium when they have N sites.
+            already_consensus = False
+            for g in group:
+                tk = _triage_key(g, resolved_mode)
+                if tk in consensus_triage_keys:
+                    already_consensus = True
+                consensus_triage_keys.add(tk)
+            if already_consensus:
+                # Location-based pass already counted this; don't double-
+                # list, but the triage_key set is now wider so per-key
+                # dispatch won't re-route the additional sites.
+                continue
+            consensus.append({
+                "key": ["invariant", inv],
+                "sources": sorted(sources),
+                "invariant": inv,
+                "findings": group,
+            })
 
     single_critical: list[dict[str, Any]] = []
     single_medium: list[dict[str, Any]] = []

--- a/.claude/skills/pr-polish/scripts/bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/bramble_ops.py
@@ -79,6 +79,14 @@ _ACTION_HISTORY_CAP = 20
 # can't blow the whole prompt.
 _TOPIC_CHAR_CAP = 80
 
+# Default truncation cap for the inter-round diff appended to the goal
+# channel (D1). 200 lines is roughly the same order of magnitude as a
+# typical round's commit; bigger diffs almost always indicate a rebase
+# or tooling-generated change that the reviewer doesn't need to re-read
+# inline. Defined here at module top because ``goal_for_round`` (defined
+# above ``round_diff``) consumes it as a default-argument value.
+_ROUND_DIFF_DEFAULT_MAX_LINES = 200
+
 
 def _is_first_round_of_series(state: dict[str, Any] | None, n: int) -> bool:
     """Mirror of pr_ops._is_first_round_of_series.
@@ -286,6 +294,45 @@ def _skipped_label(action: dict[str, Any], verb: str) -> str:
     return f"{base} {verb}"
 
 
+# Streak threshold above which the goal channel injects a one-sentence
+# convergence-pressure note. Two consecutive low-only rounds is the
+# earliest point at which "every finding costs a round, returning zero
+# is a real option" stops sounding presumptuous; at one low-only round
+# it's normal noise floor, at three+ the streak rule itself fires.
+_LOW_STREAK_PRESSURE_THRESHOLD = 2
+
+
+def _low_only_streak_pressure(state: dict[str, Any] | None, round_: int) -> str:
+    """Return the convergence-pressure sentence when streak >= 2, else ""
+
+    Reads the immediately-prior round's ``low_only_streak`` rather than
+    walking history — the counter is finalize-time persistent. The
+    sentence is appended to whatever ``goal_for_round`` produces, so
+    triage routing and action-history are unaffected.
+
+    Wording is fixed: it states a fact ("the last N rounds returned only
+    low-severity findings") and a frame ("every finding costs a round")
+    rather than prescribing a verdict. Per the skill's framing: don't
+    encode a table of phrasings keyed to streak length.
+    """
+    if not state or round_ < 2:
+        return ""
+    rounds = state.get("rounds") or []
+    prior = [r for r in rounds if (r.get("n") or 0) < round_]
+    if not prior:
+        return ""
+    prev = max(prior, key=lambda r: r.get("n") or 0)
+    streak = prev.get("low_only_streak") or 0
+    if streak < _LOW_STREAK_PRESSURE_THRESHOLD:
+        return ""
+    return (
+        f"The last {streak} rounds returned only low-severity findings. "
+        "The fixer treats your output as authoritative, and every finding "
+        "costs a round; if the diff has no structural issue, returning "
+        "zero findings is the right call."
+    )
+
+
 def goal_for_round(
     round_: int,
     pr_summary: str,
@@ -293,6 +340,8 @@ def goal_for_round(
     *,
     head_before: str | None = None,
     is_new_series: bool | None = None,
+    include_round_diff: bool = True,
+    round_diff_max_lines: int = _ROUND_DIFF_DEFAULT_MAX_LINES,
 ) -> str:
     """Return the ``--goal`` text bramble should see for this round.
 
@@ -302,20 +351,45 @@ def goal_for_round(
     ``action_history_goal``. Falls back to PR_SUMMARY when there's
     nothing to say (e.g. round 1 produced an empty action plan).
 
+    Round 2+ also gets:
+      - When the prior round's ``low_only_streak`` is >= 2, a one-line
+        convergence-pressure sentence appended (B1).
+      - When ``include_round_diff`` is True and the prior round's
+        ``head_after`` is reachable, the diff between the prior round's
+        HEAD and this round's HEAD is appended under a "Diff since
+        round N-1" header (D1). Truncated at ``round_diff_max_lines``.
+
     ``head_before`` is this round's HEAD, used to compute the
-    files-changed-since-prior-round line.
+    files-changed-since-prior-round line and the round diff.
 
     ``is_new_series`` is the orchestrator's series-boundary decision
     captured at Step 0.5 (before ``state_append_round`` clears
     ``completed: true``). When true, the round is a real round 1 from
     the model's perspective even when ``round_`` is high — the prior
     series' state is unreachable and walking it produces a noisy
-    goal blob. PR_SUMMARY is the right anchor for a fresh series.
+    goal blob. PR_SUMMARY is the right anchor for a fresh series, and
+    the streak / diff additions are skipped.
     """
     if round_ < 2 or is_new_series:
         return pr_summary
     history = action_history_goal(state, round_, head_before=head_before)
-    return history or pr_summary
+    body = history or pr_summary
+    parts = [body]
+    pressure = _low_only_streak_pressure(state, round_)
+    if pressure:
+        parts.append(pressure)
+    if include_round_diff:
+        diff_text = round_diff(
+            state, round_, head_before=head_before, max_lines=round_diff_max_lines
+        )
+        if diff_text:
+            rounds = state.get("rounds") or []
+            prior = [r for r in rounds if (r.get("n") or 0) < round_]
+            prev_n = max((r.get("n") or 0) for r in prior) if prior else round_ - 1
+            parts.append(
+                f"Diff since round {prev_n} (truncated at {round_diff_max_lines} lines):\n{diff_text}"
+            )
+    return "\n\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -855,6 +929,7 @@ def triage(
     ci_failures: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     head_path: Path | None = None,
+    prior_modified_hunks: dict[str, list[tuple[int, int]]] | None = None,
 ) -> dict[str, Any]:
     """Group findings, surface consensus, detect N+1 spiral matches.
 
@@ -989,19 +1064,43 @@ def triage(
             if (
                 resolved_mode == REVIEW_MODE_CODE
                 and not is_multi_source
-                and not _spiral_evidence_present(repr_, head=head_path)
             ):
-                demoted = dict(repr_)
-                demoted["stale_reason"] = (
-                    "spiral candidate auto-demoted: cited evidence absent at HEAD"
+                # Two demote heuristics, both safe to run when the
+                # finding has a (file, line):
+                #   1) Evidence-at-HEAD: distinctive tokens from the
+                #      finding's message no longer appear within ±10
+                #      lines of the cited line.
+                #   2) Modified-hunk: the cited line lies inside a hunk
+                #      that any prior round of this series modified —
+                #      reviewer is reading cached context against code
+                #      we already moved (e.g. doc-comment fix shifted
+                #      words within the same function).
+                # Either signal alone is enough to demote; both are
+                # noisier on multi-source spirals (real regressions
+                # often coincide with prior fixes), so multi-source
+                # spirals always escalate.
+                evidence_absent = not _spiral_evidence_present(repr_, head=head_path)
+                in_modified_hunk = bool(prior_modified_hunks) and _line_in_modified_hunk(
+                    repr_, prior_modified_hunks
                 )
-                stale_prior_commit.append(
-                    {"key": list(_triage_key(repr_, resolved_mode)), "finding": demoted}
-                )
-                # Skip the rest of the per-key dispatch — this finding
-                # is now in batch_stale and must not also land in any
-                # severity bucket.
-                continue
+                if evidence_absent or in_modified_hunk:
+                    demoted = dict(repr_)
+                    if in_modified_hunk:
+                        demoted["stale_reason"] = (
+                            "spiral candidate auto-demoted: cited line inside a "
+                            "hunk modified by a prior round"
+                        )
+                    else:
+                        demoted["stale_reason"] = (
+                            "spiral candidate auto-demoted: cited evidence absent at HEAD"
+                        )
+                    stale_prior_commit.append(
+                        {"key": list(_triage_key(repr_, resolved_mode)), "finding": demoted}
+                    )
+                    # Skip the rest of the per-key dispatch — this finding
+                    # is now in batch_stale and must not also land in any
+                    # severity bucket.
+                    continue
             spiral_matches.append({"key": list(key), "findings": group})
         if key in consensus_triage_keys:
             # Already routed to consensus by location-based grouping;
@@ -1123,12 +1222,23 @@ def prior_fixed_keys(state: dict[str, Any] | None, mode: str = REVIEW_MODE_CODE)
     return keys
 
 
+# Default: force a fresh bramble session every K rounds so accumulated
+# session context can't compound staleness across a long audit. Each
+# resume keeps the reviewer reading the same conversation history;
+# after ~4 rounds the older turns describe code that no longer exists,
+# and the model starts re-flagging stale context. K=4 is the
+# round-budget cliff PR #240's session showed: r5–r10 were mostly
+# chasing consequences of r1–r4 fixes. Override with --session-reset-k.
+SESSION_RESET_K_DEFAULT = 4
+
+
 def prior_session_id(
     state: dict[str, Any] | None,
     backend: str,
     round_: int,
     *,
     is_new_series: bool | None = None,
+    session_reset_k: int = SESSION_RESET_K_DEFAULT,
 ) -> str:
     """Return the newest prior session id for backend before ``round_``.
 
@@ -1145,6 +1255,12 @@ def prior_session_id(
     ``completed`` flag, then passes ``is_new_series`` here. When the
     caller doesn't pass it, fall back to deriving from the live state
     (works only when called before ``state_append_round`` runs).
+
+    Also returns ``""`` when the candidate session id was last written
+    ``session_reset_k`` rounds ago or more — long-running audits drift
+    further from current code with every resume, and forcing a fresh
+    session every K rounds clears accumulated stale context. Set
+    ``session_reset_k=0`` to disable the periodic reset.
     """
     if not state or round_ < 2:
         return ""
@@ -1158,13 +1274,339 @@ def prior_session_id(
             continue
         session_ids = rnd.get("session_ids") or {}
         sid = session_ids.get(backend) or rnd.get(f"{backend}_session_id")
+        if not sid:
+            reviews = rnd.get("reviews") or {}
+            env = reviews.get(backend) if isinstance(reviews, dict) else None
+            if isinstance(env, dict) and env.get("session_id"):
+                sid = env["session_id"]
         if sid:
+            # Periodic-reset gate: forcing a fresh session every K
+            # rounds clears accumulated stale context. The check is
+            # round-distance, not wall-clock, so an interrupted-and-
+            # resumed loop still gets the same reset cadence.
+            if session_reset_k > 0 and (round_ - n) >= session_reset_k:
+                return ""
             return str(sid)
-        reviews = rnd.get("reviews") or {}
-        env = reviews.get(backend) if isinstance(reviews, dict) else None
-        if isinstance(env, dict) and env.get("session_id"):
-            return str(env["session_id"])
     return ""
+
+
+# ---------------------------------------------------------------------------
+# Envelope recovery: salvage envelopes whose verdict the wrapper rejected
+# ---------------------------------------------------------------------------
+#
+# Cursor (and occasionally codex) sometimes return verdicts the bramble
+# wrapper doesn't recognize — most commonly ``approve_with_notes``,
+# ``approve``, ``request_changes``, ``comment``. The wrapper writes
+# ``status: "error"`` with a verdict-validation message and refuses to
+# expose the issues, but ``review.issues`` is fully populated underneath.
+# Throwing the round away over a vocabulary mismatch wastes a review
+# cycle, so we map the variant verdicts onto the canonical ``accepted`` /
+# ``rejected`` pair and re-emit a clean envelope.
+#
+# Recovery vocabulary (case-insensitive, substring match on the verdict
+# token extracted from the error message):
+#
+#   approve, approve_with_notes, accept, lgtm, ship           -> accepted
+#   request_changes, reject, block, needs_changes, changes    -> rejected
+#
+# ``comment`` is intentionally NOT mapped: a "just commenting" verdict
+# carries no merge signal, and triage routes the issues regardless of
+# verdict. We surface unknown verdicts as a no-op (return original path)
+# so the orchestrator's existing error-envelope handling kicks in.
+
+_RECOVERY_ACCEPTED_TOKENS = (
+    "approve_with_notes",
+    "approve",
+    "accept",
+    "lgtm",
+    "ship",
+)
+_RECOVERY_REJECTED_TOKENS = (
+    "request_changes",
+    "needs_changes",
+    "needs-changes",
+    "reject",
+    "block",
+    "changes",
+)
+# Order matters when matching: longer/more-specific tokens must come
+# first so ``approve_with_notes`` doesn't get demoted to ``approve``
+# and ``request_changes`` doesn't get demoted to ``changes``.
+
+
+def _classify_recovery_verdict(error_text: str) -> str | None:
+    """Return ``"accepted"`` / ``"rejected"`` / ``None`` for an error message.
+
+    Looks for verdict-validation language. Anything ambiguous (no verdict
+    keyword, or a recognized non-merge verdict like ``comment``) returns
+    None so the caller treats it as "no recovery applicable".
+    """
+    if not error_text:
+        return None
+    t = error_text.lower()
+    if "verdict" not in t:
+        return None
+    for token in _RECOVERY_ACCEPTED_TOKENS:
+        if token in t:
+            return "accepted"
+    for token in _RECOVERY_REJECTED_TOKENS:
+        if token in t:
+            return "rejected"
+    return None
+
+
+def recover_envelope(path: Path, *, suffix: str = "-recovered") -> Path:
+    """Salvage an error envelope whose only problem was an unrecognized verdict.
+
+    Returns the path of an envelope ready to feed into ``triage --stream``:
+
+    - When the input envelope is already ``status: "ok"``, returns ``path``
+      unchanged. Idempotent: re-running on a recovered envelope is a no-op.
+    - When the input is ``status: "error"`` but the error message indicates
+      a verdict-validation problem AND ``review.issues`` is populated,
+      writes a sibling file ``<stem><suffix>.json`` with ``status: "ok"``
+      and verdict remapped per ``_classify_recovery_verdict``. Returns the
+      sibling path.
+    - When the input is an error envelope with no recognizable verdict
+      keyword, or with empty issues, returns ``path`` unchanged so the
+      orchestrator falls through to the existing high-severity synthetic
+      finding path.
+
+    Pure mechanical recovery — no judgment calls about whether the issues
+    "are good." If the inner JSON has issues, we trust them; if it doesn't,
+    we don't synthesize anything.
+    """
+    if not path.exists():
+        return path
+    obj = read_json(path, default=None)
+    if not isinstance(obj, dict):
+        return path
+    if obj.get("status") == "ok":
+        return path
+    error_text = obj.get("error") or ""
+    verdict = _classify_recovery_verdict(error_text)
+    if verdict is None:
+        return path
+    issues = ((obj.get("review") or {}).get("issues")) or []
+    if not issues:
+        # Vocabulary problem on an empty review = no salvageable signal.
+        return path
+    recovered = dict(obj)
+    recovered["status"] = "ok"
+    recovered["error"] = None
+    review = dict(recovered.get("review") or {})
+    review["verdict"] = verdict
+    recovered["review"] = review
+    recovered.setdefault("recovery", {})["original_error"] = error_text
+    recovered["recovery"]["mapped_verdict"] = verdict
+    out_path = path.with_name(f"{path.stem}{suffix}.json")
+    # Atomic write — same shape as state writes; readers tolerate either
+    # the original or recovered file showing up first if a concurrent
+    # process is watching the directory.
+    from _common import atomic_write_json  # noqa: PLC0415
+
+    atomic_write_json(out_path, recovered)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Round diff: prior_round.head_after .. this_round.HEAD
+# ---------------------------------------------------------------------------
+
+
+def round_diff(
+    state: dict[str, Any] | None,
+    round_: int,
+    *,
+    head_before: str | None = None,
+    max_lines: int = _ROUND_DIFF_DEFAULT_MAX_LINES,
+) -> str:
+    """Return ``git diff <prior_head_after>..<head_before>`` text, truncated.
+
+    Returns ``""`` when:
+      - ``round_`` < 2 (no prior round to diff against),
+      - state has no rounds before ``round_``,
+      - the prior round's ``head_after`` is None (interrupted prior round
+        that never finalized),
+      - ``head_before`` is None or equals the prior anchor,
+      - git rejects the range (unreachable SHAs in shallow clones / worktrees).
+
+    Truncation appends a ``...elided N lines`` footer when the diff exceeds
+    ``max_lines``. The footer is on its own line so callers can grep for
+    "elided" to detect truncation.
+
+    Pure git plumbing. Used by the goal-builder to feed the resumed
+    reviewer the diff between rounds rather than re-snapshotting the
+    whole PR.
+    """
+    if round_ < 2 or not state:
+        return ""
+    rounds = state.get("rounds") or []
+    prior = [r for r in rounds if (r.get("n") or 0) < round_]
+    if not prior:
+        return ""
+    prev = max(prior, key=lambda r: r.get("n") or 0)
+    prev_anchor = prev.get("head_after")
+    if not prev_anchor or not head_before or prev_anchor == head_before:
+        return ""
+    from _common import run  # noqa: PLC0415
+
+    try:
+        res = run(
+            ["git", "diff", f"{prev_anchor}..{head_before}"],
+            check=False,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort
+        print(
+            f"bramble_ops: round-diff git diff {prev_anchor[:7]}..{head_before[:7]} "
+            f"failed: {e}",
+            file=sys.stderr,
+        )
+        return ""
+    if res.returncode != 0:
+        print(
+            f"bramble_ops: round-diff git diff {prev_anchor[:7]}..{head_before[:7]} "
+            f"returned {res.returncode}; cited SHA may be unreachable. "
+            f"stderr: {res.stderr.strip() or '(empty)'}",
+            file=sys.stderr,
+        )
+        return ""
+    text = res.stdout
+    if not text.strip():
+        return ""
+    lines = text.splitlines()
+    if len(lines) > max_lines:
+        elided = len(lines) - max_lines
+        return "\n".join(lines[:max_lines]) + f"\n...elided {elided} lines"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Modified-hunk lookup for spiral-stale demote (E1)
+# ---------------------------------------------------------------------------
+
+
+_HUNK_HEADER_RE = re.compile(
+    r"^@@\s+-\d+(?:,\d+)?\s+\+(?P<start>\d+)(?:,(?P<count>\d+))?\s+@@"
+)
+
+
+def _parse_hunk_ranges(diff_text: str) -> list[tuple[int, int]]:
+    """Extract ``(start, end)`` line ranges (inclusive, 1-based, on the +
+    side) from a unified-diff body. Used to test whether a cited line
+    falls inside a hunk a prior round modified.
+
+    A hunk header ``@@ -a,b +c,d @@`` covers lines ``[c, c+d-1]``. When the
+    count is omitted (``@@ -a +c @@``), it defaults to 1 per unified-diff
+    spec. A pure deletion (``+c,0``) yields no covered lines on the +
+    side; we drop those (caller can't have a spiral on a line that
+    doesn't exist post-fix).
+    """
+    ranges: list[tuple[int, int]] = []
+    for line in diff_text.splitlines():
+        m = _HUNK_HEADER_RE.match(line)
+        if not m:
+            continue
+        start = int(m.group("start"))
+        count_str = m.group("count")
+        count = int(count_str) if count_str is not None else 1
+        if count <= 0:
+            continue
+        ranges.append((start, start + count - 1))
+    return ranges
+
+
+def prior_round_modified_hunks(
+    state: dict[str, Any] | None,
+) -> dict[str, list[tuple[int, int]]]:
+    """Map each file path to ``[(start, end), ...]`` line ranges modified by
+    any prior round's commit (``head_before..head_after``).
+
+    Returns ``{}`` when state is missing or no prior round has both SHAs.
+    Pure git plumbing — runs ``git diff -U0 <head_before>..<head_after>``
+    once per prior round, parses hunk headers, unions ranges per file.
+
+    The SKILL feeds this into ``triage`` so a single-source spiral whose
+    cited line falls inside a prior-round-modified hunk auto-demotes to
+    ``batch_stale`` — the reviewer is replaying cached context against
+    code we already moved.
+    """
+    if not state:
+        return {}
+    from _common import run  # noqa: PLC0415
+
+    out: dict[str, list[tuple[int, int]]] = {}
+    rounds = state.get("rounds") or []
+    for rnd in rounds:
+        head_before = rnd.get("head_before")
+        head_after = rnd.get("head_after")
+        if not head_before or not head_after or head_before == head_after:
+            continue
+        try:
+            res = run(
+                ["git", "diff", "-U0", f"{head_before}..{head_after}"],
+                check=False,
+            )
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"bramble_ops: prior-round-modified-hunks git diff "
+                f"{head_before[:7]}..{head_after[:7]} failed: {e}",
+                file=sys.stderr,
+            )
+            continue
+        if res.returncode != 0:
+            # Unreachable SHAs (shallow clone / pruned worktree) — skip,
+            # don't mask other prior rounds.
+            continue
+        # Walk the diff splitting on file headers. A unified diff lists
+        # each file with ``diff --git`` then ``+++ b/<path>`` then hunk
+        # headers; the ``+++`` line gives us the post-fix path which is
+        # what triage's findings are addressed against.
+        current_path: str | None = None
+        for line in res.stdout.splitlines():
+            if line.startswith("+++ "):
+                # ``+++ b/path/to/file`` or ``+++ /dev/null`` for deletions
+                addr = line[len("+++ ") :].strip()
+                if addr == "/dev/null":
+                    current_path = None
+                elif addr.startswith("b/"):
+                    current_path = addr[2:]
+                else:
+                    current_path = addr
+                continue
+            m = _HUNK_HEADER_RE.match(line)
+            if not m or not current_path:
+                continue
+            start = int(m.group("start"))
+            count_str = m.group("count")
+            count = int(count_str) if count_str is not None else 1
+            if count <= 0:
+                continue
+            out.setdefault(current_path, []).append((start, start + count - 1))
+    return out
+
+
+def _line_in_modified_hunk(
+    finding: dict[str, Any],
+    modified_hunks: dict[str, list[tuple[int, int]]],
+) -> bool:
+    """Return True when finding's cited (file, line) falls inside any range
+    in ``modified_hunks``. Returns False for findings with no addressable
+    line (top-level / sourceless) — those don't qualify for the
+    modified-hunk demote heuristic.
+    """
+    path = finding.get("file") or finding.get("path")
+    line = finding.get("line")
+    if not path or line is None:
+        return False
+    try:
+        line = int(line)
+    except (TypeError, ValueError):
+        return False
+    ranges = modified_hunks.get(path)
+    if not ranges:
+        return False
+    return any(start <= line <= end for start, end in ranges)
 
 
 # ---------------------------------------------------------------------------
@@ -1198,6 +1640,18 @@ def _build_parser() -> argparse.ArgumentParser:
             "head_after produces a noisy goal blob (the SHA may be unreachable)."
         ),
     )
+    sp.add_argument(
+        "--no-round-diff",
+        dest="include_round_diff",
+        action="store_false",
+        default=True,
+        help="Skip the inter-round diff append (default: include).",
+    )
+    sp.add_argument(
+        "--round-diff-max-lines",
+        type=int,
+        default=_ROUND_DIFF_DEFAULT_MAX_LINES,
+    )
 
     sp = sub.add_parser(
         "prior-session-id",
@@ -1210,6 +1664,47 @@ def _build_parser() -> argparse.ArgumentParser:
         "--is-new-series",
         choices=["0", "1"],
         help="Captured at Step 0.5 before state_append_round mutates state; pass 1 to force empty.",
+    )
+    sp.add_argument(
+        "--session-reset-k",
+        type=int,
+        default=SESSION_RESET_K_DEFAULT,
+        help=(
+            "Force a fresh session every K rounds to clear accumulated stale "
+            f"context (default {SESSION_RESET_K_DEFAULT}). Set to 0 to disable."
+        ),
+    )
+
+    sp = sub.add_parser(
+        "recover-envelope",
+        help=(
+            "Salvage a status:error envelope whose only problem was an "
+            "unrecognized verdict (approve_with_notes, request_changes, etc). "
+            "Prints the recovered path on stdout, or the original path if no "
+            "recovery applied (idempotent — safe to wrap every --stream)."
+        ),
+    )
+    sp.add_argument("envelope_path")
+
+    sp = sub.add_parser(
+        "round-diff",
+        help=(
+            "Print git diff <prior_round.head_after>..<head_before> for "
+            "round N, truncated at --max-lines. Empty when no prior round "
+            "or SHAs are unreachable. Pure git plumbing — used by the "
+            "goal builder to feed the resumed reviewer the inter-round diff."
+        ),
+    )
+    sp.add_argument("state_file")
+    sp.add_argument("round_", type=int)
+    sp.add_argument(
+        "--head-before",
+        help="This round's HEAD; if omitted, falls back to git rev-parse HEAD.",
+    )
+    sp.add_argument(
+        "--max-lines",
+        type=int,
+        default=_ROUND_DIFF_DEFAULT_MAX_LINES,
     )
 
     sp = sub.add_parser(
@@ -1289,12 +1784,41 @@ def main(argv: list[str] | None = None) -> int:
                     state,
                     head_before=args.head_before,
                     is_new_series=is_new,
+                    include_round_diff=args.include_round_diff,
+                    round_diff_max_lines=args.round_diff_max_lines,
                 )
             )
         elif args.cmd == "prior-session-id":
             state = read_json(Path(args.state_file), default=None)
             is_new = (args.is_new_series == "1") if args.is_new_series is not None else None
-            print(prior_session_id(state, args.backend, args.round_, is_new_series=is_new))
+            print(
+                prior_session_id(
+                    state,
+                    args.backend,
+                    args.round_,
+                    is_new_series=is_new,
+                    session_reset_k=args.session_reset_k,
+                )
+            )
+        elif args.cmd == "recover-envelope":
+            print(str(recover_envelope(Path(args.envelope_path))))
+        elif args.cmd == "round-diff":
+            state = read_json(Path(args.state_file), default=None)
+            head_before = args.head_before
+            if head_before is None:
+                from _common import run as _run  # noqa: PLC0415
+
+                res = _run(["git", "rev-parse", "HEAD"], check=False)
+                if res.returncode == 0:
+                    head_before = res.stdout.strip() or None
+            print(
+                round_diff(
+                    state,
+                    args.round_,
+                    head_before=head_before,
+                    max_lines=args.max_lines,
+                )
+            )
         elif args.cmd == "parse-stream":
             findings = parse_stream(Path(args.stream_file), source=args.backend)
             print_json(findings)
@@ -1346,6 +1870,14 @@ def main(argv: list[str] | None = None) -> int:
                 resolved_mode = next(iter(real_modes), None) or REVIEW_MODE_CODE
             findings = parse_round(streams, fallback_mode=resolved_mode)
             head_path = Path(args.head_path) if args.head_path else None
+            # Modified-hunk demote (E1) is code-mode-only: design-doc
+            # findings address sections, not file lines, so a hunk lookup
+            # would be a no-op. Skip the git work outright in that case
+            # so a doc-mode triage on a worktree without remote SHAs
+            # doesn't spam stderr with "unreachable SHA" warnings.
+            modified_hunks: dict[str, list[tuple[int, int]]] | None = None
+            if resolved_mode == REVIEW_MODE_CODE:
+                modified_hunks = prior_round_modified_hunks(prior)
             result = triage(
                 findings,
                 prior_fixed_keys(prior, resolved_mode),
@@ -1353,6 +1885,7 @@ def main(argv: list[str] | None = None) -> int:
                 ci_failures=ci_failures,
                 mode=resolved_mode,
                 head_path=head_path,
+                prior_modified_hunks=modified_hunks,
             )
             print_json(result)
         else:  # pragma: no cover

--- a/.claude/skills/pr-polish/scripts/pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/pr_ops.py
@@ -784,6 +784,7 @@ def state_append_round(
                 "skipped_count": 0,
                 "top_severity": None,
                 "top_was_false_positive": False,
+                "low_only_streak": 0,
                 "comment_actions": [],
                 "noise_filtered": noise_filtered,
                 "noise_samples": samples,
@@ -851,6 +852,30 @@ def recompute_counts(actions: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _compute_low_only_streak(
+    prior_rounds: list[dict[str, Any]], this_top_severity: str | None
+) -> int:
+    """Increment the prior round's streak when this round's top severity is
+    low/nit/None (zero findings counts as low-only); reset to 0 otherwise.
+
+    Walks one round back rather than the whole history — the recurrence is
+    streak[N] = streak[N-1] + 1 when this round is low-only, else 0, so we
+    only need the most recent value. Round 1 starts the counter at 1 if
+    low-only.
+
+    The convergence rule reads streak >= 2 to trigger early exit; B1 reads
+    it to inject reviewer-pressure text. Any caller can derive its own
+    threshold from the same field.
+    """
+    is_low_only = severity_rank(this_top_severity) <= severity_rank("low")
+    if not is_low_only:
+        return 0
+    if not prior_rounds:
+        return 1
+    prev = max(prior_rounds, key=lambda r: r.get("n") or 0)
+    return (prev.get("low_only_streak") or 0) + 1
+
+
 def state_finalize_round(
     ctx: int | str,
     n: int,
@@ -889,6 +914,11 @@ def state_finalize_round(
     entry["comment_actions"] = merged
     entry["head_after"] = head_after
     entry.update(recompute_counts(merged))
+    # ``low_only_streak`` reflects the streak *after* this round closes, so
+    # it must be computed from rounds prior to this one (`r.n < n`) plus
+    # the freshly recomputed ``top_severity`` for this round.
+    prior_rounds = [r for r in rounds if (r.get("n") or 0) < n]
+    entry["low_only_streak"] = _compute_low_only_streak(prior_rounds, entry.get("top_severity"))
     _persist_round_findings(state_dir, entry, pr_number, branch, n, envelope_overrides or {})
     atomic_write_json(path, state)
     return state

--- a/.claude/skills/pr-polish/scripts/pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/pr_ops.py
@@ -852,6 +852,24 @@ def recompute_counts(actions: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _backfill_low_only_streak(prior_rounds: list[dict[str, Any]]) -> int:
+    """Reconstruct the streak ending at the most recent prior round when
+    its ``low_only_streak`` field is missing (state file from before the
+    field existed). Walks rounds in reverse, counting consecutive low-
+    only ``top_severity`` values from the most recent backwards. A
+    medium-or-higher round resets the count to 0.
+
+    Pure derived-from-history; no I/O.
+    """
+    streak = 0
+    for rnd in sorted(prior_rounds, key=lambda r: r.get("n") or 0, reverse=True):
+        if severity_rank(rnd.get("top_severity")) <= severity_rank("low"):
+            streak += 1
+        else:
+            break
+    return streak
+
+
 def _compute_low_only_streak(
     prior_rounds: list[dict[str, Any]], this_top_severity: str | None
 ) -> int:
@@ -863,6 +881,13 @@ def _compute_low_only_streak(
     only need the most recent value. Round 1 starts the counter at 1 if
     low-only.
 
+    Backwards-compat: when the prior round was finalized by an
+    older orchestrator that didn't write ``low_only_streak``, we
+    reconstruct it from the persisted ``top_severity`` history. Without
+    this, an in-progress audit upgraded mid-loop would lose its streak
+    continuity and the new convergence shortcut would not trigger until
+    two fresh low rounds accumulated post-upgrade.
+
     The convergence rule reads streak >= 2 to trigger early exit; B1 reads
     it to inject reviewer-pressure text. Any caller can derive its own
     threshold from the same field.
@@ -873,7 +898,10 @@ def _compute_low_only_streak(
     if not prior_rounds:
         return 1
     prev = max(prior_rounds, key=lambda r: r.get("n") or 0)
-    return (prev.get("low_only_streak") or 0) + 1
+    prev_streak = prev.get("low_only_streak")
+    if prev_streak is None:
+        prev_streak = _backfill_low_only_streak(prior_rounds)
+    return prev_streak + 1
 
 
 def state_finalize_round(

--- a/.claude/skills/pr-polish/scripts/pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/pr_ops.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -1116,12 +1118,12 @@ def _persist_round_findings(
         except Exception:  # noqa: BLE001 — malformed envelope shouldn't brick finalize
             obj = None
         entry[f"{backend}_findings"] = bramble_ops.parse_envelope(obj, source=backend)
-        # Clear any prior per-backend session_ids/resume_status before
-        # re-hydrating. Without this, an envelope that exists on disk
-        # but parses to non-dict / missing keys would let the previous
+        # Clear any prior per-backend session_ids/resume_status/sufficiency
+        # before re-hydrating. Without this, an envelope that exists on
+        # disk but parses to non-dict / missing keys would let the previous
         # finalize's values survive — same resume-stale-session class
         # of bug as the omitted-backend cleanup above.
-        for bucket_key in ("session_ids", "resume_status"):
+        for bucket_key in ("session_ids", "resume_status", "sufficiency_claims"):
             bucket = entry.get(bucket_key)
             if isinstance(bucket, dict):
                 bucket.pop(backend, None)
@@ -1132,6 +1134,13 @@ def _persist_round_findings(
                 entry.setdefault("session_ids", {})[backend] = obj.get("session_id")
             if obj.get("resume_status"):
                 entry.setdefault("resume_status", {})[backend] = obj.get("resume_status")
+            # v2 schema: the reviewer may emit a per-turn sufficiency
+            # claim. Persist it so the round summary and final report
+            # can surface it as audit-trail context. Absence is fine —
+            # parse_sufficiency returns None when the field isn't there.
+            suff = bramble_ops.parse_sufficiency(obj)
+            if suff is not None:
+                entry.setdefault("sufficiency_claims", {})[backend] = suff
         reviews_dir.mkdir(parents=True, exist_ok=True)
         dest = reviews_dir / f"r{n}-{backend}.json"
         try:
@@ -1234,6 +1243,256 @@ def _utc_now() -> str:
     from datetime import datetime
 
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration glue: preflight / round-bundle / finalize-and-report
+# ---------------------------------------------------------------------------
+#
+# These three subcommands compress the mechanical path/state plumbing the
+# orchestrator would otherwise rebuild inline each round. They are
+# deliberately thin — each returns a JSON dict the agent reads with one
+# ``jq -r`` call. Decision points (apply this fix? exit the loop?) stay
+# with the agent.
+
+
+def preflight() -> dict[str, Any]:
+    """Resolve the binaries + helper paths the round loop depends on.
+
+    Returns ``{bramble_bin, bramble_resume_supported, git_sync_path,
+    git_sync_supports_no_push, skill_dir}``. The orchestrator reads this
+    once at session start; missing-but-required pieces produce a
+    non-empty ``errors`` list so the agent can fail loudly before the
+    first round burns a Monitor budget.
+
+    Each probe is a small subprocess; this is the only place that
+    pattern lives now, instead of being copied into the SKILL.md
+    template as inline bash that the agent rebuilds verbatim.
+    """
+    out: dict[str, Any] = {
+        "bramble_bin": None,
+        "bramble_resume_supported": False,
+        "git_sync_path": None,
+        "git_sync_supports_no_push": False,
+        "skill_dir": str(Path(__file__).resolve().parent.parent),
+        "errors": [],
+    }
+    bin_candidate = Path.cwd() / "bazel-bin/bramble/bramble_/bramble"
+    if bin_candidate.is_file() and os.access(bin_candidate, os.X_OK):
+        out["bramble_bin"] = str(bin_candidate)
+    else:
+        out["bramble_bin"] = "bramble"
+    try:
+        help_res = subprocess.run(
+            [out["bramble_bin"], "code-review", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        out["bramble_resume_supported"] = "--resume-session-id" in (
+            (help_res.stdout or "") + (help_res.stderr or "")
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        out["errors"].append(f"bramble code-review --help failed: {e}")
+    if not out["bramble_resume_supported"]:
+        out["errors"].append(
+            f"{out['bramble_bin']!r} does not support --resume-session-id; "
+            "the round loop requires continuous-conversation review"
+        )
+
+    # git:sync-base — prefer the repo-local install (matches the code
+    # under review); fall back to the user-installed copy in ~/.claude.
+    sync_candidates = [
+        Path.cwd() / ".claude/skills/git:sync-base/git-sync.py",
+        Path.home() / ".claude/skills/git:sync-base/git-sync.py",
+    ]
+    for cand in sync_candidates:
+        if cand.is_file():
+            out["git_sync_path"] = str(cand)
+            break
+    if out["git_sync_path"]:
+        try:
+            help_res = subprocess.run(
+                ["python3", out["git_sync_path"], "--help"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            out["git_sync_supports_no_push"] = "--no-push" in (help_res.stdout or "")
+        except subprocess.TimeoutExpired as e:
+            out["errors"].append(f"git-sync --help timed out: {e}")
+    else:
+        out["errors"].append("git:sync-base not found on disk")
+    return out
+
+
+def round_bundle(ctx: int | str, n: int) -> dict[str, Any]:
+    """Return everything the orchestrator needs to arm Monitors for round ``n``.
+
+    Wraps four existing helpers into one call:
+      - ``state_load`` for the state + derived booleans (heartbeat,
+        is_first_round_of_series).
+      - bramble_ops's ``goal_for_round`` + ``prior_session_id`` per
+        backend (codex, cursor, gemini).
+      - ``state_paths`` for the per-round log directory.
+
+    The bash that arms Monitors becomes one ``round-bundle`` call + a
+    ``jq -r`` of the result. Backends without prior session ids return
+    empty strings (same shape ``bramble_ops.py prior-session-id``
+    prints) so the orchestrator's ``${VAR:+--resume-session-id "$VAR"}``
+    expansion keeps working.
+
+    ``head_before`` defaults to ``git rev-parse HEAD`` — the orchestrator
+    can override by post-processing the bundle, but the common path
+    doesn't need to.
+    """
+    import bramble_ops  # noqa: PLC0415
+
+    pr_number, branch = _resolve_ctx(ctx)
+    state_dir, state_file = state_paths(pr_number, branch=branch)
+    log_dir = state_dir / f"r{n}"
+    state = read_json(state_file, default=None)
+    is_new_series = 1 if _is_first_round_of_series(state, n) else 0
+
+    head_res = run(["git", "rev-parse", "HEAD"], check=False)
+    head_before = head_res.stdout.strip() if head_res.returncode == 0 else ""
+
+    # PR_SUMMARY: leave empty here — building it requires a base-branch
+    # diff that the orchestrator already computes once at Step 1. The
+    # agent threads it into goal_for_round via a separate arg. Keep this
+    # helper bramble-agnostic at the PR_SUMMARY boundary.
+    goal_text = ""
+    if state is not None:
+        try:
+            goal_text = bramble_ops.goal_for_round(
+                n,
+                pr_summary="",
+                state=state,
+                head_before=head_before or None,
+                is_new_series=bool(is_new_series),
+            )
+        except Exception as e:  # noqa: BLE001 — diagnostic, not fatal
+            goal_text = f"# goal_for_round failed: {e}"
+
+    resume_ids: dict[str, str] = {}
+    for backend in bramble_ops.BACKENDS:
+        try:
+            sid = bramble_ops.prior_session_id(
+                state,
+                backend,
+                n,
+                is_new_series=bool(is_new_series),
+            )
+        except Exception:  # noqa: BLE001 — empty resume is the safe fallback
+            sid = ""
+        resume_ids[backend] = sid or ""
+
+    return {
+        "state_dir": str(state_dir),
+        "state_file": str(state_file),
+        "log_dir": str(log_dir),
+        "envelope_paths": {
+            backend: str(log_dir / f"{backend}-envelope.json")
+            for backend in bramble_ops.BACKENDS
+        },
+        "head_before": head_before,
+        "is_new_series": is_new_series,
+        "goal_text": goal_text,
+        "resume_ids": resume_ids,
+    }
+
+
+def finalize_and_report(
+    ctx: int | str,
+    n: int,
+    head_after: str,
+    actions: list[dict[str, Any]],
+    *,
+    envelope_overrides: dict[str, Path] | None = None,
+) -> dict[str, Any]:
+    """Finalize a round and return a one-shot orchestrator-readable report.
+
+    Wraps ``state_finalize_round`` and then computes the audit-trail
+    digest the orchestrator displays per-round: top severity, sufficiency
+    consensus, low_only_streak, and a short round_summary line. The
+    convergence decision stays with the agent — this only surfaces the
+    signals consistently so the agent doesn't grep state JSON per field.
+
+    Returns: ``{converged_signal: bool|null, exit_reason_hint: str|null,
+    low_only_streak: int, top_severity: str|null, sufficiency_consensus:
+    bool|null, sufficiency_claims: dict, next_round_n: int,
+    round_summary: str}``.
+
+    ``converged_signal`` is True when the existing rules would fire
+    (``low_only_streak >= 2`` OR ``len(action_plan.must_fix) == 0 and
+    top_severity ∈ {low, nit, null}``). It's a *hint*, not a gate —
+    SKILL.md's convergence prose is still the authoritative reference.
+    ``exit_reason_hint`` mirrors the same hint as a string the agent can
+    pass to ``state-mark-complete`` if it decides to exit.
+    """
+    state = state_finalize_round(
+        ctx, n, head_after, actions, envelope_overrides=envelope_overrides,
+    )
+    rounds = state.get("rounds") or []
+    entry = next((r for r in rounds if r.get("n") == n), None)
+    if entry is None:
+        return {"error": f"round {n} missing after finalize"}
+
+    fixed = entry.get("fixed_count") or 0
+    skipped = entry.get("skipped_count") or 0
+    top_sev = entry.get("top_severity")
+    streak = entry.get("low_only_streak") or 0
+
+    claims = entry.get("sufficiency_claims") or {}
+    backends_complete = [b for b, c in claims.items() if c.get("is_confident_complete")]
+    backends_incomplete = [b for b, c in claims.items() if not c.get("is_confident_complete")]
+    # Consensus: ≥2 backends claiming complete with no backend claiming
+    # incomplete. None when fewer than 2 backends emitted a claim either
+    # way (silent backends count as "no signal").
+    if len(claims) < 2:
+        consensus: bool | None = None
+    elif len(backends_complete) >= 2 and not backends_incomplete:
+        consensus = True
+    elif backends_incomplete:
+        consensus = False
+    else:
+        consensus = None
+
+    converged: bool | None
+    exit_reason_hint: str | None
+    low_top = top_sev in (None, "low", "nit")
+    if streak >= 2 and low_top:
+        converged = True
+        exit_reason_hint = "converged"
+    elif top_sev in (None, "low", "nit") and fixed == 0 and skipped == 0:
+        converged = True
+        exit_reason_hint = "all-low"
+    else:
+        converged = None
+        exit_reason_hint = None
+
+    suffix = ""
+    if consensus is True:
+        suffix = " (both backends signalled sufficiency)"
+    elif consensus is False:
+        suffix = " (one backend signalled more sites remain)"
+    round_summary = (
+        f"Round {n}: top={top_sev or 'none'}, fixed {fixed}, skipped {skipped}, "
+        f"low_only_streak={streak}{suffix}"
+    )
+
+    return {
+        "converged_signal": converged,
+        "exit_reason_hint": exit_reason_hint,
+        "low_only_streak": streak,
+        "top_severity": top_sev,
+        "sufficiency_consensus": consensus,
+        "sufficiency_claims": claims,
+        "next_round_n": n + 1,
+        "round_summary": round_summary,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1414,6 +1673,50 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sp.add_argument("ctx", help="PR number or 'branch:<name>'")
 
+    sub.add_parser(
+        "preflight",
+        help=(
+            "Resolve bramble binary, git-sync path, and probe for "
+            "--resume-session-id / --no-push support. Returns one JSON "
+            "dict; non-empty errors[] means the round loop should fail "
+            "fast before launching Monitors."
+        ),
+    )
+
+    sp = sub.add_parser(
+        "round-bundle",
+        help=(
+            "Return everything the orchestrator needs to arm Monitors "
+            "for round N: log/state paths, envelope paths, head_before, "
+            "is_new_series, goal_text, and per-backend resume ids. "
+            "Replaces ~6 separate helper invocations."
+        ),
+    )
+    sp.add_argument("ctx", help="PR number or 'branch:<name>'")
+    sp.add_argument("n", type=int, help="round number")
+
+    sp = sub.add_parser(
+        "finalize-and-report",
+        help=(
+            "Finalize round N and emit a one-shot audit report "
+            "(converged_signal, exit_reason_hint, sufficiency_consensus, "
+            "round_summary). Same finalize semantics as "
+            "state-finalize-round; the convergence decision stays with "
+            "the agent — this only surfaces signals consistently."
+        ),
+    )
+    sp.add_argument("ctx", help="PR number or 'branch:<name>'")
+    sp.add_argument("n", type=int, help="round number")
+    sp.add_argument("head_after", help="HEAD SHA after this round's commits")
+    sp.add_argument("actions_file", help="Path to JSON file with comment_actions array")
+    sp.add_argument(
+        "--envelope",
+        action="append",
+        default=[],
+        metavar="BACKEND=PATH",
+        help="Same shape as state-finalize-round; repeat per backend.",
+    )
+
     return p
 
 
@@ -1523,6 +1826,35 @@ def main(argv: list[str] | None = None) -> int:
             print_json(state_mark_complete(args.ctx, args.reason))
         elif args.cmd == "state-mark-abandoned":
             print_json(state_mark_abandoned(args.ctx))
+        elif args.cmd == "preflight":
+            print_json(preflight())
+        elif args.cmd == "round-bundle":
+            print_json(round_bundle(args.ctx, args.n))
+        elif args.cmd == "finalize-and-report":
+            actions = json.loads(Path(args.actions_file).read_text())
+            if not isinstance(actions, list):
+                raise ValueError("actions file must be a JSON array")
+            import bramble_ops  # noqa: PLC0415
+            envelope_overrides: dict[str, Path] = {}
+            for spec in args.envelope:
+                if "=" not in spec:
+                    raise ValueError(f"--envelope must be <backend>=<path>, got {spec!r}")
+                backend, _, ep = spec.partition("=")
+                if backend not in bramble_ops.BACKENDS:
+                    raise ValueError(
+                        f"--envelope: unknown backend {backend!r}; "
+                        f"expected one of {sorted(bramble_ops.BACKENDS)}"
+                    )
+                envelope_overrides[backend] = Path(ep)
+            print_json(
+                finalize_and_report(
+                    args.ctx,
+                    args.n,
+                    args.head_after,
+                    actions,
+                    envelope_overrides=envelope_overrides,
+                )
+            )
         else:  # pragma: no cover — argparse enforces.
             raise ValueError(f"unknown cmd: {args.cmd}")
     except CommandError as e:

--- a/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
@@ -2077,5 +2077,446 @@ class TestActionLabelsModeAware(unittest.TestCase):
         self.assertIn("needs author input", got)
 
 
+class TestRecoverEnvelope(unittest.TestCase):
+    """Mechanical recovery for the ``approve_with_notes`` family. Cursor
+    occasionally returns verdicts the wrapper doesn't recognize; if the
+    inner ``review.issues`` is populated, salvage the envelope so the
+    round's actual signal isn't lost.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _write(self, name: str, obj: dict) -> Path:
+        p = self.root / name
+        p.write_text(json.dumps(obj))
+        return p
+
+    def test_approve_with_notes_remaps_to_accepted(self) -> None:
+        env = {
+            "schema_version": 1,
+            "status": "error",
+            "error": "unrecognized verdict 'approve_with_notes'",
+            "review": {
+                "issues": [
+                    {"severity": "low", "file": "a.go", "line": 3,
+                     "message": "trailing whitespace"},
+                ],
+            },
+        }
+        path = self._write("cursor.json", env)
+        out = bramble_ops.recover_envelope(path)
+        self.assertNotEqual(out, path, "expected a recovered sibling path")
+        recovered = json.loads(out.read_text())
+        self.assertEqual(recovered["status"], "ok")
+        self.assertEqual(recovered["review"]["verdict"], "accepted")
+        self.assertEqual(len(recovered["review"]["issues"]), 1)
+
+    def test_request_changes_remaps_to_rejected(self) -> None:
+        env = {
+            "schema_version": 1,
+            "status": "error",
+            "error": "verdict 'request_changes' not in allowed set",
+            "review": {
+                "issues": [{"severity": "high", "file": "x.go", "line": 1,
+                            "message": "missing nil check"}],
+            },
+        }
+        path = self._write("cursor.json", env)
+        out = bramble_ops.recover_envelope(path)
+        recovered = json.loads(out.read_text())
+        self.assertEqual(recovered["status"], "ok")
+        self.assertEqual(recovered["review"]["verdict"], "rejected")
+
+    def test_status_ok_envelope_returned_unchanged(self) -> None:
+        env = {"schema_version": 1, "status": "ok", "review": {"issues": []}}
+        path = self._write("codex.json", env)
+        out = bramble_ops.recover_envelope(path)
+        self.assertEqual(out, path)
+
+    def test_error_envelope_with_no_verdict_returns_unchanged(self) -> None:
+        env = {
+            "schema_version": 1,
+            "status": "error",
+            "error": "bramble timed out after 10m",
+            "review": {"issues": []},
+        }
+        path = self._write("codex.json", env)
+        out = bramble_ops.recover_envelope(path)
+        self.assertEqual(out, path)
+
+    def test_verdict_error_with_empty_issues_returns_unchanged(self) -> None:
+        # Vocabulary problem + no issues = nothing to salvage.
+        env = {
+            "schema_version": 1,
+            "status": "error",
+            "error": "unrecognized verdict 'approve_with_notes'",
+            "review": {"issues": []},
+        }
+        path = self._write("cursor.json", env)
+        out = bramble_ops.recover_envelope(path)
+        self.assertEqual(out, path)
+
+    def test_idempotent_on_recovered_envelope(self) -> None:
+        env = {
+            "schema_version": 1,
+            "status": "error",
+            "error": "unrecognized verdict 'approve_with_notes'",
+            "review": {"issues": [{"severity": "low", "file": "a", "line": 1,
+                                   "message": "x"}]},
+        }
+        path = self._write("cursor.json", env)
+        first = bramble_ops.recover_envelope(path)
+        # second pass on the recovered file (status ok) should no-op.
+        second = bramble_ops.recover_envelope(first)
+        self.assertEqual(first, second)
+
+    def test_missing_file_returned_unchanged(self) -> None:
+        path = self.root / "does-not-exist.json"
+        out = bramble_ops.recover_envelope(path)
+        self.assertEqual(out, path)
+
+
+class TestRoundDiff(unittest.TestCase):
+    """`round_diff` shells out to ``git diff prior_head_after..head_before``
+    and truncates. Test with a real tmp git repo so the helper exercises
+    the same plumbing the orchestrator runs through.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self._git("init", "-q")
+        self._git("config", "user.email", "t@t")
+        self._git("config", "user.name", "t")
+        self._git("config", "commit.gpgsign", "false")
+        # Run the helper as if the orchestrator launched it inside the
+        # tmp repo. ``_common.run`` honours `cwd`, so we just cd. Saves
+        # us monkey-patching subprocess plumbing per call.
+        self._old_cwd = os.getcwd()
+        os.chdir(self.root)
+        self.addCleanup(os.chdir, self._old_cwd)
+
+    def _git(self, *args: str) -> str:
+        import subprocess
+
+        res = subprocess.run(
+            ["git", *args], cwd=str(self.root),
+            capture_output=True, text=True, check=False,
+        )
+        if res.returncode != 0:
+            raise RuntimeError(f"git {args}: {res.stderr}")
+        return res.stdout
+
+    def _commit(self, name: str, body: str) -> str:
+        (self.root / name).write_text(body)
+        self._git("add", name)
+        self._git("commit", "-q", "-m", f"add {name}")
+        return self._git("rev-parse", "HEAD").strip()
+
+    def test_returns_diff_between_prior_head_after_and_head_before(self) -> None:
+        sha1 = self._commit("a.txt", "hello\n")
+        sha2 = self._commit("a.txt", "hello\nworld\n")
+        state = {"rounds": [{"n": 1, "head_before": "x", "head_after": sha1}]}
+        text = bramble_ops.round_diff(state, 2, head_before=sha2)
+        self.assertIn("+world", text)
+        self.assertIn("a.txt", text)
+
+    def test_empty_when_round_one(self) -> None:
+        self.assertEqual(bramble_ops.round_diff({}, 1, head_before="abc"), "")
+
+    def test_empty_when_no_prior_round(self) -> None:
+        self.assertEqual(bramble_ops.round_diff({"rounds": []}, 2, head_before="abc"), "")
+
+    def test_empty_when_prior_round_never_finalized(self) -> None:
+        state = {"rounds": [{"n": 1, "head_before": "x", "head_after": None}]}
+        self.assertEqual(bramble_ops.round_diff(state, 2, head_before="abc"), "")
+
+    def test_empty_when_head_before_missing(self) -> None:
+        state = {"rounds": [{"n": 1, "head_before": "x", "head_after": "y"}]}
+        self.assertEqual(bramble_ops.round_diff(state, 2, head_before=None), "")
+
+    def test_empty_when_shas_equal(self) -> None:
+        state = {"rounds": [{"n": 1, "head_before": "x", "head_after": "abc"}]}
+        self.assertEqual(bramble_ops.round_diff(state, 2, head_before="abc"), "")
+
+    def test_truncates_long_diffs_with_elision_footer(self) -> None:
+        sha1 = self._commit("a.txt", "x\n")
+        # 50 lines added to a.txt
+        big = "\n".join(f"line {i}" for i in range(50)) + "\n"
+        (self.root / "a.txt").write_text(big)
+        self._git("add", "a.txt")
+        self._git("commit", "-q", "-m", "big")
+        sha2 = self._git("rev-parse", "HEAD").strip()
+        state = {"rounds": [{"n": 1, "head_after": sha1}]}
+        text = bramble_ops.round_diff(state, 2, head_before=sha2, max_lines=10)
+        self.assertIn("...elided", text)
+        # Exactly 11 lines: 10 + footer
+        self.assertEqual(len(text.splitlines()), 11)
+
+    def test_unreachable_sha_returns_empty(self) -> None:
+        state = {
+            "rounds": [{"n": 1, "head_after": "0" * 40}],
+        }
+        text = bramble_ops.round_diff(state, 2, head_before="1" * 40)
+        self.assertEqual(text, "")
+
+
+class TestPriorRoundModifiedHunks(unittest.TestCase):
+    """E1: spiral demote when cited line falls inside a hunk a prior round
+    modified. Validates hunk-header parsing and the boundary semantics.
+    """
+
+    def test_parse_hunk_ranges_basic(self) -> None:
+        diff = """@@ -10,3 +12,5 @@
+ ctx
+-old
++new1
++new2
+@@ -100 +150,2 @@
+-old
++new
++new
+"""
+        ranges = bramble_ops._parse_hunk_ranges(diff)
+        self.assertEqual(ranges, [(12, 16), (150, 151)])
+
+    def test_parse_hunk_default_count_one(self) -> None:
+        diff = "@@ -1 +5 @@\n+x\n"
+        self.assertEqual(bramble_ops._parse_hunk_ranges(diff), [(5, 5)])
+
+    def test_parse_hunk_pure_deletion_skipped(self) -> None:
+        # +c,0 — no lines on the + side
+        diff = "@@ -10,3 +10,0 @@\n-a\n-b\n-c\n"
+        self.assertEqual(bramble_ops._parse_hunk_ranges(diff), [])
+
+    def test_line_in_modified_hunk(self) -> None:
+        hunks = {"a.go": [(10, 15), (50, 55)]}
+        # Inside both ranges
+        self.assertTrue(bramble_ops._line_in_modified_hunk(
+            {"file": "a.go", "line": 10}, hunks))
+        self.assertTrue(bramble_ops._line_in_modified_hunk(
+            {"file": "a.go", "line": 15}, hunks))
+        self.assertTrue(bramble_ops._line_in_modified_hunk(
+            {"file": "a.go", "line": 52}, hunks))
+        # Outside
+        self.assertFalse(bramble_ops._line_in_modified_hunk(
+            {"file": "a.go", "line": 9}, hunks))
+        self.assertFalse(bramble_ops._line_in_modified_hunk(
+            {"file": "a.go", "line": 100}, hunks))
+        # Different file
+        self.assertFalse(bramble_ops._line_in_modified_hunk(
+            {"file": "b.go", "line": 12}, hunks))
+        # No address
+        self.assertFalse(bramble_ops._line_in_modified_hunk(
+            {"file": None, "line": None}, hunks))
+
+
+class TestTriageSpiralModifiedHunkDemote(unittest.TestCase):
+    """When a single-source spiral lands on a line a prior round
+    modified, demote to batch_stale even when the evidence-at-HEAD
+    heuristic would have kept it. Multi-source spirals still escalate.
+    """
+
+    def test_single_source_in_modified_hunk_demoted(self) -> None:
+        # Codex re-flagging a finding at a.go:42; prior round modified
+        # lines 40-50 of a.go.
+        finding = {
+            "source": "codex",
+            "severity": "high",
+            "file": "a.go",
+            "line": 42,
+            "message": "still has `ctx.Err()` here",
+            "topic": "ctx-err",
+            "review_mode": "code",
+        }
+        prior_keys = {("a.go", 42, "ctx-err")}
+        modified_hunks = {"a.go": [(40, 50)]}
+        out = bramble_ops.triage(
+            [finding],
+            prior_keys,
+            prior_modified_hunks=modified_hunks,
+        )
+        self.assertEqual(len(out["spiral_matches"]), 0)
+        self.assertEqual(len(out["stale_prior_commit"]), 1)
+        stale = out["stale_prior_commit"][0]["finding"]
+        self.assertIn("modified by a prior round", stale["stale_reason"])
+
+    def test_single_source_outside_modified_hunk_still_escalates(self) -> None:
+        finding = {
+            "source": "codex",
+            "severity": "high",
+            "file": "a.go",
+            "line": 5,
+            "message": "still has `ctx.Err()` here",
+            "topic": "ctx-err",
+            "review_mode": "code",
+        }
+        prior_keys = {("a.go", 5, "ctx-err")}
+        # The cited line is outside the prior round's modified hunks; with
+        # head_path unset the evidence-at-HEAD check returns conservative-
+        # True (file unreadable), so spiral escalates.
+        modified_hunks = {"a.go": [(40, 50)]}
+        out = bramble_ops.triage(
+            [finding],
+            prior_keys,
+            prior_modified_hunks=modified_hunks,
+        )
+        self.assertEqual(len(out["spiral_matches"]), 1)
+        self.assertEqual(len(out["stale_prior_commit"]), 0)
+
+    def test_multi_source_in_modified_hunk_still_escalates(self) -> None:
+        # Two backends agreeing on a regression overrides the
+        # modified-hunk demote — that's a stronger signal than file plumbing.
+        f_codex = {
+            "source": "codex",
+            "severity": "high",
+            "file": "a.go",
+            "line": 42,
+            "message": "still has ctxErrSentinel here",
+            "topic": "ctx-err",
+            "review_mode": "code",
+        }
+        f_cursor = {
+            "source": "cursor",
+            "severity": "high",
+            "file": "a.go",
+            "line": 42,
+            "message": "ctxErrSentinel still returned",
+            "topic": "ctx-err",
+            "review_mode": "code",
+        }
+        prior_keys = {("a.go", 42, "ctx-err")}
+        modified_hunks = {"a.go": [(40, 50)]}
+        out = bramble_ops.triage(
+            [f_codex, f_cursor],
+            prior_keys,
+            prior_modified_hunks=modified_hunks,
+        )
+        # Multi-source spirals escalate regardless of modified-hunk
+        # signal. (They also collapse under consensus, which is fine —
+        # what matters is that the spiral isn't silently demoted.)
+        self.assertEqual(len(out["stale_prior_commit"]), 0)
+        self.assertEqual(len(out["spiral_matches"]), 1)
+
+
+class TestSessionResetEveryKRounds(unittest.TestCase):
+    """E2: forcing a fresh bramble session every K rounds clears stale
+    accumulated context. The reset gate triggers on round-distance, so
+    an interrupted-and-resumed loop still gets the same cadence.
+    """
+
+    def _state_with_session_at(self, rounds: list[tuple[int, str | None]]) -> dict:
+        return {
+            "completed": False,
+            "current_round": rounds[-1][0],
+            "rounds": [
+                {
+                    "n": n,
+                    "session_ids": ({"codex": sid} if sid else {}),
+                }
+                for n, sid in rounds
+            ],
+        }
+
+    def test_returns_empty_when_session_k_rounds_back(self) -> None:
+        # Last codex session id was at round 1; current is round 5; K=4.
+        # 5 - 1 = 4 >= 4 -> reset.
+        state = self._state_with_session_at([(1, "sid-1"), (2, None), (3, None), (4, None)])
+        out = bramble_ops.prior_session_id(
+            state, "codex", 5, is_new_series=False, session_reset_k=4
+        )
+        self.assertEqual(out, "")
+
+    def test_returns_id_when_session_within_window(self) -> None:
+        # Last id at round 2; current 4; 4-2 = 2 < 4 -> keep.
+        state = self._state_with_session_at([(1, None), (2, "sid-2"), (3, None)])
+        out = bramble_ops.prior_session_id(
+            state, "codex", 4, is_new_series=False, session_reset_k=4
+        )
+        self.assertEqual(out, "sid-2")
+
+    def test_zero_disables_reset(self) -> None:
+        state = self._state_with_session_at([(1, "sid-1")])
+        out = bramble_ops.prior_session_id(
+            state, "codex", 99, is_new_series=False, session_reset_k=0
+        )
+        self.assertEqual(out, "sid-1")
+
+    def test_default_k_is_four(self) -> None:
+        # SESSION_RESET_K_DEFAULT = 4; ensure round 5 with id at round 1 resets.
+        state = self._state_with_session_at([(1, "sid-1"), (2, None), (3, None), (4, None)])
+        out = bramble_ops.prior_session_id(state, "codex", 5, is_new_series=False)
+        self.assertEqual(out, "")
+
+
+class TestGoalLowStreakSentence(unittest.TestCase):
+    """B1: when the prior round's low_only_streak >= 2, append a single
+    sentence to the goal text stating the fact and the cost frame. The
+    sentence is appended; it does not replace the action-history
+    briefing.
+    """
+
+    def _state(self, streak: int) -> dict:
+        return {
+            "rounds": [
+                {
+                    "n": 1,
+                    "head_before": "a",
+                    "head_after": "b",
+                    "low_only_streak": streak,
+                    "comment_actions": [
+                        {"action": "fixed", "path": "a.go", "line": 5,
+                         "topic": "stub fix"},
+                    ],
+                }
+            ]
+        }
+
+    def test_streak_two_appends_sentence(self) -> None:
+        state = self._state(2)
+        out = bramble_ops.goal_for_round(
+            2, "PR_SUMMARY", state, head_before="b", include_round_diff=False
+        )
+        self.assertIn("last 2 rounds returned only low-severity findings", out)
+        self.assertIn("returning zero findings is the right call", out)
+        # action-history still present
+        self.assertIn("Round 2.", out)
+
+    def test_streak_one_no_sentence(self) -> None:
+        state = self._state(1)
+        out = bramble_ops.goal_for_round(
+            2, "PR_SUMMARY", state, head_before="b", include_round_diff=False
+        )
+        self.assertNotIn("low-severity findings", out)
+
+    def test_streak_three_uses_actual_count(self) -> None:
+        state = self._state(3)
+        out = bramble_ops.goal_for_round(
+            2, "PR_SUMMARY", state, head_before="b", include_round_diff=False
+        )
+        self.assertIn("last 3 rounds", out)
+
+    def test_is_new_series_skips_sentence(self) -> None:
+        state = self._state(2)
+        out = bramble_ops.goal_for_round(
+            2, "PR_SUMMARY", state, head_before="b",
+            is_new_series=True, include_round_diff=False,
+        )
+        self.assertEqual(out, "PR_SUMMARY")
+        self.assertNotIn("low-severity findings", out)
+
+    def test_round_one_skips_sentence(self) -> None:
+        # Round 1 always returns PR_SUMMARY; no streak logic applies.
+        state = self._state(2)
+        out = bramble_ops.goal_for_round(
+            1, "PR_SUMMARY", state, head_before="b", include_round_diff=False
+        )
+        self.assertEqual(out, "PR_SUMMARY")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
@@ -2178,6 +2178,61 @@ class TestRecoverEnvelope(unittest.TestCase):
         out = bramble_ops.recover_envelope(path)
         self.assertEqual(out, path)
 
+    def test_substring_collisions_do_not_trigger_recovery(self) -> None:
+        """Bare substring match on verdict tokens classified `disapprove`
+        as `accepted` (because `approve` is a substring) and `exchanges`
+        as `rejected` (because `changes` is a substring). The fix is
+        word-boundary-aware matching. These should all stay unrecovered.
+        """
+        cases = [
+            "verdict error: disapprove not allowed",
+            "verdict error: exchanges field invalid",
+            "verdict error: blocking validation",
+            "verdict ownership question",
+            "verdict error: unblock route returned 500",
+        ]
+        for error_text in cases:
+            env = {
+                "schema_version": 1,
+                "status": "error",
+                "error": error_text,
+                "review": {
+                    "issues": [{"severity": "low", "file": "a", "line": 1,
+                                "message": "x"}],
+                },
+            }
+            path = self._write(f"env-{abs(hash(error_text))}.json", env)
+            out = bramble_ops.recover_envelope(path)
+            self.assertEqual(
+                out, path,
+                f"unrelated error text should not trigger recovery: {error_text!r}",
+            )
+
+    def test_classify_recovery_verdict_substring_safe(self) -> None:
+        """Direct unit coverage of the classifier: substring collisions
+        return None, real verdict tokens still classify correctly.
+        """
+        # False-positives that bare `token in t` would match
+        self.assertIsNone(bramble_ops._classify_recovery_verdict(
+            "verdict error: disapprove not allowed"))
+        self.assertIsNone(bramble_ops._classify_recovery_verdict(
+            "verdict error: exchanges field invalid"))
+        self.assertIsNone(bramble_ops._classify_recovery_verdict(
+            "verdict error: blocking validation"))
+        self.assertIsNone(bramble_ops._classify_recovery_verdict(
+            "verdict ownership question"))
+        # True-positives still match
+        self.assertEqual(bramble_ops._classify_recovery_verdict(
+            "verdict 'approve' not in allowed set"), "accepted")
+        self.assertEqual(bramble_ops._classify_recovery_verdict(
+            "unrecognized verdict 'approve_with_notes'"), "accepted")
+        self.assertEqual(bramble_ops._classify_recovery_verdict(
+            "verdict 'request_changes' not in allowed set"), "rejected")
+        self.assertEqual(bramble_ops._classify_recovery_verdict(
+            "unrecognized verdict 'needs-changes'"), "rejected")
+        self.assertEqual(bramble_ops._classify_recovery_verdict(
+            "verdict 'lgtm' not allowed"), "accepted")
+
 
 class TestRoundDiff(unittest.TestCase):
     """`round_diff` shells out to ``git diff prior_head_after..head_before``
@@ -2292,6 +2347,58 @@ class TestPriorRoundModifiedHunks(unittest.TestCase):
         # +c,0 — no lines on the + side
         diff = "@@ -10,3 +10,0 @@\n-a\n-b\n-c\n"
         self.assertEqual(bramble_ops._parse_hunk_ranges(diff), [])
+
+    def test_prior_round_modified_hunks_only_round_filters(self) -> None:
+        """only_round=N must restrict the diff walk to that round, so the
+        spiral demote heuristic doesn't accumulate touched ranges across
+        a long audit. Without this, an early round's edits to file X
+        would suppress real regressions on file X reported by every
+        subsequent round.
+        """
+        # Build a real tmp git repo with two commits ("rounds")
+        import subprocess
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            def g(*args):
+                res = subprocess.run(
+                    ["git", *args], cwd=str(root),
+                    capture_output=True, text=True, check=False,
+                )
+                if res.returncode != 0:
+                    raise RuntimeError(f"git {args}: {res.stderr}")
+                return res.stdout.strip()
+            g("init", "-q"); g("config", "user.email", "t@t")
+            g("config", "user.name", "t"); g("config", "commit.gpgsign", "false")
+            (root / "a.txt").write_text("\n".join(f"a{i}" for i in range(20)) + "\n")
+            g("add", "a.txt"); g("commit", "-q", "-m", "init")
+            sha0 = g("rev-parse", "HEAD")
+            # round 1 modifies a.txt lines 1-3
+            (root / "a.txt").write_text("\n".join(["X", "Y", "Z"] + [f"a{i}" for i in range(3, 20)]) + "\n")
+            g("add", "a.txt"); g("commit", "-q", "-m", "r1")
+            sha1 = g("rev-parse", "HEAD")
+            # round 2 modifies b.txt only
+            (root / "b.txt").write_text("hi\n")
+            g("add", "b.txt"); g("commit", "-q", "-m", "r2")
+            sha2 = g("rev-parse", "HEAD")
+            state = {
+                "rounds": [
+                    {"n": 1, "head_before": sha0, "head_after": sha1},
+                    {"n": 2, "head_before": sha1, "head_after": sha2},
+                ],
+            }
+            old_cwd = os.getcwd()
+            os.chdir(root)
+            try:
+                # Default: union across all rounds — both files appear.
+                all_hunks = bramble_ops.prior_round_modified_hunks(state)
+                self.assertIn("a.txt", all_hunks)
+                self.assertIn("b.txt", all_hunks)
+                # only_round=2: only b.txt appears (a.txt was round 1).
+                last_only = bramble_ops.prior_round_modified_hunks(state, only_round=2)
+                self.assertNotIn("a.txt", last_only)
+                self.assertIn("b.txt", last_only)
+            finally:
+                os.chdir(old_cwd)
 
     def test_line_in_modified_hunk(self) -> None:
         hunks = {"a.go": [(10, 15), (50, 55)]}

--- a/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_bramble_ops.py
@@ -107,6 +107,68 @@ class TestGoalForRound(unittest.TestCase):
         self.assertIn("Round 2", out)
         self.assertIn("a.go:5", out)
 
+    def test_prior_invariants_mirrored_into_goal(self) -> None:
+        # v2 goal channel: when the prior round's comment_actions carry
+        # invariant names, the goal appends a one-section signal listing
+        # them so the resumed reviewer folds new sites into the existing
+        # finding rather than re-flagging per-site.
+        state = {
+            "rounds": [
+                {
+                    "n": 1,
+                    "comment_actions": [
+                        {
+                            "action": "fixed",
+                            "path": "a.go",
+                            "line": 5,
+                            "source": "codex",
+                            "invariant": "ambient env vars shadow explicit proxy keys",
+                        },
+                        {
+                            "action": "fixed",
+                            "path": "b.go",
+                            "line": 10,
+                            "source": "codex",
+                            "invariant": "ambient env vars shadow explicit proxy keys",
+                        },
+                        {
+                            "action": "ack",
+                            "path": "c.go",
+                            "line": 1,
+                            "source": "cursor",
+                            "invariant": "missing nil-check in builder",
+                        },
+                    ],
+                }
+            ]
+        }
+        goal = bramble_ops.goal_for_round(2, "PR_SUMMARY", state)
+        # Both distinct invariants surface; the duplicate from a.go/b.go
+        # collapses (deduped list).
+        self.assertIn("ambient env vars shadow explicit proxy keys", goal)
+        self.assertIn("missing nil-check in builder", goal)
+        # Only two bullets (the dedup), not three.
+        self.assertEqual(goal.count("\n- "), 2)
+        # The signal tells the model to fold sites, not re-flag.
+        self.assertIn("fold new sites", goal)
+
+    def test_no_prior_invariants_no_section(self) -> None:
+        # Legacy comment_actions without an invariant field don't
+        # trigger the signal — the goal stays as before.
+        state = {
+            "rounds": [
+                {
+                    "n": 1,
+                    "comment_actions": [
+                        {"action": "fixed", "path": "a.go", "line": 5, "source": "codex"},
+                    ],
+                }
+            ]
+        }
+        goal = bramble_ops.goal_for_round(2, "PR_SUMMARY", state)
+        self.assertNotIn("Invariants named in the prior round", goal)
+        self.assertNotIn("fold new sites", goal)
+
 
 class TestFilesChangedBetweenWarnings(unittest.TestCase):
     """Stderr warning when git diff rejects the cited range — the noisy
@@ -706,6 +768,107 @@ class TestParseEnvelope(unittest.TestCase):
     def test_missing_envelope_yields_empty_list(self) -> None:
         self.assertEqual(bramble_ops.parse_envelope(None, source="codex"), [])
 
+    def test_v2_class_level_issue_expands_sites_to_findings(self) -> None:
+        # v2 schema: an issue with invariant+sites[] expands into N
+        # findings that share the invariant name + topic, so the
+        # existing (file, line) consensus / per-site fix dispatch works
+        # unchanged. The representative-site row (issue.file/line) is
+        # NOT separately emitted — it's already covered by the sites
+        # loop because the validator guarantees the top-level file/line
+        # matches one of the entries.
+        env = {
+            "status": "ok",
+            "review": {
+                "issues": [
+                    {
+                        "severity": "high",
+                        "file": "a.go",
+                        "line": 10,
+                        "message": "ambient env vars shadow explicit proxy keys",
+                        "invariant": "ambient env vars shadow explicit proxy keys",
+                        "sites": [
+                            {"file": "a.go", "line": 10},
+                            {"file": "b.go", "line": 20},
+                            {"file": "c.go", "line": 30, "note": "test-only path"},
+                        ],
+                    }
+                ]
+            },
+        }
+        got = bramble_ops.parse_envelope(env, source="codex")
+        self.assertEqual(len(got), 3)
+        for f in got:
+            self.assertEqual(f["source"], "codex")
+            self.assertEqual(f["severity"], "high")
+            self.assertEqual(f["invariant"], "ambient env vars shadow explicit proxy keys")
+        files = sorted((f["file"], f["line"]) for f in got)
+        self.assertEqual(files, [("a.go", 10), ("b.go", 20), ("c.go", 30)])
+        # Per-site note threads through when present.
+        c_finding = next(f for f in got if f["file"] == "c.go")
+        self.assertEqual(c_finding["site_note"], "test-only path")
+        a_finding = next(f for f in got if f["file"] == "a.go")
+        self.assertNotIn("site_note", a_finding)
+
+    def test_v2_single_site_issue_legacy_shape(self) -> None:
+        # No invariant + no sites = legacy single-site finding. Exactly
+        # one finding per issue, no expansion.
+        env = {
+            "status": "ok",
+            "review": {
+                "issues": [
+                    {"severity": "high", "file": "a.go", "line": 10, "message": "bug"},
+                ]
+            },
+        }
+        got = bramble_ops.parse_envelope(env, source="codex")
+        self.assertEqual(len(got), 1)
+        self.assertEqual(got[0]["file"], "a.go")
+        self.assertNotIn("invariant", got[0])
+
+
+class TestParseSufficiency(unittest.TestCase):
+    def test_returns_dict_when_present(self) -> None:
+        env = {
+            "status": "ok",
+            "review": {
+                "sufficiency": {
+                    "is_confident_complete": True,
+                    "evidence": "all named invariants addressed",
+                },
+                "issues": [],
+            },
+        }
+        got = bramble_ops.parse_sufficiency(env)
+        self.assertEqual(got, {
+            "is_confident_complete": True,
+            "evidence": "all named invariants addressed",
+        })
+
+    def test_returns_none_when_absent(self) -> None:
+        env = {"status": "ok", "review": {"issues": []}}
+        self.assertIsNone(bramble_ops.parse_sufficiency(env))
+
+    def test_returns_none_when_error_status(self) -> None:
+        # A failed run's "sufficiency" claim (if any) is not trustworthy.
+        env = {
+            "status": "error",
+            "review": {"sufficiency": {"is_confident_complete": True}},
+        }
+        self.assertIsNone(bramble_ops.parse_sufficiency(env))
+
+    def test_returns_none_for_missing_required_field(self) -> None:
+        # is_confident_complete is the only required field; without it
+        # we treat the claim as malformed and ignore.
+        env = {"status": "ok", "review": {"sufficiency": {"evidence": "x"}}}
+        self.assertIsNone(bramble_ops.parse_sufficiency(env))
+
+    def test_evidence_defaults_to_empty_string(self) -> None:
+        # Bool-only claim is legal; evidence stays empty.
+        env = {"status": "ok", "review": {"sufficiency": {"is_confident_complete": False}}}
+        got = bramble_ops.parse_sufficiency(env)
+        self.assertEqual(got["evidence"], "")
+        self.assertFalse(got["is_confident_complete"])
+
 
 class TestTriage(unittest.TestCase):
     def _f(self, source: str, file: str, line: int, severity: str, message: str) -> dict:
@@ -902,6 +1065,61 @@ class TestTriage(unittest.TestCase):
         self.assertEqual(len(out["stale_prior_commit"]), 1)
         # Fresh one still routes by its own severity — single_medium.
         self.assertEqual(len(out["single_medium"]), 1)
+
+    def test_invariant_tier_consensus_across_different_sites(self) -> None:
+        # v2 schema: two reviewers naming the same invariant — even at
+        # different (file, line) sites — should count as consensus. The
+        # kernel-3964 spiral pattern is "codex finds invariant X at site
+        # A, cursor finds invariant X at site B, neither shares an
+        # address." Pre-v2 this never formed consensus and routed every
+        # site to single_medium. Now they fold into one must_fix row.
+        def _f(source: str, file: str, line: int, invariant: str) -> dict:
+            return {
+                "source": source,
+                "severity": "high",
+                "file": file,
+                "line": line,
+                "message": invariant,
+                "topic": _common.topic_of(invariant),
+                "invariant": invariant,
+            }
+        findings = [
+            _f("codex", "a.py", 10, "ambient env vars shadow explicit proxy keys"),
+            _f("cursor", "b.py", 20, "ambient env vars shadow explicit proxy keys"),
+        ]
+        out = bramble_ops.triage(findings, prior_fixed_keys=set())
+        self.assertEqual(
+            len(out["consensus"]), 1,
+            f"expected invariant-tier consensus, got {out['consensus']!r}",
+        )
+        self.assertEqual(out["consensus"][0]["sources"], ["codex", "cursor"])
+        self.assertEqual(
+            out["consensus"][0]["invariant"],
+            "ambient env vars shadow explicit proxy keys",
+        )
+        # No single-source rows should remain — invariant consensus
+        # consumed both findings.
+        self.assertEqual(len(out["single_critical"]), 0)
+        self.assertEqual(len(out["single_medium"]), 0)
+
+    def test_invariant_single_source_does_not_force_consensus(self) -> None:
+        # One reviewer naming an invariant alone is just a single-source
+        # finding (per site). Each site routes individually to its
+        # severity bucket; the invariant name still surfaces on each
+        # finding's dict for the goal-builder to mirror back next round.
+        f = {
+            "source": "codex",
+            "severity": "high",
+            "file": "a.py",
+            "line": 10,
+            "message": "ambient env vars shadow keys",
+            "topic": _common.topic_of("ambient env vars shadow keys"),
+            "invariant": "ambient env vars shadow keys",
+        }
+        out = bramble_ops.triage([f], prior_fixed_keys=set())
+        self.assertEqual(len(out["consensus"]), 0)
+        self.assertEqual(len(out["single_critical"]), 1)
+        self.assertEqual(out["single_critical"][0]["finding"]["invariant"], "ambient env vars shadow keys")
 
 
 class TestSpiralEvidencePresent(unittest.TestCase):

--- a/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
@@ -451,6 +451,57 @@ class TestLowOnlyStreak(unittest.TestCase):
         )
         self.assertEqual(state["rounds"][1]["low_only_streak"], 0)
 
+    def test_backfills_streak_from_top_severity_when_field_missing(self) -> None:
+        """An in-progress state file written by a pre-streak orchestrator
+        won't have ``low_only_streak`` on its rounds. The next finalize
+        must reconstruct the streak from ``top_severity`` history so the
+        new convergence shortcut and pressure note trigger correctly
+        instead of waiting for two fresh low rounds to accumulate.
+        """
+        # Two prior low-only rounds with no streak field — simulates state
+        # written by the pre-this-feature orchestrator.
+        prior = [
+            {"n": 1, "top_severity": "low"},
+            {"n": 2, "top_severity": "nit"},
+        ]
+        # This round is also low — streak should be 3 (2 + 1), not 1.
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "low"), 3)
+
+    def test_backfill_resets_at_first_non_low_walking_back(self) -> None:
+        """Backfill walks the top_severity ladder backwards and stops at
+        the first medium/high. A history of [high, low, low] ending in
+        low-only continues at streak=2, not 3.
+        """
+        prior = [
+            {"n": 1, "top_severity": "high"},
+            {"n": 2, "top_severity": "low"},
+            {"n": 3, "top_severity": "low"},
+        ]
+        # Most recent is low; walking back: low (n=3), low (n=2), high
+        # (n=1 — stop). prev_streak from backfill = 2; this round adds 1.
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "low"), 3)
+
+    def test_backfill_unit(self) -> None:
+        # Empty -> 0
+        self.assertEqual(pr_ops._backfill_low_only_streak([]), 0)
+        # All low -> count all
+        self.assertEqual(
+            pr_ops._backfill_low_only_streak(
+                [{"n": 1, "top_severity": "low"},
+                 {"n": 2, "top_severity": "nit"},
+                 {"n": 3, "top_severity": None}],
+            ),
+            3,
+        )
+        # Most recent is medium -> 0 (the streak ended at the most recent round)
+        self.assertEqual(
+            pr_ops._backfill_low_only_streak(
+                [{"n": 1, "top_severity": "low"},
+                 {"n": 2, "top_severity": "medium"}],
+            ),
+            0,
+        )
+
     def test_finalize_zero_findings_counts_as_low_only(self) -> None:
         # Zero findings -> top_severity is None -> still counts as low-only,
         # so the streak increments. A single zero-finding round is what

--- a/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -1318,6 +1319,77 @@ class TestPersistRoundFindings(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("without --envelope", buf.getvalue())
 
+    def test_finalize_persists_sufficiency_claim_when_present(self) -> None:
+        # v2 schema: a reviewer that emits a top-level sufficiency
+        # object has its claim persisted at rounds[n].sufficiency_claims
+        # under the backend's key. Absence stays absent — no synthesis.
+        cx_path = self.envelope_dir / "codex-envelope.json"
+        cx_path.write_text(json.dumps({
+            "status": "ok",
+            "backend": "codex",
+            "session_id": "s1",
+            "review": {
+                "verdict": "accepted",
+                "issues": [],
+                "sufficiency": {
+                    "is_confident_complete": True,
+                    "evidence": "all named invariants addressed",
+                },
+            },
+            "schema_version": 2,
+        }))
+        cu_path = self.envelope_dir / "cursor-envelope.json"
+        cu_path.write_text(json.dumps({
+            "status": "ok",
+            "backend": "cursor",
+            "session_id": "s2",
+            "review": {"verdict": "accepted", "issues": []},
+            "schema_version": 2,
+        }))
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        state = pr_ops.state_finalize_round(
+            77, 1, "sha2", [],
+            envelope_overrides={"codex": cx_path, "cursor": cu_path},
+        )
+        claims = state["rounds"][0].get("sufficiency_claims")
+        self.assertIsNotNone(claims)
+        self.assertEqual(claims["codex"]["is_confident_complete"], True)
+        self.assertEqual(claims["codex"]["evidence"], "all named invariants addressed")
+        # Cursor's envelope had no sufficiency — no entry.
+        self.assertNotIn("cursor", claims)
+
+    def test_finalize_clears_stale_sufficiency_on_re_finalize(self) -> None:
+        # Re-finalize must not let the previous turn's sufficiency
+        # claim survive when the new envelope omits the field. Same
+        # cleanup pattern as session_ids/resume_status.
+        env_path = self.envelope_dir / "codex-envelope.json"
+        env_path.write_text(json.dumps({
+            "status": "ok",
+            "backend": "codex",
+            "review": {
+                "verdict": "accepted",
+                "issues": [],
+                "sufficiency": {"is_confident_complete": True},
+            },
+        }))
+        pr_ops.state_append_round(77, 1, "sha", verify_head=False)
+        pr_ops.state_finalize_round(
+            77, 1, "sha2", [], envelope_overrides={"codex": env_path}
+        )
+        # Re-finalize with an envelope that has NO sufficiency.
+        env_path.write_text(json.dumps({
+            "status": "ok",
+            "backend": "codex",
+            "review": {"verdict": "accepted", "issues": []},
+        }))
+        state = pr_ops.state_finalize_round(
+            77, 1, "sha3", [], envelope_overrides={"codex": env_path}
+        )
+        claims = state["rounds"][0].get("sufficiency_claims")
+        # Either absent entirely or codex key removed — both are fine.
+        if claims is not None:
+            self.assertNotIn("codex", claims)
+
 
 class TestCIFailedTests(unittest.TestCase):
     """Parses per-failed-job test details from gh check output + job logs."""
@@ -1903,6 +1975,206 @@ class TestAutoReplyInFinalize(unittest.TestCase):
             {"action": "wont_fix", "reason": "design tradeoff"}, "abc123fdeadbeef"
         )
         self.assertIn("Won't fix: design tradeoff", body_wf)
+
+
+class TestPreflight(unittest.TestCase):
+    """preflight resolves the binaries + helper paths the round loop
+    needs in one JSON dict. The errors[] list signals fail-fast cases
+    (missing --resume-session-id support, git-sync not on disk)."""
+
+    def test_returns_dict_with_required_keys(self) -> None:
+        out = pr_ops.preflight()
+        for key in (
+            "bramble_bin",
+            "bramble_resume_supported",
+            "git_sync_path",
+            "git_sync_supports_no_push",
+            "skill_dir",
+            "errors",
+        ):
+            self.assertIn(key, out)
+        self.assertIsInstance(out["errors"], list)
+
+    def test_reports_missing_resume_support_in_errors(self) -> None:
+        def fake_subprocess_run(cmd, **kwargs):
+            # Simulate an old bramble that doesn't print --resume-session-id.
+            return subprocess.CompletedProcess(args=cmd, returncode=0,
+                                               stdout="usage: bramble code-review", stderr="")
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
+            out = pr_ops.preflight()
+        self.assertFalse(out["bramble_resume_supported"])
+        self.assertTrue(any("--resume-session-id" in e for e in out["errors"]))
+
+
+class TestRoundBundle(unittest.TestCase):
+    """round-bundle wraps state_load + goal_for_round + prior_session_id
+    into one JSON dict the orchestrator reads with one jq call."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self._patch_home = patch.dict(os.environ, {"HOME": str(self.tmp)})
+        self._patch_home.start()
+        # Reset the cached state dir module-level path.
+        import importlib
+        importlib.reload(pr_ops)
+
+    def tearDown(self) -> None:
+        self._patch_home.stop()
+        self._tmp.cleanup()
+        import importlib
+        importlib.reload(pr_ops)
+
+    def test_emits_paths_and_resume_ids_for_fresh_run(self) -> None:
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _common.RunResult(stdout="head-sha\n", stderr="", returncode=0)
+            return _common.RunResult(stdout="", stderr="", returncode=1)
+        with patch.object(pr_ops, "run", side_effect=fake_run):
+            out = pr_ops.round_bundle(99, 1)
+        self.assertIn("state_dir", out)
+        self.assertIn("log_dir", out)
+        self.assertTrue(out["log_dir"].endswith("/r1"))
+        self.assertEqual(out["head_before"], "head-sha")
+        self.assertIn("envelope_paths", out)
+        for backend in ("codex", "cursor", "gemini", "lint"):
+            self.assertIn(backend, out["envelope_paths"])
+            # All resume ids empty on a fresh run (no prior state).
+            self.assertEqual(out["resume_ids"].get(backend, ""), "")
+
+    def test_returns_goal_text_on_round_two_with_prior_actions(self) -> None:
+        pr_ops.state_append_round(99, 1, "sha1", verify_head=False)
+        pr_ops.state_finalize_round(
+            99, 1, "sha1f",
+            [{"comment_id": 1, "action": "fixed", "severity": "high",
+              "path": "a.go", "line": 5, "source": "codex", "topic": "bug"}],
+        )
+        pr_ops.state_append_round(99, 2, "sha1f", verify_head=False)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _common.RunResult(stdout="sha1f\n", stderr="", returncode=0)
+            return _common.RunResult(stdout="", stderr="", returncode=1)
+        with patch.object(pr_ops, "run", side_effect=fake_run):
+            out = pr_ops.round_bundle(99, 2)
+        # Round 2 with prior actions: goal_text references the prior round.
+        self.assertIn("Round 2", out["goal_text"])
+        self.assertIn("a.go:5", out["goal_text"])
+
+
+class TestFinalizeAndReport(unittest.TestCase):
+    """finalize-and-report wraps state_finalize_round and emits the
+    one-shot audit-trail digest the orchestrator displays per-round."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self._patch_home = patch.dict(os.environ, {"HOME": str(self.tmp)})
+        self._patch_home.start()
+        import importlib
+        importlib.reload(pr_ops)
+        self.envelope_dir = self.tmp / "envelopes"
+        self.envelope_dir.mkdir()
+
+    def tearDown(self) -> None:
+        self._patch_home.stop()
+        self._tmp.cleanup()
+        import importlib
+        importlib.reload(pr_ops)
+
+    def _write_envelope(self, backend: str, **kw) -> Path:
+        obj = {
+            "status": "ok",
+            "backend": backend,
+            "review": {
+                "verdict": kw.get("verdict", "rejected"),
+                "issues": kw.get("issues", []),
+            },
+        }
+        if "sufficiency" in kw:
+            obj["review"]["sufficiency"] = kw["sufficiency"]
+        path = self.envelope_dir / f"{backend}-envelope.json"
+        path.write_text(json.dumps(obj))
+        return path
+
+    def test_low_only_streak_two_signals_converged(self) -> None:
+        # Two consecutive low-only rounds: existing low_only_streak rule
+        # fires. converged_signal == True so the orchestrator can mark
+        # complete without grepping state.
+        pr_ops.state_append_round(99, 1, "sha", verify_head=False)
+        pr_ops.state_finalize_round(
+            99, 1, "sha1f",
+            [{"comment_id": 1, "action": "ack", "severity": "low"}],
+        )
+        pr_ops.state_append_round(99, 2, "sha1f", verify_head=False)
+        out = pr_ops.finalize_and_report(
+            99, 2, "sha2f",
+            [{"comment_id": 2, "action": "ack", "severity": "low"}],
+        )
+        self.assertEqual(out["low_only_streak"], 2)
+        self.assertEqual(out["converged_signal"], True)
+        self.assertEqual(out["exit_reason_hint"], "converged")
+
+    def test_high_severity_round_does_not_signal_converged(self) -> None:
+        pr_ops.state_append_round(99, 1, "sha", verify_head=False)
+        out = pr_ops.finalize_and_report(
+            99, 1, "sha1f",
+            [{"comment_id": 1, "action": "fixed", "severity": "high",
+              "commit_sha": "sha1f"}],
+        )
+        self.assertIsNone(out["converged_signal"])
+        self.assertIsNone(out["exit_reason_hint"])
+
+    def test_sufficiency_consensus_when_both_backends_agree(self) -> None:
+        cx = self._write_envelope(
+            "codex",
+            verdict="accepted",
+            sufficiency={"is_confident_complete": True, "evidence": "ok"},
+        )
+        cu = self._write_envelope(
+            "cursor",
+            verdict="accepted",
+            sufficiency={"is_confident_complete": True, "evidence": "lgtm"},
+        )
+        pr_ops.state_append_round(99, 1, "sha", verify_head=False)
+        out = pr_ops.finalize_and_report(
+            99, 1, "sha1f", [],
+            envelope_overrides={"codex": cx, "cursor": cu},
+        )
+        self.assertEqual(out["sufficiency_consensus"], True)
+        self.assertIn("both backends signalled sufficiency", out["round_summary"])
+
+    def test_sufficiency_consensus_false_when_one_dissents(self) -> None:
+        cx = self._write_envelope(
+            "codex",
+            verdict="accepted",
+            sufficiency={"is_confident_complete": True},
+        )
+        cu = self._write_envelope(
+            "cursor",
+            verdict="rejected",
+            issues=[{"severity": "medium", "file": "a.go", "line": 1, "message": "m"}],
+            sufficiency={"is_confident_complete": False, "evidence": "more sites"},
+        )
+        pr_ops.state_append_round(99, 1, "sha", verify_head=False)
+        out = pr_ops.finalize_and_report(
+            99, 1, "sha1f", [],
+            envelope_overrides={"codex": cx, "cursor": cu},
+        )
+        self.assertEqual(out["sufficiency_consensus"], False)
+        self.assertIn("one backend signalled more sites remain", out["round_summary"])
+
+    def test_round_summary_shape(self) -> None:
+        pr_ops.state_append_round(99, 1, "sha", verify_head=False)
+        out = pr_ops.finalize_and_report(
+            99, 1, "sha1f",
+            [{"comment_id": 1, "action": "fixed", "severity": "medium",
+              "commit_sha": "sha1f"}],
+        )
+        self.assertIn("Round 1", out["round_summary"])
+        self.assertIn("top=medium", out["round_summary"])
+        self.assertIn("fixed 1", out["round_summary"])
+        self.assertEqual(out["next_round_n"], 2)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
+++ b/.claude/skills/pr-polish/scripts/tests/test_pr_ops.py
@@ -371,6 +371,97 @@ class TestStateLifecycle(unittest.TestCase):
         self.assertEqual(state["current_round"], 2)
 
 
+class TestLowOnlyStreak(unittest.TestCase):
+    """`low_only_streak` powers the streak-based convergence rule and the
+    reviewer-pressure goal sentence (B1). Test the increment/reset shape
+    directly through the unit helper plus the live finalize path so a
+    state-shape regression surfaces here instead of leaking into a real run.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        tmp_root = Path(self.tmp.name)
+
+        def fake_state_paths(pr, branch=None):
+            key = pr if pr is not None else f"branch-{branch}"
+            d = tmp_root / f"proj-{key}"
+            d.mkdir(parents=True, exist_ok=True)
+            return d, d / "pr-polish-state.json"
+
+        patcher = patch.object(pr_ops, "state_paths", side_effect=fake_state_paths)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_unit_increments_when_top_severity_low(self) -> None:
+        prior = [{"n": 1, "low_only_streak": 1, "top_severity": "low"}]
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "low"), 2)
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "nit"), 2)
+        # ``None`` top_severity (zero findings) counts as low-only too.
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, None), 2)
+
+    def test_unit_resets_when_medium_or_higher(self) -> None:
+        prior = [{"n": 1, "low_only_streak": 5, "top_severity": "low"}]
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "medium"), 0)
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "high"), 0)
+        self.assertEqual(pr_ops._compute_low_only_streak(prior, "critical"), 0)
+
+    def test_unit_round_one_low_only_starts_at_one(self) -> None:
+        self.assertEqual(pr_ops._compute_low_only_streak([], "low"), 1)
+        self.assertEqual(pr_ops._compute_low_only_streak([], None), 1)
+
+    def test_unit_round_one_high_starts_at_zero(self) -> None:
+        self.assertEqual(pr_ops._compute_low_only_streak([], "high"), 0)
+
+    def test_finalize_persists_low_only_streak(self) -> None:
+        pr_ops.state_append_round(42, 1, "abc", verify_head=False)
+        state = pr_ops.state_finalize_round(
+            42,
+            1,
+            "def",
+            [{"comment_id": 1, "action": "ack", "severity": "low"}],
+        )
+        self.assertEqual(state["rounds"][0]["low_only_streak"], 1)
+
+    def test_finalize_increments_across_consecutive_low_rounds(self) -> None:
+        pr_ops.state_append_round(42, 1, "sha1", verify_head=False)
+        pr_ops.state_finalize_round(
+            42, 1, "sha1f",
+            [{"comment_id": 1, "action": "ack", "severity": "low"}],
+        )
+        pr_ops.state_append_round(42, 2, "sha1f", verify_head=False)
+        state = pr_ops.state_finalize_round(
+            42, 2, "sha2f",
+            [{"comment_id": 2, "action": "ack", "severity": "nit"}],
+        )
+        self.assertEqual(state["rounds"][0]["low_only_streak"], 1)
+        self.assertEqual(state["rounds"][1]["low_only_streak"], 2)
+
+    def test_finalize_resets_when_medium_lands(self) -> None:
+        pr_ops.state_append_round(42, 1, "sha1", verify_head=False)
+        pr_ops.state_finalize_round(
+            42, 1, "sha1f",
+            [{"comment_id": 1, "action": "ack", "severity": "low"}],
+        )
+        pr_ops.state_append_round(42, 2, "sha1f", verify_head=False)
+        state = pr_ops.state_finalize_round(
+            42, 2, "sha2f",
+            [{"comment_id": 2, "action": "fixed", "severity": "medium",
+              "commit_sha": "sha2f"}],
+        )
+        self.assertEqual(state["rounds"][1]["low_only_streak"], 0)
+
+    def test_finalize_zero_findings_counts_as_low_only(self) -> None:
+        # Zero findings -> top_severity is None -> still counts as low-only,
+        # so the streak increments. A single zero-finding round is what
+        # "converged" feels like; the convergence rule treats two of these
+        # in a row as definite.
+        pr_ops.state_append_round(42, 1, "sha1", verify_head=False)
+        state = pr_ops.state_finalize_round(42, 1, "sha1f", [])
+        self.assertIsNone(state["rounds"][0]["top_severity"])
+        self.assertEqual(state["rounds"][0]["low_only_streak"], 1)
+
+
 class TestStateFirstRoundOfSeries(unittest.TestCase):
     """state_load decorates state with is_first_round_of_series.
 

--- a/bramble/cmd/codereview/codereview.go
+++ b/bramble/cmd/codereview/codereview.go
@@ -365,16 +365,19 @@ func maxSeverity(issues []reviewer.ReviewIssue) string {
 	const unknownRank = 2 // above "low" so non-standard labels stay visible
 	best := ""
 	bestRank := 0
-	for _, issue := range issues {
-		if issue.Severity == "" {
+	// Index loop avoids the per-iteration value-copy lint (ReviewIssue
+	// is ~152 bytes once Sites/Invariant landed).
+	for i := range issues {
+		sev := issues[i].Severity
+		if sev == "" {
 			continue
 		}
-		r, known := rank[issue.Severity]
+		r, known := rank[sev]
 		if !known {
 			r = unknownRank
 		}
 		if r > bestRank {
-			best = issue.Severity
+			best = sev
 			bestRank = r
 		}
 	}

--- a/bramble/cmd/codereview/codereview_test.go
+++ b/bramble/cmd/codereview/codereview_test.go
@@ -750,12 +750,18 @@ func TestBuildPromptForRun_FollowUpUsesShortPrompt(t *testing.T) {
 		t.Fatalf("buildPromptForRun: %v", err)
 	}
 
-	// Bias-guard prose must remain.
+	// Bias-guard prose must remain. The pr-polish round-reduction
+	// work flipped the framing from "find more is more useful" to "a
+	// clean second pass is a legitimate outcome" and added the
+	// invariant-fold-not-reflag rule + sufficiency channel. Pin both
+	// the new phrases and the no-prior-context safety net.
 	for _, want := range []string{
 		"Continue the review on the same diff",
 		"Re-review the full diff with fresh eyes",
-		"DO surface any new issues",
-		"more useful than one that just confirms the prior verdict",
+		"clean second pass is a legitimate outcome",
+		"New sites of an invariant you already named in a prior turn",
+		"Do NOT re-flag the same invariant as separate per-site findings",
+		"sufficiency",
 		"same severity rubric and JSON output format",
 		// Round-8 codex+cursor consensus: pin the no-prior-context
 		// escape hatch so a future edit can't silently drop the

--- a/yoloswe/reviewer/backend.go
+++ b/yoloswe/reviewer/backend.go
@@ -272,7 +272,7 @@ func summarizeToolInput(input map[string]interface{}) string {
 		b.WriteString(k)
 		b.WriteString("=")
 		if sensitiveToolInputKeys[k] {
-			b.WriteString(fmt.Sprintf("<redacted:%d>", redactedLen(v)))
+			fmt.Fprintf(&b, "<redacted:%d>", redactedLen(v))
 			continue
 		}
 		s := fmt.Sprintf("%v", v)

--- a/yoloswe/reviewer/json_output.go
+++ b/yoloswe/reviewer/json_output.go
@@ -9,7 +9,12 @@ import (
 )
 
 // JSONSchemaVersion is the envelope schema version. Bump on breaking changes.
-const JSONSchemaVersion = 1
+//
+// v2 adds optional code-mode fields for class-level findings (Issue.Invariant,
+// Issue.Sites) and reviewer self-assessment (ReviewBody.Sufficiency). Older
+// readers that don't know v2 ignore the new fields and continue to parse
+// v2 envelopes — the additions are strictly additive on the consumer side.
+const JSONSchemaVersion = 2
 
 // ReviewIssue mirrors the per-issue shape requested by BuildJSONPrompt.
 //
@@ -25,21 +30,32 @@ const JSONSchemaVersion = 1
 // required vs forbidden. omitempty on every mode-specific field keeps the
 // wire format clean: a code-mode issue serializes without section/dimension
 // and a design-doc-mode issue serializes without file/line.
+// Field order is dictated by govet/fieldalignment: pointer + slice
+// (large-alignment) fields first, then strings, then int. The JSON wire
+// shape is unaffected — json.Marshal honors the struct fields, not the
+// source order.
 type ReviewIssue struct {
-	Confidence *float64 `json:"confidence,omitempty"`
-	Severity   string   `json:"severity"`
-	Message    string   `json:"message"`
-	Suggestion string   `json:"suggestion,omitempty"`
+	Confidence *float64    `json:"confidence,omitempty"`
+	Severity   string      `json:"severity"`
+	Message    string      `json:"message"`
+	Suggestion string      `json:"suggestion,omitempty"`
+	File       string      `json:"file,omitempty"`
+	Section    string      `json:"section,omitempty"`
+	Dimension  string      `json:"dimension,omitempty"`
+	Invariant  string      `json:"invariant,omitempty"`
+	Sites      []IssueSite `json:"sites,omitempty"`
+	Line       int         `json:"line,omitempty"`
+}
 
-	// Code-mode addressing fields.
-	File string `json:"file,omitempty"`
-
-	// Design-doc-mode addressing fields. Section is the heading text the
-	// reviewer cited (or "(whole document)" for doc-wide issues).
-	// Dimension is the rubric question id, e.g. "q1".
-	Section   string `json:"section,omitempty"`
-	Dimension string `json:"dimension,omitempty"`
-	Line      int    `json:"line,omitempty"`
+// IssueSite is one location of a class-level finding's Sites array. Note
+// is optional per-site context the reviewer may add when the same rule
+// manifests differently at different sites (e.g. one site reads stale env,
+// another writes through it). Field order: strings before int per
+// fieldalignment.
+type IssueSite struct {
+	File string `json:"file"`
+	Note string `json:"note,omitempty"`
+	Line int    `json:"line"`
 }
 
 // ReviewBody is the parsed reviewer-level JSON. When the reviewer's response
@@ -49,12 +65,23 @@ type ReviewIssue struct {
 // *float64 so the field can be distinguished between "not provided" and
 // "explicitly zero", same as ReviewIssue.Confidence. Code-mode envelopes
 // don't emit it; design-doc-mode envelopes require it.
+// Field order: pointers + slices first, then strings, per fieldalignment.
 type ReviewBody struct {
-	Confidence *float64      `json:"confidence,omitempty"`
-	Verdict    string        `json:"verdict,omitempty"`
-	Summary    string        `json:"summary,omitempty"`
-	RawText    string        `json:"raw_text,omitempty"`
-	Issues     []ReviewIssue `json:"issues,omitempty"`
+	Confidence  *float64      `json:"confidence,omitempty"`
+	Sufficiency *Sufficiency  `json:"sufficiency,omitempty"`
+	Verdict     string        `json:"verdict,omitempty"`
+	Summary     string        `json:"summary,omitempty"`
+	RawText     string        `json:"raw_text,omitempty"`
+	Issues      []ReviewIssue `json:"issues,omitempty"`
+}
+
+// Sufficiency lets the reviewer claim "I think I've found all sites of
+// every invariant I named this turn." Evidence is a 1-2 sentence
+// rationale; the orchestrator displays it but does not parse it. Field
+// order: string before bool per fieldalignment.
+type Sufficiency struct {
+	Evidence            string `json:"evidence,omitempty"`
+	IsConfidentComplete bool   `json:"is_confident_complete"`
 }
 
 // validVerdicts enumerates per-mode verdict strings the reviewer prompt
@@ -76,6 +103,60 @@ var validVerdicts = map[ReviewMode]map[string]struct{}{
 		"revise":  {}, // address issues, doc shape is right
 		"rethink": {}, // premise needs reconsideration
 	},
+}
+
+// verdictAliases maps common reviewer-emitted variants to the canonical
+// verdict token for the corresponding mode. The reviewer prompt asks for
+// the canonical token explicitly, but cursor (in particular) occasionally
+// emits PR-review-style verdicts like "approve_with_notes" or
+// "request_changes". Rather than failing validation and forcing the skill's
+// recover-envelope shim to re-map these, normalize at the validator
+// boundary so the wrapper itself converges on the canonical set.
+//
+// Keys are lowercased; lookup is case-insensitive (the validator lowercases
+// the input). Hyphen-vs-underscore variants are both keyed because models
+// pick one or the other at random.
+var verdictAliases = map[ReviewMode]map[string]string{
+	ReviewModeCode: {
+		"approve":            "accepted",
+		"approve_with_notes": "accepted",
+		"approve-with-notes": "accepted",
+		"approved":           "accepted",
+		"lgtm":               "accepted",
+		"ship":               "accepted",
+		"request_changes":    "rejected",
+		"request-changes":    "rejected",
+		"needs_changes":      "rejected",
+		"needs-changes":      "rejected",
+		"changes_requested":  "rejected",
+		"changes-requested":  "rejected",
+		"reject":             "rejected",
+		"block":              "rejected",
+	},
+	ReviewModeDesignDoc: {
+		// Design-doc verdicts (ready/revise/rethink) rarely confuse the
+		// model — the rubric framing keeps them top of mind. Leaving this
+		// empty makes adding aliases trivial later without changing the
+		// validator shape.
+	},
+}
+
+// normalizeVerdict canonicalizes verdict aliases at the validator
+// boundary. Returns the original input unchanged when it's already
+// canonical or has no alias mapping; the validator's existing
+// validVerdicts check still catches genuinely unknown verdicts.
+func normalizeVerdict(verdict string, mode ReviewMode) string {
+	if verdict == "" {
+		return verdict
+	}
+	aliases, ok := verdictAliases[mode]
+	if !ok {
+		return verdict
+	}
+	if canonical, hit := aliases[strings.ToLower(verdict)]; hit {
+		return canonical
+	}
+	return verdict
 }
 
 // validSeverities enumerates the severity labels the reviewer prompt requires.
@@ -130,6 +211,8 @@ const (
 // ("review_mode" omitted) is treated as ReviewModeCode by consumers — the
 // pre-mode envelopes shipped without this field, and we want their
 // behaviour preserved.
+// Field order: large nested struct (Review) first so its inner pointer
+// fields align cleanly, then strings, then ints. Wire format unchanged.
 type ResultEnvelope struct {
 	Status        EnvelopeStatus `json:"status"`
 	Backend       string         `json:"backend"`
@@ -177,7 +260,13 @@ func BuildEnvelope(result *ReviewResult, backend BackendType, model, sessionID s
 	body, parseErr := extractReviewBody(result.ResponseText)
 	env.Review = body
 
-	schemaErr := validateReviewBody(body, mode)
+	// validateReviewBody normalizes the verdict in place so downstream
+	// envelope readers see the canonical token — the alias map turns
+	// "approve_with_notes" into "accepted" before the validVerdicts gate
+	// fires, which means the skill's recover-envelope shim becomes a
+	// no-op on v2 envelopes. Pass &env.Review (not the local body)
+	// because the normalization must land on the envelope we emit.
+	schemaErr := validateReviewBody(&env.Review, mode)
 
 	switch {
 	case result.ErrorMessage != "":
@@ -221,7 +310,7 @@ func ValidateReviewJSON(raw []byte, mode ReviewMode) error {
 	if err := json.Unmarshal(raw, &body); err != nil {
 		return fmt.Errorf("unmarshal reviewer JSON: %w", err)
 	}
-	return validateReviewBody(body, mode)
+	return validateReviewBody(&body, mode)
 }
 
 // validateReviewBody checks the parsed body against the required reviewer
@@ -245,6 +334,49 @@ func ValidateReviewJSON(raw []byte, mode ReviewMode) error {
 //   - "ready" carries no high/critical issues
 //   - top-level confidence ∈ [0.0, 1.0]; per-issue confidence ∈ (0.0, 1.0] when present
 //
+// validateInvariantSites enforces the code-mode contract for class-level
+// findings:
+//
+//   - Issue.Invariant non-empty implies len(Sites) ≥ 1 (an invariant must
+//     point at evidence).
+//   - When Sites has ≥2 entries, Issue.File/Line must match one of them —
+//     the representative site stays in sync with the array so single-site
+//     triage and consensus matching see a coherent address.
+//   - Each Site has a non-empty File and Line ≥ 1.
+//
+// A single-site issue with no invariant has Sites empty; that's the legacy
+// shape and stays valid. A single-site issue MAY carry Invariant with one
+// Site (e.g. the reviewer found one sibling but expects more on the next
+// turn) — we accept that without forcing it.
+//
+// Takes *ReviewIssue (not a copy) because ReviewIssue is ~152 bytes once
+// Sites + Invariant landed; the validator runs per-issue in a tight loop.
+func validateInvariantSites(idx int, issue *ReviewIssue) error {
+	if issue.Invariant != "" && len(issue.Sites) == 0 {
+		return fmt.Errorf("issue[%d] invariant requires at least one site", idx)
+	}
+	if len(issue.Sites) == 0 {
+		return nil
+	}
+	matched := false
+	for j := range issue.Sites {
+		site := &issue.Sites[j]
+		if site.File == "" {
+			return fmt.Errorf("issue[%d].sites[%d] missing file", idx, j)
+		}
+		if site.Line < 1 {
+			return fmt.Errorf("issue[%d].sites[%d] missing line", idx, j)
+		}
+		if site.File == issue.File && site.Line == issue.Line {
+			matched = true
+		}
+	}
+	if !matched {
+		return fmt.Errorf("issue[%d] file/line must match one of sites[]", idx)
+	}
+	return nil
+}
+
 // Note: the design-doc prompt (designDocJSONOutputRules) describes
 // finer verdict-vs-severity calibration bands (e.g. "revise is for
 // low/medium issues only; rethink for high/critical clusters"). Those
@@ -254,7 +386,12 @@ func ValidateReviewJSON(raw []byte, mode ReviewMode) error {
 // the doc's premise needs reconsideration. Don't tighten this without
 // also updating the prompt; otherwise valid model output will trip the
 // validator.
-func validateReviewBody(body ReviewBody, mode ReviewMode) error {
+//
+// The body is mutated in place: verdict aliases (e.g. "approve_with_notes")
+// are normalized to the canonical token before the validVerdicts gate,
+// and the canonical verdict is the one downstream consumers see on the
+// emitted envelope.
+func validateReviewBody(body *ReviewBody, mode ReviewMode) error {
 	if mode == "" {
 		mode = ReviewModeCode
 	}
@@ -262,6 +399,7 @@ func validateReviewBody(body ReviewBody, mode ReviewMode) error {
 	if !ok {
 		return fmt.Errorf("unknown review mode %q", mode)
 	}
+	body.Verdict = normalizeVerdict(body.Verdict, mode)
 	if _, ok := verdicts[body.Verdict]; !ok {
 		return fmt.Errorf("verdict %q not valid for mode %q", body.Verdict, mode)
 	}
@@ -275,7 +413,11 @@ func validateReviewBody(body ReviewBody, mode ReviewMode) error {
 		}
 	}
 	hasBlocking := false
-	for i, issue := range body.Issues {
+	// Index loop avoids the per-iteration value-copy lint (each
+	// ReviewIssue is ~152 bytes once Sites/Invariant landed); see
+	// gocritic.rangeValCopy.
+	for i := range body.Issues {
+		issue := &body.Issues[i]
 		if issue.Severity == "" {
 			return fmt.Errorf("issue[%d] missing severity", i)
 		}
@@ -292,6 +434,9 @@ func validateReviewBody(body ReviewBody, mode ReviewMode) error {
 			if issue.Line < 1 {
 				return fmt.Errorf("issue[%d] missing line", i)
 			}
+			if err := validateInvariantSites(i, issue); err != nil {
+				return err
+			}
 		} else { // ReviewModeDesignDoc
 			if issue.Section == "" {
 				return fmt.Errorf("issue[%d] missing section", i)
@@ -301,6 +446,9 @@ func validateReviewBody(body ReviewBody, mode ReviewMode) error {
 			}
 			if issue.File != "" || issue.Line != 0 {
 				return fmt.Errorf("issue[%d] design-doc mode must not carry file/line", i)
+			}
+			if issue.Invariant != "" || len(issue.Sites) > 0 {
+				return fmt.Errorf("issue[%d] design-doc mode must not carry invariant/sites", i)
 			}
 		}
 		if issue.Confidence != nil {

--- a/yoloswe/reviewer/json_output_test.go
+++ b/yoloswe/reviewer/json_output_test.go
@@ -665,3 +665,185 @@ func TestBuildEnvelopeReviewModePropagated(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateVerdictAliases pins the v2 alias-normalization contract: a
+// reviewer emitting a PR-review-style verdict (approve_with_notes, etc.)
+// gets canonicalized to accepted/rejected at the envelope boundary, the
+// validator accepts it, and the emitted envelope shows the canonical
+// token so downstream consumers don't see the alias.
+func TestValidateVerdictAliases(t *testing.T) {
+	cases := []struct {
+		raw           string
+		expectVerdict string
+		needsIssue    bool // "rejected" requires at least one issue
+	}{
+		{"approve_with_notes", "accepted", false},
+		{"approve-with-notes", "accepted", false},
+		{"approve", "accepted", false},
+		{"approved", "accepted", false},
+		{"LGTM", "accepted", false}, // case-insensitive
+		{"ship", "accepted", false},
+		{"request_changes", "rejected", true},
+		{"request-changes", "rejected", true},
+		{"needs_changes", "rejected", true},
+		{"needs-changes", "rejected", true},
+		{"changes_requested", "rejected", true},
+		{"reject", "rejected", true},
+		{"block", "rejected", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			body := `{"verdict":"` + tc.raw + `","summary":"x","issues":[]}`
+			if tc.needsIssue {
+				body = `{"verdict":"` + tc.raw + `","summary":"x","issues":[{"severity":"medium","file":"a.go","line":1,"message":"m"}]}`
+			}
+			env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+			if env.Status != StatusOK {
+				t.Fatalf("status = %s (err=%q), want ok after alias normalization", env.Status, env.Error)
+			}
+			if env.Review.Verdict != tc.expectVerdict {
+				t.Errorf("normalized verdict = %q, want %q", env.Review.Verdict, tc.expectVerdict)
+			}
+		})
+	}
+}
+
+// TestValidateVerdict_UnknownStillFails guards against the alias map
+// accidentally swallowing genuinely-unknown verdicts. "maybe" must still
+// produce status=error rather than silently passing.
+func TestValidateVerdict_UnknownStillFails(t *testing.T) {
+	env := BuildEnvelope(&ReviewResult{ResponseText: `{"verdict":"maybe","issues":[]}`, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusError {
+		t.Errorf("status = %s, want error for unknown verdict", env.Status)
+	}
+}
+
+// TestValidateInvariantSites_SingleSiteAccepted: a single-site finding
+// with no invariant is the legacy shape and continues to validate.
+func TestValidateInvariantSites_SingleSiteAccepted(t *testing.T) {
+	body := `{"verdict":"rejected","issues":[{"severity":"high","file":"a.go","line":1,"message":"bug"}]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusOK {
+		t.Errorf("status = %s (err=%q), want ok for single-site issue", env.Status, env.Error)
+	}
+}
+
+// TestValidateInvariantSites_ClassLevelAccepted: an invariant with N
+// sites, where file/line points at one of them, validates.
+func TestValidateInvariantSites_ClassLevelAccepted(t *testing.T) {
+	body := `{"verdict":"rejected","issues":[{
+		"severity":"high","file":"a.go","line":10,
+		"message":"sibling sites of one rule",
+		"invariant":"ambient env vars shadow explicit proxy keys",
+		"sites":[{"file":"a.go","line":10},{"file":"b.go","line":20}]
+	}]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusOK {
+		t.Fatalf("status = %s (err=%q), want ok for invariant+sites", env.Status, env.Error)
+	}
+	if len(env.Review.Issues) != 1 || env.Review.Issues[0].Invariant == "" || len(env.Review.Issues[0].Sites) != 2 {
+		t.Errorf("invariant/sites not parsed: %+v", env.Review.Issues)
+	}
+}
+
+// TestValidateInvariantSites_FileLineMustMatchOneSite enforces back-compat
+// with single-site triage: when sites is non-empty, file/line at the top
+// must match one entry so a consumer that ignores sites still sees a
+// representative address.
+func TestValidateInvariantSites_FileLineMustMatchOneSite(t *testing.T) {
+	body := `{"verdict":"rejected","issues":[{
+		"severity":"high","file":"z.go","line":99,
+		"message":"mismatched representative site",
+		"invariant":"rule x",
+		"sites":[{"file":"a.go","line":10},{"file":"b.go","line":20}]
+	}]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusError {
+		t.Errorf("status = %s, want error when file/line doesn't match any site", env.Status)
+	}
+}
+
+// TestValidateInvariantSites_InvariantWithoutSitesRejected: naming an
+// invariant without listing sites is meaningless — there's nothing for
+// the orchestrator to act on.
+func TestValidateInvariantSites_InvariantWithoutSitesRejected(t *testing.T) {
+	body := `{"verdict":"rejected","issues":[{
+		"severity":"high","file":"a.go","line":1,
+		"message":"named invariant with no sites",
+		"invariant":"some rule"
+	}]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusError {
+		t.Errorf("status = %s, want error for invariant without sites", env.Status)
+	}
+}
+
+// TestValidateInvariantSites_SiteMissingFile guards the per-site shape.
+func TestValidateInvariantSites_SiteMissingFile(t *testing.T) {
+	body := `{"verdict":"rejected","issues":[{
+		"severity":"high","file":"a.go","line":10,
+		"message":"sites entry missing file",
+		"invariant":"r",
+		"sites":[{"file":"a.go","line":10},{"line":20}]
+	}]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusError {
+		t.Errorf("status = %s, want error for site without file", env.Status)
+	}
+}
+
+// TestValidateInvariantSites_DesignDocRejectsClassFields: invariant/sites
+// are code-mode-only; design-doc envelopes that carry them are malformed.
+func TestValidateInvariantSites_DesignDocRejectsClassFields(t *testing.T) {
+	body := `{"verdict":"revise","confidence":0.8,"issues":[{
+		"severity":"medium","section":"M1","dimension":"q1","message":"x",
+		"invariant":"r","sites":[]
+	}]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", ReviewModeDesignDoc)
+	if env.Status != StatusError {
+		t.Errorf("status = %s, want error for invariant in design-doc mode", env.Status)
+	}
+}
+
+// TestSufficiency_AcceptedAndPropagated: a top-level sufficiency object
+// parses into the envelope. Surfaces in v2 envelopes only; the field is
+// optional, so omitting it remains valid.
+func TestSufficiency_AcceptedAndPropagated(t *testing.T) {
+	body := `{"verdict":"accepted","summary":"clean","issues":[],
+		"sufficiency":{"is_confident_complete":true,"evidence":"all named invariants addressed"}}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusOK {
+		t.Fatalf("status = %s (err=%q), want ok", env.Status, env.Error)
+	}
+	if env.Review.Sufficiency == nil {
+		t.Fatal("Sufficiency should be parsed")
+	}
+	if !env.Review.Sufficiency.IsConfidentComplete {
+		t.Errorf("IsConfidentComplete = false, want true")
+	}
+	if env.Review.Sufficiency.Evidence == "" {
+		t.Errorf("Evidence should be parsed")
+	}
+}
+
+// TestSufficiency_OmittedRemainsNil: absence means no signal — the field
+// stays nil. Don't synthesize a default.
+func TestSufficiency_OmittedRemainsNil(t *testing.T) {
+	body := `{"verdict":"accepted","summary":"clean","issues":[]}`
+	env := BuildEnvelope(&ReviewResult{ResponseText: body, Success: true}, BackendCodex, "m", "", "")
+	if env.Status != StatusOK {
+		t.Fatalf("status = %s, want ok", env.Status)
+	}
+	if env.Review.Sufficiency != nil {
+		t.Errorf("Sufficiency = %+v, want nil for omitted field", env.Review.Sufficiency)
+	}
+}
+
+// TestSchemaVersion_IsV2 pins the bump. Anyone bumping JSONSchemaVersion
+// should also update the docstring on the constant and notify downstream
+// readers; this test catches accidental reverts.
+func TestSchemaVersion_IsV2(t *testing.T) {
+	if JSONSchemaVersion != 2 {
+		t.Errorf("JSONSchemaVersion = %d, want 2 (Issue.Invariant/Sites + ReviewBody.Sufficiency)", JSONSchemaVersion)
+	}
+}

--- a/yoloswe/reviewer/reviewer.go
+++ b/yoloswe/reviewer/reviewer.go
@@ -272,6 +272,10 @@ Focus on these areas:
 - performance.
 - security.
 
+When you find N >= 2 sibling sites of the same underlying rule violation (same invariant, different lines), emit ONE issue with a named "invariant" and a "sites" array. Do NOT emit N separate single-site issues. The invariant name describes the rule being violated (e.g. "ambient env vars shadow explicit proxy keys"), not the symptom. A single finding that names the producer-side invariant beats N findings that patch consumer sites — see the Class-level findings section of the output format for the exact shape.
+
+Prioritize systemic problems over local ones. If after scanning the diff and adjacent code you find no structural issues, return an empty issues array with verdict "accepted". Finding nothing on a clean diff is the right call; do not strain to find something to flag.
+
 When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
 Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
 Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.`, buildGoalText(goal))
@@ -713,12 +717,13 @@ func BuildFollowUpJSONPromptWithScope(goal string, opts PromptOptions) string {
 
 If you have no prior review context for this diff (because the backend silently fell back to a fresh session despite the resume request), treat this as a first-pass review: examine the entire diff and apply the standard severity rubric and JSON output format. Otherwise, proceed with the resume protocol below.
 
-Re-review the full diff with fresh eyes — including code you previously accepted. Pay particular attention to:
+Re-review the full diff with fresh eyes. Pay particular attention to:
 1. Issues introduced by new commits since the prior turn.
 2. Items you flagged before that you now have stronger evidence for — cite the file:line that proves it.
 3. Anything you skipped or dismissed before that, on a second look, warrants flagging.
+4. New sites of an invariant you already named in a prior turn — fold them into the existing invariant's "sites" array via a single issue. Do NOT re-flag the same invariant as separate per-site findings; the orchestrator will treat that as a spiral and waste a round chasing your symptom list.
 
-Avoid restating prior findings verbatim, but DO surface any new issues you spot — including in code you already accepted. A second pass that finds something the first pass missed is more useful than one that just confirms the prior verdict.
+If the prior turn's fixes addressed the structural issues you raised and you find nothing new at this scope, return an empty issues array with verdict "accepted". A clean second pass is a legitimate outcome — better than re-surfacing nits to justify the turn. On resumed sessions you MAY emit a top-level "sufficiency" object signalling whether you believe the prior turn's fixes addressed every invariant you can find; see the output format spec for the shape.
 
 Apply the same severity rubric and JSON output format as the prior turn.`
 	// Append the scope suffix and skip-test-execution suffix here, even
@@ -826,9 +831,12 @@ You MUST respond with valid JSON in this exact format:
       "line": 42,
       "message": "Description of the issue",
       "suggestion": "How to fix it",
-      "confidence": 0.9
+      "confidence": 0.9,
+      "invariant": "short name of the rule (optional, see Class-level findings)",
+      "sites": [{"file": "path/to/file.go", "line": 42}, {"file": "path/to/other.go", "line": 17}]
     }
-  ]
+  ],
+  "sufficiency": {"is_confident_complete": true, "evidence": "..."}
 }
 
 ## Severity Levels
@@ -837,12 +845,41 @@ You MUST respond with valid JSON in this exact format:
 - medium: Code style issues, minor inefficiencies, missing edge cases
 - low: Naming preferences, formatting, optional improvements
 
+## Class-level findings (invariant + sites)
+When you find N >= 2 sibling sites of the same rule violation, emit ONE
+issue with:
+- "invariant": a short name for the rule (3-8 words; e.g. "ambient env
+  vars shadow explicit proxy keys"). Name the rule being violated, not
+  the symptom.
+- "sites": [{"file": "...", "line": ...}, ...] listing every site.
+- "file" and "line" at the top of the issue: the most representative
+  site (pick one entry from "sites"). Required for back-compat with
+  single-site triage.
+- "message": describe the invariant once, then list the sites by reference.
+  Do not repeat the same wording per site.
+Do NOT emit N separate single-site issues for one invariant. A single
+finding that names the producer-side invariant beats N findings that
+patch consumer sites.
+
+## Sufficiency (optional, resume sessions only)
+On round 2+, you MAY emit a top-level "sufficiency" object:
+- "is_confident_complete": true if you believe the prior turn's fixes
+  addressed every invariant you can find at this scope. false if you
+  suspect more sites or a different class of issue remain.
+- "evidence": 1-2 sentences explaining why. Optional.
+This is a hint to the orchestrator, not a new gate — the verdict +
+issues array remain authoritative. Omit on first-pass reviews.
+
 ## Rules
-- verdict MUST be exactly "accepted" or "rejected"
+- verdict MUST be exactly "accepted" or "rejected". Aliases like
+  "approve_with_notes", "request_changes", "lgtm", or "needs-changes"
+  are normalized but you should pick the canonical token.
 - If there are any critical or high severity issues, verdict MUST be "rejected"
-- issues array can be empty if verdict is "accepted"
+- issues array can be empty if verdict is "accepted". A clean diff is a
+  legitimate outcome; do not strain to find something to flag.
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
 - confidence is an optional float in (0.0, 1.0]: 1.0 = certain, 0.5 = plausible but unverified; omit only when you cannot assess (the field is treated as "no signal", not as a default value)
+- When "invariant" is set, "sites" MUST list >=1 entries and "file"/"line" MUST match one of them.
 - Output ONLY the JSON object, no other text`
 
 const designDocJSONOutputRules = `

--- a/yoloswe/reviewer/reviewer_test.go
+++ b/yoloswe/reviewer/reviewer_test.go
@@ -252,15 +252,24 @@ func TestBuildFollowUpJSONPromptWithScope_KeepsBiasGuardAndDropsRedundantBlocks(
 
 				required := []string{
 					"Re-review the full diff with fresh eyes",
-					"including code you previously accepted",
-					"DO surface any new issues",
-					"more useful than one that just confirms the prior verdict",
+					// pr-polish round-reduction work: the follow-up prompt
+					// now incentivizes a clean second pass and an
+					// invariant-aware fold of new sites into existing
+					// findings, rather than rewarding "find something new"
+					// per turn. Pin both phrases so a future edit can't
+					// silently revert the framing.
+					"clean second pass is a legitimate outcome",
+					"New sites of an invariant you already named in a prior turn",
+					"Do NOT re-flag the same invariant as separate per-site findings",
 					"same severity rubric and JSON output format",
 					// Round-8 codex+cursor consensus added this: pin the
 					// no-prior-context escape hatch so a future edit can't
 					// silently drop the resume-fallback safety net.
 					"silently fell back to a fresh session",
 					"treat this as a first-pass review",
+					// Sufficiency is the v2 audit-trail channel; the model
+					// must be told it MAY emit it on resumed sessions.
+					"sufficiency",
 				}
 				for _, want := range required {
 					if !strings.Contains(prompt, want) {

--- a/yoloswe/reviewer/testdata/legacy_json_prompt.txt
+++ b/yoloswe/reviewer/testdata/legacy_json_prompt.txt
@@ -9,6 +9,10 @@ Focus on these areas:
 - performance.
 - security.
 
+When you find N >= 2 sibling sites of the same underlying rule violation (same invariant, different lines), emit ONE issue with a named "invariant" and a "sites" array. Do NOT emit N separate single-site issues. The invariant name describes the rule being violated (e.g. "ambient env vars shadow explicit proxy keys"), not the symptom. A single finding that names the producer-side invariant beats N findings that patch consumer sites — see the Class-level findings section of the output format for the exact shape.
+
+Prioritize systemic problems over local ones. If after scanning the diff and adjacent code you find no structural issues, return an empty issues array with verdict "accepted". Finding nothing on a clean diff is the right call; do not strain to find something to flag.
+
 When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
 Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
 Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.
@@ -25,9 +29,12 @@ You MUST respond with valid JSON in this exact format:
       "line": 42,
       "message": "Description of the issue",
       "suggestion": "How to fix it",
-      "confidence": 0.9
+      "confidence": 0.9,
+      "invariant": "short name of the rule (optional, see Class-level findings)",
+      "sites": [{"file": "path/to/file.go", "line": 42}, {"file": "path/to/other.go", "line": 17}]
     }
-  ]
+  ],
+  "sufficiency": {"is_confident_complete": true, "evidence": "..."}
 }
 
 ## Severity Levels
@@ -36,10 +43,39 @@ You MUST respond with valid JSON in this exact format:
 - medium: Code style issues, minor inefficiencies, missing edge cases
 - low: Naming preferences, formatting, optional improvements
 
+## Class-level findings (invariant + sites)
+When you find N >= 2 sibling sites of the same rule violation, emit ONE
+issue with:
+- "invariant": a short name for the rule (3-8 words; e.g. "ambient env
+  vars shadow explicit proxy keys"). Name the rule being violated, not
+  the symptom.
+- "sites": [{"file": "...", "line": ...}, ...] listing every site.
+- "file" and "line" at the top of the issue: the most representative
+  site (pick one entry from "sites"). Required for back-compat with
+  single-site triage.
+- "message": describe the invariant once, then list the sites by reference.
+  Do not repeat the same wording per site.
+Do NOT emit N separate single-site issues for one invariant. A single
+finding that names the producer-side invariant beats N findings that
+patch consumer sites.
+
+## Sufficiency (optional, resume sessions only)
+On round 2+, you MAY emit a top-level "sufficiency" object:
+- "is_confident_complete": true if you believe the prior turn's fixes
+  addressed every invariant you can find at this scope. false if you
+  suspect more sites or a different class of issue remain.
+- "evidence": 1-2 sentences explaining why. Optional.
+This is a hint to the orchestrator, not a new gate — the verdict +
+issues array remain authoritative. Omit on first-pass reviews.
+
 ## Rules
-- verdict MUST be exactly "accepted" or "rejected"
+- verdict MUST be exactly "accepted" or "rejected". Aliases like
+  "approve_with_notes", "request_changes", "lgtm", or "needs-changes"
+  are normalized but you should pick the canonical token.
 - If there are any critical or high severity issues, verdict MUST be "rejected"
-- issues array can be empty if verdict is "accepted"
+- issues array can be empty if verdict is "accepted". A clean diff is a
+  legitimate outcome; do not strain to find something to flag.
 - Each issue MUST include severity, file, line (>= 1), and message; suggestion is optional
 - confidence is an optional float in (0.0, 1.0]: 1.0 = certain, 0.5 = plausible but unverified; omit only when you cannot assess (the field is treated as "no signal", not as a default value)
+- When "invariant" is set, "sites" MUST list >=1 entries and "file"/"line" MUST match one of them.
 - Output ONLY the JSON object, no other text


### PR DESCRIPTION
## Summary

Reduces the number of rounds a typical `/pr-polish` session needs to converge by adding mechanisms that target the failure modes observed on PR #240: round 1–4 fixed real bugs, rounds 5–10 mostly chased consequences (new tests for new helpers, doc clarifications, fingerprint canonicality, godoc asymmetry).

Five round-reduction mechanisms plus three correctness fixes from a code-review-eval pass.

### Round-reduction mechanisms

- **`low_only_streak` convergence** — persisted per round (`pr_ops._compute_low_only_streak`). Convergence rule now exits at streak ≥ 2 regardless of remaining `--rounds` budget. The streak resets on any medium-or-higher round.
- **Reviewer convergence pressure** — when prior `low_only_streak >= 2`, `goal_for_round` appends a one-sentence note stating that low-only streaks cost rounds and zero findings is a real option. One sentence, one trigger — not a table of phrasings.
- **Inter-round diff in goal channel** — `bramble_ops round-diff` emits `git diff <prior_head_after>..<HEAD>` truncated at 200 lines. Appended to the goal text so the resumed reviewer sees the inter-round delta instead of re-snapshotting the full PR.
- **Modified-hunk spiral demote** — `prior_round_modified_hunks` reads `head_before..head_after` of the immediately-prior round; `triage` auto-demotes single-source spirals whose cited line falls inside one of those hunks (multi-source still escalates). The doc-comment-fix scenario where words shift within the same function — the original cause of late-round noise.
- **Session reset every K=4 rounds** — `prior_session_id` returns empty once a session id is K rounds old so accumulated context doesn't compound staleness across long audits.

### Helpers

- **`recover_envelope`** salvages cursor envelopes whose verdict was `approve_with_notes` / `request_changes` / etc. by remapping verdict to `accepted`/`rejected`. Word-boundary-aware token matching so `disapprove` doesn't classify as `accepted`. Idempotent.
- **Pre-commit fix-completeness checklist** in Step 3e — five questions on sibling sites, tests, docs, type contract, symmetry. Frames, not gates.

### SKILL.md hygiene

- Trims the action-history goal table from 4 rows to 2 + bullet exceptions.
- Extracts the "Why defer push" rationale to `references/why-defer-push.md`.
- Net result: SKILL.md at 499 lines after additions.

### Correctness fixes from the eval

Code-review-eval against this branch (cursor + codex + gemini, three turns each) caught three real defects in commit `bf511d1`, fixed in commit `c78fd2a`:

1. **`_classify_recovery_verdict` substring matching** — `"verdict error: disapprove not allowed"` returned `"accepted"` because `approve` was a substring of `disapprove`. Switch to word-boundary-aware matching that treats `-` and `_` as separators so `approve_with_notes` / `needs-changes` still match.
2. **Modified-hunk demote unioned across all prior rounds** — a long audit accumulated touched ranges and would suppress real regressions on any file an early round happened to edit. Narrow to the immediately-prior round only.
3. **`low_only_streak` field defaulted missing to 0** — an in-progress state file from before this branch lost streak continuity on upgrade. Added `_backfill_low_only_streak` that reconstructs the streak from persisted `top_severity` history.

## Test plan

- [x] `python3 -m unittest discover -s .claude/skills/pr-polish/scripts/tests/` — 364 tests pass (45 new across both commits)
- [x] SKILL.md ≤ 500 lines after additions (499)
- [x] Manual verification of recovery-classifier fix: `disapprove`, `exchanges`, `blocking`, `ownership` all return None; `approve_with_notes`, `needs-changes`, `lgtm`, `request_changes` still classify
- [x] Code-review-eval run against the branch (cursor=1H+1M, codex=1H+1M, gemini=0; both highs confirmed real; all three issues fixed in c78fd2a)
- [ ] Real-world: run `/pr-polish --rounds 10` on a synthetic medium-feature PR; should converge in ≤ 6 rounds where the prior version took 10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes affect the `/pr-polish` orchestration loop, review-envelope schema, and spiral/convergence heuristics, which could alter when reviews stop or how issues are triaged if edge cases are wrong.
> 
> **Overview**
> **Reduces `/pr-polish` rounds-to-converge** by adding new convergence and de-noising mechanisms: persisted `low_only_streak` (early-exit after 2 low-only rounds), a goal-channel pressure sentence when the streak is high, and appending an inter-round `git diff` (truncated) to the goal for resumed reviewers.
> 
> **Improves stale/spiral handling and session hygiene** by (1) demoting single-source spirals when the cited line is inside a hunk modified in the immediately-prior round, and (2) periodically resetting backend resume sessions every K rounds to avoid accumulating stale conversational context.
> 
> **Upgrades the review envelope to schema v2** (Go side) to support class-level findings (`issue.invariant` + `issue.sites[]`) and optional reviewer `review.sufficiency`, including verdict-alias normalization (e.g. `approve_with_notes` → `accepted`) plus Python-side parsing/triage updates to expand sites into per-location findings and form consensus by invariant.
> 
> **Adds orchestration helpers and docs/tests**: new `pr_ops.py` commands (`preflight`, `round-bundle`, `finalize-and-report`), `recover-envelope` helper for legacy verdict errors, a new reference doc on deferred pushing, and extensive unit tests covering the new heuristics and schema behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2948ceb4417333f5cef858c2e03d599ec8d7e2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->