### PR TITLE
feat(wt): add `gc --stale-locks` to clean up crashed agent worktrees

### DIFF
--- a/wt/cmd/wt/main.go
+++ b/wt/cmd/wt/main.go
@@ -903,15 +903,19 @@ var gcCmd = &cobra.Command{
 
 1. Prunes stale worktree metadata (git worktree prune)
 2. With --merged, removes worktrees whose GitHub PRs are merged
-3. Fetches and prunes remote tracking refs (git fetch --prune)
-4. Detects orphaned local branches (no corresponding worktree)
-5. Optionally deletes orphaned local branches (-D)
-6. Optionally deletes corresponding remote branches (-D -r)
-7. Garbage collects loose objects (git gc)
+3. With --stale-locks, removes worktrees whose lock references a dead process
+   and which have no open PR (e.g. crashed Claude-agent worktrees)
+4. Fetches and prunes remote tracking refs (git fetch --prune)
+5. Detects orphaned local branches (no corresponding worktree)
+6. Optionally deletes orphaned local branches (-D)
+7. Optionally deletes corresponding remote branches (-D -r)
+8. Garbage collects loose objects (git gc)
 
 Protected branches (main, master, default branch) are never deleted.
 
-Without -D, orphaned branches are listed but not deleted.`,
+Without -D, orphaned branches are listed but not deleted.
+Stale-locked worktrees are listed without --stale-locks; a stale-locked
+worktree whose branch has an OPEN PR is always kept (live work).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		m, err := getManager()
 		if err != nil {
@@ -924,12 +928,14 @@ Without -D, orphaned branches are listed but not deleted.`,
 		ctx := context.Background()
 
 		merged, _ := cmd.Flags().GetBool("merged")
+		staleLocks, _ := cmd.Flags().GetBool("stale-locks")
 
 		opts := wt.GCOptions{
 			DryRun:         dryRun,
 			DeleteBranches: deleteBranches,
 			DeleteRemote:   deleteRemote,
 			MergedPRs:      merged,
+			StaleLocks:     staleLocks,
 		}
 
 		_, err = m.GC(ctx, opts)
@@ -942,6 +948,7 @@ func init() {
 	gcCmd.Flags().BoolP("delete-branches", "D", false, "Delete orphaned local branches")
 	gcCmd.Flags().BoolP("remote", "r", false, "Also delete remote branches (requires -D)")
 	gcCmd.Flags().Bool("merged", false, "Also remove worktrees whose GitHub PRs are merged")
+	gcCmd.Flags().Bool("stale-locks", false, "Remove worktrees with stale (dead-PID) locks and no open PR (e.g. crashed agent worktrees)")
 }
 
 // shellenvCmd: wt shellenv

--- a/wt/github.go
+++ b/wt/github.go
@@ -153,6 +153,9 @@ func ListOpenPRs(ctx context.Context, runner GHRunner, dir string) ([]PRInfo, er
 	if err != nil {
 		return nil, err
 	}
+	if result == nil || result.Stdout == "" {
+		return nil, nil
+	}
 
 	var prs []PRInfo
 	if err := json.Unmarshal([]byte(result.Stdout), &prs); err != nil {
@@ -163,16 +166,20 @@ func ListOpenPRs(ctx context.Context, runner GHRunner, dir string) ([]PRInfo, er
 }
 
 // ListMergedPRs returns recently merged PRs in the repository.
-// Uses --limit 200 to cover typical worktree counts without excessive pagination.
+// Uses --limit 1000 (matching ListOpenPRs) to cover busy repos; the caller
+// still warns if the cap is hit so older merged-PR worktrees aren't silently missed.
 func ListMergedPRs(ctx context.Context, runner GHRunner, dir string) ([]PRInfo, error) {
 	result, err := runner.Run(ctx, []string{
 		"pr", "list",
 		"--json", "number,headRefName,baseRefName,state,url",
 		"--state", "merged",
-		"--limit", "200",
+		"--limit", "1000",
 	}, dir)
 	if err != nil {
 		return nil, err
+	}
+	if result == nil || result.Stdout == "" {
+		return nil, nil
 	}
 
 	var prs []PRInfo

--- a/wt/github.go
+++ b/wt/github.go
@@ -141,14 +141,28 @@ func GetPRByBranch(ctx context.Context, runner GHRunner, branch, dir string) (*P
 	return &info, nil
 }
 
+// prListLimit caps `gh pr list` results (gh's default is 30). A caller that
+// relies on the list being exhaustive must treat len(prs) >= prListLimit as
+// truncated — see PRListTruncated.
+const prListLimit = 1000
+
+// PRListTruncated reports whether a PR list returned by ListOpenPRs/ListMergedPRs
+// may be incomplete because it hit prListLimit. Callers that make destructive
+// decisions on the list (e.g. "no open PR, safe to delete") must fail closed
+// when this is true rather than act on partial data.
+func PRListTruncated(prs []PRInfo) bool {
+	return len(prs) >= prListLimit
+}
+
 // ListOpenPRs returns all open PRs in the repository with full details.
-// Uses --limit 1000 to avoid gh's default cap of 30 results.
+// Uses --limit prListLimit to avoid gh's default cap of 30 results; callers that
+// need an exhaustive list must check PRListTruncated.
 func ListOpenPRs(ctx context.Context, runner GHRunner, dir string) ([]PRInfo, error) {
 	result, err := runner.Run(ctx, []string{
 		"pr", "list",
 		"--json", "number,headRefName,baseRefName,state,isDraft,reviewDecision,url",
 		"--state", "open",
-		"--limit", "1000",
+		"--limit", strconv.Itoa(prListLimit),
 	}, dir)
 	if err != nil {
 		return nil, err
@@ -166,14 +180,14 @@ func ListOpenPRs(ctx context.Context, runner GHRunner, dir string) ([]PRInfo, er
 }
 
 // ListMergedPRs returns recently merged PRs in the repository.
-// Uses --limit 1000 (matching ListOpenPRs) to cover busy repos; the caller
-// still warns if the cap is hit so older merged-PR worktrees aren't silently missed.
+// Uses --limit prListLimit (matching ListOpenPRs) to cover busy repos; the caller
+// still warns via PRListTruncated so older merged-PR worktrees aren't silently missed.
 func ListMergedPRs(ctx context.Context, runner GHRunner, dir string) ([]PRInfo, error) {
 	result, err := runner.Run(ctx, []string{
 		"pr", "list",
 		"--json", "number,headRefName,baseRefName,state,url",
 		"--state", "merged",
-		"--limit", "1000",
+		"--limit", strconv.Itoa(prListLimit),
 	}, dir)
 	if err != nil {
 		return nil, err

--- a/wt/github_test.go
+++ b/wt/github_test.go
@@ -190,6 +190,18 @@ func TestListOpenPRsEmpty(t *testing.T) {
 	}
 }
 
+func TestPRListTruncated(t *testing.T) {
+	if PRListTruncated(make([]PRInfo, prListLimit-1)) {
+		t.Errorf("below cap must not be truncated")
+	}
+	if !PRListTruncated(make([]PRInfo, prListLimit)) {
+		t.Errorf("at cap must be reported truncated")
+	}
+	if !PRListTruncated(make([]PRInfo, prListLimit+1)) {
+		t.Errorf("above cap must be reported truncated")
+	}
+}
+
 func TestCreatePRDraft(t *testing.T) {
 	mock := NewMockGHRunner()
 	mock.Results["api repos/{owner}/{repo}/pulls -f title= -f body= -f head=feat -f base=main -F draft=true"] = &CmdResult{

--- a/wt/github_test.go
+++ b/wt/github_test.go
@@ -277,7 +277,7 @@ func TestIsAuthError(t *testing.T) {
 
 func TestListMergedPRs(t *testing.T) {
 	mock := NewMockGHRunner()
-	mock.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mock.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[
 			{"number":10,"headRefName":"feature-a","baseRefName":"main","state":"MERGED","url":"https://github.com/org/repo/pull/10"},
 			{"number":20,"headRefName":"feature-b","baseRefName":"main","state":"MERGED","url":"https://github.com/org/repo/pull/20"}
@@ -301,7 +301,7 @@ func TestListMergedPRs(t *testing.T) {
 
 func TestListMergedPRs_Empty(t *testing.T) {
 	mock := NewMockGHRunner()
-	mock.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mock.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[]`,
 	}
 

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -130,6 +130,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -145,13 +146,21 @@ var (
 
 // Worktree represents a Git worktree.
 type Worktree struct {
-	Path       string
-	Branch     string
-	Commit     string
+	Path   string
+	Branch string
+	Commit string
+	// LockReason is the text after "locked " in porcelain output, empty for a
+	// bare "locked" line.
+	LockReason string
+	// LockPID is the PID parsed from a lock reason of the form "(pid <N>)",
+	// 0 when absent or unparseable.
+	LockPID    int
 	IsDetached bool
 	// IsGone is true when git knows about the worktree but its directory no
 	// longer exists on disk (e.g. removed via `rm -rf` or `git worktree remove`).
 	IsGone bool
+	// IsLocked is true when the worktree is locked (git worktree lock).
+	IsLocked bool
 }
 
 // Name returns the worktree name (directory name).
@@ -176,11 +185,14 @@ type WorktreeStatus struct {
 
 // Manager handles worktree operations for a repository.
 type Manager struct {
-	git      GitRunner
-	gh       GHRunner
-	output   *Output
-	root     string
-	repoName string
+	git    GitRunner
+	gh     GHRunner
+	output *Output
+	// processAlive reports whether a PID is currently running. Injectable for
+	// tests; defaults to defaultProcessAlive.
+	processAlive func(pid int) bool
+	root         string
+	repoName     string
 }
 
 // Option configures a Manager.
@@ -201,19 +213,52 @@ func WithOutput(o *Output) Option {
 	return func(m *Manager) { m.output = o }
 }
 
+// WithProcessAlive sets a custom PID-liveness predicate (used in tests).
+func WithProcessAlive(f func(int) bool) Option {
+	return func(m *Manager) { m.processAlive = f }
+}
+
 // NewManager creates a Manager for the given repository.
 func NewManager(root, repoName string, opts ...Option) *Manager {
 	m := &Manager{
-		root:     root,
-		repoName: repoName,
-		git:      &DefaultGitRunner{},
-		gh:       &DefaultGHRunner{},
-		output:   DefaultOutput(),
+		root:         root,
+		repoName:     repoName,
+		git:          &DefaultGitRunner{},
+		gh:           &DefaultGHRunner{},
+		output:       DefaultOutput(),
+		processAlive: defaultProcessAlive,
 	}
 	for _, opt := range opts {
 		opt(m)
 	}
 	return m
+}
+
+// defaultProcessAlive reports whether a process with the given PID is currently
+// running, using signal 0 (delivers no signal; existence/permission check only).
+func defaultProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid) // always succeeds on Unix
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true // alive and signalable
+	}
+	return errors.Is(err, os.ErrPermission) // exists but owned by another user
+}
+
+// isStaleLock reports whether a worktree's lock is safe to treat as stale.
+// A lock is stale only when it carries a parseable PID that is not alive.
+// An unparseable PID (LockPID == 0) is treated as live (never removed).
+func (m *Manager) isStaleLock(w Worktree) bool {
+	if !w.IsLocked || w.LockPID == 0 {
+		return false
+	}
+	return !m.processAlive(w.LockPID)
 }
 
 // RepoDir returns the path to the repository root.
@@ -621,6 +666,11 @@ func parseWorktreeList(output string) []Worktree {
 			current["detached"] = "true"
 		} else if line == "prunable" || strings.HasPrefix(line, "prunable ") {
 			current["prunable"] = "true"
+		} else if line == "locked" {
+			current["locked"] = "true"
+		} else if strings.HasPrefix(line, "locked ") {
+			current["locked"] = "true"
+			current["lockreason"] = line[len("locked "):]
 		}
 	}
 	flush()
@@ -645,13 +695,39 @@ func worktreeFromFields(fields map[string]string) (Worktree, bool) {
 	if len(commit) > 8 {
 		commit = commit[:8]
 	}
+	lockReason := fields["lockreason"]
 	return Worktree{
 		Path:       fields["worktree"],
 		Branch:     branch,
 		Commit:     commit,
 		IsDetached: fields["detached"] == "true",
 		IsGone:     fields["prunable"] == "true",
+		IsLocked:   fields["locked"] == "true",
+		LockReason: lockReason,
+		LockPID:    parseLockPID(lockReason),
 	}, true
+}
+
+// parseLockPID extracts the PID embedded in a worktree lock reason of the form
+// "...(pid <N>)". Claude agents write reasons like
+// "claude agent agent-<hash> (pid 3190410)". Returns 0 when no PID is present
+// or parseable, so callers treat such locks conservatively (as live).
+func parseLockPID(reason string) int {
+	const marker = "(pid "
+	i := strings.Index(reason, marker)
+	if i < 0 {
+		return 0
+	}
+	rest := reason[i+len(marker):]
+	j := strings.IndexByte(rest, ')')
+	if j < 0 {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(rest[:j]))
+	if err != nil {
+		return 0
+	}
+	return pid
 }
 
 // GetGitStatus returns local git status for a worktree (no network calls).
@@ -813,8 +889,6 @@ func (m *Manager) GetStatus(ctx context.Context, wt Worktree) (*WorktreeStatus, 
 // If force is true, passes --force to git worktree remove, allowing removal of worktrees with
 // modified or untracked files (equivalent to git worktree remove --force).
 func (m *Manager) Remove(ctx context.Context, nameOrBranch string, deleteBranch bool, force bool) error {
-	bareDir := m.BareDir()
-
 	// First try as directory name
 	worktreePath := filepath.Join(m.RepoDir(), nameOrBranch)
 	branchName := nameOrBranch
@@ -846,6 +920,31 @@ func (m *Manager) Remove(ctx context.Context, nameOrBranch string, deleteBranch 
 		}
 	}
 
+	return m.removeResolved(ctx, worktreePath, branchName, deleteBranch, force)
+}
+
+// RemoveByPath removes the worktree at the given absolute path without
+// name/branch resolution. Use it for worktrees outside the standard RepoDir
+// layout (e.g. agent worktrees under <bare>/.claude/worktrees), where the
+// directory name and branch name are unreliable lookup keys. The branch name
+// is resolved from the worktree itself for hooks and optional branch deletion.
+func (m *Manager) RemoveByPath(ctx context.Context, worktreePath string, deleteBranch, force bool) error {
+	branchName := filepath.Base(worktreePath)
+	if result, err := m.git.Run(ctx, []string{"branch", "--show-current"}, worktreePath); err == nil {
+		if cur := strings.TrimSpace(result.Stdout); cur != "" {
+			branchName = cur
+		}
+	}
+	return m.removeResolved(ctx, worktreePath, branchName, deleteBranch, force)
+}
+
+// removeResolved runs post-remove hooks, removes the worktree at worktreePath,
+// and optionally deletes the local/remote branch. force triggers a double
+// --force so that locked worktrees (e.g. crashed agent worktrees) can be
+// removed — git refuses a single --force on a locked worktree.
+func (m *Manager) removeResolved(ctx context.Context, worktreePath, branchName string, deleteBranch, force bool) error {
+	bareDir := m.BareDir()
+
 	// Run post-remove hooks first
 	config, err := LoadRepoConfig(worktreePath)
 	if err != nil {
@@ -862,7 +961,10 @@ func (m *Manager) Remove(ctx context.Context, nameOrBranch string, deleteBranch 
 	m.output.Info(fmt.Sprintf("Removing worktree %s...", branchName))
 	removeArgs := []string{"worktree", "remove"}
 	if force {
-		removeArgs = append(removeArgs, "--force")
+		// Double --force lets git remove locked worktrees (e.g. crashed Claude
+		// agent worktrees). A single --force is refused with
+		// "cannot remove a locked working tree".
+		removeArgs = append(removeArgs, "--force", "--force")
 	}
 	removeArgs = append(removeArgs, worktreePath)
 	if result, err := m.git.Run(ctx, removeArgs, bareDir); err != nil {
@@ -1450,8 +1552,8 @@ func (m *Manager) pruneMergedPRs(ctx context.Context, bareDir string, dryRun boo
 		return nil, fmt.Errorf("failed to list merged PRs: %w", err)
 	}
 
-	if len(mergedPRs) >= 200 {
-		m.output.Warn("GitHub returned 200 merged PRs (limit reached); older merged-PR worktrees may not be detected")
+	if len(mergedPRs) >= 1000 {
+		m.output.Warn("GitHub returned 1000 merged PRs (limit reached); older merged-PR worktrees may not be detected")
 	}
 
 	mergedByBranch := make(map[string]*PRInfo, len(mergedPRs))
@@ -1491,23 +1593,118 @@ func (m *Manager) pruneMergedPRs(ctx context.Context, bareDir string, dryRun boo
 	return removed, nil
 }
 
+// StaleLockInfo describes a worktree whose lock references a dead PID.
+type StaleLockInfo struct {
+	Name       string // Worktree directory name
+	Branch     string
+	Path       string
+	LockReason string
+	KeepReason string // Why the worktree was kept; empty when Removed
+	LockPID    int
+	PRNumber   int  // PR number when HasOpenPR
+	HasOpenPR  bool // True when an open PR keeps the worktree alive
+	Removed    bool // True when removed (or would be, in dry-run)
+}
+
+// pruneStaleLocks finds worktrees whose lock references a dead PID and, when
+// remove is true, removes those that are safe to remove. A stale-locked
+// worktree is kept (never removed) when its branch still has an OPEN PR — a
+// stale lock plus an open PR means live work. Protected and detached worktrees
+// are skipped. Every kept worktree records and prints a KeepReason. With
+// remove=false the detected set is returned without any removals (list-only).
+func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, dryRun bool) ([]StaleLockInfo, []string, error) {
+	protected := protectedBranches(ctx, m.git, bareDir)
+
+	worktrees, err := m.List(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	// Determine which branches have an open PR. Fail safe: if we can't tell,
+	// degrade to list-only so we never remove a worktree with live work.
+	openByBranch := make(map[string]*PRInfo)
+	openPRs, err := ListOpenPRs(ctx, m.gh, bareDir)
+	if err != nil {
+		m.output.Warn(fmt.Sprintf("Could not list open PRs; skipping stale-lock removal: %v", err))
+		remove = false
+	} else {
+		for i := range openPRs {
+			openByBranch[openPRs[i].HeadRefName] = &openPRs[i]
+		}
+	}
+
+	var detected []StaleLockInfo
+	var removed []string
+	for _, wt := range worktrees {
+		if wt.IsDetached || protected[wt.Branch] {
+			continue
+		}
+		if !m.isStaleLock(wt) {
+			continue
+		}
+
+		info := StaleLockInfo{
+			Name:       wt.Name(),
+			Branch:     wt.Branch,
+			Path:       wt.Path,
+			LockReason: wt.LockReason,
+			LockPID:    wt.LockPID,
+		}
+		if pr, ok := openByBranch[wt.Branch]; ok {
+			info.HasOpenPR = true
+			info.PRNumber = pr.Number
+		}
+
+		switch {
+		case info.HasOpenPR:
+			info.KeepReason = fmt.Sprintf("PR #%d still OPEN", info.PRNumber)
+			m.output.Warn(fmt.Sprintf("Keeping %s: lock PID %d dead but PR #%d is OPEN (live work)", info.Name, info.LockPID, info.PRNumber))
+		case !remove:
+			info.KeepReason = "listed only; run with --stale-locks to remove"
+			m.output.Info(fmt.Sprintf("Stale-locked (PID %d dead, no open PR): %s — %q", info.LockPID, info.Name, info.LockReason))
+		case dryRun:
+			info.Removed = true
+			removed = append(removed, info.Name)
+			m.output.Info(fmt.Sprintf("[dry-run] Would remove %s (stale lock, PID %d dead, no open PR)", info.Name, info.LockPID))
+		default:
+			m.output.Info(fmt.Sprintf("Removing %s (stale lock, PID %d dead)...", info.Name, info.LockPID))
+			// deleteBranch=false: leave the (possibly unpushed) branch for the
+			// orphaned-branch step / -D to handle.
+			if err := m.RemoveByPath(ctx, wt.Path, false, true); err != nil {
+				info.KeepReason = fmt.Sprintf("removal failed: %v", err)
+				m.output.Error(fmt.Sprintf("Failed to remove %s: %v", info.Name, err))
+			} else {
+				info.Removed = true
+				removed = append(removed, info.Name)
+			}
+		}
+
+		detected = append(detected, info)
+	}
+
+	return detected, removed, nil
+}
+
 // GCOptions configures garbage collection behavior.
 type GCOptions struct {
 	DryRun         bool // Preview only, no changes
 	DeleteBranches bool // Delete orphaned local branches
 	DeleteRemote   bool // Also delete remote branches (requires DeleteBranches)
 	MergedPRs      bool // Also remove worktrees whose GitHub PRs are merged
+	StaleLocks     bool // Remove worktrees with stale (dead-PID) locks and no open PR
 }
 
 // GCResult contains the results of garbage collection.
 type GCResult struct {
-	PrunedWorktrees  []string // Lines from git worktree prune
-	MergedWorktrees  []string // Worktrees removed because their PR was merged
-	OrphanedBranches []string // Local branches with no worktree
-	DeletedBranches  []string // Actually deleted local branches
-	DeletedRemote    []string // Actually deleted remote branches
-	FetchPruned      bool     // Whether fetch --prune ran
-	GCRan            bool     // Whether git gc ran
+	PrunedWorktrees   []string        // Lines from git worktree prune
+	MergedWorktrees   []string        // Worktrees removed because their PR was merged
+	OrphanedBranches  []string        // Local branches with no worktree
+	DeletedBranches   []string        // Actually deleted local branches
+	DeletedRemote     []string        // Actually deleted remote branches
+	StaleLocked       []StaleLockInfo // Detected stale-locked worktrees (with keep/remove reason)
+	RemovedStaleLocks []string        // Stale-locked worktrees removed (or would-be in dry-run)
+	FetchPruned       bool            // Whether fetch --prune ran
+	GCRan             bool            // Whether git gc ran
 }
 
 // GC performs comprehensive garbage collection: prunes stale worktree metadata,
@@ -1533,6 +1730,22 @@ func (m *Manager) GC(ctx context.Context, opts GCOptions) (*GCResult, error) {
 	result.MergedWorktrees = pruned.MergedWorktrees
 	for _, line := range pruned.StaleWorktrees {
 		m.output.Info(fmt.Sprintf("Pruned: %s", line))
+	}
+
+	// Step 1b: stale-lock cleanup (e.g. crashed Claude-agent worktrees). Runs
+	// before orphaned-branch detection so removed worktrees' branches then
+	// surface as orphaned and are deletable with -D.
+	staleLocked, removedLocks, err := m.pruneStaleLocks(ctx, bareDir, opts.StaleLocks, opts.DryRun)
+	if err != nil {
+		m.output.Warn(fmt.Sprintf("Stale-lock check failed: %v", err))
+	} else {
+		result.StaleLocked = staleLocked
+		result.RemovedStaleLocks = removedLocks
+		if len(staleLocked) == 0 {
+			m.output.Success("No stale-locked worktrees found")
+		} else if !opts.StaleLocks {
+			m.output.Info(fmt.Sprintf("Found %d stale-locked worktree(s) (run with --stale-locks to remove)", len(staleLocked)))
+		}
 	}
 
 	// Step 2: git fetch --prune

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -1615,17 +1615,24 @@ func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, d
 	// Only the removal path needs open-PR state (to keep worktrees with live
 	// work). List-only detection skips the network call. Fail safe: if we can't
 	// tell, degrade to list-only so we never remove a worktree with live work.
+	// removeRequested records the caller's intent so a safety downgrade reports
+	// "skipped for safety" instead of "run with --stale-locks" (which the user
+	// already did).
+	removeRequested := remove
+	degradedReason := ""
 	openByBranch := make(map[string]*PRInfo)
 	if remove {
 		openPRs, err := ListOpenPRs(ctx, m.gh, bareDir)
 		switch {
 		case err != nil:
+			degradedReason = "open-PR lookup failed; skipped removal for safety"
 			m.output.Warn(fmt.Sprintf("Could not list open PRs; skipping stale-lock removal: %v", err))
 			remove = false
 		case PRListTruncated(openPRs):
 			// The open-PR list hit the gh cap, so a branch with an open PR may be
 			// absent. Removing on this partial view could destroy live work, so
 			// degrade to list-only.
+			degradedReason = fmt.Sprintf("open-PR list capped at %d; skipped removal for safety", len(openPRs))
 			m.output.Warn(fmt.Sprintf("GitHub returned %d open PRs (limit reached); skipping stale-lock removal to avoid deleting worktrees with live work", len(openPRs)))
 			remove = false
 			openByBranch = prsByHeadRef(openPRs)
@@ -1659,9 +1666,15 @@ func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, d
 		case info.HasOpenPR:
 			info.KeepReason = fmt.Sprintf("PR #%d still OPEN", info.PRNumber)
 			m.output.Warn(fmt.Sprintf("Keeping %s: lock PID %d dead but PR #%d is OPEN (live work)", info.Name, info.LockPID, info.PRNumber))
+		case !remove && removeRequested:
+			// Removal was requested but downgraded to keep the worktree safe
+			// (truncated/failed open-PR lookup). Report the downgrade rather than
+			// telling the user to pass --stale-locks, which they already did.
+			info.KeepReason = degradedReason
+			m.output.Warn(fmt.Sprintf("Keeping %s (PID %d dead): %s", info.Name, info.LockPID, degradedReason))
 		case !remove:
-			// Open PRs aren't fetched on the list-only path, so don't assert
-			// whether an open PR exists — that is evaluated only under --stale-locks.
+			// List-only path: open PRs aren't fetched, so don't assert whether an
+			// open PR exists — that is evaluated only under --stale-locks.
 			info.KeepReason = "listed only; run with --stale-locks to evaluate removal"
 			m.output.Info(fmt.Sprintf("Stale-locked (PID %d dead): %s — %q (open PR not checked; use --stale-locks to evaluate removal)", info.LockPID, info.Name, info.LockReason))
 		case dryRun:

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -886,8 +886,10 @@ func (m *Manager) GetStatus(ctx context.Context, wt Worktree) (*WorktreeStatus, 
 
 // Remove removes a worktree by name (directory) or branch name.
 // If deleteBranch is true, the local and remote branch are deleted after the worktree is removed.
-// If force is true, passes --force to git worktree remove, allowing removal of worktrees with
-// modified or untracked files (equivalent to git worktree remove --force).
+// If force is true, passes a single --force to git worktree remove, allowing removal of worktrees
+// with modified or untracked files (equivalent to git worktree remove --force). A single --force
+// still refuses a locked worktree; callers that must remove locked worktrees use removeResolved
+// with forceLocked=true.
 func (m *Manager) Remove(ctx context.Context, nameOrBranch string, deleteBranch bool, force bool) error {
 	// First try as directory name
 	worktreePath := filepath.Join(m.RepoDir(), nameOrBranch)
@@ -920,14 +922,17 @@ func (m *Manager) Remove(ctx context.Context, nameOrBranch string, deleteBranch 
 		}
 	}
 
-	return m.removeResolved(ctx, worktreePath, branchName, deleteBranch, force)
+	return m.removeResolved(ctx, worktreePath, branchName, deleteBranch, force, false)
 }
 
 // removeResolved runs post-remove hooks, removes the worktree at worktreePath,
-// and optionally deletes the local/remote branch. force triggers a double
-// --force so that locked worktrees can be removed — git refuses a single
-// --force on a locked worktree.
-func (m *Manager) removeResolved(ctx context.Context, worktreePath, branchName string, deleteBranch, force bool) error {
+// and optionally deletes the local/remote branch. force passes a single --force
+// (removes modified/untracked files but still refuses a locked worktree).
+// forceLocked adds the second --force needed to remove a locked worktree; git
+// refuses a single --force on a locked working tree. Only the stale-lock GC path
+// sets forceLocked, so an intentionally locked worktree is never silently
+// force-removed by the merged-PR path.
+func (m *Manager) removeResolved(ctx context.Context, worktreePath, branchName string, deleteBranch, force, forceLocked bool) error {
 	bareDir := m.BareDir()
 
 	// Run post-remove hooks first
@@ -945,10 +950,13 @@ func (m *Manager) removeResolved(ctx context.Context, worktreePath, branchName s
 
 	m.output.Info(fmt.Sprintf("Removing worktree %s...", branchName))
 	removeArgs := []string{"worktree", "remove"}
-	if force {
-		// Double --force removes locked worktrees; git refuses a single --force
-		// with "cannot remove a locked working tree".
-		removeArgs = append(removeArgs, "--force", "--force")
+	if force || forceLocked {
+		removeArgs = append(removeArgs, "--force")
+	}
+	if forceLocked {
+		// The second --force removes a locked worktree; git refuses a single
+		// --force with "cannot remove a locked working tree".
+		removeArgs = append(removeArgs, "--force")
 	}
 	removeArgs = append(removeArgs, worktreePath)
 	if result, err := m.git.Run(ctx, removeArgs, bareDir); err != nil {
@@ -1383,6 +1391,9 @@ func (m *Manager) findChildBranches(ctx context.Context, parentBranch, dir strin
 	if err != nil {
 		return nil, err
 	}
+	if PRListTruncated(prs) {
+		m.output.Warn(fmt.Sprintf("GitHub returned %d open PRs (limit reached); some child branches may not be detected for rebase", len(prs)))
+	}
 
 	// Get local worktrees
 	worktrees, _ := m.List(ctx)
@@ -1536,8 +1547,8 @@ func (m *Manager) pruneMergedPRs(ctx context.Context, bareDir string, dryRun boo
 		return nil, fmt.Errorf("failed to list merged PRs: %w", err)
 	}
 
-	if len(mergedPRs) >= 1000 {
-		m.output.Warn("GitHub returned 1000 merged PRs (limit reached); older merged-PR worktrees may not be detected")
+	if PRListTruncated(mergedPRs) {
+		m.output.Warn(fmt.Sprintf("GitHub returned %d merged PRs (limit reached); older merged-PR worktrees may not be detected", len(mergedPRs)))
 	}
 
 	mergedByBranch := prsByHeadRef(mergedPRs)
@@ -1607,10 +1618,18 @@ func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, d
 	openByBranch := make(map[string]*PRInfo)
 	if remove {
 		openPRs, err := ListOpenPRs(ctx, m.gh, bareDir)
-		if err != nil {
+		switch {
+		case err != nil:
 			m.output.Warn(fmt.Sprintf("Could not list open PRs; skipping stale-lock removal: %v", err))
 			remove = false
-		} else {
+		case PRListTruncated(openPRs):
+			// The open-PR list hit the gh cap, so a branch with an open PR may be
+			// absent. Removing on this partial view could destroy live work, so
+			// degrade to list-only.
+			m.output.Warn(fmt.Sprintf("GitHub returned %d open PRs (limit reached); skipping stale-lock removal to avoid deleting worktrees with live work", len(openPRs)))
+			remove = false
+			openByBranch = prsByHeadRef(openPRs)
+		default:
 			openByBranch = prsByHeadRef(openPRs)
 		}
 	}
@@ -1641,16 +1660,20 @@ func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, d
 			info.KeepReason = fmt.Sprintf("PR #%d still OPEN", info.PRNumber)
 			m.output.Warn(fmt.Sprintf("Keeping %s: lock PID %d dead but PR #%d is OPEN (live work)", info.Name, info.LockPID, info.PRNumber))
 		case !remove:
-			info.KeepReason = "listed only; run with --stale-locks to remove"
-			m.output.Info(fmt.Sprintf("Stale-locked (PID %d dead, no open PR): %s — %q", info.LockPID, info.Name, info.LockReason))
+			// Open PRs aren't fetched on the list-only path, so don't assert
+			// whether an open PR exists — that is evaluated only under --stale-locks.
+			info.KeepReason = "listed only; run with --stale-locks to evaluate removal"
+			m.output.Info(fmt.Sprintf("Stale-locked (PID %d dead): %s — %q (open PR not checked; use --stale-locks to evaluate removal)", info.LockPID, info.Name, info.LockReason))
 		case dryRun:
 			info.Removed = true
 			m.output.Info(fmt.Sprintf("[dry-run] Would remove %s (stale lock, PID %d dead, no open PR)", info.Name, info.LockPID))
 		default:
 			m.output.Info(fmt.Sprintf("Removing %s (stale lock, PID %d dead)...", info.Name, info.LockPID))
 			// deleteBranch=false: leave the (possibly unpushed) branch for the
-			// orphaned-branch step / -D to handle.
-			if err := m.removeResolved(ctx, wt.Path, wt.Branch, false, true); err != nil {
+			// orphaned-branch step / -D to handle. forceLocked=true: the worktree
+			// is locked (that is what makes it stale), so the double --force is
+			// required here.
+			if err := m.removeResolved(ctx, wt.Path, wt.Branch, false, false, true); err != nil {
 				info.KeepReason = fmt.Sprintf("removal failed: %v", err)
 				m.output.Error(fmt.Sprintf("Failed to remove %s: %v", info.Name, err))
 			} else {

--- a/wt/worktree.go
+++ b/wt/worktree.go
@@ -709,9 +709,9 @@ func worktreeFromFields(fields map[string]string) (Worktree, bool) {
 }
 
 // parseLockPID extracts the PID embedded in a worktree lock reason of the form
-// "...(pid <N>)". Claude agents write reasons like
-// "claude agent agent-<hash> (pid 3190410)". Returns 0 when no PID is present
-// or parseable, so callers treat such locks conservatively (as live).
+// "...(pid <N>)" — e.g. agents lock worktrees with a reason like
+// "agent <id> (pid 3190410)". Returns 0 when no PID is present or parseable, so
+// callers treat such locks conservatively (as live).
 func parseLockPID(reason string) int {
 	const marker = "(pid "
 	i := strings.Index(reason, marker)
@@ -923,25 +923,10 @@ func (m *Manager) Remove(ctx context.Context, nameOrBranch string, deleteBranch 
 	return m.removeResolved(ctx, worktreePath, branchName, deleteBranch, force)
 }
 
-// RemoveByPath removes the worktree at the given absolute path without
-// name/branch resolution. Use it for worktrees outside the standard RepoDir
-// layout (e.g. agent worktrees under <bare>/.claude/worktrees), where the
-// directory name and branch name are unreliable lookup keys. The branch name
-// is resolved from the worktree itself for hooks and optional branch deletion.
-func (m *Manager) RemoveByPath(ctx context.Context, worktreePath string, deleteBranch, force bool) error {
-	branchName := filepath.Base(worktreePath)
-	if result, err := m.git.Run(ctx, []string{"branch", "--show-current"}, worktreePath); err == nil {
-		if cur := strings.TrimSpace(result.Stdout); cur != "" {
-			branchName = cur
-		}
-	}
-	return m.removeResolved(ctx, worktreePath, branchName, deleteBranch, force)
-}
-
 // removeResolved runs post-remove hooks, removes the worktree at worktreePath,
 // and optionally deletes the local/remote branch. force triggers a double
-// --force so that locked worktrees (e.g. crashed agent worktrees) can be
-// removed — git refuses a single --force on a locked worktree.
+// --force so that locked worktrees can be removed — git refuses a single
+// --force on a locked worktree.
 func (m *Manager) removeResolved(ctx context.Context, worktreePath, branchName string, deleteBranch, force bool) error {
 	bareDir := m.BareDir()
 
@@ -961,9 +946,8 @@ func (m *Manager) removeResolved(ctx context.Context, worktreePath, branchName s
 	m.output.Info(fmt.Sprintf("Removing worktree %s...", branchName))
 	removeArgs := []string{"worktree", "remove"}
 	if force {
-		// Double --force lets git remove locked worktrees (e.g. crashed Claude
-		// agent worktrees). A single --force is refused with
-		// "cannot remove a locked working tree".
+		// Double --force removes locked worktrees; git refuses a single --force
+		// with "cannot remove a locked working tree".
 		removeArgs = append(removeArgs, "--force", "--force")
 	}
 	removeArgs = append(removeArgs, worktreePath)
@@ -1556,10 +1540,7 @@ func (m *Manager) pruneMergedPRs(ctx context.Context, bareDir string, dryRun boo
 		m.output.Warn("GitHub returned 1000 merged PRs (limit reached); older merged-PR worktrees may not be detected")
 	}
 
-	mergedByBranch := make(map[string]*PRInfo, len(mergedPRs))
-	for i := range mergedPRs {
-		mergedByBranch[mergedPRs[i].HeadRefName] = &mergedPRs[i]
-	}
+	mergedByBranch := prsByHeadRef(mergedPRs)
 
 	removed := []string{}
 	for _, wt := range worktrees {
@@ -1612,29 +1593,29 @@ type StaleLockInfo struct {
 // stale lock plus an open PR means live work. Protected and detached worktrees
 // are skipped. Every kept worktree records and prints a KeepReason. With
 // remove=false the detected set is returned without any removals (list-only).
-func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, dryRun bool) ([]StaleLockInfo, []string, error) {
+func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, dryRun bool) ([]StaleLockInfo, error) {
 	protected := protectedBranches(ctx, m.git, bareDir)
 
 	worktrees, err := m.List(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list worktrees: %w", err)
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
-	// Determine which branches have an open PR. Fail safe: if we can't tell,
-	// degrade to list-only so we never remove a worktree with live work.
+	// Only the removal path needs open-PR state (to keep worktrees with live
+	// work). List-only detection skips the network call. Fail safe: if we can't
+	// tell, degrade to list-only so we never remove a worktree with live work.
 	openByBranch := make(map[string]*PRInfo)
-	openPRs, err := ListOpenPRs(ctx, m.gh, bareDir)
-	if err != nil {
-		m.output.Warn(fmt.Sprintf("Could not list open PRs; skipping stale-lock removal: %v", err))
-		remove = false
-	} else {
-		for i := range openPRs {
-			openByBranch[openPRs[i].HeadRefName] = &openPRs[i]
+	if remove {
+		openPRs, err := ListOpenPRs(ctx, m.gh, bareDir)
+		if err != nil {
+			m.output.Warn(fmt.Sprintf("Could not list open PRs; skipping stale-lock removal: %v", err))
+			remove = false
+		} else {
+			openByBranch = prsByHeadRef(openPRs)
 		}
 	}
 
 	var detected []StaleLockInfo
-	var removed []string
 	for _, wt := range worktrees {
 		if wt.IsDetached || protected[wt.Branch] {
 			continue
@@ -1664,25 +1645,32 @@ func (m *Manager) pruneStaleLocks(ctx context.Context, bareDir string, remove, d
 			m.output.Info(fmt.Sprintf("Stale-locked (PID %d dead, no open PR): %s — %q", info.LockPID, info.Name, info.LockReason))
 		case dryRun:
 			info.Removed = true
-			removed = append(removed, info.Name)
 			m.output.Info(fmt.Sprintf("[dry-run] Would remove %s (stale lock, PID %d dead, no open PR)", info.Name, info.LockPID))
 		default:
 			m.output.Info(fmt.Sprintf("Removing %s (stale lock, PID %d dead)...", info.Name, info.LockPID))
 			// deleteBranch=false: leave the (possibly unpushed) branch for the
 			// orphaned-branch step / -D to handle.
-			if err := m.RemoveByPath(ctx, wt.Path, false, true); err != nil {
+			if err := m.removeResolved(ctx, wt.Path, wt.Branch, false, true); err != nil {
 				info.KeepReason = fmt.Sprintf("removal failed: %v", err)
 				m.output.Error(fmt.Sprintf("Failed to remove %s: %v", info.Name, err))
 			} else {
 				info.Removed = true
-				removed = append(removed, info.Name)
 			}
 		}
 
 		detected = append(detected, info)
 	}
 
-	return detected, removed, nil
+	return detected, nil
+}
+
+// prsByHeadRef indexes PRs by their head branch name for O(1) lookup.
+func prsByHeadRef(prs []PRInfo) map[string]*PRInfo {
+	byRef := make(map[string]*PRInfo, len(prs))
+	for i := range prs {
+		byRef[prs[i].HeadRefName] = &prs[i]
+	}
+	return byRef
 }
 
 // GCOptions configures garbage collection behavior.
@@ -1696,15 +1684,14 @@ type GCOptions struct {
 
 // GCResult contains the results of garbage collection.
 type GCResult struct {
-	PrunedWorktrees   []string        // Lines from git worktree prune
-	MergedWorktrees   []string        // Worktrees removed because their PR was merged
-	OrphanedBranches  []string        // Local branches with no worktree
-	DeletedBranches   []string        // Actually deleted local branches
-	DeletedRemote     []string        // Actually deleted remote branches
-	StaleLocked       []StaleLockInfo // Detected stale-locked worktrees (with keep/remove reason)
-	RemovedStaleLocks []string        // Stale-locked worktrees removed (or would-be in dry-run)
-	FetchPruned       bool            // Whether fetch --prune ran
-	GCRan             bool            // Whether git gc ran
+	PrunedWorktrees  []string        // Lines from git worktree prune
+	MergedWorktrees  []string        // Worktrees removed because their PR was merged
+	OrphanedBranches []string        // Local branches with no worktree
+	DeletedBranches  []string        // Actually deleted local branches
+	DeletedRemote    []string        // Actually deleted remote branches
+	StaleLocked      []StaleLockInfo // Detected stale-locked worktrees (with keep/remove reason)
+	FetchPruned      bool            // Whether fetch --prune ran
+	GCRan            bool            // Whether git gc ran
 }
 
 // GC performs comprehensive garbage collection: prunes stale worktree metadata,
@@ -1732,15 +1719,14 @@ func (m *Manager) GC(ctx context.Context, opts GCOptions) (*GCResult, error) {
 		m.output.Info(fmt.Sprintf("Pruned: %s", line))
 	}
 
-	// Step 1b: stale-lock cleanup (e.g. crashed Claude-agent worktrees). Runs
-	// before orphaned-branch detection so removed worktrees' branches then
-	// surface as orphaned and are deletable with -D.
-	staleLocked, removedLocks, err := m.pruneStaleLocks(ctx, bareDir, opts.StaleLocks, opts.DryRun)
+	// Step 1b: stale-lock cleanup. Runs before orphaned-branch detection so
+	// removed worktrees' branches then surface as orphaned and are deletable
+	// with -D.
+	staleLocked, err := m.pruneStaleLocks(ctx, bareDir, opts.StaleLocks, opts.DryRun)
 	if err != nil {
 		m.output.Warn(fmt.Sprintf("Stale-lock check failed: %v", err))
 	} else {
 		result.StaleLocked = staleLocked
-		result.RemovedStaleLocks = removedLocks
 		if len(staleLocked) == 0 {
 			m.output.Success("No stale-locked worktrees found")
 		} else if !opts.StaleLocks {

--- a/wt/worktree_test.go
+++ b/wt/worktree_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2099,7 +2100,6 @@ func TestGCMergedPRsPassthrough(t *testing.T) {
 	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[{"number":99,"headRefName":"feature/done","baseRefName":"main","state":"MERGED","url":"https://github.com/org/repo/pull/99"}]`,
 	}
-	mockGH.Results["pr list --json number,headRefName,baseRefName,state,isDraft,reviewDecision,url --state open --limit 1000"] = &CmdResult{Stdout: `[]`}
 
 	output := NewOutput(&bytes.Buffer{}, false)
 	m := NewManager(tmpDir, "test-repo", WithGitRunner(mockGit), WithGHRunner(mockGH), WithOutput(output))
@@ -2285,13 +2285,15 @@ func findStaleLock(infos []StaleLockInfo, name string) *StaleLockInfo {
 	return nil
 }
 
-func contains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
+// removedNames returns the names of stale-locked worktrees that were removed.
+func removedNames(infos []StaleLockInfo) []string {
+	var names []string
+	for _, info := range infos {
+		if info.Removed {
+			names = append(names, info.Name)
 		}
 	}
-	return false
+	return names
 }
 
 func TestPruneStaleLocks(t *testing.T) {
@@ -2299,7 +2301,7 @@ func TestPruneStaleLocks(t *testing.T) {
 
 	t.Run("stale no PR removed, open PR kept, live ignored", func(t *testing.T) {
 		m, mockGit, paths := staleLockTestEnv(t, false)
-		detected, removed, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
+		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
 		}
@@ -2309,8 +2311,8 @@ func TestPruneStaleLocks(t *testing.T) {
 		if dead == nil || !dead.Removed || dead.KeepReason != "" {
 			t.Errorf("agent-dead = %+v, want Removed with empty KeepReason", dead)
 		}
-		if !contains(removed, "agent-dead") {
-			t.Errorf("removed = %v, want to contain agent-dead", removed)
+		if !slices.Contains(removedNames(detected), "agent-dead") {
+			t.Errorf("removed = %v, want to contain agent-dead", removedNames(detected))
 		}
 		if !removeCalled(mockGit, paths["dead"]) {
 			t.Errorf("expected double-force remove of %s, calls: %v", paths["dead"], mockGit.Calls)
@@ -2349,12 +2351,12 @@ func TestPruneStaleLocks(t *testing.T) {
 
 	t.Run("dry-run records but does not remove", func(t *testing.T) {
 		m, mockGit, paths := staleLockTestEnv(t, false)
-		_, removed, err := m.pruneStaleLocks(context.Background(), bareDir, true, true)
+		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, true)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
 		}
-		if !contains(removed, "agent-dead") {
-			t.Errorf("dry-run removed = %v, want to contain agent-dead", removed)
+		if !slices.Contains(removedNames(detected), "agent-dead") {
+			t.Errorf("dry-run removed = %v, want to contain agent-dead", removedNames(detected))
 		}
 		if removeCalled(mockGit, paths["dead"]) {
 			t.Errorf("dry-run must not issue a remove call")
@@ -2363,12 +2365,12 @@ func TestPruneStaleLocks(t *testing.T) {
 
 	t.Run("list-only detects but does not remove", func(t *testing.T) {
 		m, mockGit, paths := staleLockTestEnv(t, false)
-		detected, removed, err := m.pruneStaleLocks(context.Background(), bareDir, false, false)
+		detected, err := m.pruneStaleLocks(context.Background(), bareDir, false, false)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
 		}
-		if len(removed) != 0 {
-			t.Errorf("list-only removed = %v, want empty", removed)
+		if names := removedNames(detected); len(names) != 0 {
+			t.Errorf("list-only removed = %v, want empty", names)
 		}
 		dead := findStaleLock(detected, "agent-dead")
 		if dead == nil || dead.Removed || !strings.Contains(dead.KeepReason, "--stale-locks") {
@@ -2381,12 +2383,12 @@ func TestPruneStaleLocks(t *testing.T) {
 
 	t.Run("open-PR lookup failure fails safe", func(t *testing.T) {
 		m, mockGit, paths := staleLockTestEnv(t, true)
-		_, removed, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
+		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
 		}
-		if len(removed) != 0 {
-			t.Errorf("fail-safe removed = %v, want empty (no removals when open-PR lookup fails)", removed)
+		if names := removedNames(detected); len(names) != 0 {
+			t.Errorf("fail-safe removed = %v, want empty (no removals when open-PR lookup fails)", names)
 		}
 		if removeCalled(mockGit, paths["dead"]) {
 			t.Errorf("must not remove when open-PR lookup failed")

--- a/wt/worktree_test.go
+++ b/wt/worktree_test.go
@@ -1892,9 +1892,10 @@ func TestPruneMergedPRs_RemovesWorktrees(t *testing.T) {
 			"worktree " + featurePath + "\nHEAD def456\nbranch refs/heads/feature/voice\n\n",
 	}
 	mockGit.Results["symbolic-ref refs/remotes/origin/HEAD"] = &CmdResult{Stdout: "refs/remotes/origin/main\n"}
-	// Remove calls
+	// Remove calls — merged-PR removal uses a single --force so an
+	// intentionally locked worktree is still refused by git.
 	mockGit.Results["branch --show-current"] = &CmdResult{Stdout: "feature/voice\n"}
-	mockGit.Results["worktree remove --force --force "+featurePath] = &CmdResult{}
+	mockGit.Results["worktree remove --force "+featurePath] = &CmdResult{}
 	mockGit.Results["worktree prune"] = &CmdResult{}
 	mockGit.Results["branch -D feature/voice"] = &CmdResult{}
 	mockGit.Results["push origin --delete feature/voice"] = &CmdResult{}
@@ -1913,6 +1914,23 @@ func TestPruneMergedPRs_RemovesWorktrees(t *testing.T) {
 	}
 	if len(result.MergedWorktrees) != 1 || result.MergedWorktrees[0] != "feature/voice" {
 		t.Errorf("expected [feature/voice] in MergedWorktrees, got %v", result.MergedWorktrees)
+	}
+
+	// The merged-PR path must not double --force: that would silently remove an
+	// intentionally locked worktree git would otherwise refuse.
+	for _, call := range mockGit.Calls {
+		if call[0] != "worktree" || call[1] != "remove" {
+			continue
+		}
+		forceCount := 0
+		for _, arg := range call[2:] {
+			if arg == "--force" {
+				forceCount++
+			}
+		}
+		if forceCount > 1 {
+			t.Errorf("merged-PR removal used double --force (%v); must use single --force to respect locks", call)
+		}
 	}
 }
 
@@ -2090,9 +2108,9 @@ func TestGCMergedPRsPassthrough(t *testing.T) {
 	mockGit.Results["fetch --prune"] = &CmdResult{}
 	mockGit.Results["branch --list --format=%(refname:short)"] = &CmdResult{Stdout: "main\nfeature/done\n"}
 	mockGit.Results["gc"] = &CmdResult{}
-	// Remove calls for feature/done
+	// Remove calls for feature/done (merged path uses single --force)
 	mockGit.Results["branch --show-current"] = &CmdResult{Stdout: "feature/done\n"}
-	mockGit.Results["worktree remove --force --force "+featurePath] = &CmdResult{}
+	mockGit.Results["worktree remove --force "+featurePath] = &CmdResult{}
 	mockGit.Results["branch -D feature/done"] = &CmdResult{}
 	mockGit.Results["push origin --delete feature/done"] = &CmdResult{}
 
@@ -2111,6 +2129,79 @@ func TestGCMergedPRsPassthrough(t *testing.T) {
 	if len(result.MergedWorktrees) != 1 || result.MergedWorktrees[0] != "feature/done" {
 		t.Errorf("expected [feature/done] in MergedWorktrees, got %v", result.MergedWorktrees)
 	}
+}
+
+// gcStaleLockEnv builds a Manager whose worktree list contains a stale-locked
+// agent worktree (dead PID, no PR), wired up for the full GC path.
+func gcStaleLockEnv(t *testing.T) (*Manager, *MockGitRunner, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "test-repo")
+	bareDir := filepath.Join(repoDir, ".bare")
+	deadPath := filepath.Join(bareDir, ".claude", "worktrees", "agent-dead")
+	for _, p := range []string{bareDir, filepath.Join(repoDir, "main"), deadPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mockGit := NewMockGitRunner()
+	mockGit.Results["worktree prune"] = &CmdResult{Stdout: ""}
+	mockGit.Results["fetch --prune"] = &CmdResult{}
+	mockGit.Results["symbolic-ref refs/remotes/origin/HEAD"] = &CmdResult{Stdout: "refs/remotes/origin/main\n"}
+	mockGit.Results["branch --list --format=%(refname:short)"] = &CmdResult{Stdout: "main\n"}
+	mockGit.Results["worktree list --porcelain"] = &CmdResult{
+		Stdout: "worktree " + bareDir + "\nbare\n\n" +
+			"worktree " + filepath.Join(repoDir, "main") + "\nHEAD abc123\nbranch refs/heads/main\n\n" +
+			"worktree " + deadPath + "\nHEAD def456\nbranch refs/heads/worktree-agent-dead\nlocked claude agent agent-dead (pid 3190410)\n\n",
+	}
+	mockGit.Results["worktree remove --force --force "+deadPath] = &CmdResult{}
+	mockGit.Results["gc"] = &CmdResult{}
+
+	mockGH := NewMockGHRunner()
+	mockGH.Results[openPRListKey] = &CmdResult{Stdout: "[]"}
+
+	output := NewOutput(&bytes.Buffer{}, false)
+	m := NewManager(tmpDir, "test-repo",
+		WithGitRunner(mockGit), WithGHRunner(mockGH), WithOutput(output),
+		WithProcessAlive(func(pid int) bool { return false }), // every locking PID is dead
+	)
+	return m, mockGit, deadPath
+}
+
+// TestGCStaleLocksPlumbing checks that the StaleLocks flag wires through GCOptions:
+// default GC lists stale locks without removal, --stale-locks removes them.
+func TestGCStaleLocksPlumbing(t *testing.T) {
+	t.Run("default lists without removing", func(t *testing.T) {
+		m, mockGit, deadPath := gcStaleLockEnv(t)
+		result, err := m.GC(context.Background(), GCOptions{})
+		if err != nil {
+			t.Fatalf("GC() error = %v", err)
+		}
+		if len(result.StaleLocked) != 1 || result.StaleLocked[0].Name != "agent-dead" {
+			t.Fatalf("StaleLocked = %+v, want one entry for agent-dead", result.StaleLocked)
+		}
+		if result.StaleLocked[0].Removed {
+			t.Errorf("default GC must not remove stale-locked worktree")
+		}
+		if removeCalled(mockGit, deadPath) {
+			t.Errorf("default GC must not issue a remove call, calls: %v", mockGit.Calls)
+		}
+	})
+
+	t.Run("--stale-locks removes", func(t *testing.T) {
+		m, mockGit, deadPath := gcStaleLockEnv(t)
+		result, err := m.GC(context.Background(), GCOptions{StaleLocks: true})
+		if err != nil {
+			t.Fatalf("GC() error = %v", err)
+		}
+		if len(result.StaleLocked) != 1 || !result.StaleLocked[0].Removed {
+			t.Fatalf("StaleLocked = %+v, want agent-dead removed", result.StaleLocked)
+		}
+		if !removeCalled(mockGit, deadPath) {
+			t.Errorf("--stale-locks must remove agent-dead, calls: %v", mockGit.Calls)
+		}
+	})
 }
 
 func TestRemoveForce(t *testing.T) {
@@ -2134,15 +2225,29 @@ func TestRemoveForce(t *testing.T) {
 		t.Fatalf("Remove() error = %v", err)
 	}
 
+	// force=true passes a single --force: it removes modified/untracked files but
+	// still refuses a locked worktree. Only the stale-lock path (forceLocked)
+	// doubles --force, so this must NOT emit a second --force.
 	forceFound := false
 	for _, call := range mockGit.Calls {
-		if len(call) >= 5 && call[0] == "worktree" && call[1] == "remove" && call[2] == "--force" && call[3] == "--force" && call[4] == wtPath {
+		if call[0] != "worktree" || call[1] != "remove" {
+			continue
+		}
+		forceCount := 0
+		for _, arg := range call[2:] {
+			if arg == "--force" {
+				forceCount++
+			}
+		}
+		if forceCount == 1 && call[len(call)-1] == wtPath {
 			forceFound = true
-			break
+		}
+		if forceCount > 1 {
+			t.Fatalf("Expected single '--force', got double-force call: %v", call)
 		}
 	}
 	if !forceFound {
-		t.Fatalf("Expected 'worktree remove --force --force' call, got calls: %v", mockGit.Calls)
+		t.Fatalf("Expected 'worktree remove --force %s' call, got calls: %v", wtPath, mockGit.Calls)
 	}
 }
 
@@ -2218,10 +2323,19 @@ func TestRemoveIncludesStderr(t *testing.T) {
 
 const openPRListKey = "pr list --json number,headRefName,baseRefName,state,isDraft,reviewDecision,url --state open --limit 1000"
 
+// openPRMode controls how staleLockTestEnv stubs the open-PR list query.
+type openPRMode int
+
+const (
+	openPRNormal    openPRMode = iota // one OPEN PR (#3362) for feature/INF-668
+	openPRError                       // gh fails (auth required)
+	openPRTruncated                   // prListLimit results -> list is truncated
+)
+
 // staleLockTestEnv builds a Manager over a temp repo with four worktrees:
 // an unlocked main, agent-dead (stale lock, no PR), agent-live (live lock),
 // and feature/INF-668 (stale lock but an OPEN PR #3362).
-func staleLockTestEnv(t *testing.T, openPRErr bool) (*Manager, *MockGitRunner, map[string]string) {
+func staleLockTestEnv(t *testing.T, prMode openPRMode) (*Manager, *MockGitRunner, map[string]string) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	repoDir := filepath.Join(tmpDir, "test-repo")
@@ -2251,9 +2365,12 @@ func staleLockTestEnv(t *testing.T, openPRErr bool) (*Manager, *MockGitRunner, m
 	mockGit.Results["worktree prune"] = &CmdResult{}
 
 	mockGH := NewMockGHRunner()
-	if openPRErr {
+	switch prMode {
+	case openPRError:
 		mockGH.Errors[openPRListKey] = errors.New("auth required")
-	} else {
+	case openPRTruncated:
+		mockGH.Results[openPRListKey] = &CmdResult{Stdout: truncatedOpenPRJSON()}
+	default:
 		mockGH.Results[openPRListKey] = &CmdResult{
 			Stdout: `[{"number":3362,"headRefName":"feature/INF-668-sandbox-bench","baseRefName":"main","state":"OPEN","url":"https://github.com/org/repo/pull/3362"}]`,
 		}
@@ -2265,6 +2382,18 @@ func staleLockTestEnv(t *testing.T, openPRErr bool) (*Manager, *MockGitRunner, m
 		WithProcessAlive(func(pid int) bool { return pid == 999 }), // only agent-live's PID is alive
 	)
 	return m, mockGit, paths
+}
+
+// truncatedOpenPRJSON returns a `gh pr list` payload with exactly prListLimit
+// entries (so PRListTruncated reports true). None of the head refs match the
+// stale-locked worktrees, modeling the dangerous case where a worktree's open
+// PR is just past the cap and so absent from the list.
+func truncatedOpenPRJSON() string {
+	prs := make([]string, prListLimit)
+	for i := range prs {
+		prs[i] = fmt.Sprintf(`{"number":%d,"headRefName":"unrelated/branch-%d","baseRefName":"main","state":"OPEN","url":"https://github.com/org/repo/pull/%d"}`, i+1, i, i+1)
+	}
+	return "[" + strings.Join(prs, ",") + "]"
 }
 
 func removeCalled(mockGit *MockGitRunner, path string) bool {
@@ -2300,7 +2429,7 @@ func TestPruneStaleLocks(t *testing.T) {
 	bareDir := ""
 
 	t.Run("stale no PR removed, open PR kept, live ignored", func(t *testing.T) {
-		m, mockGit, paths := staleLockTestEnv(t, false)
+		m, mockGit, paths := staleLockTestEnv(t, openPRNormal)
 		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
@@ -2350,7 +2479,7 @@ func TestPruneStaleLocks(t *testing.T) {
 	})
 
 	t.Run("dry-run records but does not remove", func(t *testing.T) {
-		m, mockGit, paths := staleLockTestEnv(t, false)
+		m, mockGit, paths := staleLockTestEnv(t, openPRNormal)
 		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, true)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
@@ -2364,7 +2493,7 @@ func TestPruneStaleLocks(t *testing.T) {
 	})
 
 	t.Run("list-only detects but does not remove", func(t *testing.T) {
-		m, mockGit, paths := staleLockTestEnv(t, false)
+		m, mockGit, paths := staleLockTestEnv(t, openPRNormal)
 		detected, err := m.pruneStaleLocks(context.Background(), bareDir, false, false)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
@@ -2382,7 +2511,7 @@ func TestPruneStaleLocks(t *testing.T) {
 	})
 
 	t.Run("open-PR lookup failure fails safe", func(t *testing.T) {
-		m, mockGit, paths := staleLockTestEnv(t, true)
+		m, mockGit, paths := staleLockTestEnv(t, openPRError)
 		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
 		if err != nil {
 			t.Fatalf("pruneStaleLocks() error = %v", err)
@@ -2392,6 +2521,47 @@ func TestPruneStaleLocks(t *testing.T) {
 		}
 		if removeCalled(mockGit, paths["dead"]) {
 			t.Errorf("must not remove when open-PR lookup failed")
+		}
+	})
+
+	t.Run("truncated open-PR list fails closed", func(t *testing.T) {
+		// The open-PR list hit the cap, so a branch's open PR may be absent. The
+		// removal path must degrade to list-only rather than delete on a partial
+		// view — otherwise a worktree with live work past the cap is destroyed.
+		m, mockGit, paths := staleLockTestEnv(t, openPRTruncated)
+		detected, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
+		if err != nil {
+			t.Fatalf("pruneStaleLocks() error = %v", err)
+		}
+		if names := removedNames(detected); len(names) != 0 {
+			t.Errorf("truncated removed = %v, want empty (no removals on a capped open-PR list)", names)
+		}
+		if removeCalled(mockGit, paths["dead"]) {
+			t.Errorf("must not remove when open-PR list is truncated")
+		}
+	})
+
+	t.Run("list-only output does not assert unchecked PR state", func(t *testing.T) {
+		// On the list-only path open PRs are never fetched, so the output must not
+		// claim a worktree has no open PR.
+		var buf bytes.Buffer
+		m, _, _ := staleLockTestEnv(t, openPRNormal)
+		m.output = NewOutput(&buf, false)
+
+		detected, err := m.pruneStaleLocks(context.Background(), bareDir, false, false)
+		if err != nil {
+			t.Fatalf("pruneStaleLocks() error = %v", err)
+		}
+		out := buf.String()
+		if strings.Contains(out, "no open PR") {
+			t.Errorf("list-only output must not assert %q; got:\n%s", "no open PR", out)
+		}
+		if !strings.Contains(out, "open PR not checked") {
+			t.Errorf("list-only output should note open PR not checked; got:\n%s", out)
+		}
+		dead := findStaleLock(detected, "agent-dead")
+		if dead == nil || strings.Contains(dead.KeepReason, "no open PR") {
+			t.Errorf("agent-dead KeepReason = %+v, must not assert no open PR", dead)
 		}
 	})
 }

--- a/wt/worktree_test.go
+++ b/wt/worktree_test.go
@@ -82,6 +82,62 @@ prunable gitdir file points to non-existent location
 			},
 		},
 		{
+			name: "locked worktree with reason and pid",
+			output: `worktree /path/to/.bare
+bare
+
+worktree /path/to/agent
+HEAD abc1234567890
+branch refs/heads/worktree-agent-x
+locked claude agent agent-x (pid 3190410)
+
+`,
+			expected: []Worktree{
+				{Path: "/path/to/agent", Branch: "worktree-agent-x", Commit: "abc12345", IsLocked: true, LockReason: "claude agent agent-x (pid 3190410)", LockPID: 3190410},
+			},
+		},
+		{
+			name: "bare locked line without reason",
+			output: `worktree /path/to/.bare
+bare
+
+worktree /path/to/held
+HEAD abc1234567890
+branch refs/heads/held
+locked
+
+`,
+			expected: []Worktree{
+				{Path: "/path/to/held", Branch: "held", Commit: "abc12345", IsLocked: true, LockReason: "", LockPID: 0},
+			},
+		},
+		{
+			name: "mixed locked and unlocked",
+			output: `worktree /path/to/.bare
+bare
+
+worktree /path/to/main
+HEAD abc1234567890
+branch refs/heads/main
+
+worktree /path/to/dead
+HEAD def5678901234
+branch refs/heads/dead
+locked claude agent agent-y (pid 999)
+
+worktree /path/to/manual
+HEAD aaa1111222233
+branch refs/heads/manual
+locked manual hold no pid
+
+`,
+			expected: []Worktree{
+				{Path: "/path/to/main", Branch: "main", Commit: "abc12345"},
+				{Path: "/path/to/dead", Branch: "dead", Commit: "def56789", IsLocked: true, LockReason: "claude agent agent-y (pid 999)", LockPID: 999},
+				{Path: "/path/to/manual", Branch: "manual", Commit: "aaa11112", IsLocked: true, LockReason: "manual hold no pid", LockPID: 0},
+			},
+		},
+		{
 			name:     "empty output",
 			output:   "",
 			expected: nil,
@@ -111,6 +167,60 @@ prunable gitdir file points to non-existent location
 				if w.IsGone != exp.IsGone {
 					t.Errorf("worktrees[%d].IsGone = %v, want %v", i, w.IsGone, exp.IsGone)
 				}
+				if w.IsLocked != exp.IsLocked {
+					t.Errorf("worktrees[%d].IsLocked = %v, want %v", i, w.IsLocked, exp.IsLocked)
+				}
+				if w.LockReason != exp.LockReason {
+					t.Errorf("worktrees[%d].LockReason = %q, want %q", i, w.LockReason, exp.LockReason)
+				}
+				if w.LockPID != exp.LockPID {
+					t.Errorf("worktrees[%d].LockPID = %d, want %d", i, w.LockPID, exp.LockPID)
+				}
+			}
+		})
+	}
+}
+
+func TestParseLockPID(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   int
+	}{
+		{"claude agent agent-x (pid 3190410)", 3190410},
+		{"feature lock (pid 3312669) extra text", 3312669},
+		{"no pid here", 0},
+		{"", 0},
+		{"(pid notanumber)", 0},
+		{"(pid )", 0},
+		{"(pid 42", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			if got := parseLockPID(tt.reason); got != tt.want {
+				t.Errorf("parseLockPID(%q) = %d, want %d", tt.reason, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsStaleLock(t *testing.T) {
+	alive := map[int]bool{999: true}
+	m := NewManager("/tmp", "repo", WithProcessAlive(func(pid int) bool { return alive[pid] }))
+
+	tests := []struct {
+		name string
+		wt   Worktree
+		want bool
+	}{
+		{"stale dead pid", Worktree{IsLocked: true, LockPID: 3190410}, true},
+		{"live pid", Worktree{IsLocked: true, LockPID: 999}, false},
+		{"unparseable pid treated live", Worktree{IsLocked: true, LockPID: 0}, false},
+		{"not locked", Worktree{IsLocked: false, LockPID: 3190410}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := m.isStaleLock(tt.wt); got != tt.want {
+				t.Errorf("isStaleLock() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1783,13 +1893,13 @@ func TestPruneMergedPRs_RemovesWorktrees(t *testing.T) {
 	mockGit.Results["symbolic-ref refs/remotes/origin/HEAD"] = &CmdResult{Stdout: "refs/remotes/origin/main\n"}
 	// Remove calls
 	mockGit.Results["branch --show-current"] = &CmdResult{Stdout: "feature/voice\n"}
-	mockGit.Results["worktree remove --force "+featurePath] = &CmdResult{}
+	mockGit.Results["worktree remove --force --force "+featurePath] = &CmdResult{}
 	mockGit.Results["worktree prune"] = &CmdResult{}
 	mockGit.Results["branch -D feature/voice"] = &CmdResult{}
 	mockGit.Results["push origin --delete feature/voice"] = &CmdResult{}
 
 	mockGH := NewMockGHRunner()
-	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[{"number":42,"headRefName":"feature/voice","baseRefName":"main","state":"MERGED","url":"https://github.com/org/repo/pull/42"}]`,
 	}
 
@@ -1820,7 +1930,7 @@ func TestPruneMergedPRs_SkipsProtected(t *testing.T) {
 	mockGit.Results["symbolic-ref refs/remotes/origin/HEAD"] = &CmdResult{Stdout: "refs/remotes/origin/main\n"}
 
 	mockGH := NewMockGHRunner()
-	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[{"number":1,"headRefName":"main","state":"MERGED"}]`,
 	}
 
@@ -1854,7 +1964,7 @@ func TestPruneMergedPRs_SkipsNoPR(t *testing.T) {
 
 	mockGH := NewMockGHRunner()
 	// No merged PRs matching feature-x
-	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[]`,
 	}
 
@@ -1887,7 +1997,7 @@ func TestPruneMergedPRs_DryRun(t *testing.T) {
 	mockGit.Results["symbolic-ref refs/remotes/origin/HEAD"] = &CmdResult{Stdout: "refs/remotes/origin/main\n"}
 
 	mockGH := NewMockGHRunner()
-	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[{"number":42,"headRefName":"feature/voice","baseRefName":"main","state":"MERGED","url":"https://github.com/org/repo/pull/42"}]`,
 	}
 
@@ -1919,7 +2029,7 @@ func TestPruneMergedPRs_GHFailure(t *testing.T) {
 	mockGit.Results["worktree prune"] = &CmdResult{Stdout: ""}
 
 	mockGH := NewMockGHRunner()
-	mockGH.Errors["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = errors.New("auth required")
+	mockGH.Errors["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = errors.New("auth required")
 
 	output := NewOutput(&bytes.Buffer{}, false)
 	m := NewManager(tmpDir, "test-repo", WithGitRunner(mockGit), WithGHRunner(mockGH), WithOutput(output))
@@ -1981,14 +2091,15 @@ func TestGCMergedPRsPassthrough(t *testing.T) {
 	mockGit.Results["gc"] = &CmdResult{}
 	// Remove calls for feature/done
 	mockGit.Results["branch --show-current"] = &CmdResult{Stdout: "feature/done\n"}
-	mockGit.Results["worktree remove --force "+featurePath] = &CmdResult{}
+	mockGit.Results["worktree remove --force --force "+featurePath] = &CmdResult{}
 	mockGit.Results["branch -D feature/done"] = &CmdResult{}
 	mockGit.Results["push origin --delete feature/done"] = &CmdResult{}
 
 	mockGH := NewMockGHRunner()
-	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 200"] = &CmdResult{
+	mockGH.Results["pr list --json number,headRefName,baseRefName,state,url --state merged --limit 1000"] = &CmdResult{
 		Stdout: `[{"number":99,"headRefName":"feature/done","baseRefName":"main","state":"MERGED","url":"https://github.com/org/repo/pull/99"}]`,
 	}
+	mockGH.Results["pr list --json number,headRefName,baseRefName,state,isDraft,reviewDecision,url --state open --limit 1000"] = &CmdResult{Stdout: `[]`}
 
 	output := NewOutput(&bytes.Buffer{}, false)
 	m := NewManager(tmpDir, "test-repo", WithGitRunner(mockGit), WithGHRunner(mockGH), WithOutput(output))
@@ -2025,13 +2136,13 @@ func TestRemoveForce(t *testing.T) {
 
 	forceFound := false
 	for _, call := range mockGit.Calls {
-		if len(call) >= 4 && call[0] == "worktree" && call[1] == "remove" && call[2] == "--force" && call[3] == wtPath {
+		if len(call) >= 5 && call[0] == "worktree" && call[1] == "remove" && call[2] == "--force" && call[3] == "--force" && call[4] == wtPath {
 			forceFound = true
 			break
 		}
 	}
 	if !forceFound {
-		t.Fatalf("Expected 'worktree remove --force' call, got calls: %v", mockGit.Calls)
+		t.Fatalf("Expected 'worktree remove --force --force' call, got calls: %v", mockGit.Calls)
 	}
 }
 
@@ -2103,4 +2214,182 @@ func TestRemoveIncludesStderr(t *testing.T) {
 	if !errors.Is(err, injectedErr) {
 		t.Errorf("Expected original error to be wrapped, got: %v", err)
 	}
+}
+
+const openPRListKey = "pr list --json number,headRefName,baseRefName,state,isDraft,reviewDecision,url --state open --limit 1000"
+
+// staleLockTestEnv builds a Manager over a temp repo with four worktrees:
+// an unlocked main, agent-dead (stale lock, no PR), agent-live (live lock),
+// and feature/INF-668 (stale lock but an OPEN PR #3362).
+func staleLockTestEnv(t *testing.T, openPRErr bool) (*Manager, *MockGitRunner, map[string]string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "test-repo")
+	bareDir := filepath.Join(repoDir, ".bare")
+	paths := map[string]string{
+		"main": filepath.Join(repoDir, "main"),
+		"dead": filepath.Join(bareDir, ".claude", "worktrees", "agent-dead"),
+		"live": filepath.Join(bareDir, ".claude", "worktrees", "agent-live"),
+		"inf":  filepath.Join(bareDir, ".claude", "worktrees", "agent-inf668"),
+	}
+	for _, p := range paths {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mockGit := NewMockGitRunner()
+	mockGit.Results["symbolic-ref refs/remotes/origin/HEAD"] = &CmdResult{Stdout: "refs/remotes/origin/main\n"}
+	mockGit.Results["worktree list --porcelain"] = &CmdResult{
+		Stdout: "worktree " + bareDir + "\nbare\n\n" +
+			"worktree " + paths["main"] + "\nHEAD abc123\nbranch refs/heads/main\n\n" +
+			"worktree " + paths["dead"] + "\nHEAD def456\nbranch refs/heads/worktree-agent-dead\nlocked claude agent agent-dead (pid 3190410)\n\n" +
+			"worktree " + paths["live"] + "\nHEAD aaa111\nbranch refs/heads/worktree-agent-live\nlocked claude agent agent-live (pid 999)\n\n" +
+			"worktree " + paths["inf"] + "\nHEAD bbb222\nbranch refs/heads/feature/INF-668-sandbox-bench\nlocked claude agent agent-inf668 (pid 3312669)\n\n",
+	}
+	mockGit.Results["worktree remove --force --force "+paths["dead"]] = &CmdResult{}
+	mockGit.Results["worktree prune"] = &CmdResult{}
+
+	mockGH := NewMockGHRunner()
+	if openPRErr {
+		mockGH.Errors[openPRListKey] = errors.New("auth required")
+	} else {
+		mockGH.Results[openPRListKey] = &CmdResult{
+			Stdout: `[{"number":3362,"headRefName":"feature/INF-668-sandbox-bench","baseRefName":"main","state":"OPEN","url":"https://github.com/org/repo/pull/3362"}]`,
+		}
+	}
+
+	output := NewOutput(&bytes.Buffer{}, false)
+	m := NewManager(tmpDir, "test-repo",
+		WithGitRunner(mockGit), WithGHRunner(mockGH), WithOutput(output),
+		WithProcessAlive(func(pid int) bool { return pid == 999 }), // only agent-live's PID is alive
+	)
+	return m, mockGit, paths
+}
+
+func removeCalled(mockGit *MockGitRunner, path string) bool {
+	for _, call := range mockGit.Calls {
+		if len(call) >= 5 && call[0] == "worktree" && call[1] == "remove" && call[len(call)-1] == path {
+			return true
+		}
+	}
+	return false
+}
+
+func findStaleLock(infos []StaleLockInfo, name string) *StaleLockInfo {
+	for i := range infos {
+		if infos[i].Name == name {
+			return &infos[i]
+		}
+	}
+	return nil
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPruneStaleLocks(t *testing.T) {
+	bareDir := ""
+
+	t.Run("stale no PR removed, open PR kept, live ignored", func(t *testing.T) {
+		m, mockGit, paths := staleLockTestEnv(t, false)
+		detected, removed, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
+		if err != nil {
+			t.Fatalf("pruneStaleLocks() error = %v", err)
+		}
+
+		// agent-dead: removed, no keep reason, double-force remove issued.
+		dead := findStaleLock(detected, "agent-dead")
+		if dead == nil || !dead.Removed || dead.KeepReason != "" {
+			t.Errorf("agent-dead = %+v, want Removed with empty KeepReason", dead)
+		}
+		if !contains(removed, "agent-dead") {
+			t.Errorf("removed = %v, want to contain agent-dead", removed)
+		}
+		if !removeCalled(mockGit, paths["dead"]) {
+			t.Errorf("expected double-force remove of %s, calls: %v", paths["dead"], mockGit.Calls)
+		}
+
+		// feature/INF-668: kept because PR #3362 is open; reason names the PR.
+		inf := findStaleLock(detected, "agent-inf668")
+		if inf == nil || inf.Removed || !inf.HasOpenPR || inf.PRNumber != 3362 {
+			t.Errorf("agent-inf668 = %+v, want kept with HasOpenPR PR 3362", inf)
+		}
+		if !strings.Contains(inf.KeepReason, "PR #3362") {
+			t.Errorf("agent-inf668 KeepReason = %q, want to mention PR #3362", inf.KeepReason)
+		}
+		if removeCalled(mockGit, paths["inf"]) {
+			t.Errorf("must not remove worktree with open PR")
+		}
+
+		// agent-live: live lock, never detected nor removed.
+		if findStaleLock(detected, "agent-live") != nil {
+			t.Errorf("agent-live (live lock) must not be detected")
+		}
+		if removeCalled(mockGit, paths["live"]) {
+			t.Errorf("must not remove live-locked worktree")
+		}
+
+		// Every kept entry has a reason; every removed entry has none.
+		for _, info := range detected {
+			if info.Removed && info.KeepReason != "" {
+				t.Errorf("%s removed but has KeepReason %q", info.Name, info.KeepReason)
+			}
+			if !info.Removed && info.KeepReason == "" {
+				t.Errorf("%s kept but has empty KeepReason", info.Name)
+			}
+		}
+	})
+
+	t.Run("dry-run records but does not remove", func(t *testing.T) {
+		m, mockGit, paths := staleLockTestEnv(t, false)
+		_, removed, err := m.pruneStaleLocks(context.Background(), bareDir, true, true)
+		if err != nil {
+			t.Fatalf("pruneStaleLocks() error = %v", err)
+		}
+		if !contains(removed, "agent-dead") {
+			t.Errorf("dry-run removed = %v, want to contain agent-dead", removed)
+		}
+		if removeCalled(mockGit, paths["dead"]) {
+			t.Errorf("dry-run must not issue a remove call")
+		}
+	})
+
+	t.Run("list-only detects but does not remove", func(t *testing.T) {
+		m, mockGit, paths := staleLockTestEnv(t, false)
+		detected, removed, err := m.pruneStaleLocks(context.Background(), bareDir, false, false)
+		if err != nil {
+			t.Fatalf("pruneStaleLocks() error = %v", err)
+		}
+		if len(removed) != 0 {
+			t.Errorf("list-only removed = %v, want empty", removed)
+		}
+		dead := findStaleLock(detected, "agent-dead")
+		if dead == nil || dead.Removed || !strings.Contains(dead.KeepReason, "--stale-locks") {
+			t.Errorf("agent-dead = %+v, want kept with --stale-locks hint", dead)
+		}
+		if removeCalled(mockGit, paths["dead"]) {
+			t.Errorf("list-only must not issue a remove call")
+		}
+	})
+
+	t.Run("open-PR lookup failure fails safe", func(t *testing.T) {
+		m, mockGit, paths := staleLockTestEnv(t, true)
+		_, removed, err := m.pruneStaleLocks(context.Background(), bareDir, true, false)
+		if err != nil {
+			t.Fatalf("pruneStaleLocks() error = %v", err)
+		}
+		if len(removed) != 0 {
+			t.Errorf("fail-safe removed = %v, want empty (no removals when open-PR lookup fails)", removed)
+		}
+		if removeCalled(mockGit, paths["dead"]) {
+			t.Errorf("must not remove when open-PR lookup failed")
+		}
+	})
 }

--- a/wt/worktree_test.go
+++ b/wt/worktree_test.go
@@ -2522,6 +2522,15 @@ func TestPruneStaleLocks(t *testing.T) {
 		if removeCalled(mockGit, paths["dead"]) {
 			t.Errorf("must not remove when open-PR lookup failed")
 		}
+		// Removal was requested (--stale-locks) but degraded for safety: the keep
+		// reason must explain the downgrade, not tell the user to re-pass the flag.
+		dead := findStaleLock(detected, "agent-dead")
+		if dead == nil || !strings.Contains(dead.KeepReason, "open-PR lookup failed") {
+			t.Errorf("agent-dead KeepReason = %+v, want to cite the failed lookup", dead)
+		}
+		if dead != nil && strings.Contains(dead.KeepReason, "--stale-locks") {
+			t.Errorf("degraded keep reason must not tell the user to pass --stale-locks: %q", dead.KeepReason)
+		}
 	})
 
 	t.Run("truncated open-PR list fails closed", func(t *testing.T) {
@@ -2538,6 +2547,15 @@ func TestPruneStaleLocks(t *testing.T) {
 		}
 		if removeCalled(mockGit, paths["dead"]) {
 			t.Errorf("must not remove when open-PR list is truncated")
+		}
+		// Degraded for safety, not list-only: keep reason cites the cap and does
+		// not tell the user to pass the flag they already passed.
+		dead := findStaleLock(detected, "agent-dead")
+		if dead == nil || !strings.Contains(dead.KeepReason, "capped") {
+			t.Errorf("agent-dead KeepReason = %+v, want to cite the open-PR cap", dead)
+		}
+		if dead != nil && strings.Contains(dead.KeepReason, "--stale-locks") {
+			t.Errorf("degraded keep reason must not tell the user to pass --stale-locks: %q", dead.KeepReason)
 		}
 	})
 


### PR DESCRIPTION
## Summary

`wt gc` could not clean up Claude-agent worktrees left behind by crashed sessions — worktrees under `<bare>/.claude/worktrees/agent-<hash>`, locked with a reference to a now-dead PID. Three root causes:

- `wt` never parsed git's `locked` porcelain field, so locks were invisible.
- `Remove` passed a single `--force`; git refuses to remove a *locked* worktree without `-f -f`.
- The only worktree-removal path matched *merged* PRs, which throwaway agent branches don't have.

This adds lock-aware GC:

- Parse `IsLocked` / `LockReason` / `LockPID` from `git worktree list --porcelain`.
- Detect *stale* locks (parseable PID that is no longer alive) via an injectable `processAlive` predicate (signal-0 check); unparseable PID ⇒ treated as live (never removed).
- `Remove` now double-forces (`--force --force`) and a new `RemoveByPath` handles worktrees outside the standard `RepoDir()` layout.
- New `wt gc --stale-locks` step removes stale-locked worktrees that have **no open PR**. A stale-locked worktree whose branch still has an **OPEN PR is always kept** (live work), and **every keep/skip decision prints its reason**. Default `gc` lists stale locks without removing, mirroring the orphaned-branch convention.
- Secondary: bumped merged/open PR list limit 200 → 1000 and hardened the list helpers against nil results.

### Behavior (verified against a live repo)

```
→ [dry-run] Would remove agent-a0dfba744… (stale lock, PID 3190410 dead, no open PR)
! Keeping agent-abd98aa16…: lock PID 3312669 dead but PR #3362 is OPEN (live work)
→ [dry-run] Would remove agent-ac5d20949… (stale lock, PID 3190410 dead, no open PR)
```

## Test plan

- [x] `scripts/lint.sh` — passes (0 issues)
- [x] `bazel test //wt/...` — all pass
- [x] New unit tests: lock-line parsing (with/without reason, mixed), `parseLockPID`, `isStaleLock` (stale/live/unparseable/unlocked), `pruneStaleLocks` (stale-no-PR→removed, stale+open-PR→kept with reason, live-lock→ignored, dry-run, list-only, open-PR-lookup-failure fail-safe), double-force `Remove`
- [x] Manual: `wt gc --stale-locks --dry-run` and real `wt gc --stale-locks` against the kernel repo — removed two pure stale-agent worktrees, kept the one with an open PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive worktree removal on `--stale-locks`, mitigated by open-PR checks, truncation fail-closed behavior, and restricting double `--force` to the stale-lock path only.
> 
> **Overview**
> Adds **`wt gc --stale-locks`** to clean up agent/crashed worktrees that stay **git-locked** with a **dead PID** in the lock reason, while **keeping** stale-locked trees whose branch still has an **open PR**.
> 
> **Lock awareness:** `git worktree list --porcelain` now records **`IsLocked`**, **`LockReason`**, and **`LockPID`** (from `(pid N)` in the reason). Stale means a parseable PID that is not running (`processAlive`, signal 0); locks without a PID are never auto-removed.
> 
> **Removal:** `Remove` is refactored through **`removeResolved`**. Normal/merged-PR removal still uses at most **one** `--force` (git still blocks locked trees). Only the stale-lock GC path uses **double `--force`** (`forceLocked`) to drop locked worktrees without deleting the branch (orphan cleanup / `-D` can follow).
> 
> **Safety:** Open PR lists use a shared **1000** cap with **`PRListTruncated`**; stale-lock **removal** is skipped if listing open PRs fails or hits the cap. Default **`wt gc`** only **lists** stale locks; **`--stale-locks`** performs removal (with **`--dry-run`** support).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb5496243bc5dd3a26f707eb79c3089cad5cf899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->