### PR TITLE
fix(multiagent): resolve clean stream close after ScheduleWakeup+bg turn as success

### DIFF
--- a/jiradozer/integration/validate_pr_polish_local_test.go
+++ b/jiradozer/integration/validate_pr_polish_local_test.go
@@ -259,6 +259,18 @@ Do these steps, then END YOUR TURN immediately (do not wait, do not summarize at
 	logs := buf.String()
 	assert.NotContains(t, strings.ToLower(logs), "agent failed",
 		"a clean ScheduleWakeup+bg turn must not surface 'agent failed'")
+
+	// The doneMarker proves the bg Monitor actually ran to completion — i.e.
+	// the ScheduleWakeup + bg-Monitor EOF path this test guards was exercised,
+	// not a degenerate run where the model skipped the tools and the step
+	// passed trivially. Mirrors the slow-marker check in TestValidate_PRPolishLocal:
+	// log (don't hard-fail) if absent, since the model could deviate, but assert
+	// it when present so a green run is real coverage.
+	if _, statErr := os.Stat(doneMarker); statErr != nil {
+		t.Logf("bg-done marker missing (%v) — model may not have launched the Monitor; EOF path may not have been exercised", statErr)
+	} else {
+		t.Logf("bg-done marker present — ScheduleWakeup + bg-Monitor EOF path exercised")
+	}
 }
 
 // multiWriter is a tiny tee that writes into two writers while grabbing a

--- a/jiradozer/integration/validate_pr_polish_local_test.go
+++ b/jiradozer/integration/validate_pr_polish_local_test.go
@@ -193,6 +193,89 @@ After BOTH settle, report their terminal statuses. Do not edit any files.`,
 		"post-refactor logs must not reference the removed guard")
 }
 
+// TestValidate_ScheduleWakeupWithBgMonitor — end-to-end regression for the
+// INF-1400 false failure (jiradozer run 1781627251447569146): a validate round
+// that ends its turn on a ScheduleWakeup plus a background Monitor that
+// completes. The terminal task notification invalidates the live wave and the
+// CLI then exits — the stream closes before any continuation ResultMessage.
+// Before the fix the multiagent provider returned Success=false/Error=nil for
+// this clean exit, which jiradozer's agent runner reported as the bare
+// "validate round N/N: agent failed" seen in the log. The Validate step must
+// instead complete successfully.
+func TestValidate_ScheduleWakeupWithBgMonitor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	workDir := t.TempDir()
+	binDir := t.TempDir()
+	writeFakeBramble(t, binDir)
+
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+
+	buf := &captureLogBuffer{}
+	logger := slog.New(slog.NewTextHandler(
+		multiWriter(os.Stderr, &buf.b, &buf.mu),
+		&slog.HandlerOptions{Level: slog.LevelInfo},
+	))
+
+	issue := e2eIssue()
+	ft := NewFakeTracker(e2eWorkflowStates())
+	ft.AddIssue(*issue)
+
+	cfg := e2eConfig(t, workDir)
+	doneMarker := filepath.Join(workDir, "inf1400_bg_done.txt")
+	cfg.Validate = jiradozer.StepConfig{
+		Model:           "haiku",
+		PermissionMode:  "bypass",
+		MaxTurns:        6,
+		MaxBudgetUSD:    2.0,
+		AutoApprove:     true,
+		CommentTemplate: e2eCompleteCommentTemplate,
+		Prompt: `Issue: {{.Identifier}} — {{.Title}}
+
+Do these steps, then END YOUR TURN immediately (do not wait, do not summarize at length):
+
+1. Launch a Monitor tool running ` + "`bramble code-review --backend cursor --goal fake && echo INF1400_BG_DONE > " + doneMarker + "`" + ` — this completes in ~12s.
+2. Call the ScheduleWakeup tool with delaySeconds 60 and a short reason like "checking background work".
+3. End your turn. Do not edit any files.`,
+	}
+
+	wf := jiradozer.NewWorkflow(ft, issue, cfg, logger)
+	var transitions []jiradozer.WorkflowStep
+	var mu sync.Mutex
+	wf.OnTransition = func(step jiradozer.WorkflowStep) {
+		mu.Lock()
+		transitions = append(transitions, step)
+		mu.Unlock()
+		t.Logf("transition → %s", step)
+	}
+
+	err := wf.Run(ctx)
+	require.NoError(t, err, "workflow must not surface a false 'agent failed' for a ScheduleWakeup+bg-Monitor turn")
+
+	mu.Lock()
+	got := append([]jiradozer.WorkflowStep(nil), transitions...)
+	mu.Unlock()
+	sawValidateReview := false
+	for _, step := range got {
+		if step == jiradozer.StepValidateReview {
+			sawValidateReview = true
+			break
+		}
+	}
+	assert.True(t, sawValidateReview, "Validate step should have transitioned to ValidateReview")
+
+	logs := buf.String()
+	assert.NotContains(t, strings.ToLower(logs), "agent failed",
+		"a clean ScheduleWakeup+bg turn must not surface 'agent failed'")
+}
+
 // multiWriter is a tiny tee that writes into two writers while grabbing a
 // mutex on the second (since bytes.Buffer is not concurrency-safe and the
 // slog handler writes from multiple goroutines).

--- a/jiradozer/integration/validate_pr_polish_local_test.go
+++ b/jiradozer/integration/validate_pr_polish_local_test.go
@@ -97,6 +97,60 @@ func (c *captureLogBuffer) String() string {
 	return c.b.String()
 }
 
+// setupValidateWorkflow wires the shared fake-bramble integration harness: a
+// fake `bramble` on PATH, a log-capturing logger, a FakeTracker seeded with the
+// e2e issue, and a Workflow whose OnTransition records every step. It returns
+// the workflow plus the capture buffer and a thread-safe accessor for the
+// recorded transitions. Callers supply the already-customised cfg (typically
+// with a per-test cfg.Validate prompt).
+func setupValidateWorkflow(t *testing.T, binDir string, cfg *jiradozer.Config) (*jiradozer.Workflow, *captureLogBuffer, func() []jiradozer.WorkflowStep) {
+	t.Helper()
+	writeFakeBramble(t, binDir)
+
+	// Prepend fake binDir to PATH so the agent's Bash/Monitor tools pick it up
+	// instead of any real bramble binary.
+	origPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+
+	buf := &captureLogBuffer{}
+	logger := slog.New(slog.NewTextHandler(
+		multiWriter(os.Stderr, &buf.b, &buf.mu),
+		&slog.HandlerOptions{Level: slog.LevelInfo},
+	))
+
+	issue := e2eIssue()
+	ft := NewFakeTracker(e2eWorkflowStates())
+	ft.AddIssue(*issue)
+
+	wf := jiradozer.NewWorkflow(ft, issue, cfg, logger)
+	var transitions []jiradozer.WorkflowStep
+	var mu sync.Mutex
+	wf.OnTransition = func(step jiradozer.WorkflowStep) {
+		mu.Lock()
+		transitions = append(transitions, step)
+		mu.Unlock()
+		t.Logf("transition → %s", step)
+	}
+
+	snapshot := func() []jiradozer.WorkflowStep {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]jiradozer.WorkflowStep(nil), transitions...)
+	}
+	return wf, buf, snapshot
+}
+
+// sawStep reports whether want appears in the recorded transitions.
+func sawStep(steps []jiradozer.WorkflowStep, want jiradozer.WorkflowStep) bool {
+	for _, step := range steps {
+		if step == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestValidate_PRPolishLocal (C14) — the post-refactor regression for the
 // INF-401 workflow failure. See file comment for invariants.
 func TestValidate_PRPolishLocal(t *testing.T) {
@@ -108,25 +162,6 @@ func TestValidate_PRPolishLocal(t *testing.T) {
 	defer cancel()
 
 	workDir := t.TempDir()
-	binDir := t.TempDir()
-	writeFakeBramble(t, binDir)
-
-	// Prepend fake binDir to PATH so the agent's Bash/Monitor tools pick
-	// it up instead of any real bramble binary.
-	origPath := os.Getenv("PATH")
-	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
-	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
-
-	// Capture logs so we can assert removed signals absent.
-	buf := &captureLogBuffer{}
-	logger := slog.New(slog.NewTextHandler(
-		multiWriter(os.Stderr, &buf.b, &buf.mu),
-		&slog.HandlerOptions{Level: slog.LevelInfo},
-	))
-
-	issue := e2eIssue()
-	ft := NewFakeTracker(e2eWorkflowStates())
-	ft.AddIssue(*issue)
 
 	cfg := e2eConfig(t, workDir)
 	// Redirect Validate to the pr-polish-style prompt. We write out the
@@ -150,15 +185,7 @@ You MUST launch TWO bg tool_uses in the SAME turn (do both before waiting):
 After BOTH settle, report their terminal statuses. Do not edit any files.`,
 	}
 
