### PR TITLE
Add agy provider integration

### DIFF
--- a/agent-cli-wrapper/agy/BUILD.bazel
+++ b/agent-cli-wrapper/agy/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "agy",
+    srcs = [
+        "doc.go",
+        "errors.go",
+        "events.go",
+        "process.go",
+        "session.go",
+        "session_options.go",
+    ],
+    importpath = "github.com/bazelment/yoloswe/agent-cli-wrapper/agy",
+    visibility = ["//visibility:public"],
+    deps = ["//agent-cli-wrapper/internal/procattr"],
+)
+
+go_test(
+    name = "agy_test",
+    srcs = ["process_test.go"],
+    embed = [":agy"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/agent-cli-wrapper/agy/doc.go
+++ b/agent-cli-wrapper/agy/doc.go
@@ -1,0 +1,2 @@
+// Package agy wraps the Antigravity CLI's non-interactive print mode.
+package agy

--- a/agent-cli-wrapper/agy/errors.go
+++ b/agent-cli-wrapper/agy/errors.go
@@ -1,0 +1,35 @@
+package agy
+
+import "fmt"
+
+var (
+	ErrAlreadyStarted = fmt.Errorf("agy session already started")
+	ErrNotStarted     = fmt.Errorf("agy session not started")
+)
+
+// CLINotFoundError is returned when the agy binary cannot be found.
+type CLINotFoundError struct {
+	Cause error
+	Path  string
+}
+
+func (e *CLINotFoundError) Error() string {
+	return fmt.Sprintf("agy CLI not found at %q: %v", e.Path, e.Cause)
+}
+
+func (e *CLINotFoundError) Unwrap() error { return e.Cause }
+
+// ProcessError wraps a process startup or execution failure.
+type ProcessError struct {
+	Cause   error
+	Message string
+}
+
+func (e *ProcessError) Error() string {
+	if e.Cause == nil {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+}
+
+func (e *ProcessError) Unwrap() error { return e.Cause }

--- a/agent-cli-wrapper/agy/events.go
+++ b/agent-cli-wrapper/agy/events.go
@@ -1,0 +1,30 @@
+package agy
+
+// Event is implemented by all agy wrapper events.
+type Event interface {
+	eventType() string
+}
+
+// TextEvent contains the final stdout emitted by print mode.
+type TextEvent struct {
+	Text string
+}
+
+func (e TextEvent) eventType() string { return "text" }
+
+// TurnCompleteEvent marks the end of a print-mode invocation.
+type TurnCompleteEvent struct {
+	Error      error
+	DurationMs int64
+	Success    bool
+}
+
+func (e TurnCompleteEvent) eventType() string { return "turn_complete" }
+
+// ErrorEvent reports a wrapper or process error.
+type ErrorEvent struct {
+	Error   error
+	Context string
+}
+
+func (e ErrorEvent) eventType() string { return "error" }

--- a/agent-cli-wrapper/agy/process.go
+++ b/agent-cli-wrapper/agy/process.go
@@ -1,0 +1,133 @@
+package agy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/internal/procattr"
+)
+
+type processManager struct {
+	cmd      *exec.Cmd
+	prompt   string
+	config   SessionConfig
+	mu       sync.Mutex
+	started  bool
+	stopping bool
+}
+
+func newProcessManager(prompt string, config SessionConfig) *processManager {
+	return &processManager{
+		config: config,
+		prompt: prompt,
+	}
+}
+
+// BuildCLIArgs builds the agy print-mode argument list.
+func (pm *processManager) BuildCLIArgs() []string {
+	args := []string{"-p", pm.prompt}
+
+	if pm.config.PrintTimeout > 0 {
+		args = append(args, "--print-timeout", formatDuration(pm.config.PrintTimeout))
+	}
+	if pm.config.ConversationID != "" {
+		args = append(args, "--conversation", pm.config.ConversationID)
+	}
+	if pm.config.LogFile != "" {
+		args = append(args, "--log-file", pm.config.LogFile)
+	}
+	for _, dir := range pm.config.AddDirs {
+		args = append(args, "--add-dir", dir)
+	}
+	if pm.config.DangerouslySkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	if pm.config.Sandbox {
+		args = append(args, "--sandbox")
+	}
+	args = append(args, pm.config.ExtraArgs...)
+	return args
+}
+
+func formatDuration(d time.Duration) string {
+	if d%time.Second == 0 {
+		return strconv.FormatInt(int64(d/time.Second), 10) + "s"
+	}
+	return d.String()
+}
+
+func (pm *processManager) Start(ctx context.Context) (stdout []byte, stderr []byte, err error) {
+	pm.mu.Lock()
+	if pm.started {
+		pm.mu.Unlock()
+		return nil, nil, ErrAlreadyStarted
+	}
+	pm.started = true
+	pm.mu.Unlock()
+
+	cliPath := pm.config.CLIPath
+	if cliPath == "" {
+		cliPath = "agy"
+	}
+
+	cmd := exec.CommandContext(ctx, cliPath, pm.BuildCLIArgs()...)
+	cmd.Env = os.Environ()
+	for k, v := range pm.config.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	if pm.config.WorkDir != "" {
+		cmd.Dir = pm.config.WorkDir
+	}
+	procattr.Set(cmd)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	pm.mu.Lock()
+	pm.cmd = cmd
+	pm.mu.Unlock()
+
+	err = cmd.Run()
+	stderr = errBuf.Bytes()
+	if len(stderr) > 0 && pm.config.StderrHandler != nil {
+		pm.config.StderrHandler(stderr)
+	}
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return outBuf.Bytes(), stderr, &CLINotFoundError{Path: cliPath, Cause: err}
+		}
+		return outBuf.Bytes(), stderr, &ProcessError{
+			Message: fmt.Sprintf("agy exited with stderr: %s", bytes.TrimSpace(stderr)),
+			Cause:   err,
+		}
+	}
+	return outBuf.Bytes(), stderr, nil
+}
+
+func (pm *processManager) Stop() error {
+	pm.mu.Lock()
+	if !pm.started || pm.stopping {
+		pm.mu.Unlock()
+		return nil
+	}
+	pm.stopping = true
+	cmd := pm.cmd
+	pm.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	_ = procattr.SignalGroup(cmd.Process, syscall.SIGTERM)
+	time.Sleep(100 * time.Millisecond)
+	_ = procattr.KillGroup(cmd.Process)
+	return nil
+}

