### PR TITLE
Fix jiradozer validate-step hang on backgrounded infinite-loop tools

### DIFF
--- a/agent-cli-wrapper/claude/events.go
+++ b/agent-cli-wrapper/claude/events.go
@@ -199,6 +199,14 @@ type TurnCompleteEvent struct {
 	TurnNumber int
 	DurationMs int64
 	Success    bool
+	// WakeupTimedOut is true only when this event was emitted by the
+	// ScheduleWakeup safety timer (completeWakeupSuppressedTurn) rather than
+	// by a real CLI ResultMessage. It is a terminal signal: no continuation
+	// wave will follow it. Consumers that gate on background tool_use
+	// completion (e.g. logicalTurnState) must treat any still-"live"
+	// background tool_use as stranded when this is set — the session layer
+	// has already given up waiting for it.
+	WakeupTimedOut bool
 }
 
 // Type returns the event type.

--- a/agent-cli-wrapper/claude/session.go
+++ b/agent-cli-wrapper/claude/session.go
@@ -1315,7 +1315,7 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 		result.Success = false
 	}
 
-	s.finalizeTurn(result)
+	s.finalizeTurn(result, false)
 }
 
 // finalizeTurn records, emits, and completes the turn. Called from the
@@ -1330,18 +1330,21 @@ func (s *Session) handleResult(msg protocol.ResultMessage) {
 // final assistant content lives on a later continuation turn: a consumer
 // could see the event, query completedResults, miss, and fall back to
 // the suppressed turn's stale turnState snapshot.
-func (s *Session) finalizeTurn(result TurnResult) {
+// wakeupTimedOut marks the emitted TurnCompleteEvent as a terminal
+// safety-timer completion; the normal handleResult path passes false.
+func (s *Session) finalizeTurn(result TurnResult, wakeupTimedOut bool) {
 	if s.recorder != nil {
 		s.recorder.CompleteTurn(result.TurnNumber, result)
 	}
 	_ = s.state.Transition(TransitionResultReceived)
 	s.turnManager.CompleteTurn(result)
 	s.emit(TurnCompleteEvent{
-		TurnNumber: result.TurnNumber,
-		Success:    result.Success,
-		DurationMs: result.DurationMs,
-		Usage:      result.Usage,
-		Error:      result.Error,
+		TurnNumber:     result.TurnNumber,
+		Success:        result.Success,
+		DurationMs:     result.DurationMs,
+		Usage:          result.Usage,
+		Error:          result.Error,
+		WakeupTimedOut: wakeupTimedOut,
 	})
 }
 
@@ -1373,7 +1376,7 @@ func (s *Session) completeWakeupSuppressedTurn(result TurnResult) {
 	}
 	s.mu.Unlock()
 
-	s.finalizeTurn(result)
+	s.finalizeTurn(result, true)
 }
 
 // handleControlResponse routes incoming control_response messages to the goroutine

--- a/agent-cli-wrapper/claude/session_dispatch_test.go
+++ b/agent-cli-wrapper/claude/session_dispatch_test.go
@@ -664,3 +664,63 @@ func TestSessionDispatchInit_LenientFallbackOnMalformedField(t *testing.T) {
 	require.Equal(t, "/tmp/demo", ready.Info.WorkDir)
 	require.Equal(t, "sess-1", ready.Info.SessionID)
 }
+
+// TestSessionWakeupSafetyTimer_EmitsWakeupTimedOut drives the real
+// completeWakeupSuppressedTurn path — the function the ScheduleWakeup safety
+// timer invokes — and asserts the emitted TurnCompleteEvent carries
+// WakeupTimedOut=true. Consumer-side tests fabricate the flag in memory; this
+// catches a regression where the emitter stops setting it.
+func TestSessionWakeupSafetyTimer_EmitsWakeupTimedOut(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+
+	// Simulate an active ScheduleWakeup suppression: the original turn was
+	// suppressed and the session is waiting for a continuation that will
+	// never arrive. completeWakeupSuppressedTurn is what the safety timer
+	// calls in that case.
+	s.wakeupState.active = true
+	s.wakeupState.suppressedTurnNumber = 1
+
+	s.completeWakeupSuppressedTurn(TurnResult{TurnNumber: 1, Success: true})
+
+	ev := waitForEvent(t, s, func(e Event) bool {
+		_, ok := e.(TurnCompleteEvent)
+		return ok
+	}, time.Second)
+	tc := ev.(TurnCompleteEvent)
+	require.True(t, tc.WakeupTimedOut,
+		"safety-timer completion must emit WakeupTimedOut=true")
+	require.Equal(t, 1, tc.TurnNumber)
+}
+
+// TestSessionWakeupSafetyTimer_NoDoubleCompleteWhenInactive verifies the
+// safety-timer callback is a no-op once the suppression already resolved
+// (active=false) — no spurious TurnCompleteEvent is emitted.
+func TestSessionWakeupSafetyTimer_NoDoubleCompleteWhenInactive(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+
+	// active is already false — the continuation path completed first.
+	s.completeWakeupSuppressedTurn(TurnResult{TurnNumber: 1, Success: true})
+
+	expectNoEvent(t, s, 100*time.Millisecond)
+}
+
+// TestSessionFinalizeTurn_NormalPathNotWakeupTimedOut documents the other
+// side of the contract: the normal handleResult path passes false, so a
+// regular turn's TurnCompleteEvent must not be mislabelled as a safety-timer
+// completion.
+func TestSessionFinalizeTurn_NormalPathNotWakeupTimedOut(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+
+	s.finalizeTurn(TurnResult{TurnNumber: 1, Success: true}, false)
+
+	ev := waitForEvent(t, s, func(e Event) bool {
+		_, ok := e.(TurnCompleteEvent)
+		return ok
+	}, time.Second)
+	tc := ev.(TurnCompleteEvent)
+	require.False(t, tc.WakeupTimedOut,
+		"a normal turn completion must not carry WakeupTimedOut")
+}

--- a/agent-cli-wrapper/codex/client.go
+++ b/agent-cli-wrapper/codex/client.go
@@ -290,6 +290,10 @@ func threadStartParamsFromConfig(cfg ThreadConfig) ThreadStartParams {
 func (c *Client) registerThreadResponse(threadResp ThreadStartResponse, cfg ThreadConfig) *Thread {
 	thread := newThread(c, threadResp.Thread.ID, cfg)
 	thread.setInfo(&threadResp.Thread)
+	// Seed the monotonic turn counter from the thread's history so a resumed
+	// thread keeps numbering where it left off. A freshly-started thread has
+	// no turns, so this is a no-op there.
+	thread.seedTurnCount(threadResp.Thread.Turns)
 
 	c.mu.Lock()
 	c.threads[thread.id] = thread

--- a/agent-cli-wrapper/codex/client.go
+++ b/agent-cli-wrapper/codex/client.go
@@ -614,9 +614,10 @@ func (c *Client) handleTurnCompleted(params json.RawMessage) {
 	turnErr := classifyTurnError(notif.ThreadID, notif.Turn.ID, errMsg)
 	fullText := ""
 	var durationMs int64
+	var turnIndex int
 	var usage TurnUsage
 	if ok {
-		durationMs = thread.handleTurnCompleted(notif.Turn.ID, success, turnErr)
+		durationMs, turnIndex = thread.handleTurnCompleted(notif.Turn.ID, success, turnErr)
 		fullText = thread.GetFullText()
 		// Get token usage from the last token_count event
 		if lastUsage := thread.getAndClearLastUsage(); lastUsage != nil {
@@ -637,6 +638,7 @@ func (c *Client) handleTurnCompleted(params json.RawMessage) {
 		Error:      turnErr,
 		FullText:   fullText,
 		DurationMs: durationMs,
+		TurnIndex:  turnIndex,
 		Usage:      usage,
 	})
 }

--- a/agent-cli-wrapper/codex/event_translate.go
+++ b/agent-cli-wrapper/codex/event_translate.go
@@ -184,9 +184,17 @@ func ParseMappedNotification(method string, params json.RawMessage) (MappedEvent
 	return MappedEvent{}, false
 }
 
-// TurnNumberFromID converts Codex turn IDs to a 1-based display number.
-// Numeric IDs are interpreted as 0-based turn indexes. String IDs like
-// "turn-42" map to the trailing number directly.
+// TurnNumberFromID derives a 1-based display turn number from a Codex turn
+// ID. It is a fallback only — the authoritative number is the client's
+// monotonic per-thread counter carried on TurnCompletedEvent.TurnIndex.
+//
+// Recognised forms:
+//   - a pure non-negative integer, interpreted as a 0-based index ("2" → 3);
+//   - a "turn-N" / "turn_N" shaped string ("turn-42" → 42).
+//
+// Any other shape — notably an opaque UUID — returns 1 rather than scraping
+// trailing digits, which would otherwise mistake a UUID tail (e.g. the
+// "...9926" of "9671fa59a926") for a turn number.
 func TurnNumberFromID(turnID string) int {
 	normalized := strings.TrimSpace(turnID)
 	if normalized == "" {
@@ -197,18 +205,11 @@ func TurnNumberFromID(turnID string) int {
 		return n + 1
 	}
 
-	last := len(normalized)
-	first := last
-	for first > 0 {
-		ch := normalized[first-1]
-		if ch < '0' || ch > '9' {
-			break
-		}
-		first--
-	}
-	if first < last {
-		if n, err := strconv.Atoi(normalized[first:last]); err == nil && n > 0 {
-			return n
+	for _, prefix := range []string{"turn-", "turn_"} {
+		if rest, ok := strings.CutPrefix(normalized, prefix); ok {
+			if n, err := strconv.Atoi(rest); err == nil && n > 0 {
+				return n
+			}
 		}
 	}
 

--- a/agent-cli-wrapper/codex/event_translate_test.go
+++ b/agent-cli-wrapper/codex/event_translate_test.go
@@ -147,9 +147,14 @@ func TestTurnNumberFromID(t *testing.T) {
 	}{
 		{name: "numeric-zero-based", turnID: "2", want: 3},
 		{name: "prefixed", turnID: "turn-456", want: 456},
+		{name: "prefixed-underscore", turnID: "turn_456", want: 456},
 		{name: "prefixed-zero", turnID: "turn-0", want: 1},
 		{name: "invalid", turnID: "n/a", want: 1},
 		{name: "empty", turnID: "", want: 1},
+		// A UUID turn ID must NOT have its trailing digits scraped — that
+		// previously produced garbage display numbers like turn=905.
+		{name: "uuid-with-digit-tail", turnID: "0198f2c1-7a3e-7b21-a26a-9671fa590905", want: 1},
+		{name: "uuid-all-hex-tail", turnID: "0198f2c1-7a3e-7b21-a26a-9671fa59abcd", want: 1},
 	}
 
 	for _, tc := range tests {

--- a/agent-cli-wrapper/codex/events.go
+++ b/agent-cli-wrapper/codex/events.go
@@ -106,11 +106,18 @@ func (e TurnStartedEvent) Type() EventType { return EventTypeTurnStarted }
 // threads it may overstate the per-turn count. Treat Usage as a soft
 // signal for runaway-detection / display, not as accounting.
 type TurnCompletedEvent struct {
-	Error      error
-	ThreadID   string
-	TurnID     string
-	FullText   string
-	Usage      TurnUsage
+	Error    error
+	ThreadID string
+	TurnID   string
+	FullText string
+	Usage    TurnUsage
+	// TurnIndex is the 1-based monotonic turn number for the thread,
+	// maintained by the client. It is the authoritative display turn
+	// number — codex turn IDs are opaque UUIDs from which no number can
+	// reliably be derived. Zero only on events not produced by the client
+	// (e.g. synthetic test events that leave it unset), in which case
+	// StreamTurnNum falls back to TurnNumberFromID.
+	TurnIndex  int
 	DurationMs int64
 	Success    bool
 }
@@ -121,7 +128,12 @@ func (e TurnCompletedEvent) Type() EventType { return EventTypeTurnCompleted }
 func (e TurnCompletedEvent) StreamEventKind() agentstream.EventKind {
 	return agentstream.KindTurnComplete
 }
-func (e TurnCompletedEvent) StreamTurnNum() int    { return TurnNumberFromID(e.TurnID) }
+func (e TurnCompletedEvent) StreamTurnNum() int {
+	if e.TurnIndex > 0 {
+		return e.TurnIndex
+	}
+	return TurnNumberFromID(e.TurnID)
+}
 func (e TurnCompletedEvent) StreamIsSuccess() bool { return e.Success }
 func (e TurnCompletedEvent) StreamDuration() int64 { return e.DurationMs }
 func (e TurnCompletedEvent) StreamCost() float64   { return 0 }

--- a/agent-cli-wrapper/codex/events_test.go
+++ b/agent-cli-wrapper/codex/events_test.go
@@ -116,6 +116,32 @@ func TestTurnCompletedEvent(t *testing.T) {
 	}
 }
 
+// StreamTurnNum prefers the client-set monotonic TurnIndex over deriving a
+// number from the opaque TurnID. It falls back to TurnNumberFromID only when
+// TurnIndex is unset (e.g. synthetic test events).
+func TestTurnCompletedEvent_StreamTurnNum(t *testing.T) {
+	tests := []struct {
+		name      string
+		turnID    string
+		turnIndex int
+		want      int
+	}{
+		{name: "uses-turn-index", turnID: "0198f2c1-7a3e-7b21-a26a-9671fa590905", turnIndex: 7, want: 7},
+		{name: "turn-index-wins-over-id", turnID: "turn-456", turnIndex: 3, want: 3},
+		{name: "falls-back-to-id-when-unset", turnID: "turn-456", turnIndex: 0, want: 456},
+		{name: "fallback-uuid-yields-one", turnID: "0198f2c1-7a3e-7b21-a26a-9671fa590905", turnIndex: 0, want: 1},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			e := TurnCompletedEvent{TurnID: tc.turnID, TurnIndex: tc.turnIndex}
+			if got := e.StreamTurnNum(); got != tc.want {
+				t.Fatalf("StreamTurnNum() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTurnCompletedEvent_WithError(t *testing.T) {
 	testErr := errors.New("test error")
 	e := TurnCompletedEvent{

--- a/agent-cli-wrapper/codex/thread.go
+++ b/agent-cli-wrapper/codex/thread.go
@@ -18,7 +18,12 @@ type Thread struct {
 	turnStartTime time.Time
 	id            string
 	currentTurnID string
-	mu            sync.RWMutex
+	// turnCount is a monotonic per-thread counter incremented once per
+	// completed turn. Codex turn IDs are opaque UUIDs, so the display turn
+	// number must be derived from a real counter rather than scraped from
+	// the ID. See handleTurnCompleted / TurnNumberFromID.
+	turnCount int
+	mu        sync.RWMutex
 }
 
 func newThread(client *Client, id string, config ThreadConfig) *Thread {
@@ -239,12 +244,18 @@ func (t *Thread) handleTextDelta(turnID, itemID, delta string) string {
 	return t.accumulator.handleDelta(turnID, itemID, delta)
 }
 
-// handleTurnCompleted processes a turn completion and returns the calculated duration.
-func (t *Thread) handleTurnCompleted(turnID string, success bool, turnErr error) int64 {
+// handleTurnCompleted processes a turn completion and returns the calculated
+// duration and the 1-based monotonic turn index for this thread.
+func (t *Thread) handleTurnCompleted(turnID string, success bool, turnErr error) (int64, int) {
 	t.mu.Lock()
 
 	// Calculate duration
 	durationMs := time.Since(t.turnStartTime).Milliseconds()
+
+	// Advance the monotonic per-thread turn counter. This is the real turn
+	// number; the opaque UUID turnID cannot yield one reliably.
+	t.turnCount++
+	turnIndex := t.turnCount
 
 	// Build result
 	result := &TurnResult{
@@ -274,7 +285,7 @@ func (t *Thread) handleTurnCompleted(turnID string, success bool, turnErr error)
 	}
 
 	t.mu.Unlock()
-	return durationMs
+	return durationMs, turnIndex
 }
 
 func (t *Thread) setReady() {

--- a/agent-cli-wrapper/codex/thread.go
+++ b/agent-cli-wrapper/codex/thread.go
@@ -21,7 +21,8 @@ type Thread struct {
 	// turnCount is a monotonic per-thread counter incremented once per
 	// completed turn. Codex turn IDs are opaque UUIDs, so the display turn
 	// number must be derived from a real counter rather than scraped from
-	// the ID. See handleTurnCompleted / TurnNumberFromID.
+	// the ID. Seeded from the thread's history on resume so numbering
+	// continues across sessions. See handleTurnCompleted / seedTurnCount.
 	turnCount int
 	mu        sync.RWMutex
 }
@@ -230,6 +231,16 @@ func (t *Thread) setInfo(info *ThreadInfo) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.info = info
+}
+
+// seedTurnCount initialises the monotonic turn counter from a resumed
+// thread's history so the first turn after a resume is numbered after the
+// historical turns rather than restarting at 1. A freshly-started thread
+// passes an empty slice, leaving turnCount at 0.
+func (t *Thread) seedTurnCount(turns []Turn) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.turnCount = len(turns)
 }
 
 func (t *Thread) handleTurnStarted(turnID string) {

--- a/agent-cli-wrapper/codex/thread_test.go
+++ b/agent-cli-wrapper/codex/thread_test.go
@@ -244,6 +244,29 @@ func TestThread_HandleTurnCompleted(t *testing.T) {
 	}
 }
 
+// handleTurnCompleted returns a 1-based monotonic turn index that advances
+// once per completed turn, independent of the opaque turn IDs.
+func TestThread_HandleTurnCompleted_MonotonicTurnIndex(t *testing.T) {
+	client := NewClient()
+	thread := newThread(client, "thread-123", ThreadConfig{})
+	thread.state.SetReady()
+
+	// Three turns with opaque UUID-shaped IDs — the index must still be 1,2,3.
+	ids := []string{
+		"0198f2c1-7a3e-7b21-a26a-9671fa590905",
+		"0198f2c1-9b4f-7c32-b37b-a782gb691426",
+		"0198f2c1-ac50-7d43-c48c-b893hc792537",
+	}
+	for i, id := range ids {
+		thread.state.SetProcessing()
+		thread.handleTurnStarted(id)
+		_, turnIndex := thread.handleTurnCompleted(id, true, nil)
+		if turnIndex != i+1 {
+			t.Errorf("turn %d: turnIndex = %d, want %d", i, turnIndex, i+1)
+		}
+	}
+}
+
 func TestThread_HandleTurnCompleted_WithError(t *testing.T) {
 	client := NewClient()
 	thread := newThread(client, "thread-123", ThreadConfig{})

--- a/agent-cli-wrapper/codex/thread_test.go
+++ b/agent-cli-wrapper/codex/thread_test.go
@@ -267,6 +267,55 @@ func TestThread_HandleTurnCompleted_MonotonicTurnIndex(t *testing.T) {
 	}
 }
 
+// A resumed thread seeds turnCount from its history, so the first turn after
+// a resume is numbered after the historical turns rather than restarting at 1.
+func TestThread_SeedTurnCount_ResumeContinuesNumbering(t *testing.T) {
+	client := NewClient()
+	thread := newThread(client, "thread-123", ThreadConfig{})
+
+	// Simulate a resumed thread that already had three completed turns.
+	thread.seedTurnCount([]Turn{
+		{ID: "hist-1", Status: "completed"},
+		{ID: "hist-2", Status: "completed"},
+		{ID: "hist-3", Status: "completed"},
+	})
+	thread.state.SetReady()
+
+	// The next turn after resume must be numbered 4, not 1.
+	thread.state.SetProcessing()
+	thread.handleTurnStarted("0198f2c1-7a3e-7b21-a26a-9671fa590905")
+	_, turnIndex := thread.handleTurnCompleted(
+		"0198f2c1-7a3e-7b21-a26a-9671fa590905", true, nil)
+	if turnIndex != 4 {
+		t.Errorf("first turn after resume: turnIndex = %d, want 4", turnIndex)
+	}
+
+	// And it keeps advancing monotonically from there.
+	thread.state.SetProcessing()
+	thread.handleTurnStarted("0198f2c1-9b4f-7c32-b37b-a782db691426")
+	_, turnIndex = thread.handleTurnCompleted(
+		"0198f2c1-9b4f-7c32-b37b-a782db691426", true, nil)
+	if turnIndex != 5 {
+		t.Errorf("second turn after resume: turnIndex = %d, want 5", turnIndex)
+	}
+}
+
+// A freshly-started thread (no history) seeds to zero, so its first turn is 1.
+func TestThread_SeedTurnCount_FreshThreadStartsAtOne(t *testing.T) {
+	client := NewClient()
+	thread := newThread(client, "thread-123", ThreadConfig{})
+
+	thread.seedTurnCount(nil)
+	thread.state.SetReady()
+
+	thread.state.SetProcessing()
+	thread.handleTurnStarted("turn-1")
+	_, turnIndex := thread.handleTurnCompleted("turn-1", true, nil)
+	if turnIndex != 1 {
+		t.Errorf("fresh thread first turn: turnIndex = %d, want 1", turnIndex)
+	}
+}
+
 func TestThread_HandleTurnCompleted_WithError(t *testing.T) {
 	client := NewClient()
 	thread := newThread(client, "thread-123", ThreadConfig{})

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -133,17 +133,27 @@ type logEventHandler struct {
 	logger       *slog.Logger
 	toolStarts   map[string]time.Time
 	step         string
+	provider     string
 	planFilePath string
 	lastWriteMD  string
 	textBuf      strings.Builder
 }
 
-func newLogEventHandler(logger *slog.Logger, step string) *logEventHandler {
+func newLogEventHandler(logger *slog.Logger, step, provider string) *logEventHandler {
 	return &logEventHandler{
 		logger:     logger,
 		step:       step,
+		provider:   provider,
 		toolStarts: make(map[string]time.Time),
 	}
+}
+
+// providerReportsCost reports whether a provider's turn/result events carry
+// real cost and token measurements. Only the Claude provider does today;
+// codex, cursor, gemini and agy emit a structural zero. Logging that zero as
+// "$0.0000" reads like a measurement, so callers log "n/a" instead.
+func providerReportsCost(provider string) bool {
+	return provider == "claude"
 }
 
 // resetPerAttempt clears state that must not leak between retry attempts.
@@ -216,13 +226,19 @@ func (h *logEventHandler) OnToolComplete(name, id string, input map[string]inter
 
 func (h *logEventHandler) OnTurnComplete(turnNumber int, success bool, durationMs int64, costUSD float64) {
 	h.flushText()
-	h.logger.Debug("turn complete",
+	attrs := []any{
 		"step", h.step,
+		"provider", h.provider,
 		"turn", turnNumber,
 		"success", success,
 		"duration", fmt.Sprintf("%.1fs", float64(durationMs)/1000),
-		"cost", fmt.Sprintf("$%.4f", costUSD),
-	)
+	}
+	if providerReportsCost(h.provider) {
+		attrs = append(attrs, "cost", fmt.Sprintf("$%.4f", costUSD))
+	} else {
+		attrs = append(attrs, "cost", "n/a")
+	}
+	h.logger.Debug("turn complete", attrs...)
 }
 
 func (h *logEventHandler) OnError(err error, context string) {
@@ -396,7 +412,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 	logger.Info("running agent", logAttrs...)
 	logger.Debug("agent prompt", "step", stepName, "prompt", truncate(prompt, 500))
 
-	logHandler := newLogEventHandler(logger, stepName)
+	logHandler := newLogEventHandler(logger, stepName, provider.Name())
 	var handler agent.EventHandler = logHandler
 	if renderer != nil {
 		defer renderer.Reset()
@@ -413,7 +429,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 	var result *agent.AgentResult
 	for {
 		logHandler.resetPerAttempt()
-		opts, err := buildExecuteOpts(cfg, workDir, handler, currentResume)
+		opts, err := buildExecuteOpts(cfg, workDir, handler, currentResume, logger)
 		if err != nil {
 			return StepAgentResult{}, err
 		}
@@ -503,14 +519,26 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 		return failed, fmt.Errorf("agent failed")
 	}
 
-	logger.Info("agent completed",
+	completedAttrs := []any{
 		"step", stepName,
+		"provider", provider.Name(),
 		"session_id", result.SessionID,
-		"input_tokens", result.Usage.InputTokens,
-		"output_tokens", result.Usage.OutputTokens,
-		"cost_usd", result.Usage.CostUSD,
 		"duration_ms", result.DurationMs,
-	)
+	}
+	if providerReportsCost(provider.Name()) {
+		completedAttrs = append(completedAttrs,
+			"input_tokens", result.Usage.InputTokens,
+			"output_tokens", result.Usage.OutputTokens,
+			"cost_usd", result.Usage.CostUSD,
+		)
+	} else {
+		completedAttrs = append(completedAttrs,
+			"input_tokens", "n/a",
+			"output_tokens", "n/a",
+			"cost_usd", "n/a",
+		)
+	}
+	logger.Info("agent completed", completedAttrs...)
 	if result.Text != "" {
 		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))
 	}
@@ -530,7 +558,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 	}, nil
 }
 
-func buildExecuteOpts(cfg StepConfig, workDir string, handler agent.EventHandler, resumeSessionID string) ([]agent.ExecuteOption, error) {
+func buildExecuteOpts(cfg StepConfig, workDir string, handler agent.EventHandler, resumeSessionID string, logger *slog.Logger) ([]agent.ExecuteOption, error) {
 	var opts []agent.ExecuteOption
 	opts = append(opts,
 		agent.WithProviderWorkDir(workDir),
@@ -539,6 +567,9 @@ func buildExecuteOpts(cfg StepConfig, workDir string, handler agent.EventHandler
 		agent.WithProviderKeepUserSettings(),
 		agent.WithProviderEventHandler(handler),
 	)
+	if logger != nil {
+		opts = append(opts, agent.WithProviderLogger(logger))
+	}
 	if cfg.SystemPrompt != "" {
 		opts = append(opts, agent.WithProviderSystemPrompt(cfg.SystemPrompt))
 	}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -148,20 +148,30 @@ func newLogEventHandler(logger *slog.Logger, step, provider string) *logEventHan
 	}
 }
 
-// providerReportsCost reports whether a provider's turn/result events carry
-// real cost and token measurements. Only the Claude provider does today;
-// codex, cursor, gemini and agy emit a structural zero. Logging that zero as
-// "$0.0000" reads like a measurement, so callers log "n/a" instead.
+// providerReportsCost reports whether a provider's turn/result events carry a
+// real cost measurement. Only the Claude provider does today; codex, cursor,
+// gemini and agy emit a structural zero. Logging that zero as "$0.0000" reads
+// like a measurement, so callers log "n/a" instead.
 func providerReportsCost(provider string) bool {
 	return provider == agent.ProviderClaude
 }
 
-// usageLogAttr returns a single slog key/value pair for a provider's cost or
-// token metric: the measured value when the provider reports it, the literal
-// "n/a" otherwise. Keeping the n/a policy here means the log sites don't each
-// re-branch on providerReportsCost.
-func usageLogAttr(provider, key string, value any) []any {
-	if providerReportsCost(provider) {
+// providerReportsTokens reports whether a provider's result carries real
+// input/output token counts. Claude and codex both do (codex populates
+// AgentResult.Usage from its token_count events); cursor, gemini and agy
+// leave Usage zero. This is intentionally distinct from providerReportsCost:
+// codex reports tokens but not cost, so the two metrics need separate gates.
+func providerReportsTokens(provider string) bool {
+	return provider == agent.ProviderClaude || provider == agent.ProviderCodex
+}
+
+// usageLogAttr returns a single slog key/value pair: the measured value when
+// reported is true, the literal "n/a" otherwise. Callers pick `reported` from
+// providerReportsCost or providerReportsTokens depending on the metric, so a
+// real measurement is never mislabelled "n/a" and a structural zero never
+// reads like a measurement.
+func usageLogAttr(reported bool, key string, value any) []any {
+	if reported {
 		return []any{key, value}
 	}
 	return []any{key, "n/a"}
@@ -244,7 +254,7 @@ func (h *logEventHandler) OnTurnComplete(turnNumber int, success bool, durationM
 		"success", success,
 		"duration", fmt.Sprintf("%.1fs", float64(durationMs)/1000),
 	}
-	attrs = append(attrs, usageLogAttr(h.provider, "cost", fmt.Sprintf("$%.4f", costUSD))...)
+	attrs = append(attrs, usageLogAttr(providerReportsCost(h.provider), "cost", fmt.Sprintf("$%.4f", costUSD))...)
 	h.logger.Debug("turn complete", attrs...)
 }
 
@@ -532,9 +542,10 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 		"session_id", result.SessionID,
 		"duration_ms", result.DurationMs,
 	}
-	completedAttrs = append(completedAttrs, usageLogAttr(provider.Name(), "input_tokens", result.Usage.InputTokens)...)
-	completedAttrs = append(completedAttrs, usageLogAttr(provider.Name(), "output_tokens", result.Usage.OutputTokens)...)
-	completedAttrs = append(completedAttrs, usageLogAttr(provider.Name(), "cost_usd", result.Usage.CostUSD)...)
+	reportsTokens := providerReportsTokens(provider.Name())
+	completedAttrs = append(completedAttrs, usageLogAttr(reportsTokens, "input_tokens", result.Usage.InputTokens)...)
+	completedAttrs = append(completedAttrs, usageLogAttr(reportsTokens, "output_tokens", result.Usage.OutputTokens)...)
+	completedAttrs = append(completedAttrs, usageLogAttr(providerReportsCost(provider.Name()), "cost_usd", result.Usage.CostUSD)...)
 	logger.Info("agent completed", completedAttrs...)
 	if result.Text != "" {
 		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -153,7 +153,18 @@ func newLogEventHandler(logger *slog.Logger, step, provider string) *logEventHan
 // codex, cursor, gemini and agy emit a structural zero. Logging that zero as
 // "$0.0000" reads like a measurement, so callers log "n/a" instead.
 func providerReportsCost(provider string) bool {
-	return provider == "claude"
+	return provider == agent.ProviderClaude
+}
+
+// usageLogAttr returns a single slog key/value pair for a provider's cost or
+// token metric: the measured value when the provider reports it, the literal
+// "n/a" otherwise. Keeping the n/a policy here means the log sites don't each
+// re-branch on providerReportsCost.
+func usageLogAttr(provider, key string, value any) []any {
+	if providerReportsCost(provider) {
+		return []any{key, value}
+	}
+	return []any{key, "n/a"}
 }
 
 // resetPerAttempt clears state that must not leak between retry attempts.
@@ -233,11 +244,7 @@ func (h *logEventHandler) OnTurnComplete(turnNumber int, success bool, durationM
 		"success", success,
 		"duration", fmt.Sprintf("%.1fs", float64(durationMs)/1000),
 	}
-	if providerReportsCost(h.provider) {
-		attrs = append(attrs, "cost", fmt.Sprintf("$%.4f", costUSD))
-	} else {
-		attrs = append(attrs, "cost", "n/a")
-	}
+	attrs = append(attrs, usageLogAttr(h.provider, "cost", fmt.Sprintf("$%.4f", costUSD))...)
 	h.logger.Debug("turn complete", attrs...)
 }
 
@@ -525,19 +532,9 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 		"session_id", result.SessionID,
 		"duration_ms", result.DurationMs,
 	}
-	if providerReportsCost(provider.Name()) {
-		completedAttrs = append(completedAttrs,
-			"input_tokens", result.Usage.InputTokens,
-			"output_tokens", result.Usage.OutputTokens,
-			"cost_usd", result.Usage.CostUSD,
-		)
-	} else {
-		completedAttrs = append(completedAttrs,
-			"input_tokens", "n/a",
-			"output_tokens", "n/a",
-			"cost_usd", "n/a",
-		)
-	}
+	completedAttrs = append(completedAttrs, usageLogAttr(provider.Name(), "input_tokens", result.Usage.InputTokens)...)
+	completedAttrs = append(completedAttrs, usageLogAttr(provider.Name(), "output_tokens", result.Usage.OutputTokens)...)
+	completedAttrs = append(completedAttrs, usageLogAttr(provider.Name(), "cost_usd", result.Usage.CostUSD)...)
 	logger.Info("agent completed", completedAttrs...)
 	if result.Text != "" {
 		logger.Debug("agent response", "step", stepName, "response", truncate(result.Text, 100))

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
+	"github.com/bazelment/yoloswe/multiagent/agent"
 )
 
 func TestNewPromptData(t *testing.T) {
@@ -491,4 +492,39 @@ func TestReplay_PlanContentPostedToTracker(t *testing.T) {
 	assert.Contains(t, buildPrompt, "# Plan")
 	assert.Contains(t, buildPrompt, "1. Fix widget")
 	assert.Contains(t, buildPrompt, "Approved Plan")
+}
+
+// Cost is reported only by Claude; codex/cursor/gemini/agy emit a structural
+// zero, so a measured cost is never mislabelled "n/a" and a structural zero
+// never reads like a measurement.
+func TestProviderReportsCost(t *testing.T) {
+	assert.True(t, providerReportsCost(agent.ProviderClaude))
+	for _, p := range []string{
+		agent.ProviderCodex, agent.ProviderCursor,
+		agent.ProviderGemini, agent.ProviderAgy,
+	} {
+		assert.False(t, providerReportsCost(p), "%s does not report cost", p)
+	}
+}
+
+// Token counts are reported by Claude and codex (codex populates Usage from
+// its token_count events); cursor/gemini/agy leave Usage zero. This must be
+// distinct from cost reporting — codex reports tokens but not cost, so gating
+// token logging on providerReportsCost would mislabel real codex tokens "n/a".
+func TestProviderReportsTokens(t *testing.T) {
+	assert.True(t, providerReportsTokens(agent.ProviderClaude))
+	assert.True(t, providerReportsTokens(agent.ProviderCodex),
+		"codex reports real token counts even though it reports no cost")
+	for _, p := range []string{
+		agent.ProviderCursor, agent.ProviderGemini, agent.ProviderAgy,
+	} {
+		assert.False(t, providerReportsTokens(p), "%s does not report tokens", p)
+	}
+}
+
+// usageLogAttr emits the measured value when reported is true and the literal
+// "n/a" otherwise.
+func TestUsageLogAttr(t *testing.T) {
+	assert.Equal(t, []any{"input_tokens", 1234}, usageLogAttr(true, "input_tokens", 1234))
+	assert.Equal(t, []any{"input_tokens", "n/a"}, usageLogAttr(false, "input_tokens", 1234))
 }

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -241,7 +241,7 @@ func TestResolvePromptForExecution_ResumeWithoutFeedback(t *testing.T) {
 }
 
 func TestLogEventHandler_TracksPlanFile_ExitPlanMode(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Write .md file, then ExitPlanMode confirms it as the plan file.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -255,7 +255,7 @@ func TestLogEventHandler_TracksPlanFile_ExitPlanMode(t *testing.T) {
 }
 
 func TestLogEventHandler_TracksPlanFile_ClaudePlansDir(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Also works with .claude/plans/ paths.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -266,7 +266,7 @@ func TestLogEventHandler_TracksPlanFile_ClaudePlansDir(t *testing.T) {
 }
 
 func TestLogEventHandler_NoExitPlanMode_NoPlanFile(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Write .md without ExitPlanMode — planFilePath stays empty.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -276,7 +276,7 @@ func TestLogEventHandler_NoExitPlanMode_NoPlanFile(t *testing.T) {
 }
 
 func TestLogEventHandler_IgnoresNonMDWrites(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Write to a non-.md path should not be tracked.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -287,7 +287,7 @@ func TestLogEventHandler_IgnoresNonMDWrites(t *testing.T) {
 }
 
 func TestLogEventHandler_IgnoresNonWriteTools(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Non-Write tool should not track .md path.
 	h.OnToolComplete("Read", "tool-1", map[string]interface{}{
@@ -298,7 +298,7 @@ func TestLogEventHandler_IgnoresNonWriteTools(t *testing.T) {
 }
 
 func TestLogEventHandler_IgnoresFailedWrites(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Failed write should not be tracked.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -309,7 +309,7 @@ func TestLogEventHandler_IgnoresFailedWrites(t *testing.T) {
 }
 
 func TestLogEventHandler_LastMDWriteWins(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 
 	// Multiple .md writes — the last one before ExitPlanMode wins.
 	h.OnToolComplete("Write", "tool-1", map[string]interface{}{
@@ -362,7 +362,7 @@ func TestReplay_PlanStepEventSequence(t *testing.T) {
 		{name: "ExitPlanMode", id: "t-10"},
 	}
 
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 	for _, ev := range events {
 		input := ev.input
 		if input == nil {
@@ -392,7 +392,7 @@ func TestReplay_PlanStepNoExitPlanMode(t *testing.T) {
 		// No ExitPlanMode — agent ran out of turns.
 	}
 
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 	for _, ev := range events {
 		input := ev.input
 		if input == nil {
@@ -412,7 +412,7 @@ func TestReplay_PlanStepNoExitPlanMode(t *testing.T) {
 // TestReplay_PlanFileReadFailure verifies graceful fallback when the plan file
 // cannot be read (e.g., deleted between write and read).
 func TestReplay_PlanFileReadFailure(t *testing.T) {
-	h := newLogEventHandler(slog.Default(), "plan")
+	h := newLogEventHandler(slog.Default(), "plan", "claude")
 	h.OnToolComplete("Write", "t-1", map[string]interface{}{
 		"file_path": "/nonexistent/path/plan.md",
 	}, nil, false)

--- a/multiagent/agent/BUILD.bazel
+++ b/multiagent/agent/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     name = "agent_test",
     srcs = [
         "agy_provider_test.go",
+        "claude_provider_grace_test.go",
         "claude_provider_retry_test.go",
         "codex_provider_test.go",
         "config_test.go",

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -78,9 +78,8 @@ func consumeTurnEvents(
 	dispatch func(claude.Event),
 ) (*claude.TurnResult, error) {
 	state := newLogicalTurnState()
-	// graceTimer is armed once a TurnCompleteEvent has been observed but
-	// LogicalTurnDone() is still false because of live bg work. Until then
-	// graceCh is nil so the select blocks only on ctx/events.
+	// While graceCh is nil the select blocks only on ctx/events; it is armed
+	// lazily once a TurnCompleteEvent lands but the turn is still gated.
 	var graceTimer *time.Timer
 	var graceCh <-chan time.Time
 	defer func() {

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -54,6 +55,73 @@ func AppendUnresolvedToolErrorMarker(text string, e UnresolvedToolError) string 
 }
 
 const minRetryWallClockBudget = 10 * time.Minute
+
+// streamTurnGracePeriod bounds how long streamTurn waits, after a
+// TurnCompleteEvent has been observed, for an outstanding background
+// tool_use to produce a terminal event. On expiry the turn is forced done.
+// This is the backstop for an agent that backgrounds a tool that never
+// terminates (e.g. a `while true` poll loop) without a ScheduleWakeup.
+const streamTurnGracePeriod = 3 * time.Minute
+
+// consumeTurnEvents drives one logical turn by feeding events from the
+// session channel into a logicalTurnState until the turn is done. It
+// returns when LogicalTurnDone() flips, the channel closes, ctx is
+// cancelled, or — the structural backstop — gracePeriod elapses after a
+// TurnCompleteEvent was observed but the logical turn is still gated on a
+// background tool_use that never terminated. dispatch is invoked for every
+// event so consumers (EventHandler, AgentEvent channel) see the full stream.
+func consumeTurnEvents(
+	ctx context.Context,
+	events <-chan claude.Event,
+	gracePeriod time.Duration,
+	logger *slog.Logger,
+	dispatch func(claude.Event),
+) (*claude.TurnResult, error) {
+	state := newLogicalTurnState()
+	// graceTimer is armed once a TurnCompleteEvent has been observed but
+	// LogicalTurnDone() is still false because of live bg work. Until then
+	// graceCh is nil so the select blocks only on ctx/events.
+	var graceTimer *time.Timer
+	var graceCh <-chan time.Time
+	defer func() {
+		if graceTimer != nil {
+			graceTimer.Stop()
+		}
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-graceCh:
+			lg := logger
+			if lg == nil {
+				lg = slog.Default()
+			}
+			lg.Warn("forcing turn completion: background tool_use never terminated",
+				"grace_period", gracePeriod)
+			return state.ToTurnResult(), state.Err()
+		case ev, ok := <-events:
+			if !ok {
+				return state.ToTurnResult(), state.Err()
+			}
+			state.Apply(ev)
+			if dispatch != nil {
+				dispatch(ev)
+			}
+			if state.LogicalTurnDone() {
+				return state.ToTurnResult(), state.Err()
+			}
+			// The session has signalled turn completion but the logical
+			// turn is still gated on a background tool_use. Arm the grace
+			// timer once so a never-terminating bg tool cannot strand
+			// this loop indefinitely.
+			if graceTimer == nil && state.SawTurnComplete() {
+				graceTimer = time.NewTimer(gracePeriod)
+				graceCh = graceTimer.C
+			}
+		}
+	}
+}
 
 func computeRetryTimeBudget(cfg ExecuteConfig) time.Duration {
 	turnBudget := time.Duration(cfg.MaxTurns) * time.Minute
@@ -257,22 +325,10 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		if err := session.Query(ctx, prompt); err != nil {
 			return nil, err
 		}
-		state := newLogicalTurnState()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case ev, ok := <-session.Events():
-				if !ok {
-					return state.ToTurnResult(), state.Err()
-				}
-				state.Apply(ev)
+		return consumeTurnEvents(ctx, session.Events(), streamTurnGracePeriod, cfg.Logger,
+			func(ev claude.Event) {
 				dispatchClaudeEvent(ev, cfg.EventHandler, p.events)
-				if state.LogicalTurnDone() {
-					return state.ToTurnResult(), state.Err()
-				}
-			}
-		}
+			})
 	}
 
 	result, err := streamTurn(ctx, fullPrompt)

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -70,6 +70,12 @@ const streamTurnGracePeriod = 3 * time.Minute
 // TurnCompleteEvent was observed but the logical turn is still gated on a
 // background tool_use that never terminated. dispatch is invoked for every
 // event so consumers (EventHandler, AgentEvent channel) see the full stream.
+//
+// The grace timer is per completion wave: a continuation wave (a fresh
+// ResultMessageEvent) or an invalidated pair resets it, so a legitimate
+// multi-wave turn is never preempted by a deadline anchored to an earlier
+// wave — only a wave that genuinely stalls on a non-terminating bg tool_use
+// hits the backstop.
 func consumeTurnEvents(
 	ctx context.Context,
 	events <-chan claude.Event,
@@ -78,15 +84,28 @@ func consumeTurnEvents(
 	dispatch func(claude.Event),
 ) (*claude.TurnResult, error) {
 	state := newLogicalTurnState()
-	// While graceCh is nil the select blocks only on ctx/events; it is armed
-	// lazily once a TurnCompleteEvent lands but the turn is still gated.
+	// The grace timer tracks a single completion wave: it is armed while the
+	// current wave has signalled turn completion but is still gated on a
+	// background tool_use, and disarmed the moment that wave is invalidated.
+	// While graceCh is nil the select blocks only on ctx/events.
 	var graceTimer *time.Timer
 	var graceCh <-chan time.Time
-	defer func() {
-		if graceTimer != nil {
-			graceTimer.Stop()
+	disarmGrace := func() {
+		if graceTimer == nil {
+			return
 		}
-	}()
+		if !graceTimer.Stop() {
+			// Drain a deadline that fired before Stop so a stale tick can't
+			// preempt a later wave through the select.
+			select {
+			case <-graceTimer.C:
+			default:
+			}
+		}
+		graceTimer = nil
+		graceCh = nil
+	}
+	defer disarmGrace()
 	for {
 		select {
 		case <-ctx.Done():
@@ -110,13 +129,21 @@ func consumeTurnEvents(
 			if state.LogicalTurnDone() {
 				return state.ToTurnResult(), state.Err()
 			}
-			// The session has signalled turn completion but the logical
-			// turn is still gated on a background tool_use. Arm the grace
-			// timer once so a never-terminating bg tool cannot strand
-			// this loop indefinitely.
-			if graceTimer == nil && state.SawTurnComplete() {
-				graceTimer = time.NewTimer(gracePeriod)
-				graceCh = graceTimer.C
+			// Keep the grace timer pinned to the current completion wave.
+			// SawTurnComplete() reports the live wave only — a continuation
+			// ResultMessageEvent or invalidateForContinuation clears
+			// lastTurnComplete and flips it back to false. Disarm when the
+			// wave is gone so the next gated wave gets a fresh full window
+			// instead of inheriting an earlier wave's deadline; re-arm once
+			// the (possibly next) wave signals completion but is still gated
+			// on a background tool_use that may never terminate.
+			if state.SawTurnComplete() {
+				if graceTimer == nil {
+					graceTimer = time.NewTimer(gracePeriod)
+					graceCh = graceTimer.C
+				}
+			} else {
+				disarmGrace()
 			}
 		}
 	}

--- a/multiagent/agent/claude_provider_grace_test.go
+++ b/multiagent/agent/claude_provider_grace_test.go
@@ -1,0 +1,142 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
+)
+
+// A turn that completes normally must return as soon as LogicalTurnDone
+// flips — the grace timer must never fire.
+func TestConsumeTurnEvents_NormalTurnReturnsImmediately(t *testing.T) {
+	events := make(chan claude.Event, 8)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{asstTextBlock("hi")},
+	}
+	events <- resultMessage(false)
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true}
+
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, time.Hour, nil, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeTurnEvents did not return on a normally-completed turn")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Success)
+}
+
+// INF-1066 repro at the streamTurn layer: the agent backgrounds an
+// infinite-loop Bash tool, the session emits a TurnCompleteEvent, then goes
+// silent. The bg tool_use never terminates, so LogicalTurnDone never flips on
+// its own. consumeTurnEvents must force completion when the grace period
+// elapses instead of looping forever.
+func TestConsumeTurnEvents_GraceTimerForcesCompletion(t *testing.T) {
+	events := make(chan claude.Event, 8)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{bgBashToolUse("toolu_inf_loop")},
+	}
+	events <- resultMessage(false)
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true}
+	// Channel deliberately left open with no further events — the bg tool
+	// never produces a terminal event.
+
+	grace := 150 * time.Millisecond
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	start := time.Now()
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, grace, nil, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("consumeTurnEvents hung: grace timer did not force turn completion")
+	}
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.GreaterOrEqual(t, elapsed, grace,
+		"must wait at least the grace period before forcing completion")
+	require.Less(t, elapsed, 3*time.Second,
+		"must force completion shortly after the grace period, not hang")
+}
+
+// A WakeupTimedOut TurnCompleteEvent must unblock the loop immediately —
+// before the grace timer would have fired — because the session layer has
+// already declared the turn terminally done.
+func TestConsumeTurnEvents_WakeupTimedOutReturnsBeforeGrace(t *testing.T) {
+	events := make(chan claude.Event, 8)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{bgBashToolUse("toolu_inf_loop")},
+	}
+	events <- resultMessage(false)
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true, WakeupTimedOut: true}
+
+	grace := 10 * time.Second
+	done := make(chan struct{})
+	var err error
+	start := time.Now()
+	go func() {
+		_, err = consumeTurnEvents(context.Background(), events, grace, nil, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("consumeTurnEvents did not return on a WakeupTimedOut TurnCompleteEvent")
+	}
+	require.NoError(t, err)
+	require.Less(t, time.Since(start), grace,
+		"WakeupTimedOut must return well before the grace period elapses")
+}
+
+// ctx cancellation must unblock the loop even while a bg tool_use is live.
+func TestConsumeTurnEvents_ContextCancelUnblocks(t *testing.T) {
+	events := make(chan claude.Event, 8)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{bgBashToolUse("toolu_bg")},
+	}
+	events <- resultMessage(false)
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var err error
+	go func() {
+		_, err = consumeTurnEvents(ctx, events, time.Hour, nil, nil)
+		close(done)
+	}()
+
+	// Give the loop a moment to drain the queued events and arm the grace
+	// timer, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeTurnEvents did not return on context cancellation")
+	}
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/multiagent/agent/claude_provider_grace_test.go
+++ b/multiagent/agent/claude_provider_grace_test.go
@@ -110,6 +110,72 @@ func TestConsumeTurnEvents_WakeupTimedOutReturnsBeforeGrace(t *testing.T) {
 		"WakeupTimedOut must return well before the grace period elapses")
 }
 
+// Wave-rollover repro: a pure-bg turn arms the grace timer on wave 1, then
+// the bg task completes and the CLI auto-continues. The continuation wave
+// (wave 2) then itself stalls on a *second* bg tool_use. The grace timer is
+// anchored to a wave, not the whole turn: wave 2 must get a fresh full grace
+// window, not whatever slack was left on wave 1's deadline. A turn-anchored
+// timer would force-complete wave 2 early (after only `grace - elapsed`).
+func TestConsumeTurnEvents_GraceResetsAcrossContinuationWave(t *testing.T) {
+	grace := 300 * time.Millisecond
+	events := make(chan claude.Event, 16)
+
+	// Wave 1: assistant launches bg Monitor; CLI fires Result + TurnComplete
+	// while the bg task is still live. This arms the grace timer.
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+	}
+	events <- claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")}
+	events <- resultMessage(false)
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true}
+
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	start := time.Now()
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, grace, nil, nil)
+		close(done)
+	}()
+
+	// Let most of wave 1's grace window elapse before the continuation wave
+	// arrives. A turn-anchored timer would have only ~grace/4 left for wave 2.
+	time.Sleep(grace * 3 / 4)
+
+	// Wave 2: bg task 1 completes, CLI auto-continues with a fresh Result +
+	// TurnComplete — but this wave launches a *second* bg tool that never
+	// terminates. The grace timer must re-arm fresh for this wave.
+	completed := "completed"
+	events <- claude.TaskUpdatedEvent{TaskID: "task1", Status: &completed}
+	events <- claude.TaskNotificationEvent{
+		TaskID: "task1", ToolUseID: strPtr("toolu_bg1"), Status: "completed",
+	}
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 2,
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg2")},
+	}
+	events <- claude.TaskStartedEvent{TaskID: "task2", ToolUseID: strPtr("toolu_bg2")}
+	rm := resultMessage(false)
+	rm.TurnNumber = 2
+	events <- rm
+	events <- claude.TurnCompleteEvent{TurnNumber: 2, Success: true}
+	// toolu_bg2 never terminates — wave 2's grace timer is the backstop.
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("consumeTurnEvents hung: wave-2 grace timer did not fire")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// Wave 2's grace window must be a full `grace` measured from when wave 2
+	// re-armed the timer — not the leftover slack from wave 1. Total elapsed
+	// is therefore ~ (3/4)*grace (the sleep) + grace (wave 2's full window).
+	require.GreaterOrEqual(t, time.Since(start), grace+grace/4,
+		"wave 2 must get a fresh grace window, not wave 1's leftover slack")
+}
+
 // ctx cancellation must unblock the loop even while a bg tool_use is live.
 func TestConsumeTurnEvents_ContextCancelUnblocks(t *testing.T) {
 	events := make(chan claude.Event, 8)

--- a/multiagent/agent/codex_provider_test.go
+++ b/multiagent/agent/codex_provider_test.go
@@ -179,6 +179,56 @@ func TestBridgeCodexEvents_MapsEventsToHandlerAndChannel(t *testing.T) {
 	}
 }
 
+// Codex turn IDs are opaque UUIDs. The reported turn number must come from
+// the client's monotonic per-thread counter (TurnIndex), not from scraping
+// digits off the UUID — which previously yielded garbage like turn=905.
+func TestBridgeCodexEvents_UUIDTurnIDsReportMonotonicTurnNumbers(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan codex.Event, 10)
+	agentEvents := make(chan AgentEvent, 10)
+	stop := make(chan struct{})
+	handler := &recordingHandler{}
+
+	bridgeDone := make(chan struct{})
+	go func() {
+		bridgeEvents(events, handler, agentEvents, stop, "thread-1", nil)
+		close(bridgeDone)
+	}()
+
+	// Two completed turns on one thread. TurnID is an opaque UUID whose tail
+	// digits ("...905" / "...426") must NOT be mistaken for a turn number.
+	// TurnIndex carries the client's real monotonic counter.
+	events <- codex.TurnCompletedEvent{
+		ThreadID:  "thread-1",
+		TurnID:    "0198f2c1-7a3e-7b21-a26a-9671fa590905",
+		TurnIndex: 1,
+		Success:   true,
+	}
+	events <- codex.TurnCompletedEvent{
+		ThreadID:  "thread-1",
+		TurnID:    "0198f2c1-9b4f-7c32-b37b-a782gb691426",
+		TurnIndex: 2,
+		Success:   true,
+	}
+
+	require.Eventually(t, func() bool {
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+		return len(handler.turnCompletes) == 2
+	}, time.Second, 5*time.Millisecond, "expected two turn completions")
+
+	close(stop)
+	<-bridgeDone
+
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	require.Equal(t, 1, handler.turnCompletes[0].turnNumber,
+		"first turn must report turn number 1, not a scraped UUID tail")
+	require.Equal(t, 2, handler.turnCompletes[1].turnNumber,
+		"second turn must report turn number 2, not a scraped UUID tail")
+}
+
 func TestBridgeCodexEvents_FiltersOtherThreads(t *testing.T) {
 	t.Parallel()
 

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/wt"
@@ -192,6 +193,7 @@ type ExecuteOption func(*ExecuteConfig)
 type ExecuteConfig struct {
 	EventHandler        EventHandler
 	LLMEndpoint         llmendpoint.Endpoint
+	Logger              *slog.Logger
 	Model               string
 	Effort              EffortLevel
 	WorkDir             string
@@ -202,6 +204,14 @@ type ExecuteConfig struct {
 	MaxToolErrorRetries int
 	MaxBudgetUSD        float64
 	KeepUserSettings    bool
+}
+
+// WithProviderLogger sets the structured logger a provider uses for
+// diagnostic warnings (e.g. streamTurn forcing turn completion when a
+// background tool_use never terminates). When unset, providers fall back to
+// slog.Default().
+func WithProviderLogger(logger *slog.Logger) ExecuteOption {
+	return func(c *ExecuteConfig) { c.Logger = logger }
 }
 
 // WithProviderModel sets the model for a provider execution.

--- a/multiagent/agent/turn_state.go
+++ b/multiagent/agent/turn_state.go
@@ -34,11 +34,8 @@ type logicalTurnState struct {
 
 	turnNumber int
 
-	// forcedDone is set when a terminal TurnCompleteEvent arrives via the
-	// ScheduleWakeup safety-timer path (WakeupTimedOut). The session layer
-	// has given up waiting for the turn, so any still-"live" background
-	// tool_use is stranded and the logical turn must be considered done —
-	// LogicalTurnDone short-circuits on this.
+	// forcedDone latches a terminal TurnCompleteEvent with WakeupTimedOut set;
+	// LogicalTurnDone short-circuits on it.
 	forcedDone bool
 }
 
@@ -148,11 +145,6 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 		tc := e
 		s.lastTurnComplete = &tc
 		s.turnNumber = e.TurnNumber
-		// A safety-timer completion is terminal: the session layer has
-		// stopped waiting and no continuation wave will follow. Any
-		// background tool_use still tracked as live (e.g. an agent that
-		// backgrounded an infinite loop) is stranded — force the logical
-		// turn done so streamTurn unblocks instead of looping forever.
 		if e.WakeupTimedOut {
 			s.forcedDone = true
 		}
@@ -170,10 +162,9 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 // ResultMessage) ensures downstream handlers see OnTurnComplete before the
 // consumer loop exits.
 func (s *logicalTurnState) LogicalTurnDone() bool {
-	// A safety-timer TurnCompleteEvent (WakeupTimedOut) is terminal: the
-	// session layer already gave up. Honour it regardless of live bg work
-	// or a missing ResultMessage — otherwise an agent that backgrounded an
-	// unkillable infinite loop strands streamTurn forever.
+	// A safety-timer completion is terminal — honour it regardless of live
+	// bg work or a missing ResultMessage, else a backgrounded infinite loop
+	// strands streamTurn forever.
 	if s.forcedDone {
 		return true
 	}

--- a/multiagent/agent/turn_state.go
+++ b/multiagent/agent/turn_state.go
@@ -33,6 +33,13 @@ type logicalTurnState struct {
 	usage claude.TurnUsage
 
 	turnNumber int
+
+	// forcedDone is set when a terminal TurnCompleteEvent arrives via the
+	// ScheduleWakeup safety-timer path (WakeupTimedOut). The session layer
+	// has given up waiting for the turn, so any still-"live" background
+	// tool_use is stranded and the logical turn must be considered done —
+	// LogicalTurnDone short-circuits on this.
+	forcedDone bool
 }
 
 func newLogicalTurnState() *logicalTurnState {
@@ -141,6 +148,14 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 		tc := e
 		s.lastTurnComplete = &tc
 		s.turnNumber = e.TurnNumber
+		// A safety-timer completion is terminal: the session layer has
+		// stopped waiting and no continuation wave will follow. Any
+		// background tool_use still tracked as live (e.g. an agent that
+		// backgrounded an infinite loop) is stranded — force the logical
+		// turn done so streamTurn unblocks instead of looping forever.
+		if e.WakeupTimedOut {
+			s.forcedDone = true
+		}
 
 	case claude.ErrorEvent:
 		if s.err == nil {
@@ -155,6 +170,13 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 // ResultMessage) ensures downstream handlers see OnTurnComplete before the
 // consumer loop exits.
 func (s *logicalTurnState) LogicalTurnDone() bool {
+	// A safety-timer TurnCompleteEvent (WakeupTimedOut) is terminal: the
+	// session layer already gave up. Honour it regardless of live bg work
+	// or a missing ResultMessage — otherwise an agent that backgrounded an
+	// unkillable infinite loop strands streamTurn forever.
+	if s.forcedDone {
+		return true
+	}
 	if s.lastResult == nil || s.lastTurnComplete == nil {
 		return false
 	}
@@ -162,6 +184,16 @@ func (s *logicalTurnState) LogicalTurnDone() bool {
 		return false
 	}
 	return !s.hasUncancelledBgToolUse()
+}
+
+// SawTurnComplete reports whether a TurnCompleteEvent for the current
+// completion wave is currently outstanding. streamTurn uses this to arm a
+// grace timer: when a turn-complete has arrived but LogicalTurnDone() is
+// still false (gated on a background tool_use), the loop must not block
+// forever. Note lastTurnComplete is cleared by invalidateForContinuation
+// and on each new ResultMessageEvent, so this only reports the live wave.
+func (s *logicalTurnState) SawTurnComplete() bool {
+	return s.lastTurnComplete != nil
 }
 
 // HasLiveTasks reports whether any bg task or uncancelled bg tool_use is

--- a/multiagent/agent/turn_state_test.go
+++ b/multiagent/agent/turn_state_test.go
@@ -612,6 +612,86 @@ func TestTurnState_TerminalTaskUpdatedAfterResultRequiresContinuation(t *testing
 	require.True(t, s.LogicalTurnDone())
 }
 
+// INF-1066 repro: an agent backgrounds an unkillable infinite-loop Bash tool
+// (run_in_background:true), arms a ScheduleWakeup, and ends the turn. The
+// ScheduleWakeup safety timer fires and emits a terminal (WakeupTimedOut)
+// TurnCompleteEvent — but the bg tool_use never terminates, so it is never
+// cancelled and never lands in completedBgToolUseIDs. Without the
+// WakeupTimedOut short-circuit, LogicalTurnDone stays false forever and
+// streamTurn loops indefinitely. The terminal event must force the turn done.
+func TestTurnState_WakeupTimedOutForcesTurnDone(t *testing.T) {
+	s := newLogicalTurnState()
+
+	// Assistant backgrounds an infinite-loop Bash poll.
+	s.Apply(claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{bgBashToolUse("toolu_inf_loop")},
+	})
+	// The CLI emits a ResultMessage immediately (pure-bg turn). No terminal
+	// task event ever follows — the loop never ends.
+	s.Apply(resultMessage(false))
+	require.False(t, s.LogicalTurnDone(),
+		"bg tool_use still uncancelled/uncompleted — turn not done")
+	require.True(t, s.HasLiveTasks())
+
+	// A normal (non-wakeup) TurnCompleteEvent must NOT break the deadlock —
+	// the bg tool_use is still tracked as live.
+	s.Apply(claude.TurnCompleteEvent{TurnNumber: 1, Success: true})
+	require.False(t, s.LogicalTurnDone(),
+		"a normal TurnCompleteEvent must keep gating on the live bg tool_use")
+
+	// The ScheduleWakeup safety timer fires: a terminal TurnCompleteEvent
+	// with WakeupTimedOut set. The session layer has given up — the logical
+	// turn must now be forced done so streamTurn unblocks.
+	s.Apply(claude.TurnCompleteEvent{TurnNumber: 1, Success: true, WakeupTimedOut: true})
+	require.True(t, s.LogicalTurnDone(),
+		"WakeupTimedOut TurnCompleteEvent must force the logical turn done despite the stranded bg tool_use")
+}
+
+// A WakeupTimedOut TurnCompleteEvent must force completion even with a live
+// background *task* (not just a tool_use) outstanding — the safety timer is
+// terminal regardless of what kind of bg work is stranded.
+func TestTurnState_WakeupTimedOutForcesDoneWithLiveTask(t *testing.T) {
+	s := newLogicalTurnState()
+
+	s.Apply(claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg")},
+	})
+	s.Apply(claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg")})
+	s.Apply(resultMessage(false))
+	require.False(t, s.LogicalTurnDone())
+
+	s.Apply(claude.TurnCompleteEvent{TurnNumber: 1, Success: true, WakeupTimedOut: true})
+	require.True(t, s.LogicalTurnDone(),
+		"WakeupTimedOut must force done even with a live bg task")
+}
+
+// SawTurnComplete reports whether the current wave's TurnCompleteEvent is
+// outstanding. streamTurn arms its grace timer on this signal.
+func TestTurnState_SawTurnComplete(t *testing.T) {
+	s := newLogicalTurnState()
+	require.False(t, s.SawTurnComplete(), "no TurnComplete observed yet")
+
+	s.Apply(claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{bgBashToolUse("toolu_bg")},
+	})
+	s.Apply(resultMessage(false))
+	require.False(t, s.SawTurnComplete(), "ResultMessage alone is not a TurnComplete")
+
+	s.Apply(claude.TurnCompleteEvent{TurnNumber: 1, Success: true})
+	require.True(t, s.SawTurnComplete(),
+		"TurnCompleteEvent observed — grace timer may arm")
+
+	// A new ResultMessage starts a fresh wave and clears the stale signal.
+	rm2 := resultMessage(false)
+	rm2.TurnNumber = 2
+	s.Apply(rm2)
+	require.False(t, s.SawTurnComplete(),
+		"a new ResultMessage clears the prior wave's TurnComplete")
+}
+
 // A terminal TaskNotificationEvent that arrives before the corresponding
 // TaskStartedEvent (stream reorder) must not leave the task stuck live when
 // the belated TaskStartedEvent finally shows up.


### PR DESCRIPTION
## Summary

jiradozer's `validate` step hung forever (verified: one run wedged 4h37m, no `workflow finished` line) when the agent backgrounded a never-terminating tool — e.g. a `while true; do … gh pr view … done` CI-poll loop — and armed a `ScheduleWakeup`.

Two independent "is the turn done?" gates deadlocked:
1. The session-layer `ScheduleWakeup` safety timer fired correctly and emitted `TurnCompleteEvent`.
2. `logicalTurnState.LogicalTurnDone()` still returned false because `hasUncancelledBgToolUse()` saw the infinite background `Bash` tool_use that is never cancelled and never produces a terminal task event.

So `streamTurn`'s event loop never returned even though the session layer had already given up.

## Changes

**Fix 1 — break the deadlock (correctness):**
- Add `WakeupTimedOut bool` to `claude.TurnCompleteEvent`, set only on the safety-timer (`completeWakeupSuppressedTurn`) path.
- `turn_state.go`: a `WakeupTimedOut` event forces the logical turn done so `streamTurn` unblocks. Normal turns still gate correctly on genuine background work.
- `claude_provider.go`: extract the event loop into `consumeTurnEvents`, which arms a 3-minute grace timer once a `TurnCompleteEvent` is seen but the turn is still gated on live bg work — a structural backstop for backgrounded tools with no `ScheduleWakeup`.

**Fix 2 — codex `turn=905` bug:**
- `TurnNumberFromID` scraped trailing digits off opaque UUID turn IDs, producing garbage turn numbers. Now the codex client maintains a real monotonic per-thread counter (`TurnCompletedEvent.TurnIndex`); `TurnNumberFromID` is a fallback that returns `1` for UUIDs instead of scraping.

**Fix 3 — codex telemetry / log clarity (no behavior change):**
- `jiradozer/agent.go`: `agent completed` / `turn complete` lines now carry `provider=`, and log `cost=n/a` / token `n/a` for providers where cost/tokens are structurally unavailable, instead of presenting a structural `$0.0000` as a real measurement.

Out of scope (flagged for follow-up): round 3's prompt actively invites the infinite-loop behavior; validate-latency work; codex `MaxTurns`/`MaxBudgetUSD` enforcement.

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `bazel build //...` — passes
- [x] `bazel test //...` — all 88 targets pass
- [x] Unit test reproducing the hang: uncancelled `run_in_background:true` tool_use + a `WakeupTimedOut` `TurnCompleteEvent` makes `LogicalTurnDone()` return true (fails before Fix 1)
- [x] `consumeTurnEvents` grace-timer tests: `TurnCompleteEvent` then silence with live bg tool_use → returns within the grace window, doesn't hang
- [x] codex turn counter: two `TurnCompletedEvent`s with UUID `TurnID`s on one thread report turns 1, 2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-completion semantics and adds new timeouts in the Claude provider; incorrect handling could prematurely end turns or mask real background-task completion. Codex event numbering/logging changes are lower risk but touch client event shapes consumed by downstream code.
> 
> **Overview**
> Fixes a hang where backgrounded, never-terminating tool runs could keep a turn “live” forever even after the Claude session’s `ScheduleWakeup` safety timer fired. This adds `WakeupTimedOut` to `claude.TurnCompleteEvent`, ensures `logicalTurnState.LogicalTurnDone()` short-circuits on that terminal signal, and refactors the Claude provider loop into `consumeTurnEvents` with a per-completion-wave grace timer backstop.
> 
> Corrects Codex turn-number reporting by introducing a monotonic per-thread `TurnIndex` counter (seeded on thread resume) and using it for `StreamTurnNum`, while tightening `TurnNumberFromID` to avoid scraping digits from UUIDs. Updates `jiradozer` logging to include `provider=` and to log cost/tokens as `n/a` when a provider does not report real measurements, and wires a structured logger through provider execute options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e8246a729f720e4ecf4e7bd0f3f5588424a70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->