-	wf := jiradozer.NewWorkflow(ft, issue, cfg, logger)
-	var transitions []jiradozer.WorkflowStep
-	var mu sync.Mutex
-	wf.OnTransition = func(step jiradozer.WorkflowStep) {
-		mu.Lock()
-		transitions = append(transitions, step)
-		mu.Unlock()
-		t.Logf("transition → %s", step)
-	}
+	wf, buf, transitions := setupValidateWorkflow(t, t.TempDir(), cfg)
 
 	start := time.Now()
 	err := wf.Run(ctx)
@@ -166,17 +193,8 @@ After BOTH settle, report their terminal statuses. Do not edit any files.`,
 	require.NoError(t, err, "workflow should not error")
 
 	// Invariant 1: Validate step transitioned past review (not refused).
-	mu.Lock()
-	got := append([]jiradozer.WorkflowStep(nil), transitions...)
-	mu.Unlock()
-	sawValidateReview := false
-	for _, step := range got {
-		if step == jiradozer.StepValidateReview {
-			sawValidateReview = true
-			break
-		}
-	}
-	assert.True(t, sawValidateReview, "Validate step should have transitioned to ValidateReview")
+	assert.True(t, sawStep(transitions(), jiradozer.StepValidateReview),
+		"Validate step should have transitioned to ValidateReview")
 
 	// Invariant 2: elapsed >= 12s (the slow Monitor ran to completion).
 	if _, statErr := os.Stat(slowMarker); statErr != nil {
@@ -211,22 +229,6 @@ func TestValidate_ScheduleWakeupWithBgMonitor(t *testing.T) {
 	defer cancel()
 
 	workDir := t.TempDir()
-	binDir := t.TempDir()
-	writeFakeBramble(t, binDir)
-
-	origPath := os.Getenv("PATH")
-	require.NoError(t, os.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath))
-	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
-
-	buf := &captureLogBuffer{}
-	logger := slog.New(slog.NewTextHandler(
-		multiWriter(os.Stderr, &buf.b, &buf.mu),
-		&slog.HandlerOptions{Level: slog.LevelInfo},
-	))
-
-	issue := e2eIssue()
-	ft := NewFakeTracker(e2eWorkflowStates())
-	ft.AddIssue(*issue)
 
 	cfg := e2eConfig(t, workDir)
 	doneMarker := filepath.Join(workDir, "inf1400_bg_done.txt")
@@ -246,30 +248,13 @@ Do these steps, then END YOUR TURN immediately (do not wait, do not summarize at
 3. End your turn. Do not edit any files.`,
 	}
 