--- a/agent-cli-wrapper/agy/process_test.go
+++ b/agent-cli-wrapper/agy/process_test.go
@@ -1,0 +1,42 @@
+package agy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCLIArgs_DefaultPrintMode(t *testing.T) {
+	t.Parallel()
+
+	pm := newProcessManager("hello", defaultConfig())
+
+	assert.Equal(t, []string{"-p", "hello"}, pm.BuildCLIArgs())
+}
+
+func TestBuildCLIArgs_AllOptions(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	WithPrintTimeout(2 * time.Minute)(&cfg)
+	WithConversation("conv-123")(&cfg)
+	WithLogFile("/tmp/agy.log")(&cfg)
+	WithAddDir("/tmp/extra")(&cfg)
+	WithDangerouslySkipPermissions()(&cfg)
+	WithSandbox()(&cfg)
+	WithExtraArgs("--future-flag")(&cfg)
+
+	pm := newProcessManager("hello", cfg)
+
+	assert.Equal(t, []string{
+		"-p", "hello",
+		"--print-timeout", "120s",
+		"--conversation", "conv-123",
+		"--log-file", "/tmp/agy.log",
+		"--add-dir", "/tmp/extra",
+		"--dangerously-skip-permissions",
+		"--sandbox",
+		"--future-flag",
+	}, pm.BuildCLIArgs())
+}

--- a/agent-cli-wrapper/agy/session.go
+++ b/agent-cli-wrapper/agy/session.go
@@ -1,0 +1,129 @@
+package agy
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+// QueryResult contains the result of a one-shot agy query.
+type QueryResult struct {
+	Text       string
+	DurationMs int64
+	Success    bool
+}
+
+// Session manages one agy print-mode invocation.
+type Session struct {
+	process *processManager
+	events  chan Event
+	done    chan struct{}
+	prompt  string
+	config  SessionConfig
+	mu      sync.RWMutex
+	started bool
+	stopped bool
+}
+
+// NewSession creates a new agy session.
+func NewSession(prompt string, opts ...SessionOption) *Session {
+	config := defaultConfig()
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return &Session{
+		prompt: prompt,
+		config: config,
+		events: make(chan Event, config.EventBufferSize),
+		done:   make(chan struct{}),
+	}
+}
+
+// Start spawns agy, waits for print-mode completion, and emits result events.
+func (s *Session) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	s.process = newProcessManager(s.prompt, s.config)
+	s.started = true
+	s.mu.Unlock()
+
+	go s.run(ctx)
+	return nil
+}
+
+// Events returns a read-only event channel.
+func (s *Session) Events() <-chan Event {
+	return s.events
+}
+
+// Stop terminates the subprocess if it is still running.
+func (s *Session) Stop() error {
+	s.mu.Lock()
+	if !s.started || s.stopped {
+		s.mu.Unlock()
+		return nil
+	}
+	s.stopped = true
+	close(s.done)
+	process := s.process
+	s.mu.Unlock()
+
+	if process != nil {
+		return process.Stop()
+	}
+	return nil
+}
+
+func (s *Session) run(ctx context.Context) {
+	defer close(s.events)
+
+	start := time.Now()
+	out, _, err := s.process.Start(ctx)
+	duration := time.Since(start).Milliseconds()
+	text := strings.TrimRight(string(out), "\r\n")
+	if text != "" {
+		s.emit(TextEvent{Text: text})
+	}
+	if err != nil {
+		s.emit(ErrorEvent{Error: err, Context: "process"})
+		s.emit(TurnCompleteEvent{Error: err, DurationMs: duration, Success: false})
+		return
+	}
+	s.emit(TurnCompleteEvent{DurationMs: duration, Success: true})
+}
+
+func (s *Session) emit(evt Event) {
+	select {
+	case <-s.done:
+		return
+	case s.events <- evt:
+	}
+}
+
+// Query runs a one-shot agy prompt and returns the result.
+func Query(ctx context.Context, prompt string, opts ...SessionOption) (*QueryResult, error) {
+	session := NewSession(prompt, opts...)
+	if err := session.Start(ctx); err != nil {
+		return nil, err
+	}
+	defer session.Stop()
+
+	var result QueryResult
+	for evt := range session.Events() {
+		switch e := evt.(type) {
+		case TextEvent:
+			result.Text += e.Text
+		case TurnCompleteEvent:
+			result.DurationMs = e.DurationMs
+			result.Success = e.Success
+			return &result, e.Error
+		case ErrorEvent:
+			return nil, e.Error
+		}
+	}
+	return nil, ErrNotStarted
+}

