### PR TITLE
fix(jiradozer): surface subprocess failures with log path, tail, and alert

### DIFF
--- a/jiradozer/BUILD.bazel
+++ b/jiradozer/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "config_test.go",
         "discovery_test.go",
         "notify_test.go",
+        "orchestrator_failure_report_test.go",
         "orchestrator_logtail_test.go",
         "orchestrator_test.go",
         "poller_test.go",

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -653,6 +653,11 @@ func TestTeamSupervisorReloadUpdatesConfigAndOrchestrator(t *testing.T) {
 		orch:   jiradozer.NewOrchestrator(issueTracker, cfg, restoreWTManager{}, "", testMainLogger(t)),
 	}
 
+	// Apply failure reporting once up front (as newTeamSupervisor does) so we
+	// can assert that reload re-applies it when the webhook changes.
+	s.applyFailureReporting()
+	require.Nil(t, s.orch.FailureNotifier(), "no webhook configured initially")
+
 	content, err := os.ReadFile(cfgPath)
 	require.NoError(t, err)
 	content = bytes.Replace(content, []byte("poll_interval: 15s"), []byte("poll_interval: 1s"), 1)
@@ -661,6 +666,8 @@ source:
     filters:
         team: ENG
     max_concurrent: 2
+notify:
+    slack_webhook: https://hooks.example.com/abc
 `)...)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0o600))
 
@@ -669,6 +676,7 @@ source:
 	require.Equal(t, 2, s.cfg.Source.MaxConcurrent)
 	require.Equal(t, time.Second, s.cfg.PollInterval)
 	require.Equal(t, 2, s.orch.ConfigSnapshot().Source.MaxConcurrent)
+	require.NotNil(t, s.orch.FailureNotifier(), "reload must re-apply the failure notifier when slack_webhook changes")
 }
 
 // TestDryRunFlagPlacement verifies --dry-run is honored regardless of where

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -127,6 +127,14 @@ func run(ctx context.Context, app *cliapp.App, args runArgs) (runErr error) {
 		if !shouldReportFailure(runErr) {
 			return
 		}
+		// When launched under an orchestrator parent, the orchestrator is the
+		// single failure reporter (it always observes the death — including
+		// watchdog/SIGINT kills this child can't reach this defer for — and it
+		// carries the child log path + tail). Suppress the child's own report
+		// to avoid a duplicate tracker comment.
+		if os.Getenv(jiradozer.OrchestratedEnvVar) != "" {
+			return
+		}
 		jiradozer.ReportFailure(ctx, logger, reportTracker, reportIssueID, reportNotifier, jiradozer.FailureReport{
 			Tool:          "jiradozer",
 			Target:        reportTarget,

--- a/jiradozer/cmd/jiradozer/team_supervisor.go
+++ b/jiradozer/cmd/jiradozer/team_supervisor.go
@@ -65,16 +65,8 @@ func newTeamSupervisor(app *cliapp.App, issueTracker tracker.IssueTracker, cfg *
 	orch := jiradozer.NewOrchestrator(issueTracker, cfg, wtMgr, repoName, app.Logger)
 	orch.SetSubprocessMode(selfPath, childArgs, logDir)
 	orch.SetForceCleanup(args.forceCleanup)
-	// Per-issue subprocess failures are reported by the orchestrator (the
-	// single reporter; children suppress their own alert). The tracker-comment
-	// sink uses issueTracker; the optional Slack sink mirrors single-issue mode.
-	var notifier jiradozer.Notifier
-	if cfg.Notify.SlackWebhook != "" {
-		notifier = jiradozer.SlackWebhookNotifier{WebhookURL: cfg.Notify.SlackWebhook}
-	}
-	orch.SetFailureReporting(notifier, app.Build.ShortRevision())
 
-	return &teamSupervisor{
+	s := &teamSupervisor{
 		app:       app,
 		cfg:       cfg,
 		args:      args,
@@ -84,7 +76,31 @@ func newTeamSupervisor(app *cliapp.App, issueTracker tracker.IssueTracker, cfg *
 		selfPath:  selfPath,
 		absConfig: absConfig,
 		logDir:    logDir,
-	}, nil
+	}
+	// Per-issue subprocess failures are reported by the orchestrator (the
+	// single reporter; children suppress their own alert). Applied here and
+	// re-applied on reload so a live notify.slack_webhook change takes effect.
+	s.applyFailureReporting()
+	return s, nil
+}
+
+// applyFailureReporting (re)configures the orchestrator's per-issue failure
+// sinks from the current config. The tracker-comment sink uses the orchestrator's
+// tracker; the optional Slack sink mirrors single-issue mode. Called at startup
+// and on every config reload so a changed webhook propagates without a restart.
+func (s *teamSupervisor) applyFailureReporting() {
+	var notifier jiradozer.Notifier
+	if s.cfg.Notify.SlackWebhook != "" {
+		notifier = jiradozer.SlackWebhookNotifier{WebhookURL: s.cfg.Notify.SlackWebhook}
+	}
+	// Build revision is optional (FailureReport omits an empty one). Guard
+	// against a nil app so the supervisor is usable in tests that construct it
+	// directly without a cliapp.App.
+	var buildRevision string
+	if s.app != nil {
+		buildRevision = s.app.Build.ShortRevision()
+	}
+	s.orch.SetFailureReporting(notifier, buildRevision)
 }
 
 func (s *teamSupervisor) Run(ctx context.Context) error {
@@ -132,6 +148,9 @@ func (s *teamSupervisor) reload() {
 
 	s.cfg = next
 	s.orch.UpdateConfig(next)
+	// Re-apply failure-reporting sinks so a changed notify.slack_webhook takes
+	// effect on the next subprocess failure instead of waiting for a restart.
+	s.applyFailureReporting()
 	s.disc.Update(next.Source.ToFilter(), next.PollInterval)
 	s.logger.Info("config reloaded",
 		"path", s.absConfig,

--- a/jiradozer/cmd/jiradozer/team_supervisor.go
+++ b/jiradozer/cmd/jiradozer/team_supervisor.go
@@ -65,6 +65,14 @@ func newTeamSupervisor(app *cliapp.App, issueTracker tracker.IssueTracker, cfg *
 	orch := jiradozer.NewOrchestrator(issueTracker, cfg, wtMgr, repoName, app.Logger)
 	orch.SetSubprocessMode(selfPath, childArgs, logDir)
 	orch.SetForceCleanup(args.forceCleanup)
+	// Per-issue subprocess failures are reported by the orchestrator (the
+	// single reporter; children suppress their own alert). The tracker-comment
+	// sink uses issueTracker; the optional Slack sink mirrors single-issue mode.
+	var notifier jiradozer.Notifier
+	if cfg.Notify.SlackWebhook != "" {
+		notifier = jiradozer.SlackWebhookNotifier{WebhookURL: cfg.Notify.SlackWebhook}
+	}
+	orch.SetFailureReporting(notifier, app.Build.ShortRevision())
 
 	return &teamSupervisor{
 		app:       app,

--- a/jiradozer/notify.go
+++ b/jiradozer/notify.go
@@ -32,6 +32,11 @@ type FailureReport struct {
 	BuildRevision string
 	// LogPath is the absolute path to the run's log file.
 	LogPath string
+	// LogTail is the last few lines of the run's log, in chronological
+	// order, surfaced inline so an on-call human can triage without opening
+	// the log. Optional: single-issue runs leave it nil. Rendered as a fenced
+	// block when present.
+	LogTail []string
 }
 
 // FailingStepFromError extracts the workflow step name from a wrapped run
@@ -77,6 +82,14 @@ func (r FailureReport) renderFailureText() string {
 	}
 	if r.LogPath != "" {
 		fmt.Fprintf(&b, "Log: %s\n", r.LogPath)
+	}
+	if len(r.LogTail) > 0 {
+		b.WriteString("Last log lines:\n```\n")
+		for _, line := range r.LogTail {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		b.WriteString("```\n")
 	}
 	return b.String()
 }