-	wf := jiradozer.NewWorkflow(ft, issue, cfg, logger)
-	var transitions []jiradozer.WorkflowStep
-	var mu sync.Mutex
-	wf.OnTransition = func(step jiradozer.WorkflowStep) {
-		mu.Lock()
-		transitions = append(transitions, step)
-		mu.Unlock()
-		t.Logf("transition → %s", step)
-	}
+	wf, buf, transitions := setupValidateWorkflow(t, t.TempDir(), cfg)
 
 	err := wf.Run(ctx)
 	require.NoError(t, err, "workflow must not surface a false 'agent failed' for a ScheduleWakeup+bg-Monitor turn")
 
-	mu.Lock()
-	got := append([]jiradozer.WorkflowStep(nil), transitions...)
-	mu.Unlock()
-	sawValidateReview := false
-	for _, step := range got {
-		if step == jiradozer.StepValidateReview {
-			sawValidateReview = true
-			break
-		}
-	}
-	assert.True(t, sawValidateReview, "Validate step should have transitioned to ValidateReview")
+	assert.True(t, sawStep(transitions(), jiradozer.StepValidateReview),
+		"Validate step should have transitioned to ValidateReview")
 
 	logs := buf.String()
 	assert.NotContains(t, strings.ToLower(logs), "agent failed",

--- a/jiradozer/integration/validate_pr_polish_local_test.go
+++ b/jiradozer/integration/validate_pr_polish_local_test.go
@@ -261,16 +261,14 @@ Do these steps, then END YOUR TURN immediately (do not wait, do not summarize at
 		"a clean ScheduleWakeup+bg turn must not surface 'agent failed'")
 
 	// The doneMarker proves the bg Monitor actually ran to completion — i.e.
-	// the ScheduleWakeup + bg-Monitor EOF path this test guards was exercised,
-	// not a degenerate run where the model skipped the tools and the step
-	// passed trivially. Mirrors the slow-marker check in TestValidate_PRPolishLocal:
-	// log (don't hard-fail) if absent, since the model could deviate, but assert
-	// it when present so a green run is real coverage.
-	if _, statErr := os.Stat(doneMarker); statErr != nil {
-		t.Logf("bg-done marker missing (%v) — model may not have launched the Monitor; EOF path may not have been exercised", statErr)
-	} else {
-		t.Logf("bg-done marker present — ScheduleWakeup + bg-Monitor EOF path exercised")
-	}
+	// the ScheduleWakeup + bg-Monitor EOF path this test guards was exercised.
+	// Required (not best-effort): unlike TestValidate_PRPolishLocal, whose
+	// prompt has a legitimate sync-tool fallback, this test's entire purpose is
+	// the bg-Monitor EOF path, so a run that skipped it gives zero regression
+	// signal and must fail rather than pass green.
+	_, statErr := os.Stat(doneMarker)
+	require.NoError(t, statErr,
+		"bg-done marker missing — the ScheduleWakeup + bg-Monitor EOF path was not exercised, so this regression proved nothing")
 }
 
 // multiWriter is a tiny tee that writes into two writers while grabbing a

--- a/multiagent/agent/claude_provider.go
+++ b/multiagent/agent/claude_provider.go
@@ -192,8 +192,10 @@ eventLoop:
 			case ev, ok := <-events:
 				if !ok {
 					// Stream closed: terminal. Mirror the closed-stream path
-					// below — never a retryable TransientError.
-					return state.ToTurnResult(), state.Err()
+					// below — never a retryable TransientError. Resolve via the
+					// terminal path so a clean EOF after a successful wave that
+					// was invalidated for an absent continuation reports success.
+					return state.ToTerminalTurnResult(), state.Err()
 				}
 				// The grace timer already fired (its channel is drained but
 				// graceTimer is still non-nil). Clear it, then fall through to
@@ -224,7 +226,12 @@ eventLoop:
 				// A closed stream is terminal, not a transient stall: unlike the
 				// grace path above, don't reclassify a Success=false/Err=nil
 				// result as transient — there is no live session left to resume.
