### PR TITLE
fix(jiradozer): reliability — model fallback, retry tuning, grace observability, build stamping

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,17 @@ common --repository_cache=~/.cache/bazel-repo-cache
 # This allows multiple bazel commands to run concurrently (each gets its own server)
 startup --noblock_for_lock
 
+# Embed git revision/time into stamped binaries (see tools/workspace_status.sh).
+# The workspace status command itself is cheap and runs on every build, but it
+# only feeds x_defs when --stamp is set; without --stamp the STABLE_* keys are
+# ignored, so normal builds stay cacheable.
+build --workspace_status_command=tools/workspace_status.sh
+
+# Opt-in stamping for release/cron builds: `bazel build --config=stamp ...`.
+# Kept off the default build because --stamp busts the action cache whenever the
+# commit changes.
+build:stamp --stamp
+
 # Python configuration
 build --python_version=PY3
 

--- a/agent-cli-wrapper/transient/transient.go
+++ b/agent-cli-wrapper/transient/transient.go
@@ -57,10 +57,11 @@ func ClassifyText(msg string) (string, bool) {
 		strings.Contains(s, "broken pipe"),
 		strings.Contains(s, "unexpected eof"),
 		strings.Contains(s, "socket connection was closed"),
-		// e.g. "API Error: Connection closed mid-response. The response above
-		// may be incomplete." — seen in jiradozer cron failures.
+		// "API Error: Connection closed mid-response. The response above may be
+		// incomplete." — seen in jiradozer cron failures. "connection closed"
+		// matches it; we don't also match a bare "mid-response" because that
+		// substring appears in unrelated, non-retryable messages.
 		strings.Contains(s, "connection closed"),
-		strings.Contains(s, "mid-response"),
 		strings.Contains(s, "websocket"):
 		return ReasonConnectionReset, true
 	case strings.Contains(s, "i/o timeout"),

--- a/agent-cli-wrapper/transient/transient.go
+++ b/agent-cli-wrapper/transient/transient.go
@@ -13,6 +13,16 @@ const (
 	ReasonHTTP5xx         = "http_5xx"
 	ReasonConnectionReset = "connection_reset"
 	ReasonTimeout         = "timeout"
+	// ReasonGraceForced marks a turn that was force-completed because a
+	// background tool_use outlived the per-turn grace period. It is still
+	// retryable (a fresh turn may not stall), but the distinct reason lets logs
+	// tell a grace-period force-complete apart from a true idle stream.
+	ReasonGraceForced = "grace_forced"
+	// ReasonOutOfCredits marks a workspace-wide out-of-credits failure. It is
+	// deliberately NOT returned by ClassifyText (a same-model retry can't refill
+	// the workspace); it exists for model-fallback logging in callers that swap
+	// to a different provider. See multiagent/agent.IsOutOfCredits.
+	ReasonOutOfCredits = "out_of_credits"
 )
 
 var httpStatusPattern = regexp.MustCompile(`(^|[^[:alnum:]])(429|500|502|503|504|529)([^[:alnum:]]|$)`)
@@ -22,6 +32,11 @@ var httpStatusPattern = regexp.MustCompile(`(^|[^[:alnum:]])(429|500|502|503|504
 func ClassifyText(msg string) (string, bool) {
 	s := strings.ToLower(msg)
 	switch {
+	// Checked before "stream idle" because the grace-period force-complete
+	// surfaces as "stream idle: turn forced complete after grace period ...";
+	// matching the more specific phrase first keeps the reason distinct (#270).
+	case strings.Contains(s, "turn forced complete after grace period"):
+		return ReasonGraceForced, true
 	case strings.Contains(s, "stream idle"),
 		strings.Contains(s, "stream timeout"),
 		strings.Contains(s, "stream disconnected"),
@@ -42,6 +57,10 @@ func ClassifyText(msg string) (string, bool) {
 		strings.Contains(s, "broken pipe"),
 		strings.Contains(s, "unexpected eof"),
 		strings.Contains(s, "socket connection was closed"),
+		// e.g. "API Error: Connection closed mid-response. The response above
+		// may be incomplete." — seen in jiradozer cron failures.
+		strings.Contains(s, "connection closed"),
+		strings.Contains(s, "mid-response"),
 		strings.Contains(s, "websocket"):
 		return ReasonConnectionReset, true
 	case strings.Contains(s, "i/o timeout"),

--- a/agent-cli-wrapper/transient/transient_test.go
+++ b/agent-cli-wrapper/transient/transient_test.go
@@ -42,6 +42,28 @@ func TestClassifyText(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			// 529 (Anthropic overload) must classify as a retryable 5xx (#273).
+			name:       "http 529 overloaded",
+			msg:        "API Error: 529 {\"type\":\"overloaded_error\"}",
+			wantReason: ReasonHTTP5xx,
+			wantOK:     true,
+		},
+		{
+			// Verbatim from jiradozer cron failures (#272).
+			name:       "connection closed mid-response",
+			msg:        "API Error: Connection closed mid-response. The response above may be incomplete.",
+			wantReason: ReasonConnectionReset,
+			wantOK:     true,
+		},
+		{
+			// Grace-period force-complete must classify distinctly (#270) while
+			// staying retryable.
+			name:       "turn forced complete after grace period",
+			msg:        "stream idle: turn forced complete after grace period gated on background tool_use",
+			wantReason: ReasonGraceForced,
+			wantOK:     true,
+		},
+		{
 			name:       "connection reset",
 			msg:        "read tcp: connection reset by peer",
 			wantReason: ReasonConnectionReset,

--- a/cliapp/buildinfo.go
+++ b/cliapp/buildinfo.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 )
 
@@ -39,6 +40,18 @@ var (
 	executablePath = os.Executable
 )
 
+// stampedRevision and stampedTime are set at link time via Bazel x_defs (see
+// jiradozer/cmd/jiradozer/BUILD.bazel + tools/workspace_status.sh) when a build
+// runs with --config=stamp. They are the most reliable provenance source for
+// Bazel binaries, which build sandboxed away from .git and so carry no
+// debug.ReadBuildInfo vcs.* settings. Empty when unstamped (normal dev builds,
+// `go run`, non-Bazel builds), in which case ReadBuildInfo falls back to the
+// debug build info and then the executable mtime. stampedTime is RFC3339.
+var (
+	stampedRevision string
+	stampedTime     string
+)
+
 // ReadBuildInfo extracts the VCS settings from the embedded build info. It
 // never fails: when build info or a VCS setting is missing, the corresponding
 // field stays at its zero value (Revision defaults to "unknown").
@@ -66,10 +79,37 @@ func ReadBuildInfo() BuildInfo {
 			}
 		}
 	}
+	// Prefer the Bazel stamp when present — it is the only reliable source for
+	// Bazel builds, which sandbox away from .git. An unstamped build leaves
+	// these empty (or as the literal placeholder when stamping is off but the
+	// key was substituted to empty), so guard against both.
+	if rev := stampValue(stampedRevision); rev != "" {
+		bi.Revision = rev
+	}
+	if ts := stampValue(stampedTime); ts != "" {
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			bi.Time = t
+		}
+	}
 	if bi.Time.IsZero() {
 		bi.Time = executableModTime()
 	}
 	return bi
+}
+
+// stampValue normalizes a linker-stamped x_def value: it returns "" for an
+// unset stamp, the literal "unknown" sentinel emitted by workspace_status.sh
+// when not in a git tree, or an unsubstituted "{STABLE_...}" placeholder (which
+// rules_go can leave verbatim on an unstamped build). A real value passes
+// through unchanged.
+func stampValue(v string) string {
+	if v == "" || v == "unknown" {
+		return ""
+	}
+	if strings.HasPrefix(v, "{") && strings.HasSuffix(v, "}") {
+		return ""
+	}
+	return v
 }
 
 // executableModTime returns the running binary's modification time, or the zero

--- a/cliapp/buildinfo_test.go
+++ b/cliapp/buildinfo_test.go
@@ -31,6 +31,15 @@ func buildInfoWith(settings ...debug.BuildSetting) *debug.BuildInfo {
 	return &debug.BuildInfo{Settings: settings}
 }
 
+// withStampedBuild pins the linker-stamped revision/time package vars for a
+// test and restores them afterward.
+func withStampedBuild(t *testing.T, rev, ts string) {
+	t.Helper()
+	prevRev, prevTime := stampedRevision, stampedTime
+	stampedRevision, stampedTime = rev, ts
+	t.Cleanup(func() { stampedRevision, stampedTime = prevRev, prevTime })
+}
+
 func TestReadBuildInfo(t *testing.T) {
 	t.Run("populated", func(t *testing.T) {
 		withStubbedBuildInfo(t, buildInfoWith(
@@ -91,6 +100,58 @@ func TestReadBuildInfo(t *testing.T) {
 		got := ReadBuildInfo()
 		if !got.Time.Equal(want) {
 			t.Errorf("Time = %v, want executable mtime %v", got.Time, want)
+		}
+	})
+
+	t.Run("bazel stamp overrides revision and time", func(t *testing.T) {
+		// No debug build info (sandboxed Bazel build), but the linker stamped
+		// the revision and time via x_defs.
+		withStubbedBuildInfo(t, nil, false)
+		stubMissingExecutable(t)
+		withStampedBuild(t, "deadbeefcafe0000", "2026-06-20T08:00:00Z")
+
+		got := ReadBuildInfo()
+		if got.Revision != "deadbeefcafe0000" {
+			t.Errorf("Revision = %q, want stamped revision", got.Revision)
+		}
+		want, _ := time.Parse(time.RFC3339, "2026-06-20T08:00:00Z")
+		if !got.Time.Equal(want) {
+			t.Errorf("Time = %v, want stamped time %v", got.Time, want)
+		}
+		if got.ShortRevision() != "deadbeefcafe" {
+			t.Errorf("ShortRevision = %q", got.ShortRevision())
+		}
+	})
+
+	t.Run("stamp takes precedence over vcs settings", func(t *testing.T) {
+		withStubbedBuildInfo(t, buildInfoWith(
+			debug.BuildSetting{Key: "vcs.revision", Value: "0000000000000000"},
+			debug.BuildSetting{Key: "vcs.time", Value: "2020-01-01T00:00:00Z"},
+		), true)
+		withStampedBuild(t, "feedface12345678", "2026-06-21T09:30:00Z")
+
+		got := ReadBuildInfo()
+		if got.Revision != "feedface12345678" {
+			t.Errorf("Revision = %q, want stamped revision", got.Revision)
+		}
+		want, _ := time.Parse(time.RFC3339, "2026-06-21T09:30:00Z")
+		if !got.Time.Equal(want) {
+			t.Errorf("Time = %v, want stamped time", got.Time)
+		}
+	})
+
+	t.Run("empty and placeholder stamps are ignored", func(t *testing.T) {
+		withStubbedBuildInfo(t, buildInfoWith(
+			debug.BuildSetting{Key: "vcs.revision", Value: "abcdef0123456789"},
+		), true)
+		stubMissingExecutable(t)
+		// Unstamped build: empty, the git-less "unknown" sentinel, or an
+		// unsubstituted placeholder must all fall back to vcs.revision.
+		for _, sentinel := range []string{"", "unknown", "{STABLE_GIT_REVISION}"} {
+			withStampedBuild(t, sentinel, "")
+			if got := ReadBuildInfo().Revision; got != "abcdef0123456789" {
+				t.Errorf("stamp %q: Revision = %q, want vcs.revision fallback", sentinel, got)
+			}
 		}
 	})
 

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -593,8 +593,11 @@ func (r agentRunner) runAgentForModel(ctx context.Context, stepName, prompt stri
 		failed := StepAgentResult{
 			SessionID: result.SessionID,
 		}
+		// Not out-of-credits: any such error already returned early from the
+		// retry loop above (the only way here is a non-transient break, which
+		// the out-of-credits check precedes).
 		if result.Error != nil {
-			return failed, agent.IsOutOfCredits(result.Error), fmt.Errorf("agent execution: %w", result.Error)
+			return failed, false, fmt.Errorf("agent execution: %w", result.Error)
 		}
 		return failed, false, fmt.Errorf("agent failed")
 	}

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -53,7 +53,10 @@ type agentRunner struct {
 
 var defaultAgentRunner = agentRunner{
 	newProviderForModel: agent.NewProviderForModel,
-	retryBackoffs:       []time.Duration{30 * time.Second, 90 * time.Second},
+	// A single shared schedule. Overload/5xx and other transients reuse the
+	// last entry once attempts exceed the slice (see retryBackoff), so a longer
+	// tail gives genuine cool-down for sustained provider overload (#273).
+	retryBackoffs: []time.Duration{30 * time.Second, 90 * time.Second, 3 * time.Minute, 5 * time.Minute},
 }
 
 // RunStepAgent runs an agent session for the given workflow step and returns
@@ -409,14 +412,65 @@ func (c *compositeEventHandler) OnRetryAbort(reason, tool, excerpt string) {
 // If renderer is non-nil, agent events are rendered to the terminal in addition
 // to being logged to the log file.
 func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, error) {
+	if renderer != nil {
+		defer renderer.Reset()
+	}
+
+	// Outer loop: the primary model followed by any configured fallbacks. A
+	// model is advanced only on a workspace-wide out-of-credits failure (a
+	// same-model retry can't refill it). Failover starts a fresh session —
+	// cross-provider resume is not reliable — so currentResume is reset.
+	models := append([]string{cfg.Model}, cfg.FallbackModels...)
+	currentResume := resumeSessionID
+	var lastErr error
+	var lastResult StepAgentResult
+	for mi, modelID := range models {
+		activeCfg := cfg
+		activeCfg.Model = modelID
+
+		res, outOfCredits, err := r.runAgentForModel(ctx, stepName, prompt, activeCfg, workDir, currentResume, renderer, logger)
+		if err == nil {
+			return res, nil
+		}
+		// A bare context cancellation is terminal regardless of model — don't
+		// burn the fallback budget on a shutdown.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return res, err
+		}
+		lastErr, lastResult = err, res
+		if outOfCredits && mi < len(models)-1 {
+			next := models[mi+1]
+			logger.Warn("model out of credits; falling back",
+				"step", stepName,
+				"from", modelID,
+				"to", next,
+			)
+			if renderer != nil {
+				renderer.Status(fmt.Sprintf("%s out of credits; falling back to %s", modelID, next))
+			}
+			// Fresh session on the next provider.
+			currentResume = ""
+			continue
+		}
+		return res, err
+	}
+	return lastResult, lastErr
+}
+
+// runAgentForModel runs the transient-retry loop for a single model. It returns
+// the step result, whether the terminal error was a workspace out-of-credits
+// failure (so the caller can decide to fall back to a different model), and a
+// terminal error (nil on success).
+func (r agentRunner) runAgentForModel(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, bool, error) {
 	model, ok := agent.ModelByID(cfg.Model)
 	if !ok {
-		return StepAgentResult{}, fmt.Errorf("unknown model: %q", cfg.Model)
+		return StepAgentResult{}, false, fmt.Errorf("unknown model: %q", cfg.Model)
 	}
 	provider, err := r.newProviderForModel(model)
 	if err != nil {
-		return StepAgentResult{}, fmt.Errorf("create provider: %w", err)
+		return StepAgentResult{}, false, fmt.Errorf("create provider: %w", err)
 	}
+	// Close this model's provider before returning so a fallback doesn't leak it.
 	defer provider.Close()
 
 	logAttrs := []any{
@@ -434,13 +488,12 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 	logHandler := newLogEventHandler(logger, stepName, provider.Name())
 	var handler agent.EventHandler = logHandler
 	if renderer != nil {
-		defer renderer.Reset()
 		handler = &compositeEventHandler{handlers: []agent.EventHandler{logHandler, &rendererEventHandler{r: renderer}}}
 	}
 
 	maxRetries := cfg.TransientRetries
 	if maxRetries == 0 {
-		maxRetries = 2
+		maxRetries = 4
 	}
 
 	currentResume := resumeSessionID
@@ -450,7 +503,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 		logHandler.resetPerAttempt()
 		opts, err := buildExecuteOpts(cfg, workDir, handler, currentResume, logger)
 		if err != nil {
-			return StepAgentResult{}, err
+			return StepAgentResult{}, false, err
 		}
 		result, err = provider.Execute(ctx, prompt, nil, opts...)
 		if err == nil {
@@ -459,6 +512,10 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 			}
 			if result.SessionID != "" {
 				currentResume = result.SessionID
+			}
+			if agent.IsOutOfCredits(result.Error) {
+				logHandler.flushText()
+				return StepAgentResult{SessionID: currentResume}, true, fmt.Errorf("agent execution: %w", result.Error)
 			}
 			transient, reason := agent.ClassifyTransient(result.Error)
 			if !transient || attempt >= maxRetries {
@@ -484,7 +541,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 					<-timer.C
 				}
 				logHandler.flushText()
-				return StepAgentResult{SessionID: currentResume}, ctx.Err()
+				return StepAgentResult{SessionID: currentResume}, false, ctx.Err()
 			case <-timer.C:
 			}
 			continue
@@ -492,10 +549,14 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 		if result != nil && result.SessionID != "" {
 			currentResume = result.SessionID
 		}
+		if agent.IsOutOfCredits(err) {
+			logHandler.flushText()
+			return StepAgentResult{SessionID: currentResume}, true, fmt.Errorf("agent execution: %w", err)
+		}
 		transient, reason := agent.ClassifyTransient(err)
 		if !transient || attempt >= maxRetries {
 			logHandler.flushText()
-			return StepAgentResult{SessionID: currentResume}, fmt.Errorf("agent execution: %w", err)
+			return StepAgentResult{SessionID: currentResume}, false, fmt.Errorf("agent execution: %w", err)
 		}
 		attempt++
 		backoff := r.retryBackoff(attempt)
@@ -517,14 +578,14 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 				<-timer.C
 			}
 			logHandler.flushText()
-			return StepAgentResult{SessionID: currentResume}, ctx.Err()
+			return StepAgentResult{SessionID: currentResume}, false, ctx.Err()
 		case <-timer.C:
 		}
 	}
 
 	if result == nil {
 		logHandler.flushText()
-		return StepAgentResult{SessionID: currentResume}, fmt.Errorf("agent execution: provider returned no result")
+		return StepAgentResult{SessionID: currentResume}, false, fmt.Errorf("agent execution: provider returned no result")
 	}
 
 	if !result.Success {
@@ -533,9 +594,9 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 			SessionID: result.SessionID,
 		}
 		if result.Error != nil {
-			return failed, fmt.Errorf("agent execution: %w", result.Error)
+			return failed, agent.IsOutOfCredits(result.Error), fmt.Errorf("agent execution: %w", result.Error)
 		}
-		return failed, fmt.Errorf("agent failed")
+		return failed, false, fmt.Errorf("agent failed")
 	}
 
 	completedAttrs := []any{
@@ -565,7 +626,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 	return StepAgentResult{
 		Output:    output,
 		SessionID: result.SessionID,
-	}, nil
+	}, false, nil
 }
 
 func buildExecuteOpts(cfg StepConfig, workDir string, handler agent.EventHandler, resumeSessionID string, logger *slog.Logger) ([]agent.ExecuteOption, error) {

--- a/jiradozer/agent_retry_test.go
+++ b/jiradozer/agent_retry_test.go
@@ -208,6 +208,159 @@ func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
+// providersByModel returns a newProviderForModel that hands out a distinct
+// fake provider per resolved model ID, recording the order models were tried.
+func providersByModel(t *testing.T, byModel map[string]*fakeRetryProvider) (func(agentpkg.AgentModel) (agentpkg.Provider, error), *[]string) {
+	t.Helper()
+	var order []string
+	return func(m agentpkg.AgentModel) (agentpkg.Provider, error) {
+		p, ok := byModel[m.ID]
+		if !ok {
+			t.Fatalf("no fake provider registered for model %q", m.ID)
+		}
+		order = append(order, m.ID)
+		return p, nil
+	}, &order
+}
+
+func TestRunAgent_OutOfCredits_FallsBackToNextModel(t *testing.T) {
+	primary := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{
+			{Success: false, SessionID: "sess-primary", Error: &codex.TurnError{Message: "Your workspace is out of credits. Ask your workspace owner to refill."}},
+		},
+		errs: []error{nil},
+	}
+	fallback := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{
+			{Success: true, SessionID: "sess-fallback", Text: "done on fallback"},
+		},
+		errs: []error{nil},
+	}
+	newProvider, order := providersByModel(t, map[string]*fakeRetryProvider{
+		"gpt-5.5": primary,
+		"opus":    fallback,
+	})
+	runner := agentRunner{newProviderForModel: newProvider, retryBackoffs: []time.Duration{0}}
+
+	got, err := runner.runAgent(context.Background(), "ship", "prompt", StepConfig{
+		Model:            "gpt-5.5",
+		FallbackModels:   []string{"opus"},
+		TransientRetries: 2,
+	}, t.TempDir(), "resume-orig", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	require.Equal(t, "done on fallback", got.Output)
+	require.Equal(t, "sess-fallback", got.SessionID)
+	require.Equal(t, []string{"gpt-5.5", "opus"}, *order, "both models tried in order")
+
+	// The primary saw the original resume session; the fallback must start
+	// FRESH (empty resume) since cross-provider resume is unreliable.
+	require.Len(t, primary.resumeSession, 1)
+	require.Equal(t, "resume-orig", primary.resumeSession[0])
+	require.Len(t, fallback.resumeSession, 1)
+	require.Empty(t, fallback.resumeSession[0], "fallback must start a fresh session")
+}
+
+func TestRunAgent_OutOfCredits_NoFallbackConfigured_Fails(t *testing.T) {
+	primary := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{
+			{Success: false, SessionID: "sess-primary", Error: &codex.TurnError{Message: "out of credits"}},
+		},
+		errs: []error{nil},
+	}
+	newProvider, order := providersByModel(t, map[string]*fakeRetryProvider{"gpt-5.5": primary})
+	runner := agentRunner{newProviderForModel: newProvider, retryBackoffs: []time.Duration{0}}
+
+	got, err := runner.runAgent(context.Background(), "ship", "prompt", StepConfig{
+		Model:            "gpt-5.5",
+		TransientRetries: 2,
+	}, t.TempDir(), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of credits")
+	require.Equal(t, []string{"gpt-5.5"}, *order, "no fallback configured — only primary tried")
+	require.Equal(t, "sess-primary", got.SessionID)
+}
+
+func TestRunAgent_OutOfCredits_AllModelsExhausted(t *testing.T) {
+	ooc := func(sess string) *fakeRetryProvider {
+		return &fakeRetryProvider{
+			results: []*agentpkg.AgentResult{
+				{Success: false, SessionID: sess, Error: &claude.TurnError{Message: "please ask your Workspace Owner to refill"}},
+			},
+			errs: []error{nil},
+		}
+	}
+	newProvider, order := providersByModel(t, map[string]*fakeRetryProvider{
+		"gpt-5.5": ooc("sess-a"),
+		"opus":    ooc("sess-b"),
+		"sonnet":  ooc("sess-c"),
+	})
+	runner := agentRunner{newProviderForModel: newProvider, retryBackoffs: []time.Duration{0}}
+
+	_, err := runner.runAgent(context.Background(), "ship", "prompt", StepConfig{
+		Model:            "gpt-5.5",
+		FallbackModels:   []string{"opus", "sonnet"},
+		TransientRetries: 2,
+	}, t.TempDir(), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refill")
+	require.Equal(t, []string{"gpt-5.5", "opus", "sonnet"}, *order, "all models tried in order before failing")
+}
+
+// TestRunAgent_ConnectionClosed_NowRetried pins #272: a "connection closed
+// mid-response" error is now transient and retried rather than terminal.
+func TestRunAgent_ConnectionClosed_NowRetried(t *testing.T) {
+	// Verbatim provider error string — must stay capitalized to exercise the
+	// case-insensitive classifier match.
+	connClosed := errors.New("API Error: Connection closed mid-response. The response above may be incomplete.") //nolint:revive // verbatim provider error
+	provider := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{
+			{SessionID: "sess-1"},
+			{Success: true, SessionID: "sess-1", Text: "recovered"},
+		},
+		errs: []error{connClosed, nil},
+	}
+	runner := agentRunner{
+		newProviderForModel: func(agentpkg.AgentModel) (agentpkg.Provider, error) { return provider, nil },
+		retryBackoffs:       []time.Duration{0},
+	}
+
+	got, err := runner.runAgent(context.Background(), "build", "prompt", StepConfig{
+		Model:            "gpt-5.5",
+		TransientRetries: 2,
+	}, t.TempDir(), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	require.Equal(t, "recovered", got.Output)
+	require.Len(t, provider.resumeSession, 2, "connection-closed error must be retried")
+}
+
+// TestRunAgent_DefaultMaxRetriesIsFour pins #272/#273: with no TransientRetries
+// override, the default budget is 4 — a run that fails transiently 3 times then
+// succeeds must NOT exhaust the budget.
+func TestRunAgent_DefaultMaxRetriesIsFour(t *testing.T) {
+	transient := &claude.TransientError{Message: "stream idle"}
+	provider := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{
+			{SessionID: "sess-1"},
+			{SessionID: "sess-1"},
+			{SessionID: "sess-1"},
+			{Success: true, SessionID: "sess-1", Text: "done"},
+		},
+		errs: []error{transient, transient, transient, nil},
+	}
+	runner := agentRunner{
+		newProviderForModel: func(agentpkg.AgentModel) (agentpkg.Provider, error) { return provider, nil },
+		retryBackoffs:       []time.Duration{0},
+	}
+
+	got, err := runner.runAgent(context.Background(), "build", "prompt", StepConfig{
+		Model: "gpt-5.5",
+		// TransientRetries left 0 → default 4.
+	}, t.TempDir(), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err, "3 transient failures must fit within the default budget of 4")
+	require.Equal(t, "done", got.Output)
+	require.Len(t, provider.resumeSession, 4)
+}
+
 func TestRunAgentRetryTransientResultErrorExhaustsBudget(t *testing.T) {
 	transient := &codex.TransientError{Message: "stream idle", Reason: "stream_idle"}
 	provider := &fakeRetryProvider{

--- a/jiradozer/agent_retry_test.go
+++ b/jiradozer/agent_retry_test.go
@@ -260,6 +260,39 @@ func TestRunAgent_OutOfCredits_FallsBackToNextModel(t *testing.T) {
 	require.Empty(t, fallback.resumeSession[0], "fallback must start a fresh session")
 }
 
+// TestRunAgent_OutOfCredits_ExecuteErrorPath_FallsBack covers the second
+// out-of-credits detection site: when the provider surfaces the failure as
+// Execute's returned error (not a result.Error). A regression removing the
+// err-path IsOutOfCredits branch in runAgentForModel would otherwise go
+// uncaught — the existing fallback tests only drive the result.Error path.
+func TestRunAgent_OutOfCredits_ExecuteErrorPath_FallsBack(t *testing.T) {
+	primary := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{nil},
+		errs:    []error{&codex.TurnError{Message: "Your workspace is out of credits. Ask your workspace owner to refill."}},
+	}
+	fallback := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{
+			{Success: true, SessionID: "sess-fallback", Text: "done on fallback"},
+		},
+		errs: []error{nil},
+	}
+	newProvider, order := providersByModel(t, map[string]*fakeRetryProvider{
+		"gpt-5.5": primary,
+		"opus":    fallback,
+	})
+	runner := agentRunner{newProviderForModel: newProvider, retryBackoffs: []time.Duration{0}}
+
+	got, err := runner.runAgent(context.Background(), "ship", "prompt", StepConfig{
+		Model:            "gpt-5.5",
+		FallbackModels:   []string{"opus"},
+		TransientRetries: 2,
+	}, t.TempDir(), "resume-orig", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	require.Equal(t, "done on fallback", got.Output)
+	require.Equal(t, []string{"gpt-5.5", "opus"}, *order, "both models tried in order")
+	require.Empty(t, fallback.resumeSession[0], "fallback must start a fresh session")
+}
+
 func TestRunAgent_OutOfCredits_NoFallbackConfigured_Fails(t *testing.T) {
 	primary := &fakeRetryProvider{
 		results: []*agentpkg.AgentResult{

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -31,6 +31,10 @@ go_binary(
     name = "jiradozer",
     embed = [":jiradozer_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/bazelment/yoloswe/cliapp.stampedRevision": "{STABLE_GIT_REVISION}",
+        "github.com/bazelment/yoloswe/cliapp.stampedTime": "{STABLE_GIT_TIME}",
+    },
 )
 
 go_test(

--- a/jiradozer/cmd/jiradozer/bootstrap.go
+++ b/jiradozer/cmd/jiradozer/bootstrap.go
@@ -307,30 +307,34 @@ func bootstrapYAML(workDir string, baseBranchOverride ...string) ([]byte, error)
 		IdleTimeoutComment:   "create_pr is short — gh + git push only — so a tight timeout catches gh hangs quickly.",
 	}))
 	b.WriteString(renderStepBlock(stepBlock{
-		Key:                  "validate",
-		Heading:              "validate — run tests/linters and fix failures",
-		Description:          "Agent runs the project's tests and linters in the PR branch and fixes anything it broke before handing back to the reviewer.",
-		Prompt:               jiradozer.BootstrapValidatePrompt,
-		CommentTemplate:      jiradozer.BootstrapCompleteCommentTemplate,
-		PermissionMode:       "bypass",
-		MaxTurns:             10,
-		RoundsCapable:        true,
-		RoundCommentTemplate: jiradozer.BootstrapRoundCommentTemplate,
-		IdleTimeout:          20 * time.Minute,
-		IdleTimeoutComment:   "Validate runs tests + linters (potentially long); the gap-based watchdog only trips when output truly stops.",
+		Key:                   "validate",
+		Heading:               "validate — run tests/linters and fix failures",
+		Description:           "Agent runs the project's tests and linters in the PR branch and fixes anything it broke before handing back to the reviewer.",
+		Prompt:                jiradozer.BootstrapValidatePrompt,
+		CommentTemplate:       jiradozer.BootstrapCompleteCommentTemplate,
+		PermissionMode:        "bypass",
+		MaxTurns:              10,
+		RoundsCapable:         true,
+		RoundCommentTemplate:  jiradozer.BootstrapRoundCommentTemplate,
+		IdleTimeout:           20 * time.Minute,
+		IdleTimeoutComment:    "Validate runs tests + linters (potentially long); the gap-based watchdog only trips when output truly stops.",
+		StreamTurnGracePeriod: 3 * time.Minute,
+		GracePeriodComment:    "validate is poll-heavy (it babysits a background Monitor loop). Cap the grace at 3m so a wedged tool_use is cut off fast and the turn is force-completed + retried rather than burning the full 10m default.",
 	}))
 	b.WriteString(renderStepBlock(stepBlock{
-		Key:                  "ship",
-		Heading:              "ship — final PR readiness pass",
-		Description:          "Agent makes sure the PR exists, has a good title/body, and is ready for review. Jiradozer does not merge for you — it stops at the ShipReview gate.",
-		Prompt:               jiradozer.BootstrapShipPrompt,
-		CommentTemplate:      jiradozer.BootstrapCompleteCommentTemplate,
-		PermissionMode:       "bypass",
-		MaxTurns:             10,
-		RoundsCapable:        true,
-		RoundCommentTemplate: jiradozer.BootstrapRoundCommentTemplate,
-		IdleTimeout:          5 * time.Minute,
-		IdleTimeoutComment:   "Ship is short — gh PR-update only — so a tight timeout catches gh hangs quickly.",
+		Key:                   "ship",
+		Heading:               "ship — final PR readiness pass",
+		Description:           "Agent makes sure the PR exists, has a good title/body, and is ready for review. Jiradozer does not merge for you — it stops at the ShipReview gate.",
+		Prompt:                jiradozer.BootstrapShipPrompt,
+		CommentTemplate:       jiradozer.BootstrapCompleteCommentTemplate,
+		PermissionMode:        "bypass",
+		MaxTurns:              10,
+		RoundsCapable:         true,
+		RoundCommentTemplate:  jiradozer.BootstrapRoundCommentTemplate,
+		IdleTimeout:           5 * time.Minute,
+		IdleTimeoutComment:    "Ship is short — gh PR-update only — so a tight timeout catches gh hangs quickly.",
+		StreamTurnGracePeriod: 3 * time.Minute,
+		GracePeriodComment:    "ship is poll-heavy (it babysits PR readiness via a background Monitor loop). Cap the grace at 3m so a wedged tool_use is cut off fast and the turn is force-completed + retried rather than hanging for the full 10m.",
 	}))
 
 	b.WriteString(bootstrapTopLevelTail)
@@ -432,6 +436,12 @@ agent:
     # Model ID from agent.AllModels (e.g. "sonnet", "opus", "fable", "gpt-5.5",
     # "gemini-3.1-pro-preview", "cursor-default").
     model: sonnet
+    # Models to fall back to (in order) when the primary model fails with a
+    # workspace-wide "out of credits" error. A same-provider swap can't escape
+    # an out-of-credits workspace, so name a model on a *different* provider.
+    # Failover starts a fresh session (cross-provider resume is unreliable).
+    # Empty = no fallback. Per-step ` + "`fallback_models:`" + ` overrides this.
+    #fallback_models: [opus]
     # Reasoning effort: low, medium, high, max, auto. Empty = provider default.
     #effort: ""
     # Optional: route inference through a third-party LLM API endpoint
@@ -533,9 +543,14 @@ type stepBlock struct {
 	PermissionMode       string        // step default permission mode
 	RoundCommentTemplate string        // canonical round comment template (only used when RoundsCapable)
 	IdleTimeoutComment   string        // step-specific blurb describing why this timeout (rendered in YAML comment); only emitted when IdleTimeout > 0
+	GracePeriodComment   string        // step-specific blurb explaining why this step tightens the grace period; only emitted when StreamTurnGracePeriod > 0
 	MaxTurns             int           // step default max turns
 	IdleTimeout          time.Duration // step default idle timeout; 0 = omit from rendered YAML
-	RoundsCapable        bool          // whether bootstrap should seed round_comment_template uncommented
+	// StreamTurnGracePeriod, when > 0, renders an uncommented
+	// stream_turn_grace_period for this step (a tighter cap for poll-heavy steps
+	// that babysit a background Monitor loop); 0 = render the commented default.
+	StreamTurnGracePeriod time.Duration
+	RoundsCapable         bool // whether bootstrap should seed round_comment_template uncommented
 }
 
 // renderStepBlock emits one step's YAML with field-level comments. Optional
@@ -610,7 +625,14 @@ func renderStepBlock(s stepBlock) string {
 	b.WriteString("    # work (e.g. bramble reviewers a skill backgrounds) to finish before the\n")
 	b.WriteString("    # turn is force-completed; 0 = provider default (10m). Raise it for steps\n")
 	b.WriteString("    # that launch long-running background tools.\n")
-	b.WriteString("    #stream_turn_grace_period: 0\n")
+	if s.StreamTurnGracePeriod > 0 {
+		b.WriteString("    #\n")
+		const firstLinePrefix = "    # "
+		fmt.Fprintf(&b, "%s%s\n", firstLinePrefix, wrapComment(s.GracePeriodComment, 76-len(firstLinePrefix), firstLinePrefix))
+		fmt.Fprintf(&b, "    stream_turn_grace_period: %s\n", formatDurationShort(s.StreamTurnGracePeriod))
+	} else {
+		b.WriteString("    #stream_turn_grace_period: 0\n")
+	}
 	b.WriteString("    # Skip the human review gate after this step.\n")
 	b.WriteString("    #auto_approve: false\n")
 

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -437,6 +437,31 @@ func TestLoadRunConfigAppliesCLIOverrides(t *testing.T) {
 	require.Equal(t, []string{"plan", "validate"}, cfg.SkipPhases)
 }
 
+// TestLoadRunConfigRejectsCLIFallbackCollidingWithStepModel pins that the
+// --fallback-models CLI override is re-validated against effective (post-
+// inheritance) step/round primaries, not just the agent-level pair. A config
+// whose plan step overrides model: opus must reject `--fallback-models opus`
+// because ResolveStep would run [opus, opus] at runtime — even though the YAML
+// itself sets no fallback list and so passed LoadConfig.
+func TestLoadRunConfigRejectsCLIFallbackCollidingWithStepModel(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "test-key")
+	yaml := "tracker:\n  kind: linear\n  api_key: $LINEAR_API_KEY\nagent:\n  model: sonnet\n" +
+		"plan:\n  prompt: \"p\"\n  comment_template: \"c\"\n  model: opus\n" +
+		"build:\n  prompt: \"b\"\n  comment_template: \"c\"\ncreate_pr:\n  prompt: \"pr\"\n  comment_template: \"c\"\n" +
+		"validate:\n  prompt: \"v\"\n  comment_template: \"c\"\nship:\n  prompt: \"s\"\n  comment_template: \"c\"\n"
+	cfgPath := filepath.Join(t.TempDir(), "jiradozer.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0o600))
+
+	_, err := loadRunConfig(runArgs{
+		configPath:     cfgPath,
+		issueID:        "ENG-1",
+		fallbackModels: []string{"opus"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "plan.fallback_models")
+	require.Contains(t, err.Error(), "must differ from the primary model")
+}
+
 func TestLoadRunConfigSkipPhasesCLIBeatsConfig(t *testing.T) {
 	cfgPath := writeRunConfig(t, "linear", t.TempDir())
 	content, err := os.ReadFile(cfgPath)

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -407,16 +407,11 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 	if _, ok := agent.ModelByID(cfg.Agent.Model); !ok {
 		return nil, fmt.Errorf("unknown model %q — available models: %s", cfg.Agent.Model, availableModels())
 	}
-	// Validate fallback models after CLI overrides — LoadConfig's validate()
+	// Re-validate fallback models after CLI overrides — LoadConfig's validate()
 	// ran before --model/--fallback-models were applied, so a bad CLI value
 	// would otherwise slip through to runtime.
-	for _, m := range cfg.Agent.FallbackModels {
-		if _, ok := agent.ModelByID(m); !ok {
-			return nil, fmt.Errorf("unknown fallback model %q — available models: %s", m, availableModels())
-		}
-		if m == cfg.Agent.Model {
-			return nil, fmt.Errorf("fallback model %q must differ from the primary model", m)
-		}
+	if err := jiradozer.ValidateFallbackModels("agent.fallback_models", cfg.Agent.Model, cfg.Agent.FallbackModels); err != nil {
+		return nil, err
 	}
 	return cfg, nil
 }

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -408,9 +408,11 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 		return nil, fmt.Errorf("unknown model %q — available models: %s", cfg.Agent.Model, availableModels())
 	}
 	// Re-validate fallback models after CLI overrides — LoadConfig's validate()
-	// ran before --model/--fallback-models were applied, so a bad CLI value
-	// would otherwise slip through to runtime.
-	if err := jiradozer.ValidateFallbackModels("agent.fallback_models", cfg.Agent.Model, cfg.Agent.FallbackModels); err != nil {
+	// ran before --model/--fallback-models were applied. Use the effective
+	// (post-inheritance) check so a step/round model override that collides with
+	// the CLI-supplied fallback list (e.g. plan.model=opus + --fallback-models
+	// opus → [opus, opus]) is rejected, not just the agent-level pair.
+	if err := cfg.ValidateEffectiveFallbacks(); err != nil {
 		return nil, err
 	}
 	return cfg, nil

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -32,6 +32,7 @@ type runArgs struct {
 	modelID         string
 	thinkingLevel   string
 	runStep         string
+	fallbackModels  []string
 	autoApprove     string
 	skipPhases      string
 	branchPrefix    string
@@ -86,6 +87,7 @@ func registerRunFlags(cmd *cobra.Command, args *runArgs) {
 	cmd.Flags().StringVar(&args.issueID, "issue", "", "Issue identifier for single-issue mode (e.g. ENG-123, owner/repo#42, or https://github.com/owner/repo/issues/42)")
 	cmd.Flags().StringVar(&args.workDir, "work-dir", "", "Working directory (overrides config)")
 	cmd.Flags().StringVar(&args.modelID, "model", "", "Agent model ID (overrides config)")
+	cmd.Flags().StringSliceVar(&args.fallbackModels, "fallback-models", nil, "Comma-separated model IDs to fall back to (in order) when the primary model is out of credits; each should be on a different provider (overrides config)")
 	cmd.Flags().StringVar(&args.thinkingLevel, "thinking-level", "", "Agent reasoning effort level: low, medium, high, max, auto (overrides config; rejected by providers without an effort knob, e.g. cursor, gemini)")
 	cmd.Flags().DurationVar(&args.pollInterval, "poll-interval", 0, "Comment polling interval (overrides config)")
 	cmd.Flags().Float64Var(&args.maxBudget, "max-budget", 0, "Max budget in USD (overrides config)")
@@ -299,6 +301,9 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 	if args.modelID != "" {
 		cfg.Agent.Model = args.modelID
 	}
+	if len(args.fallbackModels) > 0 {
+		cfg.Agent.FallbackModels = args.fallbackModels
+	}
 	if args.thinkingLevel != "" {
 		if _, err := agent.ParseEffort(args.thinkingLevel); err != nil {
 			return nil, fmt.Errorf("--thinking-level: %w", err)
@@ -401,6 +406,17 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 	// Validate agent model.
 	if _, ok := agent.ModelByID(cfg.Agent.Model); !ok {
 		return nil, fmt.Errorf("unknown model %q — available models: %s", cfg.Agent.Model, availableModels())
+	}
+	// Validate fallback models after CLI overrides — LoadConfig's validate()
+	// ran before --model/--fallback-models were applied, so a bad CLI value
+	// would otherwise slip through to runtime.
+	for _, m := range cfg.Agent.FallbackModels {
+		if _, ok := agent.ModelByID(m); !ok {
+			return nil, fmt.Errorf("unknown fallback model %q — available models: %s", m, availableModels())
+		}
+		if m == cfg.Agent.Model {
+			return nil, fmt.Errorf("fallback model %q must differ from the primary model", m)
+		}
 	}
 	return cfg, nil
 }

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -258,9 +258,6 @@ func (c *Config) validate() error {
 			return fmt.Errorf("agent.effort: %w", err)
 		}
 	}
-	if err := ValidateFallbackModels("agent.fallback_models", c.Agent.Model, c.Agent.FallbackModels); err != nil {
-		return err
-	}
 	if err := c.Agent.LLMEndpoint.ToEndpoint().Validate(); err != nil {
 		return fmt.Errorf("agent.llm_endpoint: %w", err)
 	}
@@ -278,13 +275,30 @@ func (c *Config) validate() error {
 		if err := validateStep(ns.name, ns.step); err != nil {
 			return err
 		}
-		// Validate fallback models against the step's *effective* primary and
-		// *effective* fallback list — i.e. after the same step<-agent
-		// inheritance ResolveStep applies at runtime. A step can override the
-		// model while inheriting the agent's fallback list (or vice versa), so a
-		// fallback equal to the effective primary (e.g. agent.model=sonnet +
-		// fallback=[opus] with plan.model=opus → [opus, opus]) must be rejected
-		// even though the step set neither field explicitly.
+	}
+	if err := c.ValidateEffectiveFallbacks(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateEffectiveFallbacks checks the fallback list of every agent run — step
+// and round — against the primary model it will actually run with, after the
+// step<-agent / round<-step inheritance that ResolveStep/ResolveRound apply at
+// runtime. A fallback equal to the effective primary (e.g. agent.model=sonnet +
+// fallback=[opus] with plan.model=opus → [opus, opus]) is a useless failover
+// slot and must be rejected even when the step/round set neither field
+// explicitly.
+//
+// It is exported and validates effective (post-inheritance) values precisely so
+// the CLI can re-run it after --model/--fallback-models overrides: LoadConfig's
+// validate() ran before those overrides, and an agent-level-only re-check would
+// miss a step/round whose model override collides with the new fallback list.
+func (c *Config) ValidateEffectiveFallbacks() error {
+	if err := ValidateFallbackModels("agent.fallback_models", c.Agent.Model, c.Agent.FallbackModels); err != nil {
+		return err
+	}
+	for _, ns := range c.orderedSteps() {
 		primary := ns.step.Model
 		if primary == "" {
 			primary = c.Agent.Model
@@ -293,16 +307,15 @@ func (c *Config) validate() error {
 		if fallbacks == nil {
 			fallbacks = c.Agent.FallbackModels
 		}
-		if len(fallbacks) > 0 {
-			if err := ValidateFallbackModels(ns.name+".fallback_models", primary, fallbacks); err != nil {
-				return err
-			}
+		if len(fallbacks) == 0 {
+			continue
 		}
-		// Same invariant one resolve layer deeper: an agent round can override
-		// the model (ResolveRound: round.Model → step → agent) while inheriting
-		// the step's fallback list, so a round model equal to an inherited
-		// fallback would also produce a useless [opus, opus] failover sequence.
-		// Command rounds run no agent, so they're exempt.
+		if err := ValidateFallbackModels(ns.name+".fallback_models", primary, fallbacks); err != nil {
+			return err
+		}
+		// One resolve layer deeper: an agent round can override the model
+		// (ResolveRound: round.Model → step → agent) while inheriting the step's
+		// fallback list. Command rounds run no agent, so they're exempt.
 		for ri, round := range ns.step.Rounds {
 			if round.IsCommand() {
 				continue
@@ -311,11 +324,9 @@ func (c *Config) validate() error {
 			if roundPrimary == "" {
 				roundPrimary = primary
 			}
-			if len(fallbacks) > 0 {
-				label := fmt.Sprintf("%s.rounds[%d].fallback_models", ns.name, ri)
-				if err := ValidateFallbackModels(label, roundPrimary, fallbacks); err != nil {
-					return err
-				}
+			label := fmt.Sprintf("%s.rounds[%d].fallback_models", ns.name, ri)
+			if err := ValidateFallbackModels(label, roundPrimary, fallbacks); err != nil {
+				return err
 			}
 		}
 	}

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -298,6 +298,26 @@ func (c *Config) validate() error {
 				return err
 			}
 		}
+		// Same invariant one resolve layer deeper: an agent round can override
+		// the model (ResolveRound: round.Model → step → agent) while inheriting
+		// the step's fallback list, so a round model equal to an inherited
+		// fallback would also produce a useless [opus, opus] failover sequence.
+		// Command rounds run no agent, so they're exempt.
+		for ri, round := range ns.step.Rounds {
+			if round.IsCommand() {
+				continue
+			}
+			roundPrimary := round.Model
+			if roundPrimary == "" {
+				roundPrimary = primary
+			}
+			if len(fallbacks) > 0 {
+				label := fmt.Sprintf("%s.rounds[%d].fallback_models", ns.name, ri)
+				if err := ValidateFallbackModels(label, roundPrimary, fallbacks); err != nil {
+					return err
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -127,7 +127,7 @@ type StepConfig struct {
 	MaxBudgetUSD         float64            `yaml:"max_budget_usd"`         // override top-level; 0 = inherit
 	MaxTurns             int                `yaml:"max_turns"`
 	MaxToolErrorRetries  int                `yaml:"max_tool_error_retries"` // retries when a turn ends with an unresolved tool error; 0 = disabled
-	TransientRetries     int                `yaml:"transient_retries"`      // retries when provider execution fails with a transient error; 0 = default (2)
+	TransientRetries     int                `yaml:"transient_retries"`      // retries when provider execution fails with a transient error; 0 = default (4)
 	IdleTimeout          time.Duration      `yaml:"idle_timeout"`           // parent watchdog kills the subprocess if it emits no log line for this long while inside this step; 0 disables
 	// StreamTurnGracePeriod overrides how long a turn waits, after completion,
 	// for an outstanding background tool_use to terminate before the turn is
@@ -278,17 +278,23 @@ func (c *Config) validate() error {
 		if err := validateStep(ns.name, ns.step); err != nil {
 			return err
 		}
-		// Validate fallback models against the step's *resolved* primary model
-		// (a step with its own model: override and an inherited fallback list,
-		// or vice versa, must not name a fallback equal to its effective
-		// primary). Only validate when the step actually sets fallbacks; an
-		// inherited list is already validated at the agent level above.
-		if len(ns.step.FallbackModels) > 0 {
-			primary := ns.step.Model
-			if primary == "" {
-				primary = c.Agent.Model
-			}
-			if err := ValidateFallbackModels(ns.name+".fallback_models", primary, ns.step.FallbackModels); err != nil {
+		// Validate fallback models against the step's *effective* primary and
+		// *effective* fallback list — i.e. after the same step<-agent
+		// inheritance ResolveStep applies at runtime. A step can override the
+		// model while inheriting the agent's fallback list (or vice versa), so a
+		// fallback equal to the effective primary (e.g. agent.model=sonnet +
+		// fallback=[opus] with plan.model=opus → [opus, opus]) must be rejected
+		// even though the step set neither field explicitly.
+		primary := ns.step.Model
+		if primary == "" {
+			primary = c.Agent.Model
+		}
+		fallbacks := ns.step.FallbackModels
+		if fallbacks == nil {
+			fallbacks = c.Agent.FallbackModels
+		}
+		if len(fallbacks) > 0 {
+			if err := ValidateFallbackModels(ns.name+".fallback_models", primary, fallbacks); err != nil {
 				return err
 			}
 		}
@@ -613,6 +619,7 @@ func ResolveRound(round RoundConfig, parent StepConfig) StepConfig {
 		SystemPrompt:          systemPrompt,
 		PermissionMode:        parent.PermissionMode,
 		Effort:                parent.Effort,
+		FallbackModels:        parent.FallbackModels,
 		TransientRetries:      parent.TransientRetries,
 		StreamTurnGracePeriod: parent.StreamTurnGracePeriod,
 		LLMEndpoint:           parent.LLMEndpoint,

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -258,7 +258,7 @@ func (c *Config) validate() error {
 			return fmt.Errorf("agent.effort: %w", err)
 		}
 	}
-	if err := validateFallbackModels("agent.fallback_models", c.Agent.Model, c.Agent.FallbackModels); err != nil {
+	if err := ValidateFallbackModels("agent.fallback_models", c.Agent.Model, c.Agent.FallbackModels); err != nil {
 		return err
 	}
 	if err := c.Agent.LLMEndpoint.ToEndpoint().Validate(); err != nil {
@@ -288,7 +288,7 @@ func (c *Config) validate() error {
 			if primary == "" {
 				primary = c.Agent.Model
 			}
-			if err := validateFallbackModels(ns.name+".fallback_models", primary, ns.step.FallbackModels); err != nil {
+			if err := ValidateFallbackModels(ns.name+".fallback_models", primary, ns.step.FallbackModels); err != nil {
 				return err
 			}
 		}
@@ -296,11 +296,12 @@ func (c *Config) validate() error {
 	return nil
 }
 
-// validateFallbackModels checks that each fallback model ID resolves via
+// ValidateFallbackModels checks that each fallback model ID resolves via
 // agent.ModelByID and that none duplicates the primary model (a fallback equal
 // to the primary can never help). label names the config field for error
-// messages (e.g. "agent.fallback_models").
-func validateFallbackModels(label, primary string, fallbacks []string) error {
+// messages (e.g. "agent.fallback_models"). Exported so the CLI can reuse it for
+// flag overrides applied after LoadConfig's validate() has already run.
+func ValidateFallbackModels(label, primary string, fallbacks []string) error {
 	for _, m := range fallbacks {
 		if m == "" {
 			return fmt.Errorf("%s: fallback model must not be empty", label)

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -68,9 +68,14 @@ type TrackerConfig struct {
 //
 //nolint:govet // fieldalignment: keep YAML fields in config-file order.
 type AgentConfig struct {
-	Model       string             `yaml:"model"`        // model ID from agent.AllModels (e.g. "fable", "gpt-5.5")
-	Effort      string             `yaml:"effort"`       // reasoning effort; see agent.EffortLevel constants (low, medium, high, max, auto)
-	LLMEndpoint *LLMEndpointConfig `yaml:"llm_endpoint"` // optional third-party LLM API endpoint
+	Model string `yaml:"model"` // model ID from agent.AllModels (e.g. "fable", "gpt-5.5")
+	// FallbackModels are tried, in order, when the primary model fails with a
+	// workspace-wide out-of-credits error. Each should name a model on a
+	// *different* provider (a same-provider swap can't escape an out-of-credits
+	// workspace). Failover starts a fresh session. Empty = no fallback.
+	FallbackModels []string           `yaml:"fallback_models"`
+	Effort         string             `yaml:"effort"`       // reasoning effort; see agent.EffortLevel constants (low, medium, high, max, auto)
+	LLMEndpoint    *LLMEndpointConfig `yaml:"llm_endpoint"` // optional third-party LLM API endpoint
 }
 
 // LLMEndpointConfig points the underlying CLI at a third-party LLM endpoint
@@ -112,6 +117,7 @@ type StepConfig struct {
 	Prompt               string             `yaml:"prompt"`                 // Go text/template; required unless rounds is set. No built-in default — run `jiradozer bootstrap` to scaffold.
 	SystemPrompt         string             `yaml:"system_prompt"`          // optional system prompt passed to the agent
 	Model                string             `yaml:"model"`                  // override agent.model; empty = inherit
+	FallbackModels       []string           `yaml:"fallback_models"`        // override agent.fallback_models; nil = inherit. See AgentConfig.FallbackModels.
 	Effort               string             `yaml:"effort"`                 // override agent.effort; empty = inherit
 	PermissionMode       string             `yaml:"permission_mode"`        // "plan", "bypass", etc.; empty = step default
 	CommentTemplate      string             `yaml:"comment_template"`       // text/template rendered with CommentData; required for single-shot steps (rounds-only steps may omit it)
@@ -252,6 +258,9 @@ func (c *Config) validate() error {
 			return fmt.Errorf("agent.effort: %w", err)
 		}
 	}
+	if err := validateFallbackModels("agent.fallback_models", c.Agent.Model, c.Agent.FallbackModels); err != nil {
+		return err
+	}
 	if err := c.Agent.LLMEndpoint.ToEndpoint().Validate(); err != nil {
 		return fmt.Errorf("agent.llm_endpoint: %w", err)
 	}
@@ -268,6 +277,39 @@ func (c *Config) validate() error {
 	for _, ns := range c.orderedSteps() {
 		if err := validateStep(ns.name, ns.step); err != nil {
 			return err
+		}
+		// Validate fallback models against the step's *resolved* primary model
+		// (a step with its own model: override and an inherited fallback list,
+		// or vice versa, must not name a fallback equal to its effective
+		// primary). Only validate when the step actually sets fallbacks; an
+		// inherited list is already validated at the agent level above.
+		if len(ns.step.FallbackModels) > 0 {
+			primary := ns.step.Model
+			if primary == "" {
+				primary = c.Agent.Model
+			}
+			if err := validateFallbackModels(ns.name+".fallback_models", primary, ns.step.FallbackModels); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateFallbackModels checks that each fallback model ID resolves via
+// agent.ModelByID and that none duplicates the primary model (a fallback equal
+// to the primary can never help). label names the config field for error
+// messages (e.g. "agent.fallback_models").
+func validateFallbackModels(label, primary string, fallbacks []string) error {
+	for _, m := range fallbacks {
+		if m == "" {
+			return fmt.Errorf("%s: fallback model must not be empty", label)
+		}
+		if _, ok := agent.ModelByID(m); !ok {
+			return fmt.Errorf("%s: unknown model %q", label, m)
+		}
+		if m == primary {
+			return fmt.Errorf("%s: fallback model %q must differ from the primary model", label, m)
 		}
 	}
 	return nil
@@ -527,6 +569,9 @@ func (c *Config) StepByName(name string) (StepConfig, bool) {
 func (c *Config) ResolveStep(step StepConfig) StepConfig {
 	if step.Model == "" {
 		step.Model = c.Agent.Model
+	}
+	if step.FallbackModels == nil {
+		step.FallbackModels = c.Agent.FallbackModels
 	}
 	if step.Effort == "" {
 		step.Effort = c.Agent.Effort

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -306,6 +306,24 @@ func TestLoadConfig_FallbackModels_RejectsInheritedFallbackEqualToOverriddenPrim
 	assert.Contains(t, err.Error(), "must differ from the primary model")
 }
 
+func TestLoadConfig_FallbackModels_RejectsRoundModelEqualToInheritedFallback(t *testing.T) {
+	// agent.fallback_models=[opus] is inherited by the build step, and an agent
+	// round overrides its model to opus. At runtime ResolveRound yields
+	// Model=opus + FallbackModels=[opus] → a useless [opus, opus] failover, so
+	// validate() must reject it even though neither the step nor the agent set
+	// model=opus directly.
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  fallback_models: [opus]\n" +
+		"plan:\n  prompt: \"p\"\n  comment_template: \"c\"\n" +
+		"build:\n  comment_template: \"c\"\n  round_comment_template: \"## {{.Heading}} {{.Round}}/{{.TotalRounds}}\"\n  rounds:\n    - prompt: \"r1\"\n      model: opus\n" +
+		"create_pr:\n  prompt: \"pr\"\n  comment_template: \"c\"\nvalidate:\n  prompt: \"v\"\n  comment_template: \"c\"\nship:\n  prompt: \"s\"\n  comment_template: \"c\"\n"
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build.rounds[0].fallback_models")
+	assert.Contains(t, err.Error(), "must differ from the primary model")
+}
+
 func TestLoadConfig_InvalidEffort(t *testing.T) {
 	cases := []struct {
 		name string

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -245,6 +245,52 @@ func TestResolveStep_InheritsFromTopLevel(t *testing.T) {
 	assert.Equal(t, 50.0, build.MaxBudgetUSD)
 }
 
+func TestLoadConfig_FallbackModels_ParseAndInherit(t *testing.T) {
+	cfg, err := LoadConfig("testdata/with_fallback_models.yaml")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"opus", "sonnet"}, cfg.Agent.FallbackModels)
+
+	// plan sets its own fallback list — must NOT inherit the agent list.
+	plan := cfg.ResolveStep(cfg.Plan)
+	assert.Equal(t, []string{"haiku"}, plan.FallbackModels)
+
+	// ship leaves fallback_models empty — must inherit the agent list.
+	ship := cfg.ResolveStep(cfg.Ship)
+	assert.Equal(t, []string{"opus", "sonnet"}, ship.FallbackModels)
+}
+
+func TestLoadConfig_FallbackModels_RejectsUnknownModel(t *testing.T) {
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  fallback_models: [not-a-real-model]\n" + minimalSteps()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fallback_models")
+	assert.Contains(t, err.Error(), "not-a-real-model")
+}
+
+func TestLoadConfig_FallbackModels_RejectsDuplicateOfPrimary(t *testing.T) {
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  fallback_models: [sonnet]\n" + minimalSteps()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must differ from the primary model")
+}
+
+func TestLoadConfig_FallbackModels_RejectsStepFallbackEqualToInheritedPrimary(t *testing.T) {
+	// build inherits the agent primary (gpt-5.5) but names it as a step-level
+	// fallback — that can never help, so it must be rejected.
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: gpt-5.5\nbuild:\n  prompt: \"b\"\n  comment_template: \"c\"\n  fallback_models: [gpt-5.5]\n" +
+		"plan:\n  prompt: \"p\"\n  comment_template: \"c\"\ncreate_pr:\n  prompt: \"pr\"\n  comment_template: \"c\"\nvalidate:\n  prompt: \"v\"\n  comment_template: \"c\"\nship:\n  prompt: \"s\"\n  comment_template: \"c\"\n"
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build.fallback_models")
+}
+
 func TestLoadConfig_InvalidEffort(t *testing.T) {
 	cases := []struct {
 		name string

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -291,6 +291,21 @@ func TestLoadConfig_FallbackModels_RejectsStepFallbackEqualToInheritedPrimary(t 
 	assert.Contains(t, err.Error(), "build.fallback_models")
 }
 
+func TestLoadConfig_FallbackModels_RejectsInheritedFallbackEqualToOverriddenPrimary(t *testing.T) {
+	// agent.fallback_models=[opus] is inherited by plan, but plan overrides the
+	// model to opus — so plan would run [opus, opus] at runtime. validate() must
+	// reject this even though plan sets no fallback_models of its own.
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  fallback_models: [opus]\n" +
+		"plan:\n  prompt: \"p\"\n  comment_template: \"c\"\n  model: opus\n" +
+		"build:\n  prompt: \"b\"\n  comment_template: \"c\"\ncreate_pr:\n  prompt: \"pr\"\n  comment_template: \"c\"\nvalidate:\n  prompt: \"v\"\n  comment_template: \"c\"\nship:\n  prompt: \"s\"\n  comment_template: \"c\"\n"
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plan.fallback_models")
+	assert.Contains(t, err.Error(), "must differ from the primary model")
+}
+
 func TestLoadConfig_InvalidEffort(t *testing.T) {
 	cases := []struct {
 		name string
@@ -614,6 +629,7 @@ ship:
 func TestResolveRound_InheritsFromStep(t *testing.T) {
 	parent := StepConfig{
 		Model:                 "sonnet",
+		FallbackModels:        []string{"opus", "gpt-5.5"},
 		Effort:                "high",
 		SystemPrompt:          "parent system prompt",
 		PermissionMode:        "bypass",
@@ -640,6 +656,10 @@ func TestResolveRound_InheritsFromStep(t *testing.T) {
 	// inherits the parent's value verbatim (the wiring cursor flagged as
 	// untested in PR #259).
 	assert.Equal(t, 12*time.Minute, resolved.StreamTurnGracePeriod)
+	// FallbackModels has no per-round override field either; a round must
+	// inherit the parent's list verbatim so out-of-credits failover still
+	// triggers inside multi-round steps.
+	assert.Equal(t, []string{"opus", "gpt-5.5"}, resolved.FallbackModels)
 }
 
 // loadConfigFromYAML writes a YAML body to a temp file and loads it. Used by

--- a/jiradozer/jiradozer.example.yaml
+++ b/jiradozer/jiradozer.example.yaml
@@ -76,6 +76,12 @@ agent:
     # Model ID from agent.AllModels (e.g. "sonnet", "opus", "fable", "gpt-5.5",
     # "gemini-3.1-pro-preview", "cursor-default").
     model: sonnet
+    # Models to fall back to (in order) when the primary model fails with a
+    # workspace-wide "out of credits" error. A same-provider swap can't escape
+    # an out-of-credits workspace, so name a model on a *different* provider.
+    # Failover starts a fresh session (cross-provider resume is unreliable).
+    # Empty = no fallback. Per-step `fallback_models:` overrides this.
+    #fallback_models: [opus]
     # Reasoning effort: low, medium, high, max, auto. Empty = provider default.
     #effort: ""
     # Optional: route inference through a third-party LLM API endpoint
@@ -379,7 +385,11 @@ validate:
     # work (e.g. bramble reviewers a skill backgrounds) to finish before the
     # turn is force-completed; 0 = provider default (10m). Raise it for steps
     # that launch long-running background tools.
-    #stream_turn_grace_period: 0
+    #
+    # validate is poll-heavy (it babysits a background Monitor loop). Cap
+    # the grace at 3m so a wedged tool_use is cut off fast and the turn is
+    # force-completed + retried rather than burning the full 10m default.
+    stream_turn_grace_period: 3m
     # Skip the human review gate after this step.
     #auto_approve: false
 
@@ -455,7 +465,12 @@ ship:
     # work (e.g. bramble reviewers a skill backgrounds) to finish before the
     # turn is force-completed; 0 = provider default (10m). Raise it for steps
     # that launch long-running background tools.
-    #stream_turn_grace_period: 0
+    #
+    # ship is poll-heavy (it babysits PR readiness via a background Monitor
+    # loop). Cap the grace at 3m so a wedged tool_use is cut off fast and
+    # the turn is force-completed + retried rather than hanging for the full
+    # 10m.
+    stream_turn_grace_period: 3m
     # Skip the human review gate after this step.
     #auto_approve: false
 

--- a/jiradozer/testdata/with_fallback_models.yaml
+++ b/jiradozer/testdata/with_fallback_models.yaml
@@ -1,0 +1,25 @@
+tracker:
+  kind: linear
+  api_key: test-key
+
+agent:
+  model: gpt-5.5
+  fallback_models: [opus, sonnet]
+
+# plan overrides the fallback list for its step; ship inherits the agent list.
+plan:
+  prompt: "Plan {{.Identifier}}: {{.Title}}"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+  fallback_models: [haiku]
+build:
+  prompt: "Build {{.Identifier}}"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+create_pr:
+  prompt: "Open PR"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+validate:
+  prompt: "Run tests"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"
+ship:
+  prompt: "Ship it"
+  comment_template: "## {{.Heading}} Complete\n\n{{.Output}}"

--- a/multiagent/agent/transient.go
+++ b/multiagent/agent/transient.go
@@ -2,11 +2,27 @@ package agent
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/claude"
 	"github.com/bazelment/yoloswe/agent-cli-wrapper/codex"
 	transientmeta "github.com/bazelment/yoloswe/agent-cli-wrapper/transient"
 )
+
+// IsOutOfCredits reports whether err is a workspace-wide out-of-credits failure.
+// This is distinct from a transient error: a same-model retry can't refill the
+// workspace, so callers use it to trigger a fallback to a different provider's
+// model rather than to retry. It is text-based and provider-agnostic — both
+// claude.TurnError and codex.TurnError render the upstream message into
+// Error(), so matching the rendered string works across providers.
+func IsOutOfCredits(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "out of credits") ||
+		strings.Contains(s, "workspace owner to refill")
+}
 
 // IsTransient reports whether err originates from a known retryable provider
 // failure, such as stream-idle, rate limiting, or a temporary network break.

--- a/multiagent/agent/transient_test.go
+++ b/multiagent/agent/transient_test.go
@@ -37,6 +37,45 @@ func TestIsTransient(t *testing.T) {
 	}
 }
 
+func TestIsOutOfCredits(t *testing.T) {
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{
+			name: "claude turn error out of credits",
+			err:  &claude.TurnError{Message: "Your workspace is out of credits. Ask your workspace owner to refill."},
+			want: true,
+		},
+		{
+			name: "codex turn error out of credits",
+			err:  &codex.TurnError{Message: "request failed: out of credits"},
+			want: true,
+		},
+		{
+			name: "wrapped out of credits",
+			err:  fmt.Errorf("agent execution: %w", &codex.TurnError{Message: "please ask your Workspace Owner to refill"}),
+			want: true,
+		},
+		{
+			name: "transient stream idle is not out of credits",
+			err:  &claude.TransientError{Message: "stream idle"},
+			want: false,
+		},
+		{name: "plain error", err: errors.New("syntax error"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOutOfCredits(tt.err); got != tt.want {
+				t.Fatalf("IsOutOfCredits() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClassifyTransientReason(t *testing.T) {
 	requireTransientReason(t,
 		&codex.TransientError{Message: "turn never reached turn/completed", Reason: transientmeta.ReasonCodexIncomplete},

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Bazel workspace status command. Emits STABLE_* keys that, when a build runs
+# with --stamp (see .bazelrc's `stamp` config), are substituted into go_binary
+# x_defs so the binary self-identifies the commit and build time it was built
+# from. Resilient to a non-git tree (CI tarball, sandbox): falls back to
+# "unknown" rather than failing the build.
+#
+# STABLE_ keys force a re-link when their value changes; volatile keys (no
+# STABLE_ prefix) would not. We want the embedded revision to track the commit,
+# so both keys are STABLE_.
+set -euo pipefail
+
+revision="unknown"
+build_time="unknown"
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    if rev="$(git rev-parse HEAD 2>/dev/null)"; then
+        revision="$rev"
+    fi
+    if t="$(git show -s --format=%cI HEAD 2>/dev/null)"; then
+        build_time="$t"
+    fi
+fi
+
+echo "STABLE_GIT_REVISION ${revision}"
+echo "STABLE_GIT_TIME ${build_time}"


### PR DESCRIPTION
Five jiradozer reliability fixes from the cron-log triage. Closes #268, #270, #271, #272, #273.

## #271 — Model fallback on out-of-credits (headline)
The out-of-credits error dominated the logs (26 occurrences / 12 runs, mostly dying at `ship` after the real work was done). It's workspace-wide, so a same-provider retry can't help.

- `multiagent/agent.IsOutOfCredits(err)` — text-match (`out of credits` / `workspace owner to refill`) that works across `claude.TurnError` and `codex.TurnError`.
- `agent-cli-wrapper/transient.ReasonOutOfCredits` constant for logging (deliberately **not** added to `ClassifyText`'s retryable set).
- `agent.fallback_models` / per-step `fallback_models` config (a **list**, **cross-provider**), inherited step←agent in `ResolveStep`, validated via `agent.ModelByID` (rejects unknown models and a fallback equal to the primary).
- `--fallback-models` (comma-separated) CLI flag.
- `runAgent` now wraps the transient-retry loop in an **outer model loop** over `[cfg.Model] + cfg.FallbackModels`. On a terminal out-of-credits error with a next model available, it logs a warn (`model out of credits; falling back` from/to/step), resets the attempt counter, and reruns on the next model from a **fresh session** (cross-provider resume is unreliable — explicit decision). Each model's provider is built/closed inside the loop.

## #272 + #273 — Transient retry tuning
- `ClassifyText` now matches `connection closed` / `mid-response` → `connection_reset` (#272). 529 already classifies as `http_5xx` via the HTTP-status pattern (#273) — no classifier change.
- `defaultAgentRunner`: default `maxRetries` 2→4; backoff schedule 30s/90s → **30s, 90s, 3m, 5m** (single shared schedule; `retryBackoff` caps at the last entry so later attempts reuse 5m) for real overload cool-down.

## #270 — Background tool_use force-complete observability
- New `ReasonGraceForced = "grace_forced"` + a `ClassifyText` branch matching `turn forced complete after grace period` (checked before `stream idle` so the more specific phrase wins), still retryable — logs now distinguish a grace-forced complete from a true idle stream.
- The example/bootstrap set a tighter `stream_turn_grace_period: 3m` on the poll-heavy `validate`/`ship` steps (with inline rationale) so a wedged Monitor loop is cut off fast instead of burning the 10m default. The per-step wiring already existed.

## #268 — Bazel stamping for real build revision/time
`build_revision=unknown` because rules_go builds sandboxed away from `.git`.

- `tools/workspace_status.sh` (chmod +x) emits `STABLE_GIT_REVISION` + `STABLE_GIT_TIME` (RFC3339), resilient to non-git → `unknown`.
- `.bazelrc`: `--workspace_status_command=tools/workspace_status.sh` + an opt-in `build:stamp --stamp` config (not forced globally — would bust the cache).
- jiradozer `go_binary` `x_defs` map `cliapp.stampedRevision`/`stampedTime` to the stamp keys.
- `cliapp/buildinfo.go`: new package vars `stampedRevision`/`stampedTime`; `ReadBuildInfo` prefers them over the `unknown` default and the mtime fallback, with `debug.ReadBuildInfo` kept as a secondary source for non-Bazel builds. `stampValue` ignores empty / `unknown` / unsubstituted `{…}` placeholders.

> Cron alignment (doc-only, not in this repo): `~/magent/scripts/jiradozer-rebuild.sh` must build with `--config=stamp` (or `--stamp`) for the stamp to take effect.

## Verification

`scripts/lint.sh` → **All checks passed**. `bazel build //...` and `bazel test //...`:

```
Executed 83 out of 92 tests: 92 tests pass.
```

Affected-package tests:
```
//agent-cli-wrapper/transient:transient_test   PASSED
//cliapp:cliapp_test                           PASSED
//jiradozer:jiradozer_test                     PASSED
//jiradozer/cmd/jiradozer:jiradozer_test       PASSED
//multiagent/agent:agent_test                  PASSED
```

New tests: `IsOutOfCredits` (claude+codex TurnError + negative stream_idle); `ClassifyText` connection-closed-mid-response / 529 / grace-forced; `runAgent` out-of-credits→falls back to next model with **empty resume** and succeeds, no-fallback→error propagates, all-models-exhausted→final error, connection-closed now retried, default `maxRetries==4`; config `fallback_models` parse + inherit + validation (unknown model, duplicate-of-primary, step-fallback-equal-to-inherited-primary); buildinfo stamped revision/time surfaced + empty/placeholder ignored.

Manual #268 check — stamped build self-identifies its commit:
```
$ bazel build --config=stamp //jiradozer/cmd/jiradozer
$ jiradozer --help   # startup log:
jiradozer starting ... build_revision=dc3f0f3f6300 build_time=2026-06-16T20:31:46Z
```
Unstamped build still falls back cleanly to `build_revision=unknown` (no leaked `{STABLE_GIT_REVISION}` placeholder).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent execution (model failover, retry budgets, and error classification) and config validation; behavior is well-tested but affects production cron reliability paths.
> 
> **Overview**
> Improves **jiradozer** cron reliability: out-of-credits no longer kills late steps when another provider is configured, transient failures get more retries and backoff, grace-period force-completes are easier to diagnose, and stamped Bazel builds report a real git revision.
> 
> **Out-of-credits model fallback** adds `agent.IsOutOfCredits`, YAML/CLI `fallback_models`, and an outer model loop in `runAgent` that switches to the next model on workspace out-of-credits (fresh session, providers closed per attempt). Config validates effective primary vs fallback after inheritance (steps, rounds, and CLI overrides).
> 
> **Transient retry tuning** treats more provider strings as retryable (`connection closed`, distinct `grace_forced` before generic stream idle), raises default transient retries **2→4**, and lengthens backoff to **30s / 90s / 3m / 5m**.
> 
> **Build provenance** wires Bazel `workspace_status.sh` + opt-in `--config=stamp` into `jiradozer` `x_defs`; `cliapp.ReadBuildInfo` prefers linker stamps over sandboxed `unknown` revision.
> 
> **Bootstrap/example** documents `fallback_models` and sets **`stream_turn_grace_period: 3m`** on poll-heavy `validate` and `ship` steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d58c52e88f9fee36125625bf6e79299f93edd35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->