### PR TITLE
fix(cursor): tolerate array-shaped tool_call frames and stop aborting reviews

### DIFF
--- a/agent-cli-wrapper/cursor/protocol.go
+++ b/agent-cli-wrapper/cursor/protocol.go
@@ -44,15 +44,24 @@ type AssistantMessage struct {
 }
 
 // ToolCallMessage represents a tool call event (started or completed).
-// The tool_call field is a map with a single key (the tool name) mapping to the tool call detail.
+//
+// The tool_call field carries a single tool call but the cursor-agent CLI emits
+// it in more than one JSON shape, so it is held as a raw message and decoded by
+// ParseToolCallDetail rather than typed directly (a typed field made the whole
+// frame — and therefore the whole session — fail when the shape drifted).
+//
+// Observed shapes:
+//   - object (documented): {"readToolCall":{"args":{...},"result":...}}
+//   - array:               [{"readToolCall":{"args":{...}}}]
+//
 // Example: {"type":"tool_call","subtype":"started","call_id":"...","tool_call":{"readToolCall":{"args":{"path":"..."}}},"session_id":"..."}
 // Example: {"type":"tool_call","subtype":"completed","call_id":"...","tool_call":{"readToolCall":{"args":{"path":"..."},"result":"..."}},"session_id":"..."}
 type ToolCallMessage struct {
-	Type      string                            `json:"type"`
-	Subtype   string                            `json:"subtype"`
-	CallID    string                            `json:"call_id"`
-	ToolCall  map[string]map[string]interface{} `json:"tool_call"`
-	SessionID string                            `json:"session_id"`
+	Type      string          `json:"type"`
+	Subtype   string          `json:"subtype"`
+	CallID    string          `json:"call_id"`
+	SessionID string          `json:"session_id"`
+	ToolCall  json.RawMessage `json:"tool_call"`
 }
 
 // ToolCallDetail holds the extracted name, args, and optional result from a tool call.
@@ -62,14 +71,24 @@ type ToolCallDetail struct {
 	Name   string
 }
 
+// toolCallEntry is the {tool_name → {args, result?}} mapping that appears either
+// directly as the tool_call object or as the elements of the tool_call array.
+type toolCallEntry map[string]map[string]interface{}
+
 // ParseToolCallDetail extracts the tool call detail from a ToolCallMessage.