-				return state.ToTurnResult(), state.Err()
+				// Resolve via the terminal path: a clean EOF after a successful
+				// wave that was invalidated for a continuation which never
+				// re-resulted (e.g. a turn that ended on ScheduleWakeup + a
+				// completed background Monitor) is a success, not a silent
+				// Success=false/Error=nil that callers read as "agent failed".
+				return state.ToTerminalTurnResult(), state.Err()
 			}
 			state.Apply(ev)
 			if dispatch != nil {

--- a/multiagent/agent/claude_provider_grace_test.go
+++ b/multiagent/agent/claude_provider_grace_test.go
@@ -530,6 +530,114 @@ func TestConsumeTurnEvents_GraceResetsAcrossContinuationWave(t *testing.T) {
 		"wave 2 must get a fresh grace window, not wave 1's leftover slack")
 }
 
+// INF-1400 repro at the streamTurn layer (jiradozer run 1781627251447569146,
+// /pr-polish-style validate round 3): the agent ends its turn on a
+// ScheduleWakeup plus a background Monitor that *completes*; a terminal task
+// notification invalidates the wave's Result+TurnComplete pair (lastResult ->
+// nil), and the CLI then exits cleanly — the event stream CLOSES before any
+// continuation ResultMessage arrives. This is distinct from the grace path
+// (TestConsumeTurnEvents_GraceForcedNonSuccessIsTransient): there the stream
+// stays open and silent with a live bg tool, so the stall is transient. Here
+// the stream is closed — the CLI process is gone, there is nothing to resume —
+// so a turn that produced a successful wave must resolve as a terminal success,
+// NOT the silent Success=false/Error=nil that a caller (jiradozer) reads as a
+// bare "agent failed".
+func TestConsumeTurnEvents_ClosedStreamAfterInvalidatedSuccessIsSuccess(t *testing.T) {
+	events := make(chan claude.Event, 16)
+	// Wave 1: assistant ends on a bg Monitor; CLI fires a successful Result +
+	// TurnComplete while the bg task is still live.
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+	}
+	events <- claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")}
+	events <- resultMessage(false) // Success=true; recorded as lastSuccessfulResult
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true}
+	// The bg work completes: a terminal notification invalidates the wave's
+	// Result+TurnComplete pair (lastResult -> nil) and the bg tool finishes.
+	events <- claude.TaskNotificationEvent{
+		TaskID: "task1", ToolUseID: strPtr("toolu_bg1"), Status: "completed",
+	}
+	// The CLI exits cleanly — no continuation ResultMessage arrives.
+	close(events)
+
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, time.Hour, nil, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeTurnEvents hung on a closed stream")
+	}
+	require.NoError(t, err, "a clean EOF must not synthesize an error")
+	require.NotNil(t, result)
+	require.True(t, result.Success,
+		"a clean stream close after a successful-then-invalidated wave must resolve as success")
+}
+
+// Negative case: a stream that closes before ANY successful ResultMessage is a
+// real failure — the terminal-EOF resolution must NOT manufacture success.
+func TestConsumeTurnEvents_ClosedStreamBeforeAnyResultIsFailure(t *testing.T) {
+	events := make(chan claude.Event, 8)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{asstTextBlock("starting")},
+	}
+	// No ResultMessage ever arrives; the stream just closes.
+	close(events)
+
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, time.Hour, nil, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeTurnEvents hung on a closed stream")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.Success,
+		"a stream that closes before any successful result must report Success=false")
+}
+
+// Negative case: a stream that closes after an ERROR result must surface the
+// error unchanged — the terminal-EOF resolution must never mask a real error,
+// even though no live bg tool keeps the turn gated.
+func TestConsumeTurnEvents_ClosedStreamAfterErrorPreservesError(t *testing.T) {
+	events := make(chan claude.Event, 8)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{asstTextBlock("oops")},
+	}
+	events <- resultMessage(true) // error result -> state.err set, Success=false
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: false}
+	close(events)
+
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, time.Hour, nil, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeTurnEvents hung on a closed stream")
+	}
+	require.Error(t, err, "a closed stream after an error result must surface the error")
+	require.NotNil(t, result)
+	require.False(t, result.Success)
+}
+
 // resolveGracePeriod must honor a positive ExecuteConfig override and fall back
 // to the provider default for the zero value. This is the per-step
 // configurability that lets long-running background work (e.g. bramble