--- a/agent-cli-wrapper/agy/session_options.go
+++ b/agent-cli-wrapper/agy/session_options.go
@@ -1,0 +1,113 @@
+package agy
+
+import "time"
+
+// SessionConfig holds configuration for one agy print-mode invocation.
+type SessionConfig struct {
+	StderrHandler              func([]byte)
+	Env                        map[string]string
+	WorkDir                    string
+	CLIPath                    string
+	ConversationID             string
+	LogFile                    string
+	ExtraArgs                  []string
+	AddDirs                    []string
+	PrintTimeout               time.Duration
+	EventBufferSize            int
+	DangerouslySkipPermissions bool
+	Sandbox                    bool
+}
+
+// SessionOption configures a Session.
+type SessionOption func(*SessionConfig)
+
+// WithWorkDir sets the subprocess working directory.
+func WithWorkDir(dir string) SessionOption {
+	return func(c *SessionConfig) {
+		c.WorkDir = dir
+	}
+}
+
+// WithCLIPath sets a custom agy binary path.
+func WithCLIPath(path string) SessionOption {
+	return func(c *SessionConfig) {
+		c.CLIPath = path
+	}
+}
+
+// WithConversation resumes a previous agy conversation by ID.
+func WithConversation(id string) SessionOption {
+	return func(c *SessionConfig) {
+		c.ConversationID = id
+	}
+}
+
+// WithLogFile writes agy logs to a specific file.
+func WithLogFile(path string) SessionOption {
+	return func(c *SessionConfig) {
+		c.LogFile = path
+	}
+}
+
+// WithAddDir adds an additional workspace directory. It can be repeated.
+func WithAddDir(dir string) SessionOption {
+	return func(c *SessionConfig) {
+		c.AddDirs = append(c.AddDirs, dir)
+	}
+}
+
+// WithPrintTimeout sets agy's print-mode wait timeout.
+func WithPrintTimeout(timeout time.Duration) SessionOption {
+	return func(c *SessionConfig) {
+		c.PrintTimeout = timeout
+	}
+}
+
+// WithDangerouslySkipPermissions auto-approves agy tool permission requests.
+func WithDangerouslySkipPermissions() SessionOption {
+	return func(c *SessionConfig) {
+		c.DangerouslySkipPermissions = true
+	}
+}
+
+// WithSandbox asks agy to run with terminal sandbox restrictions.
+func WithSandbox() SessionOption {
+	return func(c *SessionConfig) {
+		c.Sandbox = true
+	}
+}
+
+// WithEnv adds environment variables to the subprocess.
+func WithEnv(env map[string]string) SessionOption {
+	return func(c *SessionConfig) {
+		c.Env = env
+	}
+}
+
+// WithExtraArgs appends raw CLI arguments.
+func WithExtraArgs(args ...string) SessionOption {
+	return func(c *SessionConfig) {
+		c.ExtraArgs = args
+	}
+}
+
+// WithEventBufferSize sets the event channel buffer size.
+func WithEventBufferSize(size int) SessionOption {
+	return func(c *SessionConfig) {
+		c.EventBufferSize = size
+	}
+}
+
+// WithStderrHandler sets a handler for CLI stderr output.
+func WithStderrHandler(h func([]byte)) SessionOption {
+	return func(c *SessionConfig) {
+		c.StderrHandler = h
+	}
+}
+
+func defaultConfig() SessionConfig {
+	return SessionConfig{
+		CLIPath:         "agy",
+		EventBufferSize: 100,
+	}
+}

--- a/bramble/main.go
+++ b/bramble/main.go
@@ -803,7 +803,7 @@ func init() {
 }
 
 // pickRouterProvider selects the best available provider for the task router.