-// The tool_call field is a map with a single key (tool name) → {args, result?}.
+// The tool_call field is a single-key map (tool name) → {args, result?}, which
+// the CLI emits either bare (object shape) or wrapped in a one-element array.
 func ParseToolCallDetail(msg *ToolCallMessage) (*ToolCallDetail, error) {
 	if msg == nil || len(msg.ToolCall) == 0 {
 		return nil, fmt.Errorf("empty tool_call field")
 	}
 
-	for name, detail := range msg.ToolCall {
+	entry, err := decodeToolCallEntry(msg.ToolCall)
+	if err != nil {
+		return nil, err
+	}
+
+	for name, detail := range entry {
 		d := &ToolCallDetail{Name: name}
 
 		if args, ok := detail["args"]; ok {
@@ -86,6 +105,52 @@ func ParseToolCallDetail(msg *ToolCallMessage) (*ToolCallDetail, error) {
 	}
 
 	return nil, fmt.Errorf("no tool call entries found")
+}
+
+// decodeToolCallEntry decodes the raw tool_call field into a single
+// {tool_name → detail} entry, tolerating both the object and array shapes the
+// cursor-agent CLI emits.
+func decodeToolCallEntry(raw json.RawMessage) (toolCallEntry, error) {
+	trimmed := skipJSONSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty tool_call field")
+	}
+
+	switch trimmed[0] {
+	case '{':
+		var entry toolCallEntry
+		if err := json.Unmarshal(trimmed, &entry); err != nil {
+			return nil, fmt.Errorf("decode tool_call object: %w", err)
+		}
+		return entry, nil
+	case '[':
+		var entries []toolCallEntry
+		if err := json.Unmarshal(trimmed, &entries); err != nil {
+			return nil, fmt.Errorf("decode tool_call array: %w", err)
+		}
+		for _, entry := range entries {
+			if len(entry) > 0 {
+				return entry, nil
+			}
+		}
+		return nil, fmt.Errorf("no tool call entries found")
+	default:
+		return nil, fmt.Errorf("unexpected tool_call shape: %s", string(trimmed[:1]))
+	}
+}
+
+// skipJSONSpace trims leading JSON whitespace so the first meaningful byte can
+// be inspected to discriminate object vs array shape.
+func skipJSONSpace(b []byte) []byte {
+	for len(b) > 0 {
+		switch b[0] {
+		case ' ', '\t', '\r', '\n':
+			b = b[1:]
+		default:
+			return b
+		}
+	}
+	return b
 }
 
 // ResultMessage represents the final result of a session.

--- a/agent-cli-wrapper/cursor/protocol.go
+++ b/agent-cli-wrapper/cursor/protocol.go
@@ -1,6 +1,7 @@
 package cursor
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -45,17 +46,10 @@ type AssistantMessage struct {
 
 // ToolCallMessage represents a tool call event (started or completed).
 //
-// The tool_call field carries a single tool call but the cursor-agent CLI emits
-// it in more than one JSON shape, so it is held as a raw message and decoded by
-// ParseToolCallDetail rather than typed directly (a typed field made the whole
-// frame — and therefore the whole session — fail when the shape drifted).
-//
-// Observed shapes:
+// tool_call is held raw and decoded by ParseToolCallDetail because the
+// cursor-agent CLI emits it in more than one shape:
 //   - object (documented): {"readToolCall":{"args":{...},"result":...}}
 //   - array:               [{"readToolCall":{"args":{...}}}]
-//
-// Example: {"type":"tool_call","subtype":"started","call_id":"...","tool_call":{"readToolCall":{"args":{"path":"..."}}},"session_id":"..."}
-// Example: {"type":"tool_call","subtype":"completed","call_id":"...","tool_call":{"readToolCall":{"args":{"path":"..."},"result":"..."}},"session_id":"..."}
 type ToolCallMessage struct {
 	Type      string          `json:"type"`
 	Subtype   string          `json:"subtype"`
@@ -111,7 +105,7 @@ func ParseToolCallDetail(msg *ToolCallMessage) (*ToolCallDetail, error) {
 // {tool_name → detail} entry, tolerating both the object and array shapes the
 // cursor-agent CLI emits.
 func decodeToolCallEntry(raw json.RawMessage) (toolCallEntry, error) {
-	trimmed := skipJSONSpace(raw)
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
 	if len(trimmed) == 0 {
 		return nil, fmt.Errorf("empty tool_call field")
 	}
@@ -135,22 +129,8 @@ func decodeToolCallEntry(raw json.RawMessage) (toolCallEntry, error) {
 		}
 		return nil, fmt.Errorf("no tool call entries found")
 	default:
-		return nil, fmt.Errorf("unexpected tool_call shape: %s", string(trimmed[:1]))
+		return nil, fmt.Errorf("unexpected tool_call shape: %q", trimmed[0])
 	}
-}
-
-// skipJSONSpace trims leading JSON whitespace so the first meaningful byte can
-// be inspected to discriminate object vs array shape.
-func skipJSONSpace(b []byte) []byte {
-	for len(b) > 0 {
-		switch b[0] {
-		case ' ', '\t', '\r', '\n':
-			b = b[1:]
-		default:
-			return b
-		}
-	}
-	return b
 }
 
 // ResultMessage represents the final result of a session.

--- a/agent-cli-wrapper/cursor/protocol_test.go
+++ b/agent-cli-wrapper/cursor/protocol_test.go
@@ -74,6 +74,66 @@ func TestParseMessage_ToolCallCompleted(t *testing.T) {
 	assert.Equal(t, "file contents here", detail.Result)
 }
 
+// The cursor-agent CLI sometimes emits the tool_call field as a one-element
+// array instead of a bare object. Previously this failed to unmarshal and
+// aborted the entire session; now it must parse identically to the object shape.
+func TestParseMessage_ToolCallArrayShapeStarted(t *testing.T) {
+	line := []byte(`{"type":"tool_call","subtype":"started","call_id":"call-1","tool_call":[{"readToolCall":{"args":{"path":"/tmp/test.go"}}}],"session_id":"sess-123"}`)
+
+	msg, err := ParseMessage(line)
+	require.NoError(t, err, "array-shaped tool_call must not fail to parse")
+
+	tcMsg, ok := msg.(*ToolCallMessage)
+	require.True(t, ok)
+	assert.Equal(t, "started", tcMsg.Subtype)
+	assert.Equal(t, "call-1", tcMsg.CallID)
+
+	detail, err := ParseToolCallDetail(tcMsg)
+	require.NoError(t, err)
+	assert.Equal(t, "readToolCall", detail.Name)
+	assert.Equal(t, "/tmp/test.go", detail.Args["path"])
+	assert.Nil(t, detail.Result)
+}
+
+func TestParseMessage_ToolCallArrayShapeCompleted(t *testing.T) {
+	line := []byte(`{"type":"tool_call","subtype":"completed","call_id":"call-1","tool_call":[{"readToolCall":{"args":{"path":"/tmp/test.go"},"result":"file contents here"}}],"session_id":"sess-123"}`)
+
+	msg, err := ParseMessage(line)
+	require.NoError(t, err)
+
+	tcMsg, ok := msg.(*ToolCallMessage)
+	require.True(t, ok)
+	assert.Equal(t, "completed", tcMsg.Subtype)
+
+	detail, err := ParseToolCallDetail(tcMsg)
+	require.NoError(t, err)
+	assert.Equal(t, "readToolCall", detail.Name)
+	assert.Equal(t, "/tmp/test.go", detail.Args["path"])
+	assert.Equal(t, "file contents here", detail.Result)
+}
+
+// A tool_call frame whose detail can't be interpreted still parses as a frame
+// (ParseMessage succeeds) — the session skips it rather than aborting. Only
+// ParseToolCallDetail surfaces the unusable shape, as an error the caller drops.
+func TestParseMessage_ToolCallUnrecognizedShapeIsNonFatal(t *testing.T) {
+	line := []byte(`{"type":"tool_call","subtype":"started","call_id":"call-1","tool_call":"unexpected-string","session_id":"sess-123"}`)
+
+	msg, err := ParseMessage(line)
+	require.NoError(t, err, "the frame itself must parse; only detail extraction may fail")
+
+	tcMsg, ok := msg.(*ToolCallMessage)
+	require.True(t, ok)
+
+	_, err = ParseToolCallDetail(tcMsg)
+	require.Error(t, err, "an unrecognized tool_call shape yields a detail error, not a panic")
+}
+
+func TestParseToolCallDetail_EmptyArray(t *testing.T) {
+	msg := &ToolCallMessage{ToolCall: []byte(`[]`)}
+	_, err := ParseToolCallDetail(msg)
+	require.Error(t, err)
+}
+
 func TestParseMessage_ResultSuccess(t *testing.T) {
 	line := []byte(`{"type":"result","subtype":"success","duration_ms":1234,"duration_api_ms":1000,"is_error":false,"result":"All done","session_id":"sess-123"}`)
 

--- a/agent-cli-wrapper/cursor/protocol_test.go
+++ b/agent-cli-wrapper/cursor/protocol_test.go
@@ -74,9 +74,8 @@ func TestParseMessage_ToolCallCompleted(t *testing.T) {
 	assert.Equal(t, "file contents here", detail.Result)
 }
 
-// The cursor-agent CLI sometimes emits the tool_call field as a one-element
-// array instead of a bare object. Previously this failed to unmarshal and
-// aborted the entire session; now it must parse identically to the object shape.
+// The cursor-agent CLI sometimes emits tool_call as a one-element array instead
+// of a bare object; both shapes must parse identically.
 func TestParseMessage_ToolCallArrayShapeStarted(t *testing.T) {
 	line := []byte(`{"type":"tool_call","subtype":"started","call_id":"call-1","tool_call":[{"readToolCall":{"args":{"path":"/tmp/test.go"}}}],"session_id":"sess-123"}`)
 

--- a/agent-cli-wrapper/cursor/session.go
+++ b/agent-cli-wrapper/cursor/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"sync"
 )
@@ -177,20 +178,15 @@ func (s *Session) stderrLoop() {
 	}
 }
 
-// handleLine processes a single NDJSON line.
-//
-// A line that fails to parse is skipped, not treated as fatal. The cursor-agent
-// protocol drifts (new fields, new shapes for known frames), and a single
-// unparseable line must not abort a session that is otherwise streaming useful
-// frames — historically one array-shaped tool_call frame would kill an entire
-// code-review run. Skipping mirrors how unknown-but-valid message types are
-// already dropped below. Genuinely fatal conditions (process read errors) are
-// surfaced as ErrorEvents by readLoop, not here.
+// handleLine processes a single NDJSON line. Lines that fail to parse are
+// skipped rather than aborting the session: the cursor-agent protocol drifts
+// (new shapes for known frames), and one bad frame must not discard a session
+// that is otherwise streaming useful frames. Process read errors stay fatal and
+// are surfaced as ErrorEvents by readLoop.
 func (s *Session) handleLine(line []byte, textBuilder *strings.Builder) {
 	msg, err := ParseMessage(line)
 	if err != nil {
-		// Unparseable frame (e.g. an unrecognized shape of a known type) —
-		// skip it rather than failing the whole session.
+		slog.Debug("cursor: skipping unparseable frame", "error", err, "line", string(line))
 		return
 	}
 	if msg == nil {
@@ -240,9 +236,9 @@ func (s *Session) handleAssistant(msg *AssistantMessage, textBuilder *strings.Bu
 func (s *Session) handleToolCall(msg *ToolCallMessage) {
 	detail, err := ParseToolCallDetail(msg)
 	if err != nil {
-		// Tool call frames are informational (they drive display only). If the
-		// detail can't be extracted — e.g. an unrecognized tool_call shape —
-		// skip this one frame rather than aborting the whole session.
+		// Tool call frames drive display only; skip a frame whose detail can't
+		// be extracted rather than aborting the session.
+		slog.Debug("cursor: skipping tool_call with unreadable detail", "error", err, "call_id", msg.CallID)
 		return
 	}
 

--- a/agent-cli-wrapper/cursor/session.go
+++ b/agent-cli-wrapper/cursor/session.go
@@ -2,6 +2,7 @@ package cursor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -178,14 +179,24 @@ func (s *Session) stderrLoop() {
 	}
 }
 
-// handleLine processes a single NDJSON line. Lines that fail to parse are
-// skipped rather than aborting the session: the cursor-agent protocol drifts
-// (new shapes for known frames), and one bad frame must not discard a session
-// that is otherwise streaming useful frames. Process read errors stay fatal and
-// are surfaced as ErrorEvents by readLoop.
+// handleLine processes a single NDJSON line.
+//
+// A malformed non-terminal frame (assistant, tool_call, system) is skipped, not
+// fatal: the cursor-agent protocol drifts (new shapes for known frames), and one
+// bad frame must not discard a session that is otherwise streaming useful
+// frames. The terminal "result" frame is the exception — losing it would leave
+// the caller with no TurnCompleteEvent (truncated output, or a QueryStream that
+// blocks until EOF), so a malformed result frame stays a fatal ErrorEvent.
 func (s *Session) handleLine(line []byte, textBuilder *strings.Builder) {
 	msg, err := ParseMessage(line)
 	if err != nil {
+		if isTerminalFrame(line) {
+			s.emit(ErrorEvent{
+				Error:   &ProtocolError{Message: "failed to parse message", Line: string(line), Cause: err},
+				Context: "parse_message",
+			})
+			return
+		}
 		slog.Debug("cursor: skipping unparseable frame", "error", err, "line", string(line))
 		return
 	}
@@ -204,6 +215,18 @@ func (s *Session) handleLine(line []byte, textBuilder *strings.Builder) {
 	case *ResultMessage:
 		s.handleResult(m)
 	}
+}
+
+// isTerminalFrame reports whether the raw line is a "result" frame — the one
+// frame whose loss breaks the caller contract (no TurnCompleteEvent). A line
+// whose type can't even be read is not treated as terminal: that's the
+// shape-drift case handleLine deliberately tolerates.
+func isTerminalFrame(line []byte) bool {
+	var raw RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return false
+	}
+	return raw.Type == "result"
 }
 
 func (s *Session) handleSystemInit(msg *SystemInitMessage) {

--- a/agent-cli-wrapper/cursor/session.go
+++ b/agent-cli-wrapper/cursor/session.go
@@ -1,6 +1,7 @@
 package cursor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -218,15 +219,35 @@ func (s *Session) handleLine(line []byte, textBuilder *strings.Builder) {
 }
 
 // isTerminalFrame reports whether the raw line is a "result" frame — the one
-// frame whose loss breaks the caller contract (no TurnCompleteEvent). A line
-// whose type can't even be read is not treated as terminal: that's the
-// shape-drift case handleLine deliberately tolerates.
+// frame whose loss breaks the caller contract (no TurnCompleteEvent).
+//
+// It must catch a result frame even when the line is *not* valid JSON: a
+// truncated final line is exactly the corruption most likely to hit the
+// terminal frame, and skipping it would drop the only completion signal. So a
+// clean decode is tried first, then a byte-level fallback that recognizes the
+// "type":"result" discriminator without requiring the whole line to parse.
 func isTerminalFrame(line []byte) bool {
 	var raw RawMessage
-	if err := json.Unmarshal(line, &raw); err != nil {
+	if err := json.Unmarshal(line, &raw); err == nil {
+		return raw.Type == "result"
+	}
+	return hasResultTypeDiscriminator(line)
+}
+
+// hasResultTypeDiscriminator scans raw bytes for a `"type":"result"` field,
+// tolerating insignificant whitespace around the colon, so a truncated or
+// otherwise invalid result frame is still recognized as terminal.
+func hasResultTypeDiscriminator(line []byte) bool {
+	idx := bytes.Index(line, []byte(`"type"`))
+	if idx < 0 {
 		return false
 	}
-	return raw.Type == "result"
+	rest := bytes.TrimLeft(line[idx+len(`"type"`):], " \t\r\n")
+	if len(rest) == 0 || rest[0] != ':' {
+		return false
+	}
+	rest = bytes.TrimLeft(rest[1:], " \t\r\n")
+	return bytes.HasPrefix(rest, []byte(`"result"`))
 }
 
 func (s *Session) handleSystemInit(msg *SystemInitMessage) {

--- a/agent-cli-wrapper/cursor/session.go
+++ b/agent-cli-wrapper/cursor/session.go
@@ -178,17 +178,19 @@ func (s *Session) stderrLoop() {
 }
 
 // handleLine processes a single NDJSON line.
+//
+// A line that fails to parse is skipped, not treated as fatal. The cursor-agent
+// protocol drifts (new fields, new shapes for known frames), and a single
+// unparseable line must not abort a session that is otherwise streaming useful
+// frames — historically one array-shaped tool_call frame would kill an entire
+// code-review run. Skipping mirrors how unknown-but-valid message types are
+// already dropped below. Genuinely fatal conditions (process read errors) are
+// surfaced as ErrorEvents by readLoop, not here.
 func (s *Session) handleLine(line []byte, textBuilder *strings.Builder) {
 	msg, err := ParseMessage(line)
 	if err != nil {
-		s.emit(ErrorEvent{
-			Error: &ProtocolError{
-				Message: "failed to parse message",
-				Line:    string(line),
-				Cause:   err,
-			},
-			Context: "parse_message",
-		})
+		// Unparseable frame (e.g. an unrecognized shape of a known type) —
+		// skip it rather than failing the whole session.
 		return
 	}
 	if msg == nil {
@@ -238,10 +240,9 @@ func (s *Session) handleAssistant(msg *AssistantMessage, textBuilder *strings.Bu
 func (s *Session) handleToolCall(msg *ToolCallMessage) {
 	detail, err := ParseToolCallDetail(msg)
 	if err != nil {
-		s.emit(ErrorEvent{
-			Error:   &ProtocolError{Message: "failed to parse tool call detail", Cause: err},
-			Context: "parse_tool_call",
-		})
+		// Tool call frames are informational (they drive display only). If the
+		// detail can't be extracted — e.g. an unrecognized tool_call shape —
+		// skip this one frame rather than aborting the whole session.
 		return
 	}
 

--- a/agent-cli-wrapper/cursor/session_test.go
+++ b/agent-cli-wrapper/cursor/session_test.go
@@ -130,10 +130,8 @@ func TestSession_MalformedLine(t *testing.T) {
 	assert.Empty(t, events, "a malformed line should be skipped, producing no events")
 }
 
-// A malformed or unrecognized frame in the middle of a stream must not abort the
-// session: frames before and after it are still delivered. This is the core
-// regression guard — historically one array-shaped tool_call frame killed an
-// entire code-review run.
+// A malformed or unrecognized frame mid-stream must not abort the session:
+// frames before and after it are still delivered.
 func TestSession_SkipsBadFrameAndContinues(t *testing.T) {
 	lines := []string{
 		`{"type":"system","subtype":"init","session_id":"s1","model":"cursor-fast","cwd":"/tmp","permissionMode":"auto","apiKeySource":"env"}`,

--- a/agent-cli-wrapper/cursor/session_test.go
+++ b/agent-cli-wrapper/cursor/session_test.go
@@ -118,9 +118,8 @@ func TestSession_ErrorResult(t *testing.T) {
 	assert.False(t, turnComplete.Success)
 }
 
-// A malformed line is skipped, not surfaced as a (fatal) ErrorEvent. Parse-time
-// failures must never abort the session — only process read errors (handled in
-// readLoop) are fatal.
+// A malformed line whose type can't be read is skipped, not surfaced as a
+// (fatal) ErrorEvent — it's indistinguishable from the shape-drift case.
 func TestSession_MalformedLine(t *testing.T) {
 	lines := []string{
 		`{bad json}`,
@@ -128,6 +127,35 @@ func TestSession_MalformedLine(t *testing.T) {
 
 	events := fakeSession(t, lines)
 	assert.Empty(t, events, "a malformed line should be skipped, producing no events")
+}
+
+// A malformed terminal "result" frame stays fatal: losing it would leave the
+// caller with no TurnCompleteEvent (truncated output / a stream that blocks
+// until EOF), so it must surface as an ErrorEvent rather than being skipped.
+func TestSession_MalformedResultFrameIsFatal(t *testing.T) {
+	lines := []string{
+		// Valid type discriminator, but duration_ms is a string where an int64
+		// is expected — the result body fails to unmarshal.
+		`{"type":"result","subtype":"success","duration_ms":"oops","session_id":"s1"}`,
+	}
+
+	events := fakeSession(t, lines)
+	require.Len(t, events, 1)
+
+	errEvt, ok := events[0].(ErrorEvent)
+	require.True(t, ok, "a malformed result frame must surface as an ErrorEvent")
+	assert.Equal(t, "parse_message", errEvt.Context)
+}
+
+// A malformed non-terminal frame (here, assistant) is skipped — only the result
+// frame is fatal. Losing one assistant delta is better than aborting the run.
+func TestSession_MalformedAssistantFrameIsSkipped(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","message":{"role":"assistant","content":"not-an-array"},"session_id":"s1"}`,
+	}
+
+	events := fakeSession(t, lines)
+	assert.Empty(t, events, "a malformed non-terminal frame should be skipped")
 }
 
 // A malformed or unrecognized frame mid-stream must not abort the session:

--- a/agent-cli-wrapper/cursor/session_test.go
+++ b/agent-cli-wrapper/cursor/session_test.go
@@ -12,16 +12,22 @@ import (
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/internal/ndjson"
 )
 
-// fakeSession simulates a cursor session by writing NDJSON lines to a pipe
-// and reading events from the session's handleLine method.
+// fakeSession drives the real Session.handleLine dispatch over a set of NDJSON
+// lines and collects the events it emits. It exercises production parsing code
+// directly rather than reimplementing it, so the test stays in lockstep with
+// session.go (e.g. parse/skip behavior) instead of drifting from it.
 func fakeSession(t *testing.T, lines []string) []Event {
 	t.Helper()
+
+	s := &Session{
+		events: make(chan Event, 100),
+		done:   make(chan struct{}),
+	}
 
 	pr, pw := io.Pipe()
 	go func() {
 		w := ndjson.NewWriter(pw)
 		for _, line := range lines {
-			// Write raw JSON lines
 			if err := w.WriteRaw([]byte(line)); err != nil {
 				t.Logf("write error: %v", err)
 			}
@@ -30,58 +36,18 @@ func fakeSession(t *testing.T, lines []string) []Event {
 	}()
 
 	reader := ndjson.NewReader(pr)
-	events := make(chan Event, 100)
-
-	go func() {
-		defer close(events)
-		var textBuilder strings.Builder
-		for {
-			line, err := reader.ReadLine()
-			if err != nil {
-				return
-			}
-
-			msg, err := ParseMessage(line)
-			if err != nil {
-				events <- ErrorEvent{Error: err, Context: "parse"}
-				continue
-			}
-			if msg == nil {
-				// Unknown but valid message type — skip (mirrors session.go behavior).
-				continue
-			}
-
-			// Simulate session's handleLine dispatch
-			switch m := msg.(type) {
-			case *SystemInitMessage:
-				events <- ReadyEvent{SessionID: m.SessionID, Model: m.Model}
-			case *AssistantMessage:
-				for _, block := range m.Message.Content {
-					if block.Type == "text" && block.Text != "" {
-						textBuilder.WriteString(block.Text)
-						events <- TextEvent{Text: block.Text, FullText: textBuilder.String()}
-					}
-				}
-			case *ToolCallMessage:
-				detail, err := ParseToolCallDetail(m)
-				if err != nil {
-					events <- ErrorEvent{Error: err, Context: "tool_call"}
-					continue
-				}
-				switch m.Subtype {
-				case "started":
-					events <- ToolStartEvent{ID: m.CallID, Name: detail.Name, Input: detail.Args}
-				case "completed":
-					events <- ToolCompleteEvent{ID: m.CallID, Name: detail.Name, Input: detail.Args, Result: detail.Result}
-				}
-			case *ResultMessage:
-				events <- TurnCompleteEvent{Success: !m.IsError, DurationMs: m.DurationMs, DurationAPIMs: m.DurationAPIMs}
-			}
+	var textBuilder strings.Builder
+	for {
+		line, err := reader.ReadLine()
+		if err != nil {
+			break
 		}
-	}()
+		s.handleLine(line, &textBuilder)
+	}
+	close(s.events)
 
 	var collected []Event
-	for evt := range events {
+	for evt := range s.events {
 		collected = append(collected, evt)
 	}
 	return collected
@@ -152,17 +118,55 @@ func TestSession_ErrorResult(t *testing.T) {
 	assert.False(t, turnComplete.Success)
 }
 
+// A malformed line is skipped, not surfaced as a (fatal) ErrorEvent. Parse-time
+// failures must never abort the session — only process read errors (handled in
+// readLoop) are fatal.
 func TestSession_MalformedLine(t *testing.T) {
 	lines := []string{
 		`{bad json}`,
 	}
 
 	events := fakeSession(t, lines)
-	require.Len(t, events, 1)
+	assert.Empty(t, events, "a malformed line should be skipped, producing no events")
+}
 
-	errEvt, ok := events[0].(ErrorEvent)
+// A malformed or unrecognized frame in the middle of a stream must not abort the
+// session: frames before and after it are still delivered. This is the core
+// regression guard — historically one array-shaped tool_call frame killed an
+// entire code-review run.
+func TestSession_SkipsBadFrameAndContinues(t *testing.T) {
+	lines := []string{
+		`{"type":"system","subtype":"init","session_id":"s1","model":"cursor-fast","cwd":"/tmp","permissionMode":"auto","apiKeySource":"env"}`,
+		`{bad json}`, // malformed — skipped
+		`{"type":"tool_call","subtype":"started","call_id":"c1","tool_call":"unparseable-detail","session_id":"s1"}`,                             // bad detail — skipped
+		`{"type":"tool_call","subtype":"started","call_id":"c2","tool_call":[{"readToolCall":{"args":{"path":"/tmp/x.go"}}}],"session_id":"s1"}`, // array shape — delivered
+		`{"type":"result","subtype":"success","duration_ms":1,"duration_api_ms":1,"is_error":false,"result":"done","session_id":"s1"}`,
+	}
+
+	events := fakeSession(t, lines)
+
+	// No ErrorEvents — nothing here is fatal.
+	for _, evt := range events {
+		_, isErr := evt.(ErrorEvent)
+		assert.False(t, isErr, "no frame in this stream should produce a fatal ErrorEvent")
+	}
+
+	// Ready, the array-shaped tool start, and the terminal result all survive.
+	require.Len(t, events, 3)
+
+	ready, ok := events[0].(ReadyEvent)
 	require.True(t, ok)
-	assert.Equal(t, "parse", errEvt.Context)
+	assert.Equal(t, "s1", ready.SessionID)
+
+	toolStart, ok := events[1].(ToolStartEvent)
+	require.True(t, ok)
+	assert.Equal(t, "c2", toolStart.ID)
+	assert.Equal(t, "readToolCall", toolStart.Name)
+	assert.Equal(t, "/tmp/x.go", toolStart.Input["path"])
+
+	turn, ok := events[2].(TurnCompleteEvent)
+	require.True(t, ok)
+	assert.True(t, turn.Success)
 }
 
 func TestNewSession_DefaultConfig(t *testing.T) {

--- a/agent-cli-wrapper/cursor/session_test.go
+++ b/agent-cli-wrapper/cursor/session_test.go
@@ -147,6 +147,24 @@ func TestSession_MalformedResultFrameIsFatal(t *testing.T) {
 	assert.Equal(t, "parse_message", errEvt.Context)
 }
 
+// A truncated (syntactically invalid) result frame must still be fatal —
+// truncation is the corruption most likely to hit the final line, and the raw
+// "type":"result" discriminator must trip the fatal path even when the line
+// can't be decoded.
+func TestSession_TruncatedResultFrameIsFatal(t *testing.T) {
+	lines := []string{
+		// Valid up to the type discriminator, then cut off mid-frame.
+		`{"type":"result","subtype":"success","duration_ms":12`,
+	}
+
+	events := fakeSession(t, lines)
+	require.Len(t, events, 1)
+
+	errEvt, ok := events[0].(ErrorEvent)
+	require.True(t, ok, "a truncated result frame must surface as an ErrorEvent")
+	assert.Equal(t, "parse_message", errEvt.Context)
+}
+
 // A malformed non-terminal frame (here, assistant) is skipped — only the result
 // frame is fatal. Losing one assistant delta is better than aborting the run.
 func TestSession_MalformedAssistantFrameIsSkipped(t *testing.T) {


### PR DESCRIPTION
## Problem

Recent bramble code-review runs against the **cursor backend** were failing. Across the last ~7 days of `~/.bramble/logs/code-review/*.log`, **42 cursor runs exited with `status=error`**, with this exact error in 27 logs:

```
E backend.go:414] reviewer error context=parse_message
  error="protocol error: failed to parse message: failed to parse tool_call message:
  json: cannot unmarshal array into Go struct field ToolCallMessage.tool_call of type map[string]interface {}"
E codereview.go:291] review failed error="cursor: error: protocol error: ..."
```

## Root cause

`agent-cli-wrapper/cursor/protocol.go` typed the `tool_call` field as `map[string]map[string]interface{}`, but the cursor-agent CLI (v`2026.06.15`) **intermittently emits it as a JSON array** instead of the documented object shape. `json.Unmarshal` fails on the type mismatch.

Worse, the failure was **fatal**: `session.go:handleLine` emitted an `ErrorEvent` on any parse error, which the reviewer bridge (`reviewer/backend.go`) treats as terminal — so a *single* unparseable frame discarded an otherwise-complete review (often within the first ~40s, `issue_count=0`), even though cursor had done useful work.

## Fix

Two changes, both in the cursor wrapper (the correct layer — this is the wrapper's own parser being too strict about real CLI output, per the repo's "fix in the tool, not the wrapper" principle):

1. **Shape tolerance** — `ToolCallMessage.ToolCall` is now `json.RawMessage`, decoded in `ParseToolCallDetail`, which handles both the object shape and the one-element array shape (and rejects anything else gracefully).
2. **Non-fatal frames** — parse failures in `handleLine` and `handleToolCall` are now **skipped** (mirroring how unknown message types were already dropped) instead of aborting the session. Only genuine process read errors remain fatal. Defense-in-depth against future cursor protocol drift.

Also refactors the `fakeSession` test helper to drive the **real** `Session.handleLine` instead of reimplementing it — the duplicate had already drifted from production (a parallel-path-drift risk flagged in the repo's engineering principles).

## Tests

- `protocol_test.go`: array-shape started/completed, unrecognized-shape non-fatal, empty array.
- `session_test.go`: malformed line skipped (no events); stream-level regression guard proving a bad frame mid-stream doesn't abort delivery of surrounding frames.

## Verification

- `scripts/lint.sh` → all checks passed
- `bazel build //...` → success
- `bazel test //...` → all pass (`//agent-cli-wrapper/cursor` and `//yoloswe/reviewer` green)
- **End-to-end:** a real `bramble code-review --backend cursor` run against a seeded diff completed with `status=ok`, `verdict=rejected`, `issue_count=2` (correctly found a division-by-zero bug), with **no** `parse_message` / `review failed` lines in the new log.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cursor session completion semantics (only `result` parse failures are fatal); behavior is well-tested but affects how reviewer streams terminate on partial/corrupt output.
> 
> **Overview**
> Fixes **cursor-backed code reviews** failing when the cursor-agent CLI emits `tool_call` as a one-element JSON array instead of the documented object shape.
> 
> **Protocol:** `ToolCallMessage.tool_call` is now `json.RawMessage`, with `decodeToolCallEntry` accepting both object and array forms. Unrecognized shapes still fail at `ParseToolCallDetail`, not at frame unmarshal.
> 
> **Session resilience:** `handleLine` **skips** bad non-terminal frames (debug log only) instead of emitting fatal `ErrorEvent`s; malformed **`result`** frames remain fatal, including truncated lines detected via `isTerminalFrame` / `hasResultTypeDiscriminator`. Unreadable tool-call details are skipped rather than aborting the stream.
> 
> **Tests:** `fakeSession` now drives real `Session.handleLine`; added protocol and session tests for array shapes, skip-vs-fatal behavior, and mid-stream recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087ae16cc54ec052f6bbf8f769ac9498ff0519c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->