--- a/jiradozer/notify_test.go
+++ b/jiradozer/notify_test.go
@@ -59,6 +59,25 @@ func TestRenderFailureText(t *testing.T) {
 			t.Errorf("rendered text missing %q\ngot:\n%s", want, got)
 		}
 	}
+	if strings.Contains(got, "```") {
+		t.Errorf("nil LogTail should not render a fenced block\ngot:\n%s", got)
+	}
+}
+
+func TestRenderFailureText_LogTail(t *testing.T) {
+	t.Parallel()
+	r := FailureReport{
+		Tool:    "jiradozer",
+		Target:  "INF-703",
+		Err:     errors.New("exit status 1"),
+		LogTail: []string{"E0610 build.go:42] codex auth error", "build step failed"},
+	}
+	got := r.renderFailureText()
+	for _, want := range []string{"Last log lines:", "```", "codex auth error", "build step failed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered text missing %q\ngot:\n%s", want, got)
+		}
+	}
 }
 
 func TestSlackWebhookNotifier(t *testing.T) {

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -574,23 +574,28 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 		defer close(stop)
 		err := cmd.Wait()
 		switch {
+		case wfCtx.Err() != nil && mw.hung.Load():
+			// A watchdog-initiated kill is a real failure — the agent was stuck
+			// — so it must be reported AND classified as StepFailed end to end:
+			// the alert, the supervisor status, and the preserved-worktree
+			// summary must all agree it failed. (Checked before the plain
+			// cancellation case below; a hung run is not an expected stop.)
+			hungErr := fmt.Errorf("subprocess hung and was cancelled by watchdog: %w", err)
+			o.logger.Error("subprocess hung — reporting failure",
+				"issue", issue.Identifier,
+				"error", err,
+				"log", mw.logPath,
+				"tail", strings.Join(mw.tailLines(), " ⏎ "),
+			)
+			o.reportSubprocessFailure(mw, hungErr)
+			o.emitStatus(mw, StepFailed, hungErr)
+			o.cleanup(context.Background(), mw, StepFailed)
 		case wfCtx.Err() != nil:
-			// Context was cancelled. Check this first: a child that traps
-			// SIGINT and exits 0 would otherwise be misclassified as StepDone.
-			// A watchdog-initiated kill (mw.hung) is a real failure — the
-			// agent was stuck — so it must still alert, even though the child
-			// suppressed its own report under orchestration. A user/shutdown
-			// cancellation is an expected stop and stays quiet.
-			if mw.hung.Load() {
-				o.logger.Error("subprocess hung — reporting failure",
-					"issue", issue.Identifier,
-					"error", err,
-					"log", mw.logPath,
-				)
-				o.reportSubprocessFailure(mw, fmt.Errorf("subprocess hung and was cancelled by watchdog: %w", err))
-			} else {
-				o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
-			}
+			// Context was cancelled by the user / shutdown. Check before the
+			// success case: a child that traps SIGINT and exits 0 would
+			// otherwise be misclassified as StepDone. An expected stop — the
+			// child suppressed its own report and we stay quiet here too.
+			o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
 			o.emitStatus(mw, StepCancelled, wfCtx.Err())
 			o.cleanup(context.Background(), mw, StepCancelled)
 		case err == nil:

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -1,6 +1,7 @@
 package jiradozer
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -141,25 +142,43 @@ type managedWorkflow struct {
 	// idle check during this window — otherwise a long human review
 	// would be killed by the prior step's timeout.
 	inReview atomic.Bool
+	// hung is set by runWatchdog just before it cancels a stalled workflow.
+	// It lets the cmd.Wait goroutine distinguish a watchdog-initiated kill (a
+	// genuine failure worth alerting — the agent was stuck) from a user/
+	// shutdown cancellation (an expected stop). Without it, a hung child would
+	// be silently classified as cancelled and no failure alert would fire,
+	// even though detecting stuck agents is the whole point of the watchdog.
+	hung atomic.Bool
 }
 
-// appendTail records one subprocess log line in the bounded ring buffer.
-// The trailing newline is stripped and over-long lines are truncated so a
-// runaway child can't grow memory. Safe for concurrent use.
-func (mw *managedWorkflow) appendTail(line string) {
+// capTailLine strips a line's trailing newline and truncates it to tailLineMax
+// bytes on a rune boundary so a retained tail line stays valid UTF-8 (a split
+// multibyte rune renders as garbage in a tracker comment). Shared by the live
+// ring buffer (appendTail) and the file-sourced fallback (readLogTail) so both
+// retain lines identically. Returns "" for an empty/blank line.
+func capTailLine(line string) string {
 	line = strings.TrimRight(line, "\n")
 	if line == "" {
-		return
+		return ""
 	}
 	if len(line) > tailLineMax {
-		// Truncate on a rune boundary so the retained line stays valid UTF-8
-		// (a tracker comment with a split multibyte rune renders as garbage).
 		// Back up from the byte cap to the start of the rune it lands in.
 		cut := tailLineMax
 		for cut > 0 && !utf8.RuneStart(line[cut]) {
 			cut--
 		}
 		line = line[:cut] + "…"
+	}
+	return line
+}
+
+// appendTail records one subprocess log line in the bounded ring buffer.
+// The trailing newline is stripped and over-long lines are truncated so a
+// runaway child can't grow memory. Safe for concurrent use.
+func (mw *managedWorkflow) appendTail(line string) {
+	line = capTailLine(line)
+	if line == "" {
+		return
 	}
 	mw.tailMu.Lock()
 	defer mw.tailMu.Unlock()
@@ -228,6 +247,15 @@ func (o *Orchestrator) SetFailureReporting(notifier Notifier, buildRevision stri
 	defer o.mu.Unlock()
 	o.notifier = notifier
 	o.buildRevision = buildRevision
+}
+
+// FailureNotifier returns the currently-configured external failure notifier
+// (nil when none is set). Exposed so callers/tests can verify the sink after a
+// config reload re-applies SetFailureReporting.
+func (o *Orchestrator) FailureNotifier() Notifier {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.notifier
 }
 
 // SetForceCleanup controls whether worktrees are deleted when workflows are
@@ -547,10 +575,22 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 		err := cmd.Wait()
 		switch {
 		case wfCtx.Err() != nil:
-			// Context was cancelled (user pressed Ctrl+C). Check this first:
-			// a child that traps SIGINT and exits 0 would otherwise be
-			// misclassified as StepDone.
-			o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
+			// Context was cancelled. Check this first: a child that traps
+			// SIGINT and exits 0 would otherwise be misclassified as StepDone.
+			// A watchdog-initiated kill (mw.hung) is a real failure — the
+			// agent was stuck — so it must still alert, even though the child
+			// suppressed its own report under orchestration. A user/shutdown
+			// cancellation is an expected stop and stays quiet.
+			if mw.hung.Load() {
+				o.logger.Error("subprocess hung — reporting failure",
+					"issue", issue.Identifier,
+					"error", err,
+					"log", mw.logPath,
+				)
+				o.reportSubprocessFailure(mw, fmt.Errorf("subprocess hung and was cancelled by watchdog: %w", err))
+			} else {
+				o.logger.Warn("subprocess cancelled", "issue", issue.Identifier, "error", err)
+			}
 			o.emitStatus(mw, StepCancelled, wfCtx.Err())
 			o.cleanup(context.Background(), mw, StepCancelled)
 		case err == nil:
@@ -948,6 +988,15 @@ func (o *Orchestrator) reportSubprocessFailure(mw *managedWorkflow, err error) {
 		mw.stepMu.Unlock()
 	}
 
+	// Prefer the live in-memory ring; fall back to reading the log file when
+	// it's empty. The ring is empty for exec-restored workflows (no tailer is
+	// re-attached after a restart) and for children that exit so fast the
+	// tailer never ran — exactly the cases where a human most needs the tail.
+	tail := mw.tailLines()
+	if len(tail) == 0 && mw.logPath != "" {
+		tail = readLogTail(mw.logPath, tailRingMax)
+	}
+
 	report := FailureReport{
 		Tool:          "jiradozer",
 		Target:        mw.issue.Identifier,
@@ -955,9 +1004,60 @@ func (o *Orchestrator) reportSubprocessFailure(mw *managedWorkflow, err error) {
 		Err:           err,
 		BuildRevision: buildRevision,
 		LogPath:       mw.logPath,
-		LogTail:       mw.tailLines(),
+		LogTail:       tail,
 	}
 	ReportFailure(context.Background(), o.logger, o.tracker, mw.issue.ID, notifier, report)
+}
+
+// readLogTail returns the last n lines of the file at path, each trimmed and
+// length-capped the same way the live ring buffer is, so a file-sourced tail
+// is indistinguishable from an in-memory one. Best-effort: returns nil on any
+// read error — a missing tail must never block the failure report itself.
+func readLogTail(path string, n int) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	// Bound the read so a multi-GB child log can't be slurped into memory: the
+	// tail lives in the last chunk. tailRingMax short lines fit comfortably in
+	// 64 KiB; seek to the tail and scan forward.
+	const tailReadBytes = 64 * 1024
+	size, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil
+	}
+	start := size - tailReadBytes
+	if start < 0 {
+		start = 0
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), tailLineMax*2)
+	ring := make([]string, 0, n)
+	first := start > 0 // dropped a partial first line by seeking mid-file
+	for scanner.Scan() {
+		if first {
+			first = false // discard the partial line at the seek boundary
+			continue
+		}
+		line := capTailLine(scanner.Text())
+		if line == "" {
+			continue
+		}
+		ring = append(ring, line)
+		if len(ring) > n {
+			ring = ring[1:]
+		}
+	}
+	if err := scanner.Err(); err != nil || len(ring) == 0 {
+		return nil
+	}
+	return ring
 }
 
 func (o *Orchestrator) wasCancelled(mw *managedWorkflow) bool {

--- a/jiradozer/orchestrator.go
+++ b/jiradozer/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bazelment/yoloswe/jiradozer/tracker"
 )
@@ -28,6 +29,21 @@ var errConcurrencyLimit = errors.New("concurrency limit reached")
 // another process polls a different state set, the label signals that the
 // issue is already being handled.
 const LockLabel = "jiradozer-active"
+
+// OrchestratedEnvVar is set in each child subprocess's environment so the
+// child knows it runs under an orchestrator parent and must not post its own
+// failure report — the orchestrator is the single reporter for per-issue
+// failures. Read by the child CLI (cmd/jiradozer) to suppress its own alert.
+const OrchestratedEnvVar = "JIRADOZER_ORCHESTRATED"
+
+// tailRingMax bounds the per-issue tail ring buffer: the last N subprocess
+// log lines retained for surfacing on failure. Small on purpose — enough
+// context for a human to triage, not a full transcript.
+const tailRingMax = 20
+
+// tailLineMax caps the length of any single retained tail line so a child
+// printing a huge line (e.g. a base64 blob) can't blow up the ring buffer.
+const tailLineMax = 2000
 
 // WorktreeManager is the interface for creating and removing git worktrees.
 type WorktreeManager interface {
@@ -63,23 +79,29 @@ type PreservedWorktree struct {
 //
 //nolint:govet // fieldalignment: sync types at the end require padding
 type Orchestrator struct {
-	tracker      tracker.IssueTracker
-	wtManager    WorktreeManager
-	out          io.Writer
-	config       *Config
-	logger       *slog.Logger
-	active       map[string]*managedWorkflow
-	statusChan   chan IssueStatus
-	slotFreed    chan struct{}
-	done         chan struct{}
-	childArgs    []string
-	repoName     string
-	selfPath     string
-	logDir       string
-	mu           sync.RWMutex
-	wg           sync.WaitGroup
-	forceCleanup bool
-	preserved    []PreservedWorktree
+	tracker    tracker.IssueTracker
+	wtManager  WorktreeManager
+	out        io.Writer
+	config     *Config
+	logger     *slog.Logger
+	active     map[string]*managedWorkflow
+	statusChan chan IssueStatus
+	slotFreed  chan struct{}
+	done       chan struct{}
+	childArgs  []string
+	repoName   string
+	selfPath   string
+	logDir     string
+	// notifier delivers the external failure alert (e.g. Slack) for per-issue
+	// subprocess failures. Nil disables the external sink; the tracker-comment
+	// sink (o.tracker) is always available. buildRevision is stamped into the
+	// failure report so a stale-deploy failure is obvious from the alert.
+	notifier      Notifier
+	buildRevision string
+	mu            sync.RWMutex
+	wg            sync.WaitGroup
+	forceCleanup  bool
+	preserved     []PreservedWorktree
 }
 
 //nolint:govet // fieldalignment: grouping by purpose (lifecycle vs watchdog) is more readable than tighter packing
@@ -88,6 +110,7 @@ type managedWorkflow struct {
 	issue        *tracker.Issue
 	cmd          *exec.Cmd
 	logFile      *os.File
+	logPath      string
 	cancel       context.CancelFunc
 	worktreePath string
 	branch       string
@@ -95,6 +118,13 @@ type managedWorkflow struct {
 	cancelled    bool
 	currentStep  string
 	stepMu       sync.Mutex
+	// tailRing is a bounded ring buffer of the most recent subprocess log
+	// lines, appended by tailSubprocessLog and read by the failure path so
+	// an on-call human sees what the child printed before it died without
+	// opening the per-issue log file. Guarded by tailMu. tailLines() returns
+	// a snapshot in chronological order.
+	tailMu   sync.Mutex
+	tailRing []string
 	// lastOutputAt is unix-nanos of the most recent log line from the
 	// subprocess. Written by tailSubprocessLog, read by runWatchdog to
 	// detect idle gaps.
@@ -111,6 +141,45 @@ type managedWorkflow struct {
 	// idle check during this window — otherwise a long human review
 	// would be killed by the prior step's timeout.
 	inReview atomic.Bool
+}
+
+// appendTail records one subprocess log line in the bounded ring buffer.
+// The trailing newline is stripped and over-long lines are truncated so a
+// runaway child can't grow memory. Safe for concurrent use.
+func (mw *managedWorkflow) appendTail(line string) {
+	line = strings.TrimRight(line, "\n")
+	if line == "" {
+		return
+	}
+	if len(line) > tailLineMax {
+		// Truncate on a rune boundary so the retained line stays valid UTF-8
+		// (a tracker comment with a split multibyte rune renders as garbage).
+		// Back up from the byte cap to the start of the rune it lands in.
+		cut := tailLineMax
+		for cut > 0 && !utf8.RuneStart(line[cut]) {
+			cut--
+		}
+		line = line[:cut] + "…"
+	}
+	mw.tailMu.Lock()
+	defer mw.tailMu.Unlock()
+	mw.tailRing = append(mw.tailRing, line)
+	if len(mw.tailRing) > tailRingMax {
+		// Drop the oldest lines, keeping the last tailRingMax. Re-slice into
+		// a fresh backing array so the dropped lines can be garbage-collected
+		// instead of being pinned by a growing underlying array.
+		mw.tailRing = append([]string(nil), mw.tailRing[len(mw.tailRing)-tailRingMax:]...)
+	}
+}
+
+// tailLines returns a chronological snapshot of the retained tail lines.
+func (mw *managedWorkflow) tailLines() []string {
+	mw.tailMu.Lock()
+	defer mw.tailMu.Unlock()
+	if len(mw.tailRing) == 0 {
+		return nil
+	}
+	return append([]string(nil), mw.tailRing...)
 }
 
 // NewOrchestrator creates a new multi-issue orchestrator.
@@ -147,6 +216,18 @@ func (o *Orchestrator) SetSubprocessMode(selfPath string, childArgs []string, lo
 	o.selfPath = selfPath
 	o.childArgs = append([]string(nil), childArgs...)
 	o.logDir = logDir
+}
+
+// SetFailureReporting configures per-issue subprocess-failure alerting. The
+// tracker comment sink always uses o.tracker; notifier is the optional
+// external sink (e.g. Slack), and buildRevision is stamped into each report.
+// Both arguments are optional: a nil notifier and empty revision degrade
+// gracefully (ReportFailure is nil-safe; FailureReport omits empty fields).
+func (o *Orchestrator) SetFailureReporting(notifier Notifier, buildRevision string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.notifier = notifier
+	o.buildRevision = buildRevision
 }
 
 // SetForceCleanup controls whether worktrees are deleted when workflows are
@@ -211,6 +292,7 @@ func (o *Orchestrator) ActiveWorkflowSnapshots() []ManagedWorkflowSnapshot {
 			PID:          mw.pid,
 			Branch:       mw.branch,
 			WorktreePath: mw.worktreePath,
+			LogPath:      mw.logPath,
 			StartedAt:    mw.startedAt,
 		})
 	}
@@ -358,6 +440,12 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 
 	cmd := exec.CommandContext(wfCtx, selfPath, args...)
 	cmd.Dir = worktreePath
+	// Mark the child as orchestrated so it suppresses its own failure
+	// report: the orchestrator is the single source of truth for per-issue
+	// failures (it always observes the death, including watchdog/SIGINT
+	// kills the child can't self-report), and it carries the log path + tail
+	// the child's self-report lacks. Inherit the rest of the environment.
+	cmd.Env = append(os.Environ(), OrchestratedEnvVar+"=1")
 	// Graceful shutdown: send SIGINT so the child can clean up, then
 	// force-kill after WaitDelay if it hasn't exited.
 	cmd.Cancel = func() error { return cmd.Process.Signal(os.Interrupt) }
@@ -421,6 +509,7 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 		startedAt:    time.Now(),
 		cmd:          cmd,
 		logFile:      logFile,
+		logPath:      logPath,
 		pid:          cmd.Process.Pid,
 	}
 
@@ -469,7 +558,13 @@ func (o *Orchestrator) Start(ctx context.Context, issue *tracker.Issue) error {
 			o.emitStatus(mw, StepDone, nil)
 			o.cleanup(context.Background(), mw, StepDone)
 		default:
-			o.logger.Error("subprocess failed", "issue", issue.Identifier, "error", err)
+			o.logger.Error("subprocess failed",
+				"issue", issue.Identifier,
+				"error", err,
+				"log", mw.logPath,
+				"tail", strings.Join(mw.tailLines(), " ⏎ "),
+			)
+			o.reportSubprocessFailure(mw, err)
 			o.emitStatus(mw, StepFailed, err)
 			o.cleanup(context.Background(), mw, StepFailed)
 		}
@@ -782,6 +877,7 @@ func (o *Orchestrator) RestoreActive(snapshots []ManagedWorkflowSnapshot) []stri
 			startedAt:    snap.StartedAt,
 			worktreePath: snap.WorktreePath,
 			branch:       snap.Branch,
+			logPath:      snap.LogPath,
 			pid:          snap.PID,
 		}
 		o.mu.Lock()
@@ -806,7 +902,8 @@ func (o *Orchestrator) waitRestored(mw *managedWorkflow) {
 	_, err := syscall.Wait4(mw.pid, &status, 0, &usage)
 	switch {
 	case err != nil:
-		o.logger.Error("restored subprocess wait failed", "issue", mw.issue.Identifier, "pid", mw.pid, "error", err)
+		o.logger.Error("restored subprocess wait failed", "issue", mw.issue.Identifier, "pid", mw.pid, "error", err, "log", mw.logPath)
+		o.reportSubprocessFailure(mw, err)
 		o.emitStatus(mw, StepFailed, err)
 		o.cleanup(context.Background(), mw, StepFailed)
 	case status.Exited() && status.ExitStatus() == 0:
@@ -819,10 +916,48 @@ func (o *Orchestrator) waitRestored(mw *managedWorkflow) {
 		o.cleanup(context.Background(), mw, StepCancelled)
 	default:
 		err := fmt.Errorf("subprocess pid %d exited with wait status %d", mw.pid, status)
-		o.logger.Error("restored subprocess failed", "issue", mw.issue.Identifier, "pid", mw.pid, "status", int(status))
+		o.logger.Error("restored subprocess failed", "issue", mw.issue.Identifier, "pid", mw.pid, "status", int(status), "log", mw.logPath)
+		o.reportSubprocessFailure(mw, err)
 		o.emitStatus(mw, StepFailed, err)
 		o.cleanup(context.Background(), mw, StepFailed)
 	}
+}
+
+// reportSubprocessFailure fans a per-issue subprocess failure out to the
+// configured sinks (tracker comment + optional notifier), carrying the child
+// log path and a tail of its final output so an on-call human can triage
+// without grepping the log directory. Best-effort: ReportFailure never errors
+// and a nil notifier / unavailable tracker simply skips that sink.
+//
+// The orchestrator is the single reporter for per-issue failures — children
+// launched under it suppress their own report (see OrchestratedEnvVar) — so a
+// cleanly-failing child does not double-comment.
+func (o *Orchestrator) reportSubprocessFailure(mw *managedWorkflow, err error) {
+	o.mu.RLock()
+	notifier := o.notifier
+	buildRevision := o.buildRevision
+	o.mu.RUnlock()
+
+	step := FailingStepFromError(err)
+	if step == "" {
+		// The child error from the orchestrator's vantage point is a bare
+		// "exit status N" with no step prefix, so fall back to the last step
+		// the tailer observed.
+		mw.stepMu.Lock()
+		step = mw.currentStep
+		mw.stepMu.Unlock()
+	}
+
+	report := FailureReport{
+		Tool:          "jiradozer",
+		Target:        mw.issue.Identifier,
+		Step:          step,
+		Err:           err,
+		BuildRevision: buildRevision,
+		LogPath:       mw.logPath,
+		LogTail:       mw.tailLines(),
+	}
+	ReportFailure(context.Background(), o.logger, o.tracker, mw.issue.ID, notifier, report)
 }
 
 func (o *Orchestrator) wasCancelled(mw *managedWorkflow) bool {

--- a/jiradozer/orchestrator_failure_report_test.go
+++ b/jiradozer/orchestrator_failure_report_test.go
@@ -1,0 +1,202 @@
+package jiradozer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bazelment/yoloswe/jiradozer/tracker"
+)
+
+// TestManagedWorkflow_TailRing verifies the per-issue tail ring buffer bounds
+// its size, drops oldest lines, strips newlines, truncates over-long lines,
+// and returns an independent snapshot.
+func TestManagedWorkflow_TailRing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty before any append", func(t *testing.T) {
+		t.Parallel()
+		mw := &managedWorkflow{}
+		require.Nil(t, mw.tailLines())
+	})
+
+	t.Run("keeps only the last tailRingMax lines", func(t *testing.T) {
+		t.Parallel()
+		mw := &managedWorkflow{}
+		total := tailRingMax + 10
+		for i := 0; i < total; i++ {
+			mw.appendTail(fmt.Sprintf("line %d\n", i))
+		}
+		got := mw.tailLines()
+		require.Len(t, got, tailRingMax)
+		// Oldest dropped: first retained line is total-tailRingMax.
+		require.Equal(t, fmt.Sprintf("line %d", total-tailRingMax), got[0])
+		require.Equal(t, fmt.Sprintf("line %d", total-1), got[len(got)-1])
+	})
+
+	t.Run("strips trailing newline and skips blank lines", func(t *testing.T) {
+		t.Parallel()
+		mw := &managedWorkflow{}
+		mw.appendTail("hello\n")
+		mw.appendTail("\n")    // blank after trim — skipped
+		mw.appendTail("")      // empty — skipped
+		mw.appendTail("world") // no newline (partial trailing line)
+		require.Equal(t, []string{"hello", "world"}, mw.tailLines())
+	})
+
+	t.Run("truncates over-long lines", func(t *testing.T) {
+		t.Parallel()
+		mw := &managedWorkflow{}
+		mw.appendTail(strings.Repeat("x", tailLineMax+500))
+		got := mw.tailLines()
+		require.Len(t, got, 1)
+		require.True(t, strings.HasSuffix(got[0], "…"))
+		require.LessOrEqual(t, len(got[0]), tailLineMax+len("…"))
+	})
+
+	t.Run("truncation stays valid UTF-8 on a rune boundary", func(t *testing.T) {
+		t.Parallel()
+		mw := &managedWorkflow{}
+		// Multibyte runes (3 bytes each) so a naive byte-slice at tailLineMax
+		// would land mid-rune and produce invalid UTF-8.
+		mw.appendTail(strings.Repeat("世", tailLineMax))
+		got := mw.tailLines()
+		require.Len(t, got, 1)
+		require.True(t, utf8.ValidString(got[0]), "truncated line must remain valid UTF-8")
+		require.True(t, strings.HasSuffix(got[0], "…"))
+	})
+
+	t.Run("snapshot is independent of later appends", func(t *testing.T) {
+		t.Parallel()
+		mw := &managedWorkflow{}
+		mw.appendTail("a")
+		snap := mw.tailLines()
+		mw.appendTail("b")
+		require.Equal(t, []string{"a"}, snap, "snapshot must not see later appends")
+	})
+}
+
+// capturedComment is one recorded PostComment call.
+type capturedComment struct {
+	issueID string
+	body    string
+}
+
+// commentCapturingTracker records PostComment calls so the failure-report
+// fan-out can be asserted without a real tracker.
+//
+//nolint:govet // fieldalignment: test fixture; embedded mock dictates layout
+type commentCapturingTracker struct {
+	mockDiscoveryTracker
+	mu       sync.Mutex
+	comments []capturedComment
+}
+
+func (m *commentCapturingTracker) PostComment(_ context.Context, issueID, body string) (tracker.Comment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.comments = append(m.comments, capturedComment{issueID: issueID, body: body})
+	return tracker.Comment{ID: fmt.Sprintf("c%d", len(m.comments))}, nil
+}
+
+func (m *commentCapturingTracker) getComments() []capturedComment {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]capturedComment(nil), m.comments...)
+}
+
+// TestReportSubprocessFailure verifies the orchestrator fans a per-issue
+// subprocess failure out to the tracker comment + notifier sinks, carrying the
+// log path and tail, with the step falling back to the last observed step when
+// the error carries no step prefix.
+func TestReportSubprocessFailure(t *testing.T) {
+	t.Parallel()
+
+	tr := &commentCapturingTracker{}
+	notifier := &captureNotifier{}
+	o := &Orchestrator{
+		tracker:       tr,
+		logger:        discardLogger(),
+		config:        testOrchestratorConfig(),
+		notifier:      notifier,
+		buildRevision: "deadbeef",
+	}
+
+	mw := &managedWorkflow{
+		issue:       &tracker.Issue{ID: "issue-1", Identifier: "INF-1369"},
+		logPath:     "/tmp/jiradozer/INF-1369.log",
+		currentStep: "build",
+	}
+	mw.appendTail("E0610 build.go:42] codex auth error: 401\n")
+	mw.appendTail("build step failed\n")
+
+	// Bare "exit status 1" carries no step prefix -> falls back to currentStep.
+	o.reportSubprocessFailure(mw, errors.New("exit status 1"))
+
+	comments := tr.getComments()
+	require.Len(t, comments, 1)
+	require.Equal(t, "issue-1", comments[0].issueID)
+	body := comments[0].body
+	for _, want := range []string{"INF-1369", "`build`", "exit status 1", "deadbeef", "/tmp/jiradozer/INF-1369.log", "codex auth error", "build step failed"} {
+		require.Containsf(t, body, want, "comment body missing %q\ngot:\n%s", want, body)
+	}
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	require.Len(t, notifier.reports, 1)
+	rep := notifier.reports[0]
+	require.Equal(t, "INF-1369", rep.Target)
+	require.Equal(t, "build", rep.Step)
+	require.Equal(t, "/tmp/jiradozer/INF-1369.log", rep.LogPath)
+	require.Equal(t, []string{"E0610 build.go:42] codex auth error: 401", "build step failed"}, rep.LogTail)
+}
+
+// TestReportSubprocessFailure_NilNotifier confirms a nil external notifier is
+// safe (tracker comment still posts).
+func TestReportSubprocessFailure_NilNotifier(t *testing.T) {
+	t.Parallel()
+
+	tr := &commentCapturingTracker{}
+	o := &Orchestrator{
+		tracker: tr,
+		logger:  discardLogger(),
+		config:  testOrchestratorConfig(),
+	}
+	mw := &managedWorkflow{issue: &tracker.Issue{ID: "issue-2", Identifier: "INF-2"}}
+
+	require.NotPanics(t, func() {
+		o.reportSubprocessFailure(mw, errors.New("boom"))
+	})
+	require.Len(t, tr.getComments(), 1)
+}
+
+// TestReportSubprocessFailure_StepFromError confirms a step-prefixed error
+// takes precedence over the last observed step.
+func TestReportSubprocessFailure_StepFromError(t *testing.T) {
+	t.Parallel()
+
+	notifier := &captureNotifier{}
+	o := &Orchestrator{
+		tracker:  &commentCapturingTracker{},
+		logger:   discardLogger(),
+		config:   testOrchestratorConfig(),
+		notifier: notifier,
+	}
+	mw := &managedWorkflow{
+		issue:       &tracker.Issue{ID: "i", Identifier: "INF-3"},
+		currentStep: "build", // would be the fallback
+	}
+	// Error explicitly names the plan step.
+	o.reportSubprocessFailure(mw, fmt.Errorf("plan step: %w", errors.New("x")))
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	require.Len(t, notifier.reports, 1)
+	require.Equal(t, "plan", notifier.reports[0].Step, "step from error must win over currentStep")
+}

