### PR TITLE
feat(jiradozer): accept cursor models by prefix + add `models` command

### DIFF
--- a/bramble/meetingbot/agent_client.go
+++ b/bramble/meetingbot/agent_client.go
@@ -25,13 +25,9 @@ func (ProviderAgentClient) Run(ctx context.Context, req AgentRequest) (AgentResp
 	if modelID == "" {
 		return AgentResponse{}, fmt.Errorf("missing model for %s", req.Role)
 	}
-	m, ok := agent.ModelByID(modelID)
+	m, ok := agent.ResolveModel(modelID)
 	if !ok {
-		provider, found := agent.ProviderByModelPrefix(modelID)
-		if !found {
-			return AgentResponse{}, fmt.Errorf("unknown model %q; expected one of registered models or prefixes %s", modelID, agent.KnownModelPrefixes())
-		}
-		m = agent.AgentModel{ID: modelID, Provider: provider, Label: modelID}
+		return AgentResponse{}, fmt.Errorf("unknown model %q; expected one of registered models or prefixes %s", modelID, agent.KnownModelPrefixes())
 	}
 
 	provider, err := agent.NewProviderForModel(m)

--- a/bramble/session/manager.go
+++ b/bramble/session/manager.go
@@ -1326,11 +1326,8 @@ func resolveAgentModel(modelID string, registry *agent.ModelRegistry) (agent.Age
 			return m, nil
 		}
 	}
-	if m, ok := agent.ModelByID(modelID); ok {
+	if m, ok := agent.ResolveModel(modelID); ok {
 		return m, nil
-	}
-	if provider, ok := agent.ProviderByModelPrefix(modelID); ok {
-		return agent.AgentModel{ID: modelID, Provider: provider, Label: modelID}, nil
 	}
 	return agent.AgentModel{}, fmt.Errorf("unknown model %q: no curated entry and no recognized prefix (%s)", modelID, agent.KnownModelPrefixes())
 }

