### PR TITLE
fix(grace): raise streamTurn grace period to 10m + make it per-step configurable

### DIFF
--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -590,6 +590,9 @@ func buildExecuteOpts(cfg StepConfig, workDir string, handler agent.EventHandler
 	if cfg.MaxBudgetUSD > 0 {
 		opts = append(opts, agent.WithProviderMaxBudgetUSD(cfg.MaxBudgetUSD))
 	}
+	if cfg.StreamTurnGracePeriod > 0 {
+		opts = append(opts, agent.WithProviderStreamTurnGracePeriod(cfg.StreamTurnGracePeriod))
+	}
 	if cfg.Effort != "" {
 		level, err := agent.ParseEffort(cfg.Effort)
 		if err != nil {

--- a/jiradozer/agent_test.go
+++ b/jiradozer/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,42 @@ import (
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 	"github.com/bazelment/yoloswe/multiagent/agent"
 )
+
+// applyExecuteOpts collapses the option slice buildExecuteOpts returns into the
+// agent.ExecuteConfig a provider would actually see — each ExecuteOption is a
+// func(*ExecuteConfig), so applying them in order reproduces the provider-side
+// view without standing up a real provider. Mirrors the pattern in
+// agent_retry_test.go.
+func applyExecuteOpts(t *testing.T, cfg StepConfig) agent.ExecuteConfig {
+	t.Helper()
+	opts, err := buildExecuteOpts(cfg, t.TempDir(), nil, "", nil)
+	require.NoError(t, err)
+	var ec agent.ExecuteConfig
+	for _, o := range opts {
+		o(&ec)
+	}
+	return ec
+}
+
+// TestBuildExecuteOpts_StreamTurnGracePeriod pins the config-to-provider
+// handoff for the grace-period knob: a positive StepConfig value must reach
+// ExecuteConfig.StreamTurnGracePeriod, and a zero value must leave it unset so
+// the provider falls back to its own default. Without this, deleting the wiring
+// block in buildExecuteOpts would leave every other test green while YAML
+// overrides silently became no-ops (callers always getting the provider's
+// default).
+func TestBuildExecuteOpts_StreamTurnGracePeriod(t *testing.T) {
+	t.Run("positive value is forwarded", func(t *testing.T) {
+		ec := applyExecuteOpts(t, StepConfig{StreamTurnGracePeriod: 15 * time.Minute})
+		require.Equal(t, 15*time.Minute, ec.StreamTurnGracePeriod)
+	})
+
+	t.Run("zero value is not forwarded (provider default applies)", func(t *testing.T) {
+		ec := applyExecuteOpts(t, StepConfig{})
+		require.Zero(t, ec.StreamTurnGracePeriod,
+			"a zero StepConfig grace period must not emit an option, so the provider default stands")
+	})
+}
 
 func TestNewPromptData(t *testing.T) {
 	desc := "Fix the widget rendering"

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -597,6 +597,11 @@ func renderStepBlock(s stepBlock) string {
 	b.WriteString("    #max_budget_usd: 0\n")
 	b.WriteString("    # Auto-retry when a turn ends with an unresolved tool error.\n")
 	b.WriteString("    #max_tool_error_retries: 0\n")
+	b.WriteString("    # Grace period a turn waits, after completion, for outstanding background\n")
+	b.WriteString("    # work (e.g. bramble reviewers a skill backgrounds) to finish before the\n")
+	b.WriteString("    # turn is force-completed; 0 = provider default (10m). Raise it for steps\n")
+	b.WriteString("    # that launch long-running background tools.\n")
+	b.WriteString("    #stream_turn_grace_period: 0\n")
 	b.WriteString("    # Skip the human review gate after this step.\n")
 	b.WriteString("    #auto_approve: false\n")
 

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -112,7 +112,12 @@ type StepConfig struct {
 	MaxToolErrorRetries  int                `yaml:"max_tool_error_retries"` // retries when a turn ends with an unresolved tool error; 0 = disabled
 	TransientRetries     int                `yaml:"transient_retries"`      // retries when provider execution fails with a transient error; 0 = default (2)
 	IdleTimeout          time.Duration      `yaml:"idle_timeout"`           // parent watchdog kills the subprocess if it emits no log line for this long while inside this step; 0 disables
-	AutoApprove          bool               `yaml:"auto_approve"`           // skip human review after this step
+	// StreamTurnGracePeriod overrides how long a turn waits, after completion,
+	// for an outstanding background tool_use to terminate before the turn is
+	// force-completed. Raise it for steps (e.g. /pr-polish) that background
+	// long-running work like bramble reviewers; 0 = provider default.
+	StreamTurnGracePeriod time.Duration `yaml:"stream_turn_grace_period"`
+	AutoApprove           bool          `yaml:"auto_approve"` // skip human review after this step
 }
 
 // RoundConfig configures a single round within a multi-round step.
@@ -343,6 +348,12 @@ func validateStep(name string, step *StepConfig) error {
 	if step.IdleTimeout < 0 {
 		return fmt.Errorf("%s.idle_timeout: must not be negative (got %s); use 0 to disable", name, step.IdleTimeout)
 	}
+	// StreamTurnGracePeriod treats 0 as "use provider default"; a negative
+	// value would be meaningless (and silently coerced away at the option
+	// boundary, which only honors >0). Reject loudly so a typo surfaces.
+	if step.StreamTurnGracePeriod < 0 {
+		return fmt.Errorf("%s.stream_turn_grace_period: must not be negative (got %s); use 0 for the provider default", name, step.StreamTurnGracePeriod)
+	}
 	if name == "create_pr" && len(step.Rounds) > 0 {
 		return fmt.Errorf("create_pr does not support rounds")
 	}
@@ -515,12 +526,13 @@ func ResolveRound(round RoundConfig, parent StepConfig) StepConfig {
 		systemPrompt = parent.SystemPrompt
 	}
 	resolved := StepConfig{
-		Prompt:           round.Prompt,
-		SystemPrompt:     systemPrompt,
-		PermissionMode:   parent.PermissionMode,
-		Effort:           parent.Effort,
-		TransientRetries: parent.TransientRetries,
-		LLMEndpoint:      parent.LLMEndpoint,
+		Prompt:                round.Prompt,
+		SystemPrompt:          systemPrompt,
+		PermissionMode:        parent.PermissionMode,
+		Effort:                parent.Effort,
+		TransientRetries:      parent.TransientRetries,
+		StreamTurnGracePeriod: parent.StreamTurnGracePeriod,
+		LLMEndpoint:           parent.LLMEndpoint,
 	}
 	if round.Model != "" {
 		resolved.Model = round.Model

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -553,14 +553,15 @@ ship:
 
 func TestResolveRound_InheritsFromStep(t *testing.T) {
 	parent := StepConfig{
-		Model:               "sonnet",
-		Effort:              "high",
-		SystemPrompt:        "parent system prompt",
-		PermissionMode:      "bypass",
-		MaxTurns:            10,
-		MaxBudgetUSD:        25.0,
-		TransientRetries:    4,
-		MaxToolErrorRetries: 3,
+		Model:                 "sonnet",
+		Effort:                "high",
+		SystemPrompt:          "parent system prompt",
+		PermissionMode:        "bypass",
+		MaxTurns:              10,
+		MaxBudgetUSD:          25.0,
+		TransientRetries:      4,
+		MaxToolErrorRetries:   3,
+		StreamTurnGracePeriod: 12 * time.Minute,
 	}
 
 	// Round with no overrides — inherits everything.
@@ -575,6 +576,10 @@ func TestResolveRound_InheritsFromStep(t *testing.T) {
 	assert.Equal(t, 25.0, resolved.MaxBudgetUSD)
 	assert.Equal(t, 4, resolved.TransientRetries)
 	assert.Equal(t, 3, resolved.MaxToolErrorRetries)
+	// StreamTurnGracePeriod has no per-round override field, so a round always
+	// inherits the parent's value verbatim (the wiring cursor flagged as
+	// untested in PR #259).
+	assert.Equal(t, 12*time.Minute, resolved.StreamTurnGracePeriod)
 }
 
 // loadConfigFromYAML writes a YAML body to a temp file and loads it. Used by
@@ -915,6 +920,48 @@ ship:
 	_, err := LoadConfig(path)
 	require.Error(t, err, "negative idle_timeout must be rejected")
 	assert.Contains(t, err.Error(), "idle_timeout")
+	assert.Contains(t, err.Error(), "must not be negative")
+}
+
+// TestValidateStepRejectsNegativeStreamTurnGracePeriod mirrors the
+// idle_timeout guard: a typo'd negative stream_turn_grace_period must fail
+// config load loudly rather than be silently coerced to "use the provider
+// default" at the option boundary (buildExecuteOpts only honors >0).
+func TestValidateStepRejectsNegativeStreamTurnGracePeriod(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+tracker:
+  kind: linear
+  api_key: test-key
+agent:
+  model: sonnet
+plan:
+  permission_mode: plan
+  prompt: "Plan {{.Identifier}}"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+  stream_turn_grace_period: -5m
+build:
+  permission_mode: bypass
+  prompt: "Build {{.Identifier}}"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+create_pr:
+  permission_mode: bypass
+  prompt: "PR"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+validate:
+  permission_mode: bypass
+  prompt: "Validate"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+ship:
+  permission_mode: bypass
+  prompt: "Ship"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+`
+	path := filepath.Join(dir, "cfg.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	_, err := LoadConfig(path)
+	require.Error(t, err, "negative stream_turn_grace_period must be rejected")
+	assert.Contains(t, err.Error(), "stream_turn_grace_period")
 	assert.Contains(t, err.Error(), "must not be negative")
 }
 

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -173,6 +173,11 @@ plan:
     #max_budget_usd: 0
     # Auto-retry when a turn ends with an unresolved tool error.
     #max_tool_error_retries: 0
+    # Grace period a turn waits, after completion, for outstanding background
+    # work (e.g. bramble reviewers a skill backgrounds) to finish before the
+    # turn is force-completed; 0 = provider default (10m). Raise it for steps
+    # that launch long-running background tools.
+    #stream_turn_grace_period: 0
     # Skip the human review gate after this step.
     #auto_approve: false
 
@@ -251,6 +256,11 @@ build:
     #max_budget_usd: 0
     # Auto-retry when a turn ends with an unresolved tool error.
     #max_tool_error_retries: 0
+    # Grace period a turn waits, after completion, for outstanding background
+    # work (e.g. bramble reviewers a skill backgrounds) to finish before the
+    # turn is force-completed; 0 = provider default (10m). Raise it for steps
+    # that launch long-running background tools.
+    #stream_turn_grace_period: 0
     # Skip the human review gate after this step.
     #auto_approve: false
 
@@ -295,6 +305,11 @@ create_pr:
     #max_budget_usd: 0
     # Auto-retry when a turn ends with an unresolved tool error.
     #max_tool_error_retries: 0
+    # Grace period a turn waits, after completion, for outstanding background
+    # work (e.g. bramble reviewers a skill backgrounds) to finish before the
+    # turn is force-completed; 0 = provider default (10m). Raise it for steps
+    # that launch long-running background tools.
+    #stream_turn_grace_period: 0
     # Skip the human review gate after this step.
     #auto_approve: false
 
@@ -360,6 +375,11 @@ validate:
     #max_budget_usd: 0
     # Auto-retry when a turn ends with an unresolved tool error.
     #max_tool_error_retries: 0
+    # Grace period a turn waits, after completion, for outstanding background
+    # work (e.g. bramble reviewers a skill backgrounds) to finish before the
+    # turn is force-completed; 0 = provider default (10m). Raise it for steps
+    # that launch long-running background tools.
+    #stream_turn_grace_period: 0
     # Skip the human review gate after this step.
     #auto_approve: false
 
@@ -431,6 +451,11 @@ ship:
     #max_budget_usd: 0
     # Auto-retry when a turn ends with an unresolved tool error.
     #max_tool_error_retries: 0
+    # Grace period a turn waits, after completion, for outstanding background
+    # work (e.g. bramble reviewers a skill backgrounds) to finish before the
+    # turn is force-completed; 0 = provider default (10m). Raise it for steps
+    # that launch long-running background tools.
+    #stream_turn_grace_period: 0
     # Skip the human review gate after this step.
     #auto_approve: false
 

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -173,8 +173,8 @@ eventLoop:
 			//      Critically, a Success==true result is NOT returned as-is here:
 			//      a skill (e.g. /pr-polish) that yielded the turn awaiting a long
 			//      run_in_background join keeps lastResult successful for the whole
-			//      join, so returning it after the 3-minute grace would report the
-			//      step as done to a non-interactive caller (jiradozer) while the
+			//      join, so returning it after the grace period elapses would report
+			//      the step as done to a non-interactive caller (jiradozer) while the
 			//      reviewers are still running. Treat it as resumable instead.
 			if err := state.Err(); err != nil {
 				return result, err

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -61,7 +61,26 @@ const minRetryWallClockBudget = 10 * time.Minute
 // tool_use to produce a terminal event. On expiry the turn is forced done.
 // This is the backstop for an agent that backgrounds a tool that never
 // terminates (e.g. a `while true` poll loop) without a ScheduleWakeup.
-const streamTurnGracePeriod = 3 * time.Minute
+//
+// The default is generous (10m) because legitimate background work — e.g.
+// bramble code reviewers driven by /pr-polish — routinely runs 3-7+ minutes
+// before producing a terminal event; a tighter bound force-completes the turn
+// and KillGroup tears down those processes, so retries restart from scratch
+// and exhaust the retry budget. Callers that need a different bound set it via
+// ExecuteConfig.StreamTurnGracePeriod (WithProviderStreamTurnGracePeriod).
+const streamTurnGracePeriod = 10 * time.Minute
+
+// resolveGracePeriod returns the per-execution grace period: the caller's
+// override (ExecuteConfig.StreamTurnGracePeriod) when set to a positive value,
+// otherwise the provider default. A zero or negative override means "use the
+// default" — config validation rejects negatives upstream, so this only guards
+// against the zero value reaching the option boundary.
+func resolveGracePeriod(cfg ExecuteConfig) time.Duration {
+	if cfg.StreamTurnGracePeriod > 0 {
+		return cfg.StreamTurnGracePeriod
+	}
+	return streamTurnGracePeriod
+}
 
 // consumeTurnEvents drives one logical turn by feeding events from the
 // session channel into a logicalTurnState until the turn is done. It
@@ -426,7 +445,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, wtCtx *wt.W
 		if err := session.Query(ctx, prompt); err != nil {
 			return nil, err
 		}
-		return consumeTurnEvents(ctx, session.Events(), streamTurnGracePeriod, cfg.Logger,
+		return consumeTurnEvents(ctx, session.Events(), resolveGracePeriod(cfg), cfg.Logger,
 			func(ev claude.Event) {
 				dispatchClaudeEvent(ev, cfg.EventHandler, p.events)
 			})

--- a/multiagent/agent/claude_provider_grace_test.go
+++ b/multiagent/agent/claude_provider_grace_test.go
@@ -530,6 +530,28 @@ func TestConsumeTurnEvents_GraceResetsAcrossContinuationWave(t *testing.T) {
 		"wave 2 must get a fresh grace window, not wave 1's leftover slack")
 }
 
+// resolveGracePeriod must honor a positive ExecuteConfig override and fall back
+// to the provider default for the zero value. This is the per-step
+// configurability that lets long-running background work (e.g. bramble
+// reviewers driven by /pr-polish) raise the grace period above the default.
+func TestResolveGracePeriod(t *testing.T) {
+	// Unset (zero) -> provider default.
+	require.Equal(t, streamTurnGracePeriod, resolveGracePeriod(ExecuteConfig{}),
+		"a zero override must fall back to the provider default")
+
+	// Positive override -> used verbatim.
+	override := 25 * time.Minute
+	require.Equal(t, override,
+		resolveGracePeriod(ExecuteConfig{StreamTurnGracePeriod: override}),
+		"a positive override must take precedence over the default")
+
+	// WithProviderStreamTurnGracePeriod must set the field the resolver reads.
+	cfg := ExecuteConfig{}
+	WithProviderStreamTurnGracePeriod(override)(&cfg)
+	require.Equal(t, override, resolveGracePeriod(cfg),
+		"WithProviderStreamTurnGracePeriod must flow through to resolveGracePeriod")
+}
+
 // ctx cancellation must unblock the loop even while a bg tool_use is live.
 func TestConsumeTurnEvents_ContextCancelUnblocks(t *testing.T) {
 	events := make(chan claude.Event, 8)

--- a/multiagent/agent/provider.go
+++ b/multiagent/agent/provider.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/llmendpoint"
 	"github.com/bazelment/yoloswe/wt"
@@ -204,6 +205,12 @@ type ExecuteConfig struct {
 	MaxToolErrorRetries int
 	MaxBudgetUSD        float64
 	KeepUserSettings    bool
+
+	// StreamTurnGracePeriod overrides the provider's default grace period —
+	// how long a turn waits, after completion, for an outstanding background
+	// tool_use to terminate before the turn is force-completed. Zero uses the
+	// provider default.
+	StreamTurnGracePeriod time.Duration
 }
 
 // WithProviderLogger sets the structured logger a provider uses for
@@ -273,6 +280,14 @@ func WithProviderResumeSessionID(id string) ExecuteOption {
 // the feature (the provider returns the errored result without retrying).
 func WithProviderMaxToolErrorRetries(n int) ExecuteOption {
 	return func(c *ExecuteConfig) { c.MaxToolErrorRetries = n }
+}
+
+// WithProviderStreamTurnGracePeriod overrides how long a turn waits, after
+// completion, for an outstanding background tool_use to terminate before the
+// turn is force-completed. Zero (the default) uses the provider's built-in
+// grace period.
+func WithProviderStreamTurnGracePeriod(d time.Duration) ExecuteOption {
+	return func(c *ExecuteConfig) { c.StreamTurnGracePeriod = d }
 }
 
 // WithProviderLLMEndpoint points the underlying CLI at a third-party LLM API


### PR DESCRIPTION
## Problem

The jiradozer validate step runs `/pr-polish`, which launches bramble reviewers (codex + cursor) via `run_in_background`. The agent correctly waits for the completion notification, but `streamTurnGracePeriod = 3 * time.Minute` fired before the reviewers finished — they routinely run **3-7+ minutes**.

On grace expiry the turn is force-completed as a `TransientError` (the PR #258 fix, working correctly), then `KillGroup` tears down the reviewer process group via SIGKILL. On retry the agent restarts reviewers from scratch → killed again → retry budget (`maxRetries=2`) exhausted → step fails.

**Evidence:** 2/5 recent jiradozer runs failed this way. Codex reviewer stderr showed active analysis at the 3-minute mark when killed. The "successful" runs also hit the grace period but got lucky on retry timing.

## Changes

1. **Raise the default 3m → 10m** (`multiagent/agent/claude_provider.go`) so legitimate long-running background work survives the grace window. Comment updated to document the rationale.

2. **Per-step configurability**, threaded end-to-end:
   - `ExecuteConfig.StreamTurnGracePeriod` + `WithProviderStreamTurnGracePeriod()` (`multiagent/agent/provider.go`)
   - `resolveGracePeriod(cfg)` helper (override-if-positive, else default), wired into the `streamTurn` closure (`multiagent/agent/claude_provider.go`)
   - jiradozer `StepConfig.StreamTurnGracePeriod` (YAML `stream_turn_grace_period`) with negative-value validation mirroring `IdleTimeout`, and parent→round inheritance in `ResolveRound` (`jiradozer/config.go`)
   - forwarded in `buildExecuteOpts` (`jiradozer/agent.go`)

## Tests

Added `TestResolveGracePeriod` covering zero→default, positive→override, and the option function flowing through. Existing grace tests pass `gracePeriod` directly to `consumeTurnEvents` and are unaffected.

## Verification

- `scripts/lint.sh` ✓
- `bazel build //multiagent/agent/... //jiradozer/...` ✓
- `bazel test //multiagent/agent/... //jiradozer/... --test_timeout=60` → 7/7 pass ✓
- `bazel run //:gazelle` → no BUILD.bazel changes

## Note

The override logic was extracted into `resolveGracePeriod` (rather than left inline in the closure) so the override path is genuinely unit-tested — the closure itself requires a live `claude.Session` that the suite doesn't stub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when agent turns are force-completed and can kill background subprocesses; mis-tuned values could still stall or prematurely end validate-style steps, though defaults and validation reduce typo risk.
> 
> **Overview**
> Raises the Claude provider’s post–turn-complete **background tool grace** default from **3m to 10m** so long-running background work (e.g. bramble reviewers from `/pr-polish`) is less often force-completed and killed mid-run.
> 
> Adds **per-step override** end-to-end: `ExecuteConfig.StreamTurnGracePeriod` / `WithProviderStreamTurnGracePeriod`, `resolveGracePeriod` in the provider, jiradozer `stream_turn_grace_period` on `StepConfig` (validation, round inheritance, `buildExecuteOpts` wiring), plus bootstrap/example docs. Tests cover resolver behavior, config→provider forwarding, and negative YAML rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b7a6f330d800eb7ede2a3b380a838cf49f56c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->