--- a/multiagent/agent/claude_provider_grace_test.go
+++ b/multiagent/agent/claude_provider_grace_test.go
@@ -577,6 +577,47 @@ func TestConsumeTurnEvents_ClosedStreamAfterInvalidatedSuccessIsSuccess(t *testi
 	require.NotNil(t, result)
 	require.True(t, result.Success,
 		"a clean stream close after a successful-then-invalidated wave must resolve as success")
+	require.Equal(t, int64(100), result.DurationMs,
+		"terminal resolution must restore the successful wave's duration (resultMessage sets 100)")
+}
+
+// A failed/killed/timeout bg task at a clean stream close must NOT be reported
+// as success: the successful end-of-turn result fired while the Monitor was
+// still live, the Monitor then failed, and the CLI exited without a
+// continuation. Without the failed-task gate this would mask the failure as a
+// terminal success.
+func TestConsumeTurnEvents_ClosedStreamAfterFailedBgTaskIsFailure(t *testing.T) {
+	events := make(chan claude.Event, 16)
+	events <- claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+	}
+	events <- claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")}
+	events <- resultMessage(false) // successful end-of-turn while bg still live
+	events <- claude.TurnCompleteEvent{TurnNumber: 1, Success: true}
+	// The Monitor FAILS: terminal notification invalidates the wave and marks
+	// the bg work failed.
+	events <- claude.TaskNotificationEvent{
+		TaskID: "task1", ToolUseID: strPtr("toolu_bg1"), Status: "failed",
+	}
+	close(events) // CLI exits without a continuation ResultMessage
+
+	done := make(chan struct{})
+	var result *claude.TurnResult
+	var err error
+	go func() {
+		result, err = consumeTurnEvents(context.Background(), events, time.Hour, nil, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeTurnEvents hung on a closed stream")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.Success,
+		"a clean stream close after a FAILED bg task must not be reported as success")
 }
 
 // Negative case: a stream that closes before ANY successful ResultMessage is a

--- a/multiagent/agent/turn_state.go
+++ b/multiagent/agent/turn_state.go
@@ -14,6 +14,16 @@ type logicalTurnState struct {
 	lastResult       *claude.ResultMessageEvent
 	lastTurnComplete *claude.TurnCompleteEvent
 
+	// lastSuccessfulResult records the most recent non-error ResultMessageEvent
+	// of the logical turn. Unlike lastResult, it is NOT cleared by
+	// invalidateForContinuation, so it survives a continuation wave that was
+	// armed but never re-resulted before the stream closed. This is the only
+	// evidence that the turn ever succeeded once invalidation has nilled
+	// lastResult; the terminal-EOF resolution path consults it so a clean CLI
+	// exit after a successful wave is reported as success, not a silent
+	// Success=false. See claude_provider.go's closed-stream branches.
+	lastSuccessfulResult *claude.ResultMessageEvent
+
 	err error
 
 	liveTaskIDs           map[string]struct{}
@@ -139,6 +149,10 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 			s.err = e.Error
 		} else {
 			s.err = nil
+			// Record the last non-error completion. This sticks across
+			// invalidateForContinuation so a clean stream close after a
+			// successful wave can still be resolved as success.
+			s.lastSuccessfulResult = &result
 		}
 
 	case claude.TurnCompleteEvent:
@@ -239,6 +253,14 @@ func (s *logicalTurnState) Success() bool {
 	return s.lastResult != nil && !s.lastResult.IsError
 }
 