--- a/jiradozer/orchestrator_failure_report_test.go
+++ b/jiradozer/orchestrator_failure_report_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -199,4 +201,131 @@ func TestReportSubprocessFailure_StepFromError(t *testing.T) {
 	defer notifier.mu.Unlock()
 	require.Len(t, notifier.reports, 1)
 	require.Equal(t, "plan", notifier.reports[0].Step, "step from error must win over currentStep")
+}
+
+// TestReportSubprocessFailure_TailFromFile verifies the file fallback: when the
+// in-memory ring is empty (exec-restored or fast-exit child), the tail is read
+// from the log file at mw.logPath so restored/quick failures still surface
+// their final lines.
+func TestReportSubprocessFailure_TailFromFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "INF-9.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("starting\nstep: build\nE0610 build failed: 401\n"), 0o600))
+
+	notifier := &captureNotifier{}
+	o := &Orchestrator{
+		tracker:  &commentCapturingTracker{},
+		logger:   discardLogger(),
+		config:   testOrchestratorConfig(),
+		notifier: notifier,
+	}
+	// No appendTail calls: the in-memory ring is empty, as it is for a
+	// restored workflow whose tailer was never re-attached.
+	mw := &managedWorkflow{
+		issue:   &tracker.Issue{ID: "i9", Identifier: "INF-9"},
+		logPath: logPath,
+	}
+	o.reportSubprocessFailure(mw, errors.New("exit status 1"))
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	require.Len(t, notifier.reports, 1)
+	require.Equal(t, []string{"starting", "step: build", "E0610 build failed: 401"}, notifier.reports[0].LogTail,
+		"empty ring must fall back to reading the log file")
+}
+
+// TestReportSubprocessFailure_RingBeatsFile confirms the live ring is preferred
+// over the file when both are available.
+func TestReportSubprocessFailure_RingBeatsFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "INF-10.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("file line\n"), 0o600))
+
+	notifier := &captureNotifier{}
+	o := &Orchestrator{
+		tracker:  &commentCapturingTracker{},
+		logger:   discardLogger(),
+		config:   testOrchestratorConfig(),
+		notifier: notifier,
+	}
+	mw := &managedWorkflow{issue: &tracker.Issue{ID: "i10", Identifier: "INF-10"}, logPath: logPath}
+	mw.appendTail("ring line\n")
+
+	o.reportSubprocessFailure(mw, errors.New("boom"))
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	require.Equal(t, []string{"ring line"}, notifier.reports[0].LogTail)
+}
+
+func TestReadLogTail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file returns nil", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, readLogTail(filepath.Join(t.TempDir(), "nope.log"), 5))
+	})
+
+	t.Run("returns last n lines", func(t *testing.T) {
+		t.Parallel()
+		p := filepath.Join(t.TempDir(), "a.log")
+		var sb strings.Builder
+		for i := 0; i < 50; i++ {
+			fmt.Fprintf(&sb, "line %d\n", i)
+		}
+		require.NoError(t, os.WriteFile(p, []byte(sb.String()), 0o600))
+		got := readLogTail(p, 5)
+		require.Equal(t, []string{"line 45", "line 46", "line 47", "line 48", "line 49"}, got)
+	})
+
+	t.Run("fewer lines than n returns all", func(t *testing.T) {
+		t.Parallel()
+		p := filepath.Join(t.TempDir(), "b.log")
+		require.NoError(t, os.WriteFile(p, []byte("only\ntwo\n"), 0o600))
+		require.Equal(t, []string{"only", "two"}, readLogTail(p, 20))
+	})
+
+	t.Run("empty file returns nil", func(t *testing.T) {
+		t.Parallel()
+		p := filepath.Join(t.TempDir(), "c.log")
+		require.NoError(t, os.WriteFile(p, nil, 0o600))
+		require.Nil(t, readLogTail(p, 5))
+	})
+}
+
+// TestWatchdogHungReporting verifies the watchdog marks a stalled workflow as
+// hung and that a hung workflow is reported as a failure (not silently
+// classified as a cancellation). The cmd.Wait branch keys off mw.hung; here we
+// assert the flag plumbs through to a failure report.
+func TestWatchdogHungReporting(t *testing.T) {
+	t.Parallel()
+
+	notifier := &captureNotifier{}
+	o := &Orchestrator{
+		tracker:  &commentCapturingTracker{},
+		logger:   discardLogger(),
+		config:   testOrchestratorConfig(),
+		notifier: notifier,
+	}
+	mw := &managedWorkflow{
+		issue:       &tracker.Issue{ID: "ih", Identifier: "INF-HUNG"},
+		currentStep: "validate",
+	}
+	mw.hung.Store(true)
+	require.True(t, mw.hung.Load())
+
+	// The cmd.Wait goroutine reports a hung workflow via reportSubprocessFailure
+	// with a watchdog-wrapped error; assert that path produces an alert naming
+	// the stuck step.
+	o.reportSubprocessFailure(mw, fmt.Errorf("subprocess hung and was cancelled by watchdog: %w", errors.New("signal: interrupt")))
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	require.Len(t, notifier.reports, 1, "a hung (watchdog-killed) subprocess must alert")
+	require.Equal(t, "validate", notifier.reports[0].Step)
+	require.Contains(t, notifier.reports[0].Err.Error(), "hung")
 }