-// Prefers codex (original default), then claude, then gemini.
+// Prefers codex (original default), then claude, then gemini, then agy.
 // Returns nil if no suitable provider is installed and enabled.
 func pickRouterProvider(availability *agent.ProviderAvailability, enabledProviders []string) agent.Provider {
 	enabled := func(name string) bool {
@@ -829,6 +829,9 @@ func pickRouterProvider(availability *agent.ProviderAvailability, enabledProvide
 	// Fall back to gemini
 	if availability.IsInstalled(agent.ProviderGemini) && enabled(agent.ProviderGemini) {
 		return agent.NewGeminiProvider()
+	}
+	if availability.IsInstalled(agent.ProviderAgy) && enabled(agent.ProviderAgy) {
+		return agent.NewAgyProvider()
 	}
 	return nil
 }

--- a/bramble/main_test.go
+++ b/bramble/main_test.go
@@ -125,6 +125,12 @@ func TestCheckCodetalkModel(t *testing.T) {
 			errSubstr: "bramble TUI",
 		},
 		{
+			name:      "agy-default is agy — error with TUI hint",
+			modelID:   "agy-default",
+			wantErr:   true,
+			errSubstr: "bramble TUI",
+		},
+		{
 			name:      "gpt- prefix triggers Codex routing — error",
 			modelID:   "gpt-9-future",
 			wantErr:   true,
@@ -135,6 +141,12 @@ func TestCheckCodetalkModel(t *testing.T) {
 			modelID:   "gemini-99",
 			wantErr:   true,
 			errSubstr: "gemini",
+		},
+		{
+			name:      "agy- prefix triggers agy routing — error",
+			modelID:   "agy-future",
+			wantErr:   true,
+			errSubstr: "agy",
 		},
 	}
 

--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -68,7 +68,7 @@ func (r *plannerRunner) RunTurn(ctx context.Context, message string) (*claude.Tu
 }
 
 // providerRunner adapts agent.Provider to the sessionRunner interface.
-// This allows plugging in any provider backend (Claude, Codex, Gemini)
+// This allows plugging in any provider backend (Claude, Codex, Gemini, agy)
 // via the ManagerConfig.Provider field.
 type providerRunner struct { //nolint:govet // fieldalignment: keep related lifecycle fields grouped
 	provider        agent.Provider
@@ -1518,6 +1518,20 @@ func (m *Manager) runSession(session *Session, prompt string) {
 				eventHandler: eventHandler,
 				model:        session.Model,
 				workDir:      session.WorktreePath,
+			}
+		} else if agentModel.Provider == ProviderAgy {
+			// Antigravity provider backend
+			runner = &providerRunner{
+				provider:     agent.NewAgyProvider(),
+				eventHandler: eventHandler,
+				model:        session.Model,
+				permissionMode: func() string {
+					if session.Type == SessionTypePlanner || session.Type == SessionTypeCodeTalk {
+						return "plan"
+					}
+					return "bypass"
+				}(),
+				workDir: session.WorktreePath,
 			}
 		} else {
 			// Default: use hardcoded planner/builder runners with model from session

--- a/bramble/session/resolve_agent_model_test.go
+++ b/bramble/session/resolve_agent_model_test.go
@@ -27,6 +27,7 @@ func TestResolveAgentModel_ExactMatchFromRegistry(t *testing.T) {
 		agent.ProviderCodex:  {Provider: agent.ProviderCodex, Installed: false},
 		agent.ProviderGemini: {Provider: agent.ProviderGemini, Installed: false},
 		agent.ProviderCursor: {Provider: agent.ProviderCursor, Installed: false},
+		agent.ProviderAgy:    {Provider: agent.ProviderAgy, Installed: false},
 	})
 	reg := agent.NewModelRegistry(avail, nil)
 
@@ -47,6 +48,7 @@ func TestResolveAgentModel_PrefixFallback(t *testing.T) {
 		{"gemini-99-ultra", agent.ProviderGemini},
 		{"cursor-fast", agent.ProviderCursor},
 		{"composer-3", agent.ProviderCursor},
+		{"agy-pro", agent.ProviderAgy},
 		{"claude-opus-5", agent.ProviderClaude},
 	}
 
@@ -95,6 +97,7 @@ func TestManager_PrefixModelRoutesToCorrectProvider(t *testing.T) {
 		{"gemini-99-ultra", agent.ProviderGemini, agent.ProviderClaude},
 		{"cursor-fast-99", agent.ProviderCursor, agent.ProviderClaude},
 		{"composer-v9", agent.ProviderCursor, agent.ProviderClaude},
+		{"agy-pro", agent.ProviderAgy, agent.ProviderClaude},
 	}
 
 	for _, tc := range cases {
@@ -106,6 +109,7 @@ func TestManager_PrefixModelRoutesToCorrectProvider(t *testing.T) {
 				agent.ProviderCodex:  {Provider: agent.ProviderCodex, Installed: true},
 				agent.ProviderGemini: {Provider: agent.ProviderGemini, Installed: true},
 				agent.ProviderCursor: {Provider: agent.ProviderCursor, Installed: true},
+				agent.ProviderAgy:    {Provider: agent.ProviderAgy, Installed: true},
 			}
 			// Mark the target provider as not installed so runSession rejects it
 			// with a message naming that provider — proving routing chose it.
@@ -147,6 +151,7 @@ func TestManager_UnknownModelLandsInStatusFailed(t *testing.T) {
 		agent.ProviderCodex:  {Provider: agent.ProviderCodex, Installed: true},
 		agent.ProviderGemini: {Provider: agent.ProviderGemini, Installed: true},
 		agent.ProviderCursor: {Provider: agent.ProviderCursor, Installed: true},
+		agent.ProviderAgy:    {Provider: agent.ProviderAgy, Installed: true},
 	})
 	reg := agent.NewModelRegistry(avail, nil)
 

--- a/bramble/session/tmux_runner.go
+++ b/bramble/session/tmux_runner.go
@@ -162,6 +162,17 @@ func (r *tmuxRunner) buildCommand() (binary string, args []string) {
 		if r.permissionMode == "plan" {
 			args = append(args, "--approval-mode", "plan")
 		}
+	case ProviderAgy:
+		if r.yoloMode {
+			args = append(args, "--dangerously-skip-permissions")
+		}
+		if r.permissionMode == "plan" {
+			args = append(args, "--sandbox")
+		}
+		if r.resumeSessionID != "" {
+			args = append(args, "--conversation", r.resumeSessionID)
+		}
+		args = append(args, "--prompt-interactive")
 	default:
 		// Claude-specific flags
 		if r.yoloMode {

--- a/bramble/session/types.go
+++ b/bramble/session/types.go
@@ -26,6 +26,7 @@ const (
 	ProviderCodex  = agent.ProviderCodex
 	ProviderGemini = agent.ProviderGemini
 	ProviderCursor = agent.ProviderCursor
+	ProviderAgy    = agent.ProviderAgy
 )
 
 // AgentModel is an alias for agent.AgentModel.

--- a/bramble/taskrouter/router.go
+++ b/bramble/taskrouter/router.go
@@ -3,7 +3,7 @@
 // for a new task - either using an existing worktree or creating a new one.
 //
 // This package uses the multiagent/agent.Provider interface so any backend
-// (Claude, Codex, Gemini) can be plugged in for routing decisions.
+// (Claude, Codex, Gemini, agy) can be plugged in for routing decisions.
 package taskrouter
 
 import (

--- a/multiagent/agent/BUILD.bazel
+++ b/multiagent/agent/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "agent",
     srcs = [
         "agent.go",
+        "agy_provider.go",
         "bridge.go",
         "claude_provider.go",
         "codex_provider.go",
@@ -24,6 +25,7 @@ go_library(
     deps = [
         "//agent-cli-wrapper/acp",
         "//agent-cli-wrapper/agentstream",
+        "//agent-cli-wrapper/agy",
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/codex",
         "//agent-cli-wrapper/cursor",
@@ -37,6 +39,7 @@ go_library(
 go_test(
     name = "agent_test",
     srcs = [
+        "agy_provider_test.go",
         "claude_provider_retry_test.go",
         "codex_provider_test.go",
         "config_test.go",
@@ -54,6 +57,7 @@ go_test(
     embed = [":agent"],
     deps = [
         "//agent-cli-wrapper/acp",
+        "//agent-cli-wrapper/agy",
         "//agent-cli-wrapper/claude",
         "//agent-cli-wrapper/codex",
         "//agent-cli-wrapper/llmendpoint",

--- a/multiagent/agent/agy_provider.go
+++ b/multiagent/agent/agy_provider.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/agy"
+	"github.com/bazelment/yoloswe/wt"
+)
+
+// AgyProvider wraps Antigravity's agy CLI behind the Provider interface.
+type AgyProvider struct {
+	events      chan AgentEvent
+	sessionOpts []agy.SessionOption
+}
+
+// NewAgyProvider creates a new Antigravity provider.
+func NewAgyProvider(sessionOpts ...agy.SessionOption) *AgyProvider {
+	return &AgyProvider{
+		events:      make(chan AgentEvent, 100),
+		sessionOpts: sessionOpts,
+	}
+}
+
+func (p *AgyProvider) Name() string { return ProviderAgy }
+
+func (p *AgyProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.WorktreeContext, opts ...ExecuteOption) (*AgentResult, error) {
+	cfg := applyOptions(opts)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	if cfg.Effort != "" && cfg.Effort != EffortAuto {
+		return nil, EffortUnsupportedError(p.Name(), cfg.Effort)
+	}
+
+	fullPrompt := prompt
+	if wtCtx != nil {
+		fullPrompt = wtCtx.FormatForPrompt() + "\n\n" + prompt
+	}
+
+	sessionOpts := append([]agy.SessionOption{}, p.sessionOpts...)
+	if cfg.WorkDir != "" {
+		sessionOpts = append(sessionOpts, agy.WithWorkDir(cfg.WorkDir))
+	}
+	if cfg.ResumeSessionID != "" {
+		sessionOpts = append(sessionOpts, agy.WithConversation(cfg.ResumeSessionID))
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.PermissionMode)) {
+	case "bypass":
+		sessionOpts = append(sessionOpts, agy.WithDangerouslySkipPermissions())
+	case "plan":
+		sessionOpts = append(sessionOpts, agy.WithSandbox())
+	}
+
+	session := agy.NewSession(fullPrompt, sessionOpts...)
+	if err := session.Start(ctx); err != nil {
+		return nil, err
+	}
+	defer session.Stop()
+
+	var resultText strings.Builder
+	for evt := range session.Events() {
+		switch e := evt.(type) {
+		case agy.TextEvent:
+			resultText.WriteString(e.Text)
+			if cfg.EventHandler != nil {
+				cfg.EventHandler.OnText(e.Text)
+			}
+			p.events <- TextAgentEvent{Text: e.Text}
+		case agy.TurnCompleteEvent:
+			if cfg.EventHandler != nil {
+				cfg.EventHandler.OnTurnComplete(1, e.Success, e.DurationMs, 0)
+			}
+			p.events <- TurnCompleteAgentEvent{TurnNumber: 1, Success: e.Success, DurationMs: e.DurationMs}
+			return &AgentResult{
+				Text:       resultText.String(),
+				Success:    e.Success,
+				Error:      e.Error,
+				DurationMs: e.DurationMs,
+			}, nil
+		case agy.ErrorEvent:
+			if cfg.EventHandler != nil {
+				cfg.EventHandler.OnError(e.Error, e.Context)
+			}
+			p.events <- ErrorAgentEvent{Err: e.Error, Context: e.Context}
+			return nil, e.Error
+		}
+	}
+
+	return nil, agy.ErrNotStarted
+}
+
+func (p *AgyProvider) Events() <-chan AgentEvent { return p.events }
+
+func (p *AgyProvider) Close() error {
+	close(p.events)
+	return nil
+}

--- a/multiagent/agent/agy_provider_test.go
+++ b/multiagent/agent/agy_provider_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgyProvider_Name(t *testing.T) {
+	t.Parallel()
+
+	p := NewAgyProvider()
+	defer p.Close()
+
+	assert.Equal(t, ProviderAgy, p.Name())
+}
+
+func TestAgyProvider_EventsChannel(t *testing.T) {
+	t.Parallel()
+
+	p := NewAgyProvider()
+	defer p.Close()
+
+	ch := p.Events()
+	require.NotNil(t, ch)
+	assert.Equal(t, (<-chan AgentEvent)(p.events), ch)
+}
+
+func TestAgyProvider_RejectsExplicitEffort(t *testing.T) {
+	t.Parallel()
+
+	p := NewAgyProvider()
+	defer p.Close()
+
+	_, err := p.Execute(context.Background(), "ignored", nil, WithProviderEffort(EffortHigh))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEffortUnsupported)
+	assert.Contains(t, err.Error(), ProviderAgy)
+}

--- a/multiagent/agent/effort_test.go
+++ b/multiagent/agent/effort_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/acp"
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/agy"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 )
 
@@ -78,10 +79,10 @@ func TestClaudeEffortLevel_MapsAllLevels(t *testing.T) {
 }
 
 // TestProviderEffortMatrix locks in the support matrix across providers.
-// When a fifth provider is added, this table forces a deliberate choice
+// When a provider is added, this table forces a deliberate choice
 // rather than another silent ignore.
 //
-// Claude and Codex accept all five levels; Cursor and Gemini reject any
+// Claude and Codex accept all five levels; Cursor, Gemini, and agy reject any
 // explicit non-auto effort with ErrEffortUnsupported. EffortAuto and empty
 // effort both mean "use the provider default" and are never rejected.
 // (Invalid string parsing is covered by TestParseEffort_RejectsInvalidLevels
@@ -142,6 +143,16 @@ func TestProviderEffortMatrix(t *testing.T) {
 				return err
 			},
 		},
+		{
+			name: "agy",
+			run: func(t *testing.T, level EffortLevel) error {
+				t.Helper()
+				p := NewAgyProvider(agy.WithCLIPath("missing-agy-effort-test-binary"))
+				defer p.Close()
+				_, err := p.Execute(context.Background(), "ignored", nil, WithProviderEffort(level))
+				return err
+			},
+		},
 	}
 
 	for _, prov := range providers {
@@ -159,7 +170,7 @@ func TestProviderEffortMatrix(t *testing.T) {
 				assert.NoError(t, err, "empty effort should be a no-op")
 			}
 
-			noKnobProvider := prov.name == "cursor" || prov.name == "gemini"
+			noKnobProvider := prov.name == "cursor" || prov.name == "gemini" || prov.name == "agy"
 			for _, level := range validLevels {
 				err := prov.run(t, level)
 				// EffortAuto means "use provider default" — a no-knob

--- a/multiagent/agent/model_registry.go
+++ b/multiagent/agent/model_registry.go
@@ -8,7 +8,7 @@ import (
 // AgentModel describes a model available for session execution.
 type AgentModel struct {
 	ID       string // Model identifier passed to --model flag (e.g. "opus", "gpt-5.3-codex")
-	Provider string // Binary/provider name: "claude", "codex", or "gemini"
+	Provider string // Binary/provider name: "claude", "codex", "gemini", etc.
 	Label    string // Display label for the UI (e.g. "opus (claude)")
 }
 
@@ -28,6 +28,7 @@ var AllModels = []AgentModel{
 	{ID: "gemini-2.5-flash", Provider: ProviderGemini, Label: "gemini-2.5-flash"},
 	{ID: "gemini-2.5-flash-lite", Provider: ProviderGemini, Label: "gemini-2.5-flash-lite"},
 	{ID: "cursor-default", Provider: ProviderCursor, Label: "cursor-default"},
+	{ID: "agy-default", Provider: ProviderAgy, Label: "agy-default"},
 }
 
 // ModelByID returns the AgentModel for the given ID from the full list, or false if not found.
@@ -50,6 +51,7 @@ var modelPrefixRules = []struct {
 	{"gemini-", ProviderGemini},
 	{"cursor-", ProviderCursor},
 	{"composer-", ProviderCursor},
+	{"agy-", ProviderAgy},
 	{"claude-", ProviderClaude},
 }
 

--- a/multiagent/agent/model_registry_test.go
+++ b/multiagent/agent/model_registry_test.go
@@ -24,6 +24,7 @@ func TestModelRegistry_AllInstalled(t *testing.T) {
 		ProviderCodex:  true,
 		ProviderGemini: true,
 		ProviderCursor: true,
+		ProviderAgy:    true,
 	})
 	reg := NewModelRegistry(avail, nil)
 	assert.Len(t, reg.Models(), len(AllModels))
@@ -34,6 +35,8 @@ func TestModelRegistry_OnlyClaude(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  false,
 		ProviderGemini: false,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	reg := NewModelRegistry(avail, nil)
 	for _, m := range reg.Models() {
@@ -49,6 +52,8 @@ func TestModelRegistry_FilteredCycling(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  false,
 		ProviderGemini: true,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	reg := NewModelRegistry(avail, nil)
 
@@ -66,6 +71,8 @@ func TestModelRegistry_NotFoundReturnsFirst(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  false,
 		ProviderGemini: false,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	reg := NewModelRegistry(avail, nil)
 	next := reg.NextModel("nonexistent")
@@ -77,6 +84,8 @@ func TestModelRegistry_EmptyFallback(t *testing.T) {
 		ProviderClaude: false,
 		ProviderCodex:  false,
 		ProviderGemini: false,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	reg := NewModelRegistry(avail, nil)
 	assert.Empty(t, reg.Models())
@@ -100,6 +109,8 @@ func TestModelRegistry_RebuildWithEnabled(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  true,
 		ProviderGemini: true,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 
 	reg := NewModelRegistry(avail, []string{ProviderClaude})
@@ -121,6 +132,8 @@ func TestModelRegistry_InstalledButNotEnabled(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  true,
 		ProviderGemini: true,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	// Only enable gemini
 	reg := NewModelRegistry(avail, []string{ProviderGemini})
@@ -134,6 +147,8 @@ func TestModelRegistry_ModelByID(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  false,
 		ProviderGemini: false,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	reg := NewModelRegistry(avail, nil)
 
@@ -150,6 +165,8 @@ func TestModelRegistry_FirstModelForProvider(t *testing.T) {
 		ProviderClaude: true,
 		ProviderCodex:  true,
 		ProviderGemini: false,
+		ProviderCursor: false,
+		ProviderAgy:    false,
 	})
 	reg := NewModelRegistry(avail, nil)
 
@@ -186,6 +203,7 @@ func TestProviderForModelID(t *testing.T) {
 		{"gemini-99-ultra", ProviderGemini, true},
 		{"cursor-fast", ProviderCursor, true},
 		{"composer-3", ProviderCursor, true},
+		{"agy-pro", ProviderAgy, true},
 		{"claude-opus-5", ProviderClaude, true},
 		// Non-matching
 		{"foo-bar", "", false},
@@ -216,6 +234,7 @@ func TestProviderByModelPrefix(t *testing.T) {
 		{"gemini-99-ultra", ProviderGemini, true},
 		{"cursor-fast", ProviderCursor, true},
 		{"composer-3", ProviderCursor, true},
+		{"agy-pro", ProviderAgy, true},
 		{"claude-opus-5", ProviderClaude, true},
 		// Exact-match IDs still work via prefix
 		{"gpt-5.5", ProviderCodex, true},
@@ -241,4 +260,5 @@ func TestKnownModelPrefixes(t *testing.T) {
 	assert.Contains(t, s, "gpt-")
 	assert.Contains(t, s, "gemini-")
 	assert.Contains(t, s, "claude-")
+	assert.Contains(t, s, "agy-")
 }

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -271,7 +271,7 @@ func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
 // Behavior is intentionally asymmetric across providers, mirroring how each
 // upstream CLI honors endpoint config:
 //
-//   - claude / cursor: rebuild the underlying session per Execute, so each
+//   - claude / cursor / agy: rebuild the underlying session per Execute, so each
 //     call may pass a different endpoint.
 //   - codex / gemini:  bind the endpoint at client construction time (the
 //     first Execute call), since `--config` overrides / acp BinaryArgs are
@@ -280,7 +280,7 @@ func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
 //     rather than silently routing to the originally-bound endpoint. To
 //     switch endpoints on a codex/gemini provider, construct a fresh one.
 //
-// All four providers validate the endpoint at the start of Execute (see
+// All providers validate the endpoint at the start of Execute (see
 // ExecuteConfig.validate), so partial-but-non-zero endpoints fail loudly
 // regardless of which provider you target.
 func WithProviderLLMEndpoint(ep llmendpoint.Endpoint) ExecuteOption {

--- a/multiagent/agent/provider_check.go
+++ b/multiagent/agent/provider_check.go
@@ -15,10 +15,11 @@ const (
 	ProviderCodex  = "codex"
 	ProviderGemini = "gemini"
 	ProviderCursor = "cursor"
+	ProviderAgy    = "agy"
 )
 
 // AllProviders is the ordered list of known provider names.
-var AllProviders = []string{ProviderClaude, ProviderCodex, ProviderGemini, ProviderCursor}
+var AllProviders = []string{ProviderClaude, ProviderCodex, ProviderGemini, ProviderCursor, ProviderAgy}
 
 // providerBinaries maps provider names to their CLI binary names.
 var providerBinaries = map[string]string{
@@ -26,6 +27,7 @@ var providerBinaries = map[string]string{
 	ProviderCodex:  "codex",
 	ProviderGemini: "gemini",
 	ProviderCursor: "agent",
+	ProviderAgy:    "agy",
 }
 
 // ProviderStatus describes the availability of a single provider CLI.

--- a/multiagent/agent/provider_check_test.go
+++ b/multiagent/agent/provider_check_test.go
@@ -28,6 +28,7 @@ func TestProviderAvailability_Accessors(t *testing.T) {
 			ProviderCodex:  {Provider: ProviderCodex, Installed: false, Error: "not found in PATH"},
 			ProviderGemini: {Provider: ProviderGemini, Installed: true, Version: "2.0.0"},
 			ProviderCursor: {Provider: ProviderCursor, Installed: false, Error: "not found in PATH"},
+			ProviderAgy:    {Provider: ProviderAgy, Installed: false, Error: "not found in PATH"},
 		},
 	}
 
@@ -35,21 +36,23 @@ func TestProviderAvailability_Accessors(t *testing.T) {
 	assert.False(t, pa.IsInstalled(ProviderCodex))
 	assert.True(t, pa.IsInstalled(ProviderGemini))
 	assert.False(t, pa.IsInstalled(ProviderCursor))
+	assert.False(t, pa.IsInstalled(ProviderAgy))
 
 	s := pa.Status(ProviderClaude)
 	assert.Equal(t, "1.0.0", s.Version)
 
 	all := pa.AllStatuses()
-	require.Len(t, all, 4)
+	require.Len(t, all, 5)
 	assert.Equal(t, ProviderClaude, all[0].Provider)
 	assert.Equal(t, ProviderCodex, all[1].Provider)
 	assert.Equal(t, ProviderGemini, all[2].Provider)
 	assert.Equal(t, ProviderCursor, all[3].Provider)
+	assert.Equal(t, ProviderAgy, all[4].Provider)
 
 	installed := pa.InstalledProviders()
 	assert.Equal(t, []string{ProviderClaude, ProviderGemini}, installed)
 }
 
 func TestAllProviders(t *testing.T) {
-	assert.Equal(t, []string{ProviderClaude, ProviderCodex, ProviderGemini, ProviderCursor}, AllProviders)
+	assert.Equal(t, []string{ProviderClaude, ProviderCodex, ProviderGemini, ProviderCursor, ProviderAgy}, AllProviders)
 }

--- a/multiagent/agent/query.go
+++ b/multiagent/agent/query.go
@@ -24,6 +24,8 @@ func NewProviderForModel(m AgentModel) (Provider, error) {
 		return NewCodexProvider(), nil
 	case ProviderCursor:
 		return NewCursorProvider(), nil
+	case ProviderAgy:
+		return NewAgyProvider(), nil
 	default:
 		return nil, fmt.Errorf("unknown provider %q for model %q", m.Provider, m.ID)
 	}


### PR DESCRIPTION
## Summary

- Add an `agent-cli-wrapper/agy` package for Antigravity `agy` print-mode execution, events, process handling, and session options.
- Add `AgyProvider` support in `multiagent/agent`, including model registry, provider availability checks, query construction, and focused tests.
- Wire `agy` into Bramble session execution, tmux command construction, and task-router provider fallback selection.

## Validation

- `scripts/lint.sh`
- `bazel test //... --test_timeout=60`
- `bazel build //...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces a new subprocess-backed provider (`agy`) and wires it into model routing and tmux argument construction, which can affect session execution and provider selection paths.
> 
> **Overview**
> Adds a new `agent-cli-wrapper/agy` module that runs the Antigravity `agy` CLI in print mode, including session lifecycle, option-to-flag mapping, event emission, and process error handling.
> 
> Integrates `agy` as a first-class provider in `multiagent/agent` (new `AgyProvider`, provider availability checks, `Query` construction, and model registry/prefix routing via `agy-` and `agy-default`), with corresponding test updates.
> 
> Wires `agy` through Bramble by enabling provider/model routing to select `agy`, adding tmux-mode flag construction for `agy` (permissions, sandboxing, resume conversation), and extending task-router fallback selection to include `agy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5000d6113eb0ad96c8bd066439841709e2cd66b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->