+// TurnSucceededTerminally reports whether the logical turn ever produced a
+// successful completion that should hold at a clean stream close, even if the
+// last wave was invalidated for a continuation that never re-resulted. It is
+// only meaningful when no error is outstanding — a real error always wins.
+func (s *logicalTurnState) TurnSucceededTerminally() bool {
+	return s.err == nil && s.lastSuccessfulResult != nil
+}
+
 func (s *logicalTurnState) DurationMs() int64 {
 	if s.lastResult == nil {
 		return 0
@@ -257,6 +279,25 @@ func (s *logicalTurnState) ToTurnResult() *claude.TurnResult {
 		ContentBlocks: s.blocks,
 		Error:         s.err,
 	}
+}
+
+// ToTerminalTurnResult resolves the turn at a clean stream close (EOF with no
+// error). It differs from ToTurnResult only in the success determination: when
+// the live wave was invalidated for a continuation that never arrived
+// (lastResult == nil) but an earlier wave succeeded (TurnSucceededTerminally),
+// the turn is reported as success. A real error or a turn that closed before
+// any successful result still reports Success=false via the normal path.
+func (s *logicalTurnState) ToTerminalTurnResult() *claude.TurnResult {
+	result := s.ToTurnResult()
+	if !result.Success && s.TurnSucceededTerminally() {
+		result.Success = true
+		// Surface the last successful wave's duration; usage/text/blocks
+		// already accumulate across waves and survive invalidation.
+		if s.lastSuccessfulResult != nil {
+			result.DurationMs = s.lastSuccessfulResult.DurationMs
+		}
+	}
+	return result
 }
 
 // backgroundToolNames lists tool names the CLI treats as background even

--- a/multiagent/agent/turn_state.go
+++ b/multiagent/agent/turn_state.go
@@ -291,11 +291,11 @@ func (s *logicalTurnState) ToTerminalTurnResult() *claude.TurnResult {
 	result := s.ToTurnResult()
 	if !result.Success && s.TurnSucceededTerminally() {
 		result.Success = true
-		// Surface the last successful wave's duration; usage/text/blocks
-		// already accumulate across waves and survive invalidation.
-		if s.lastSuccessfulResult != nil {
-			result.DurationMs = s.lastSuccessfulResult.DurationMs
-		}
+		// Surface the last successful wave's duration (ToTurnResult derived 0
+		// from the nilled lastResult); usage/text/blocks already accumulate
+		// across waves and survive invalidation. TurnSucceededTerminally
+		// guarantees lastSuccessfulResult is non-nil here.
+		result.DurationMs = s.lastSuccessfulResult.DurationMs
 	}
 	return result
 }

--- a/multiagent/agent/turn_state.go
+++ b/multiagent/agent/turn_state.go
@@ -47,6 +47,15 @@ type logicalTurnState struct {
 	// forcedDone latches a terminal TurnCompleteEvent with WakeupTimedOut set;
 	// LogicalTurnDone short-circuits on it.
 	forcedDone bool
+
+	// sawFailedBgTask latches when any background task reached a non-success
+	// terminal status (failed/killed/timeout). The terminal-EOF resolution
+	// must NOT report success when a bg task failed: a turn can emit a
+	// successful end-of-turn result while a Monitor is still live, then have
+	// that Monitor fail and the CLI exit without a continuation result. Without
+	// this gate, lastSuccessfulResult alone would mask the failed bg work as
+	// success. Consulted only by TurnSucceededTerminally.
+	sawFailedBgTask bool
 }
 
 func newLogicalTurnState() *logicalTurnState {
@@ -107,6 +116,9 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 		// set — completed, failed, killed, timeout all count as "done".
 		s.terminalTaskIDs[e.TaskID] = struct{}{}
 		delete(s.liveTaskIDs, e.TaskID)
+		if isFailedTaskStatus(e.Status) {
+			s.sawFailedBgTask = true
+		}
 		toolUseID := ""
 		if e.ToolUseID != nil {
 			toolUseID = *e.ToolUseID
@@ -127,6 +139,9 @@ func (s *logicalTurnState) Apply(ev claude.Event) {
 				delete(s.liveTaskIDs, e.TaskID)
 				if tuid := s.taskToToolUse[e.TaskID]; tuid != "" {
 					s.completedBgToolUseIDs[tuid] = struct{}{}
+				}
+				if isFailedTaskStatus(*e.Status) {
+					s.sawFailedBgTask = true
 				}
 				s.invalidateForContinuation()
 			}
@@ -256,9 +271,11 @@ func (s *logicalTurnState) Success() bool {
 // TurnSucceededTerminally reports whether the logical turn ever produced a
 // successful completion that should hold at a clean stream close, even if the
 // last wave was invalidated for a continuation that never re-resulted. It is
-// only meaningful when no error is outstanding — a real error always wins.
+// only meaningful when no error is outstanding — a real error always wins —
+// and never holds when a background task reached a failed/killed/timeout
+// terminal status, which the absent continuation result would otherwise mask.
 func (s *logicalTurnState) TurnSucceededTerminally() bool {
-	return s.err == nil && s.lastSuccessfulResult != nil
+	return s.err == nil && !s.sawFailedBgTask && s.lastSuccessfulResult != nil
 }
 
 func (s *logicalTurnState) DurationMs() int64 {
@@ -298,6 +315,18 @@ func (s *logicalTurnState) ToTerminalTurnResult() *claude.TurnResult {
 		result.DurationMs = s.lastSuccessfulResult.DurationMs
 	}
 	return result
+}
+
+// isFailedTaskStatus reports whether a terminal background-task status is a
+// failure rather than a clean completion. "completed" is the only success;
+// failed/killed/timeout all indicate the bg work did not succeed.
+func isFailedTaskStatus(status string) bool {
+	switch status {
+	case "failed", "killed", "timeout":
+		return true
+	default:
+		return false
+	}
 }
 
 // backgroundToolNames lists tool names the CLI treats as background even

--- a/multiagent/agent/turn_state_test.go
+++ b/multiagent/agent/turn_state_test.go
@@ -692,6 +692,93 @@ func TestTurnState_SawTurnComplete(t *testing.T) {
 		"a new ResultMessage clears the prior wave's TurnComplete")
 }
 
+// INF-1400 state-machine repro: a successful wave's ResultMessage is recorded
+// as lastSuccessfulResult, and a terminal bg-task event then invalidates the
+// live wave (lastResult -> nil) awaiting a continuation that never arrives.
+// TurnSucceededTerminally must still report true so a clean stream close can
+// resolve the turn as success, and ToTerminalTurnResult must flip Success to
+// true even though the live-path Success()/ToTurnResult() report false.
+func TestTurnState_SuccessfulWaveSurvivesInvalidation(t *testing.T) {
+	s := newLogicalTurnState()
+
+	s.Apply(claude.AssistantMessageEvent{
+		TurnNumber: 1,
+		Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+	})
+	s.Apply(claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")})
+	endOfCLITurn(s, false) // successful wave -> lastSuccessfulResult recorded
+
+	require.True(t, s.Success(), "live wave is successful before invalidation")
+	require.True(t, s.TurnSucceededTerminally())
+
+	// Terminal bg event invalidates the wave: lastResult -> nil, so the live
+	// path now reports failure while awaiting a continuation.
+	s.Apply(claude.TaskNotificationEvent{
+		TaskID: "task1", ToolUseID: strPtr("toolu_bg1"), Status: "completed",
+	})
+	require.False(t, s.Success(),
+		"after invalidation the live path reports Success=false (lastResult nil)")
+	require.False(t, s.ToTurnResult().Success,
+		"live-path ToTurnResult mirrors Success() — still gating")
+	require.True(t, s.TurnSucceededTerminally(),
+		"the successful wave must survive invalidation")
+
+	// Terminal-EOF resolution recovers the success.
+	terminal := s.ToTerminalTurnResult()
+	require.True(t, terminal.Success,
+		"ToTerminalTurnResult must resolve a clean EOF after a successful wave as success")
+	require.NoError(t, terminal.Error)
+}
+
+// TurnSucceededTerminally / ToTerminalTurnResult must NOT manufacture success
+// when no successful ResultMessage was ever seen, nor mask a real error.
+func TestTurnState_TerminalResolutionRespectsFailures(t *testing.T) {
+	t.Run("no result ever", func(t *testing.T) {
+		s := newLogicalTurnState()
+		s.Apply(claude.AssistantMessageEvent{
+			TurnNumber: 1,
+			Blocks:     claude.ContentBlocks{asstTextBlock("starting")},
+		})
+		require.False(t, s.TurnSucceededTerminally())
+		require.False(t, s.ToTerminalTurnResult().Success,
+			"a turn with no successful result must not be resolved as success")
+	})
+
+	t.Run("error result", func(t *testing.T) {
+		s := newLogicalTurnState()
+		s.Apply(claude.AssistantMessageEvent{
+			TurnNumber: 1,
+			Blocks:     claude.ContentBlocks{asstTextBlock("oops")},
+		})
+		endOfCLITurn(s, true) // error wave -> state.err set
+		require.False(t, s.TurnSucceededTerminally(),
+			"an outstanding error must suppress terminal success")
+		terminal := s.ToTerminalTurnResult()
+		require.False(t, terminal.Success)
+		require.Error(t, terminal.Error, "a real error must be preserved, not masked")
+	})
+
+	t.Run("success then later error", func(t *testing.T) {
+		s := newLogicalTurnState()
+		// A successful wave, then a continuation that errors: the live error
+		// must win over the earlier success.
+		s.Apply(claude.AssistantMessageEvent{
+			TurnNumber: 1,
+			Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+		})
+		s.Apply(claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")})
+		endOfCLITurn(s, false)
+		s.Apply(claude.TaskNotificationEvent{
+			TaskID: "task1", ToolUseID: strPtr("toolu_bg1"), Status: "completed",
+		})
+		s.Apply(resultMessage(true)) // continuation errors -> state.err set
+		require.False(t, s.TurnSucceededTerminally(),
+			"a later error must override an earlier successful wave")
+		require.False(t, s.ToTerminalTurnResult().Success)
+		require.Error(t, s.ToTerminalTurnResult().Error)
+	})
+}
+
 // A terminal TaskNotificationEvent that arrives before the corresponding
 // TaskStartedEvent (stream reorder) must not leave the task stuck live when
 // the belated TaskStartedEvent finally shows up.

--- a/multiagent/agent/turn_state_test.go
+++ b/multiagent/agent/turn_state_test.go
@@ -723,11 +723,68 @@ func TestTurnState_SuccessfulWaveSurvivesInvalidation(t *testing.T) {
 	require.True(t, s.TurnSucceededTerminally(),
 		"the successful wave must survive invalidation")
 
-	// Terminal-EOF resolution recovers the success.
+	// Terminal-EOF resolution recovers the success — including the duration
+	// from the last successful wave (ToTurnResult derived 0 from the nilled
+	// lastResult). resultMessage(false) sets DurationMs=100.
 	terminal := s.ToTerminalTurnResult()
 	require.True(t, terminal.Success,
 		"ToTerminalTurnResult must resolve a clean EOF after a successful wave as success")
 	require.NoError(t, terminal.Error)
+	require.Equal(t, int64(100), terminal.DurationMs,
+		"terminal resolution must restore the successful wave's duration, not fall back to 0")
+}
+
+// A background task that reaches a failed/killed/timeout terminal status must
+// suppress terminal success: the CLI can emit a successful end-of-turn result
+// while a Monitor is still live, then have that Monitor fail and exit without a
+// continuation result. Resolving such an EOF as success would mask the failed
+// bg work. Covers both terminal event shapes.
+func TestTurnState_FailedBgTaskSuppressesTerminalSuccess(t *testing.T) {
+	failureCases := []struct {
+		name   string
+		status string
+	}{
+		{"failed", "failed"},
+		{"killed", "killed"},
+		{"timeout", "timeout"},
+	}
+	for _, tc := range failureCases {
+		t.Run("notification/"+tc.name, func(t *testing.T) {
+			s := newLogicalTurnState()
+			s.Apply(claude.AssistantMessageEvent{
+				TurnNumber: 1,
+				Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+			})
+			s.Apply(claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")})
+			endOfCLITurn(s, false) // successful end-of-turn while bg still live
+			require.True(t, s.TurnSucceededTerminally())
+
+			s.Apply(claude.TaskNotificationEvent{
+				TaskID: "task1", ToolUseID: strPtr("toolu_bg1"), Status: tc.status,
+			})
+			require.False(t, s.TurnSucceededTerminally(),
+				"a %s bg task must suppress terminal success", tc.status)
+			require.False(t, s.ToTerminalTurnResult().Success,
+				"the failed bg task must not be reported as a terminal success")
+		})
+
+		t.Run("updated/"+tc.name, func(t *testing.T) {
+			s := newLogicalTurnState()
+			s.Apply(claude.AssistantMessageEvent{
+				TurnNumber: 1,
+				Blocks:     claude.ContentBlocks{monitorToolUse("toolu_bg1")},
+			})
+			s.Apply(claude.TaskStartedEvent{TaskID: "task1", ToolUseID: strPtr("toolu_bg1")})
+			endOfCLITurn(s, false)
+			require.True(t, s.TurnSucceededTerminally())
+
+			status := tc.status
+			s.Apply(claude.TaskUpdatedEvent{TaskID: "task1", Status: &status})
+			require.False(t, s.TurnSucceededTerminally(),
+				"a %s bg task (via TaskUpdatedEvent) must suppress terminal success", tc.status)
+			require.False(t, s.ToTerminalTurnResult().Success)
+		})
+	}
 }
 
 // TurnSucceededTerminally / ToTerminalTurnResult must NOT manufacture success


### PR DESCRIPTION
## Problem

A jiradozer run (`INF-1400-20260616-...75023.log`) completed **every step successfully** — plan → build → create_pr → validate rounds 1 & 2, and round 3 even polled CI to green and confirmed merge readiness, printing `✓ Turn 1 complete (305.8s)`. Yet the orchestrator reported:

```
Error: validate round 3/3: agent failed
```

This is a **false failure** in the multiagent streaming layer.

## Root cause

Round 3 ended its turn on a `ScheduleWakeup` plus a background `Monitor` (a ~12 min CI poll). When the background work finished:

1. A terminal task notification invalidated the live completion wave → `invalidateForContinuation()` nilled `lastResult`/`lastTurnComplete`.
2. The CLI then exited cleanly — the event stream **closed before** any continuation `ResultMessage` arrived.
3. The closed-stream branch in `consumeTurnEvents` returned `state.ToTurnResult()` → `Success=false, Error=nil`.
4. jiradozer's agent runner (`jiradozer/agent.go:530-538`) reads exactly `Success=false && Error=nil` as the bare `fmt.Errorf("agent failed")`.

So a terminally-successful run (CLI exited cleanly after doing the work) was reported as a failed turn purely because the stream closed during the post-invalidation continuation gap.

## Fix (provider-only)

- **`multiagent/agent/turn_state.go`** — add a sticky `lastSuccessfulResult` (set on each non-error `ResultMessageEvent`, **not** cleared by `invalidateForContinuation`), a `TurnSucceededTerminally()` helper, and `ToTerminalTurnResult()` that resolves a clean EOF after a successful-then-invalidated wave as success. Live-path `Success()` / `LogicalTurnDone()` / `ToTurnResult()` semantics are unchanged.
- **`multiagent/agent/claude_provider.go`** — the two closed-stream (`!ok`) branches now call `ToTerminalTurnResult()`. The grace-period transient path is untouched (the CLI is still alive there — a genuinely different scenario).
- **`jiradozer/agent.go`** — deliberately unchanged; its classification is correct once the provider returns an accurate result.

Guards so genuine failures still surface: a real error at EOF is preserved unchanged; a stream that closes before any successful result still reports `Success=false`; a later error overrides an earlier successful wave.

## Tests

- `turn_state_test.go` — `TestTurnState_SuccessfulWaveSurvivesInvalidation` + `TestTurnState_TerminalResolutionRespectsFailures` (no-result / error-result / success-then-error).
- `claude_provider_grace_test.go` — `TestConsumeTurnEvents_ClosedStreamAfterInvalidatedSuccessIsSuccess` (the exact INF-1400 interleaving) plus two negative cases.
- `jiradozer/integration/validate_pr_polish_local_test.go` — `TestValidate_ScheduleWakeupWithBgMonitor`, an end-to-end manual-tagged regression mirroring the round-3 shape.

## Verification

- `scripts/lint.sh` — clean
- `bazel build //...` — clean
- `bazel test //...` — 92/92 pass
- `bazel run //:gazelle` — no BUILD changes (hand-maintained integration BUILD untouched)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core multiagent turn completion semantics on stream close; guards limit false positives, but EOF success inference could misclassify edge cases if event ordering diverges from expectations.
> 
> **Overview**
> Fixes **false "agent failed"** outcomes when a validate turn ends on **ScheduleWakeup** plus a **background Monitor** that finishes, the CLI exits, and the event stream closes before a continuation `ResultMessage` arrives.
> 
> **`logicalTurnState`** now keeps a sticky **`lastSuccessfulResult`** (not cleared by continuation invalidation), tracks **`sawFailedBgTask`**, and exposes **`TurnSucceededTerminally()`** / **`ToTerminalTurnResult()`** so a clean EOF can report success when an earlier wave succeeded. Failed/killed/timeout bg tasks, missing results, and real errors still resolve as failure.
> 
> **`consumeTurnEvents`** closed-stream paths call **`ToTerminalTurnResult()`** instead of **`ToTurnResult()`**; the grace-period transient behavior is unchanged.
> 
> Integration tests add **`setupValidateWorkflow`** / **`sawStep`**, refactor C14, and add **`TestValidate_ScheduleWakeupWithBgMonitor`** as an end-to-end INF-1400 regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a220d20f89c847953c32c0da8815db2e762b5e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->