--- a/jiradozer/agent.go
+++ b/jiradozer/agent.go
@@ -462,7 +462,7 @@ func (r agentRunner) runAgent(ctx context.Context, stepName, prompt string, cfg 
 // failure (so the caller can decide to fall back to a different model), and a
 // terminal error (nil on success).
 func (r agentRunner) runAgentForModel(ctx context.Context, stepName, prompt string, cfg StepConfig, workDir string, resumeSessionID string, renderer *render.Renderer, logger *slog.Logger) (StepAgentResult, bool, error) {
-	model, ok := agent.ModelByID(cfg.Model)
+	model, ok := agent.ResolveModel(cfg.Model)
 	if !ok {
 		return StepAgentResult{}, false, fmt.Errorf("unknown model: %q", cfg.Model)
 	}

--- a/jiradozer/agent_retry_test.go
+++ b/jiradozer/agent_retry_test.go
@@ -75,6 +75,31 @@ func TestRunAgentRetryTransientThenSuccess(t *testing.T) {
 	require.Equal(t, "sess-1", provider.resumeSession[1])
 }
 
+func TestRunAgentResolvesCursorPrefixModel(t *testing.T) {
+	// A prefix-only model (not curated in AllModels) must resolve to its
+	// provider and flow into newProviderForModel, not be rejected as unknown.
+	provider := &fakeRetryProvider{
+		results: []*agentpkg.AgentResult{{Success: true, SessionID: "sess-1", Text: "done"}},
+		errs:    []error{nil},
+	}
+	var gotModel agentpkg.AgentModel
+	runner := agentRunner{
+		newProviderForModel: func(m agentpkg.AgentModel) (agentpkg.Provider, error) {
+			gotModel = m
+			return provider, nil
+		},
+		retryBackoffs: []time.Duration{0},
+	}
+
+	got, err := runner.runAgent(context.Background(), "build", "prompt", StepConfig{
+		Model: "composer-2.5",
+	}, t.TempDir(), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	require.Equal(t, "done", got.Output)
+	require.Equal(t, "composer-2.5", gotModel.ID)
+	require.Equal(t, agentpkg.ProviderCursor, gotModel.Provider)
+}
+
 func TestRunAgentRetryTransientResultErrorThenSuccess(t *testing.T) {
 	provider := &fakeRetryProvider{
 		results: []*agentpkg.AgentResult{

--- a/jiradozer/cmd/jiradozer/BUILD.bazel
+++ b/jiradozer/cmd/jiradozer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bootstrap.go",
         "main.go",
+        "models.go",
         "run.go",
         "team_signals_other.go",
         "team_signals_unix.go",

--- a/jiradozer/cmd/jiradozer/main.go
+++ b/jiradozer/cmd/jiradozer/main.go
@@ -24,8 +24,8 @@ func main() {
 	}))
 }
 
-// newRootCommand builds the cobra tree: a root with three subcommands
-// (run, bootstrap, validate-config). The root's RunE delegates to run's
+// newRootCommand builds the cobra tree: a root with four subcommands
+// (run, bootstrap, validate-config, models). The root's RunE delegates to run's
 // handler so plain `jiradozer` (with no subcommand) keeps working for
 // existing invocations and shell scripts; for that to be useful, the same
 // run-only flags (--issue, --filter, --description, etc.) are also bound
@@ -49,8 +49,9 @@ func newRootCommand(opts *cliapp.Options) *cobra.Command {
 	runCmd := newRunCommand(&rargs)
 	bootstrapCmd := newBootstrapCommand(&bargs, &rargs.configPath)
 	validateConfigCmd := newValidateConfigCommand(&rargs.configPath)
+	modelsCmd := newModelsCommand()
 
-	rootCmd.AddCommand(runCmd, bootstrapCmd, validateConfigCmd)
+	rootCmd.AddCommand(runCmd, bootstrapCmd, validateConfigCmd, modelsCmd)
 
 	// Back-compat: bare `jiradozer --issue X --description Y` (no
 	// subcommand) behaves like `jiradozer run --issue X --description Y`.

--- a/jiradozer/cmd/jiradozer/main_test.go
+++ b/jiradozer/cmd/jiradozer/main_test.go
@@ -955,6 +955,21 @@ func TestValidateConfigUsesConfigPathFromRoot(t *testing.T) {
 	}
 }
 
+func TestModelsCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRootCommand(&cliapp.Options{ToolName: "jiradozer"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"models"})
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	assert.Contains(t, got, "Supported models by backend:")
+	assert.Contains(t, got, "cursor: cursor-default")
+	assert.Contains(t, got, "composer-")
+}
+
 // TestShouldReportFailure pins the run() failure-reporting guard: a real step
 // error must alert even when the context was cancelled (the fail-loudly goal),
 // while a bare cancellation/deadline is an expected stop and stays silent.

--- a/jiradozer/cmd/jiradozer/models.go
+++ b/jiradozer/cmd/jiradozer/models.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bazelment/yoloswe/multiagent/agent"
+)
+
+func newModelsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: "List supported models and backends",
+		Long: "Print the curated models grouped by backend and the provider prefixes that are " +
+			"accepted for model IDs that are not curated (e.g. composer-2.5).",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			writeModels(cmd.OutOrStdout())
+			return nil
+		},
+	}
+	cmd.SilenceUsage = true
+	return cmd
+}
+
+func writeModels(w io.Writer) {
+	fmt.Fprintln(w, "Supported models by backend:")
+	for _, provider := range agent.AllProviders {
+		var ids []string
+		for _, m := range agent.AllModels {
+			if m.Provider == provider {
+				ids = append(ids, m.ID)
+			}
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %s: %s\n", provider, strings.Join(ids, ", "))
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, supportedModelsHelp())
+}
+
+// supportedModelsHelp returns a one-line summary of the curated models and the
+// accepted provider prefixes. Shared by the `models` command and the
+// "unknown model" errors so both stay in sync.
+func supportedModelsHelp() string {
+	return fmt.Sprintf(
+		"available models: [%s]; any ID matching a known backend prefix (%s) is also accepted (e.g. composer-2.5). Run `jiradozer models` for details.",
+		strings.Join(agent.AllModelIDs(), ", "),
+		agent.KnownModelPrefixes(),
+	)
+}

--- a/jiradozer/cmd/jiradozer/run.go
+++ b/jiradozer/cmd/jiradozer/run.go
@@ -403,9 +403,10 @@ func loadRunConfig(args runArgs) (*jiradozer.Config, error) {
 		return nil, err
 	}
 
-	// Validate agent model.
-	if _, ok := agent.ModelByID(cfg.Agent.Model); !ok {
-		return nil, fmt.Errorf("unknown model %q — available models: %s", cfg.Agent.Model, availableModels())
+	// Validate agent model. ResolveModel accepts curated IDs and any ID matching
+	// a known provider prefix (e.g. "composer-2.5" → cursor); see `jiradozer models`.
+	if _, ok := agent.ResolveModel(cfg.Agent.Model); !ok {
+		return nil, fmt.Errorf("unknown model %q — %s", cfg.Agent.Model, supportedModelsHelp())
 	}
 	// Re-validate fallback models after CLI overrides — LoadConfig's validate()
 	// ran before --model/--fallback-models were applied. Use the effective
@@ -767,14 +768,6 @@ func parseAutoApprove(value string) []string {
 		return allSteps
 	}
 	return tracker.SplitCSV(value)
-}
-
-func availableModels() string {
-	var names []string
-	for _, m := range agent.AllModels {
-		names = append(names, m.ID)
-	}
-	return fmt.Sprintf("[%s]", strings.Join(names, ", "))
 }
 
 // rendererStatus is a nil-safe wrapper around renderer.Status.

--- a/jiradozer/config.go
+++ b/jiradozer/config.go
@@ -334,7 +334,8 @@ func (c *Config) ValidateEffectiveFallbacks() error {
 }
 
 // ValidateFallbackModels checks that each fallback model ID resolves via
-// agent.ModelByID and that none duplicates the primary model (a fallback equal
+// agent.ResolveModel (curated entry or recognized provider prefix, e.g.
+// "composer-2.5") and that none duplicates the primary model (a fallback equal
 // to the primary can never help). label names the config field for error
 // messages (e.g. "agent.fallback_models"). Exported so the CLI can reuse it for
 // flag overrides applied after LoadConfig's validate() has already run.
@@ -343,7 +344,7 @@ func ValidateFallbackModels(label, primary string, fallbacks []string) error {
 		if m == "" {
 			return fmt.Errorf("%s: fallback model must not be empty", label)
 		}
-		if _, ok := agent.ModelByID(m); !ok {
+		if _, ok := agent.ResolveModel(m); !ok {
 			return fmt.Errorf("%s: unknown model %q", label, m)
 		}
 		if m == primary {

--- a/jiradozer/config_test.go
+++ b/jiradozer/config_test.go
@@ -270,6 +270,27 @@ func TestLoadConfig_FallbackModels_RejectsUnknownModel(t *testing.T) {
 	assert.Contains(t, err.Error(), "not-a-real-model")
 }
 
+func TestLoadConfig_FallbackModels_AcceptsCursorPrefixModel(t *testing.T) {
+	// composer-2.5 is recognized by prefix though not curated in AllModels;
+	// both the primary and fallback slots must accept such IDs.
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: composer-2.5\n  fallback_models: [opus]\n" + minimalSteps()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "composer-2.5", cfg.Agent.Model)
+	assert.Equal(t, []string{"opus"}, cfg.Agent.FallbackModels)
+}
+
+func TestLoadConfig_FallbackModels_AcceptsCursorPrefixFallback(t *testing.T) {
+	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  fallback_models: [composer-2.5]\n" + minimalSteps()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0644))
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"composer-2.5"}, cfg.Agent.FallbackModels)
+}
+
 func TestLoadConfig_FallbackModels_RejectsDuplicateOfPrimary(t *testing.T) {
 	yaml := "tracker:\n  kind: linear\n  api_key: k\nagent:\n  model: sonnet\n  fallback_models: [sonnet]\n" + minimalSteps()
 	path := filepath.Join(t.TempDir(), "config.yaml")

--- a/multiagent/agent/model_registry.go
+++ b/multiagent/agent/model_registry.go
@@ -35,12 +35,34 @@ var AllModels = []AgentModel{
 	{ID: "agy-default", Provider: ProviderAgy, Label: "agy-default"},
 }
 
+// AllModelIDs returns the IDs of every curated model, in AllModels order.
+func AllModelIDs() []string {
+	ids := make([]string, len(AllModels))
+	for i, m := range AllModels {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
 // ModelByID returns the AgentModel for the given ID from the full list, or false if not found.
 func ModelByID(id string) (AgentModel, bool) {
 	for _, m := range AllModels {
 		if m.ID == id {
 			return m, true
 		}
+	}
+	return AgentModel{}, false
+}
+
+// ResolveModel resolves a model ID via exact match against AllModels, then a
+// prefix rule (e.g. "composer-2.5" → ProviderCursor) so not-yet-curated IDs
+// still work. Returns false only when neither matches.
+func ResolveModel(id string) (AgentModel, bool) {
+	if m, ok := ModelByID(id); ok {
+		return m, true
+	}
+	if provider, ok := ProviderByModelPrefix(id); ok {
+		return AgentModel{ID: id, Provider: provider, Label: id}, true
 	}
 	return AgentModel{}, false
 }

--- a/multiagent/agent/model_registry_test.go
+++ b/multiagent/agent/model_registry_test.go
@@ -280,3 +280,34 @@ func TestKnownModelPrefixes(t *testing.T) {
 	assert.Contains(t, s, "claude-")
 	assert.Contains(t, s, "agy-")
 }
+
+func TestResolveModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		id       string
+		provider string
+		ok       bool
+	}{
+		// Curated exact match wins.
+		{"opus", ProviderClaude, true},
+		// Prefix-only match synthesizes an AgentModel (not curated in AllModels).
+		{"composer-2.5", ProviderCursor, true},
+		// Unknown — neither curated nor prefix-recognized.
+		{"totally-bogus", "", false},
+		{"", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+			m, ok := ResolveModel(tc.id)
+			assert.Equal(t, tc.ok, ok)
+			if tc.ok {
+				assert.Equal(t, tc.id, m.ID)
+				assert.Equal(t, tc.provider, m.Provider)
+				assert.Equal(t, tc.id, m.Label)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Running jiradozer with a Cursor model failed at config load:

```
Error: load config: agent.fallback_models: unknown model "composer-2.5"
```

`composer-2.5` is a legitimate Cursor model — the `composer-` prefix rule already maps it to `ProviderCursor`, and `NewProviderForModel` already passes the raw model ID to the cursor backend. The only blocker was that jiradozer validated/resolved models strictly through `agent.ModelByID`, which requires an exact entry in the curated `AllModels` list.

## Changes

**Accept models by prefix**
- Add `agent.ResolveModel(id)` (`multiagent/agent/model_registry.go`): exact curated match, then prefix fallback (e.g. `composer-2.5` → cursor). This is the registry-free version of bramble's existing `resolveAgentModel` logic.
- Route jiradozer's three model sites through it: config fallback validation (`config.go`), run config (`run.go`), and runtime provider creation (`agent.go`). The config-load path (the reported failure) is covered transitively.

**`jiradozer models` discovery command**
- New `models` subcommand lists curated models grouped by backend plus the accepted prefixes. A shared `supportedModelsHelp()` keeps the command output and the "unknown model" error message in sync.

**Cleanup folded in**
- Collapse bramble's `resolveAgentModel` and the duplicated `meetingbot/agent_client.go` resolution onto `agent.ResolveModel`.
- Add `agent.AllModelIDs()` so the flat model-ID list lives in the registry rather than the cmd layer.

## Verification

- `scripts/lint.sh` ✓, `bazel build //...` ✓
- `bazel test //multiagent/agent/... //jiradozer/... //bramble/meetingbot/... //bramble/session/...` ✓
- `jiradozer models` prints the grouped listing + prefixes
- `validate-config` on a config with `agent.model: composer-2.5` + `fallback_models: [opus]` now returns `ok` instead of `unknown model "composer-2.5"`

## Tests added
- `ResolveModel` (exact / prefix-only / unknown)
- Config accepts `composer-2.5` as primary and as fallback
- `runAgent` resolves a prefix-only cursor model to a `ProviderCursor` `AgentModel`
- `models` subcommand output assertions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused refactor of model validation and resolution with tests; no auth, data, or payment paths—only broader acceptance of known provider prefixes.
> 
> **Overview**
> **Centralizes model resolution** so IDs like `composer-2.5` work without a curated `AllModels` entry: new `agent.ResolveModel` tries an exact curated match, then provider prefix rules (e.g. `composer-` → Cursor).
> 
> **jiradozer** now validates primary and fallback models through `ResolveModel` (config load, CLI `loadRunConfig`, and runtime `runAgentForModel`), fixing config errors such as `unknown model "composer-2.5"`. A **`jiradozer models`** subcommand lists curated models by backend plus accepted prefixes; **`supportedModelsHelp()`** keeps that text aligned with “unknown model” errors. **`agent.AllModelIDs()`** supplies the flat ID list for those messages.
> 
> **bramble** drops duplicated prefix logic in `meetingbot/agent_client.go` and `session/manager.resolveAgentModel` in favor of `agent.ResolveModel`.
> 
> Tests cover `ResolveModel`, config accepting prefix-only Cursor IDs, runtime resolution to `ProviderCursor`, and the `models` command output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce046a77346d58caddfaabec0147c049e628426d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->