--- a/jiradozer/orchestrator_logtail.go
+++ b/jiradozer/orchestrator_logtail.go
@@ -104,6 +104,7 @@ func (o *Orchestrator) tailSubprocessLog(mw *managedWorkflow, logPath string, st
 		if line != "" {
 			offset += int64(len(line))
 			mw.lastOutputAt.Store(time.Now().UnixNano())
+			mw.appendTail(line)
 			if o.maybeEmitTransition(mw, line, !emittedPRURL) {
 				emittedPRURL = true
 			}

--- a/jiradozer/orchestrator_logtail.go
+++ b/jiradozer/orchestrator_logtail.go
@@ -333,6 +333,11 @@ func (o *Orchestrator) runWatchdog(mw *managedWorkflow, tickInterval time.Durati
 				"idle_for", gap.Round(time.Second),
 				"idle_timeout", timeout,
 			)
+			// Mark hung before cancelling so the cmd.Wait goroutine reports
+			// this as a failure (stuck agent) rather than an expected
+			// cancellation. Set before cancel() to avoid a race where Wait
+			// returns and inspects the flag before we write it.
+			mw.hung.Store(true)
 			if mw.cancel != nil {
 				mw.cancel()
 			}

--- a/jiradozer/orchestrator_test.go
+++ b/jiradozer/orchestrator_test.go
@@ -605,6 +605,58 @@ func TestOrchestrator_CancelWithCleanExit(t *testing.T) {
 	require.Empty(t, removed, "cancelled worktree should not be removed")
 }
 
+// TestOrchestrator_HungIsFailedNotCancelled verifies that a watchdog-killed
+// (hung) subprocess is classified as StepFailed end to end — the emitted
+// status AND the preserved-worktree summary — not StepCancelled, so the alert,
+// the supervisor UI, and the summary all agree the run failed.
+//
+// Not t.Parallel(): same ETXTBSY fork/exec race as the other Cancel* tests.
+func TestOrchestrator_HungIsFailedNotCancelled(t *testing.T) {
+	cfg := testOrchestratorConfig()
+
+	// Child traps SIGINT and exits non-zero, as a stuck agent killed by the
+	// watchdog's mw.cancel() (SIGINT) would.
+	script := writeTestScript(t, "trap 'exit 1' INT; sleep 60")
+	orch, _ := setupSubprocessOrch(t, cfg, script)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	issue := &tracker.Issue{ID: "1", Identifier: "ENG-1", Title: "Test"}
+	require.NoError(t, orch.Start(ctx, issue))
+
+	// Drain StepInit.
+	select {
+	case <-orch.StatusUpdates():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for StepInit")
+	}
+
+	// Simulate the watchdog's decision: mark the live workflow hung, then
+	// cancel (the watchdog sets mw.hung before calling mw.cancel()).
+	orch.mu.RLock()
+	mw := orch.active[issue.ID]
+	orch.mu.RUnlock()
+	require.NotNil(t, mw, "workflow should be active")
+	mw.hung.Store(true)
+	cancel()
+
+	// A hung run must surface as StepFailed, not StepCancelled.
+	select {
+	case status := <-orch.StatusUpdates():
+		require.Equal(t, StepFailed, status.Step, "hung run must be StepFailed, not StepCancelled")
+		require.Error(t, status.Error)
+		require.Contains(t, status.Error.Error(), "hung")
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for StepFailed")
+	}
+
+	orch.Wait()
+
+	// Preserved (default), and recorded as StepFailed — not StepCancelled.
+	preserved := orch.PreservedWorktrees()
+	require.Len(t, preserved, 1)
+	require.Equal(t, StepFailed, preserved[0].Step, "preserved summary must label a hung run as failed")
+}
+
 // TestOrchestrator_FailedWorktreePreservedByDefault asserts that a StepFailed
 // workflow preserves its worktree and branches by default. Failing steps
 // often fire mid-workflow after real work exists (pushed branch, open PR);

--- a/jiradozer/runtime_state.go
+++ b/jiradozer/runtime_state.go
@@ -25,6 +25,7 @@ type ManagedWorkflowSnapshot struct {
 	StartedAt    time.Time      `json:"started_at"`
 	WorktreePath string         `json:"worktree_path"`
 	Branch       string         `json:"branch"`
+	LogPath      string         `json:"log_path"`
 	PID          int            `json:"pid"`
 }
 


### PR DESCRIPTION
## Context

Reviewing the last 10 jiradozer cron runs (`~/.jiradozer/logs/`, Jun 5–11) surfaced a reliability gap: when the multi-issue orchestrator's per-issue child subprocess dies, the orchestrator log records only

```
subprocess failed issue=INF-1369 error="exit status 1"
```

— no pointer to the child's per-issue log file, no tail of what it printed before dying, and **no failure alert**, even though a rich failure-reporting path (tracker comment + optional Slack via `ReportFailure`) already exists and is used by single-issue runs. The orchestrator's own design comment claims *"Per-issue failures are isolated and reported by the orchestrator"* — but the failure branch never actually called it. This PR makes that real.

The child *tries* to self-report, but can't when it's SIGINT/force-killed by the watchdog, panics, or OOM-dies — exactly the `exit status 1` cases in the logs. The orchestrator is the only component that always observes the death, so it's now the backstop.

## Changes

- **Retain `logPath`** on `managedWorkflow` (and in the restart snapshot, so it survives an exec-restart).
- **Tail ring buffer** — bounded (last 20 lines), per-line length-capped, UTF-8-safe truncation — fed by the existing log tailer.
- **`FailureReport.LogTail`** (optional) rendered as a fenced block; single-issue callers leave it nil.
- **Wire `ReportFailure` into all three orchestrator failure branches** (live + both restored paths) via a new `reportSubprocessFailure` helper carrying log path, tail, step (`FailingStepFromError`, falling back to the last observed step), and build revision. The slog line is enriched with the log path + tail too.
- **Single-reporter design:** the orchestrator sets `JIRADOZER_ORCHESTRATED=1` on each child's env; the child suppresses its own `ReportFailure` to avoid a duplicate tracker comment. Notifier + build revision threaded in via `SetFailureReporting` (no `NewOrchestrator` signature churn).

## Out of scope (recorded for follow-up)

The same log review flagged two issues that don't live in jiradozer's Go code: the Codex `sk-test` 401 (a cron env/config fix) and the Datadog `/api/v1/monitor` `IncompleteRead` workaround (lives in an external health-audit agent prompt).

## Test plan

- New unit tests: tail ring bounding / newline-strip / over-long truncation / UTF-8-boundary safety; `LogTail` rendering; `reportSubprocessFailure` fan-out (tracker comment + notifier, step-from-error precedence, nil-notifier safety).
- `scripts/lint.sh` — all checks pass
- `bazel build //jiradozer/...` and `bazel test //jiradozer/...` — 6/6 targets pass; gazelle clean, no integration BUILD churn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-issue failure alerting, watchdog classification, and config reload behavior for Slack webhooks; well-covered by new tests but affects production on-call paths.
> 
> **Overview**
> Team-mode orchestrator subprocess deaths now drive the existing **tracker comment + optional Slack** path via `ReportFailure`, with per-issue **log path** and an inline **log tail** so on-call can triage without opening log files.
> 
> The orchestrator becomes the **single reporter**: children get `JIRADOZER_ORCHESTRATED=1` and skip their own failure defer; `SetFailureReporting` / `applyFailureReporting` wire Slack and build revision at startup and on config reload. A bounded in-memory tail ring (fed by the log tailer, with file fallback after exec-restore) populates `FailureReport.LogTail` in alerts. **Watchdog kills** set `mw.hung` so hung runs are `StepFailed` with alerts, not silent cancellations. `log_path` is persisted in runtime snapshots for restored children.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e84fa2bac27eb2c71b44e60b4b68dac0c89e72b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->